### PR TITLE
test(viewer): regression test for LVLH central-body orientation (#50)

### DIFF
--- a/viewer/src/components/EarthBody.tsx
+++ b/viewer/src/components/EarthBody.tsx
@@ -73,6 +73,7 @@ export function EarthBody({
   textureBaseUrl,
 }: EarthBodyProps) {
   const materialRef = useRef<THREE.ShaderMaterial | null>(null);
+  const poleGroupRef = useRef<THREE.Group>(null);
   const [ready, setReady] = useState(false);
   const [upgraded, setUpgraded] = useState(false);
 
@@ -205,11 +206,29 @@ export function EarthBody({
     }
   }, [sunIntensity, ready]);
 
+  // Dev/E2E-only: expose the rendered Earth orientation (mesh world quaternion,
+  // which includes the internal POLE_ALIGNMENT_ROTATION) so E2E tests can assert
+  // the central-body orientation from the live scene graph without reading pixels.
+  // See viewer/tests/lvlh-orientation.spec.ts.
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    const w = window as unknown as Record<string, unknown>;
+    w.__debug_get_earth_world_quat = (): [number, number, number, number] | null => {
+      const g = poleGroupRef.current;
+      if (!g) return null;
+      const q = g.getWorldQuaternion(new THREE.Quaternion());
+      return [q.x, q.y, q.z, q.w];
+    };
+    return () => {
+      delete w.__debug_get_earth_world_quat;
+    };
+  }, []);
+
   return (
     <group>
       <group rotation={[0, 0, rotationAngle ?? 0]}>
         {/* Inner group: align Three.js Y-pole to ECI Z-pole (north pole → +Z) */}
-        <group rotation={POLE_ALIGNMENT_ROTATION}>
+        <group ref={poleGroupRef} rotation={POLE_ALIGNMENT_ROTATION}>
           <mesh material={materialRef.current ?? undefined}>
             <sphereGeometry args={[radius, 64, 64]} />
             {!ready && (

--- a/viewer/tests/lvlh-orientation.spec.ts
+++ b/viewer/tests/lvlh-orientation.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * E2E regression test for the satellite-centered (LVLH) central-body orientation.
+ *
+ * Guards against the bug in #50, where the Earth's pole-alignment rotation
+ * `R_x(π/2)` was applied twice in the LVLH path, tilting the central body 90°
+ * about the in-track axis. The visible symptom: from an *equatorial* orbit the
+ * pole/ice cap appears directly below the satellite instead of the equator.
+ *
+ * Rather than reading pixels (texture/lighting/AA make that flaky), this reads
+ * the rendered Earth mesh world quaternion from the live Three.js scene graph
+ * (exposed via `window.__debug_get_earth_world_quat` in dev/E2E builds) and
+ * checks a frame-invariant: for an equatorial orbit the Earth's north pole must
+ * lie along the LVLH cross-track axis (scene +Y), i.e. `|pole.y| ≈ 1`. The
+ * double-rotation bug puts the pole in the in-track/radial plane → `pole.y ≈ 0`.
+ *
+ * The check is independent of orbital phase and of the ERA value (R_z(ERA)
+ * leaves the pole on the cross-track axis), so it does not depend on the
+ * arika WASM rotation model being correct — only on the viewer's compositing.
+ */
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+
+/** Equatorial circular orbit with position + velocity and a J2000 epoch. */
+function generateEquatorialCSV(numPoints: number, dt: number): string {
+  const mu = 398600.4418;
+  const r = 7378; // ~1000 km altitude
+  const v = Math.sqrt(mu / r);
+  const omega = v / r;
+  const lines = [
+    "# orts 2-body orbit propagation",
+    `# mu = ${mu} km^3/s^2`,
+    "# epoch_jd = 2451545.0",
+    "# central_body = earth",
+    "# central_body_radius = 6378.137 km",
+  ];
+  for (let i = 0; i < numPoints; i++) {
+    const t = i * dt;
+    const a = omega * t;
+    const x = r * Math.cos(a);
+    const y = r * Math.sin(a);
+    const vx = -v * Math.sin(a);
+    const vy = v * Math.cos(a);
+    lines.push(`${t},${x},${y},0,${vx},${vy},0,${r},0,0,0,0,${a}`);
+  }
+  return lines.join("\n");
+}
+
+test("equatorial orbit: LVLH central body keeps the pole on cross-track (not nadir)", async ({
+  page,
+}) => {
+  const csvPath = join(tmpdir(), `orts-lvlh-orientation-${Date.now()}.csv`);
+  writeFileSync(csvPath, generateEquatorialCSV(120, 30));
+
+  await page.goto("/?noAutoConnect=1");
+  await page.locator('input[type="file"]').setInputFiles(csvPath);
+  await expect(page.locator('[data-testid="orbit-info-file"]')).toContainText("points", {
+    timeout: 10000,
+  });
+
+  await expect(page.locator("canvas").first()).toBeVisible();
+
+  // Deterministic state: pause playback and seek to a fixed phase.
+  const playPause = page.locator('[data-testid="play-pause-btn"]');
+  if ((await playPause.textContent())?.includes("Pause")) {
+    await playPause.click();
+  }
+  await page.locator('[data-testid="time-slider"]').fill("500");
+
+  // Center the view on the satellite → activates the LVLH (body-fixed) frame.
+  await page.locator('[data-testid="frame-selector-select"]').selectOption("satellite:default");
+
+  // Wait until the Earth's orientation is published from the scene graph.
+  await page.waitForFunction(
+    () =>
+      typeof (window as unknown as Record<string, unknown>).__debug_get_earth_world_quat ===
+      "function",
+    { timeout: 10000 },
+  );
+  await page.waitForTimeout(1500); // let the LVLH frame switch apply + render a frame
+
+  const quat = (await page.evaluate(() => {
+    const get = (window as unknown as Record<string, unknown>).__debug_get_earth_world_quat as
+      | (() => [number, number, number, number] | null)
+      | undefined;
+    return get ? get() : null;
+  })) as [number, number, number, number] | null;
+
+  expect(quat, "Earth world quaternion should be exposed once LVLH is active").not.toBeNull();
+  if (quat == null) return; // narrows type; unreachable — expect() throws above on null
+  const [qx, , qz] = quat;
+
+  // World direction of the geographic north pole = quat · (0,1,0); its Y (cross-track)
+  // component is `1 - 2(qx² + qz²)`. Equatorial orbit ⇒ pole is the orbit normal ⇒
+  // it must lie on cross-track (scene +Y), so |pole.y| ≈ 1.
+  const poleY = 1 - 2 * (qx * qx + qz * qz);
+  expect(
+    Math.abs(poleY),
+    `north pole should lie on the LVLH cross-track axis (|pole.y|≈1), got pole.y=${poleY.toFixed(
+      3,
+    )} — a value near 0 means the central body is tilted 90° (pole at nadir)`,
+  ).toBeGreaterThan(0.9);
+});


### PR DESCRIPTION
## Summary
Adds an E2E regression guard for #50 — the satellite-centered (LVLH) view rotated the central body 90° about the in-track axis because the Earth pole-alignment `R_x(π/2)` was applied twice. Symptom: from an **equatorial** orbit the pole / ice cap appeared at nadir instead of the equator.

## How it works
- Loads an equatorial circular orbit (CSV, J2000 epoch), pauses + seeks for a deterministic state, then centers the view on the satellite to activate the LVLH frame.
- Reads the **rendered Earth mesh world quaternion** from the live Three.js scene graph (exposed via a dev/E2E-only `__debug_get_earth_world_quat` hook in `EarthBody`) — no pixel reads, so it's deterministic.
- Asserts the frame-invariant: for an equatorial orbit the north pole must lie on the LVLH cross-track axis, `|pole.y| ≈ 1`. The double-rotation bug puts the pole in the in-track/radial plane → `pole.y ≈ 0`.
- The check is independent of orbital phase and of the ERA value (R_z(ERA) leaves the pole on cross-track), so it does **not** depend on the arika WASM rotation model — only on the viewer's compositing (`bodyLvlhQuaternion` × `EarthBody`'s internal pole alignment), which is exactly where the bug lived.

## Expected status
⚠️ **This is expected to FAIL on `main`** — the bug is still present. Verified locally:
- `main`: ❌ `pole.y = 0.000` (pole at nadir)
- with #51 applied: ✅ `|pole.y| ≈ 1`

Merge **after** #51 (the fix) lands; rebasing onto the fixed `main` turns it green.

Relates to #50, guards #51.