### PR TITLE
chore(renovate): auto-merge patch, lockfile, and security updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,18 @@
       "matchManagers": ["cargo"],
       "matchPackagePatterns": ["^rerun$", "^re_"],
       "groupName": "rerun"
+    },
+    {
+      "description": "Auto-merge patch-level updates once required CI checks pass",
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
     }
-  ]
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
+  "vulnerabilityAlerts": {
+    "automerge": true
+  }
 }


### PR DESCRIPTION
## Summary
Renovate の auto-merge を保守的なサブセットで有効化します(方針: **patch + lockfile + security のみ**)。

- **patch** レベルの更新 → auto-merge
- **lock file maintenance** → 有効化 + auto-merge
- **security**(`vulnerabilityAlerts`)→ auto-merge

minor / major(非セキュリティ)は引き続き手動マージ。

## Gate
auto-merge は `protect main` ruleset の **必須14チェック**(PR で走る CI)に gating されるため、**緑の更新だけが着地**します。CI が落ちる更新は自動マージされません。
(strict=false / merge queue なし。詳細はブランチ保護設定を参照)

## Changes
- `renovate.json`:
  - `packageRules` に patch 用 auto-merge ルールを追加
  - `lockFileMaintenance: { enabled, automerge }`
  - `vulnerabilityAlerts: { automerge }`

`renovate-config-validator` で検証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)