### PR TITLE
ci: trigger on merge_group for the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main]
+  # Run the same checks on merge-queue groups so required checks are
+  # validated against (main + queued PRs) before landing. The 14 PR
+  # jobs have no event guard, so they run here too; the main/tag-only
+  # jobs stay skipped (their ref guard is false for the queue branch).
+  merge_group:
 
 permissions:
   contents: write # softprops/action-gh-release (rust-dist, tag push only)


### PR DESCRIPTION
## Summary
merge queue を有効化する前段として、CI に **`merge_group` トリガー**を追加します。

```yaml
on:
  push: { branches: [main], tags: ["v*"] }
  pull_request: { branches: [main] }
  merge_group:        # ← 追加
```

## なぜ必要 / 順序
merge queue は「main + キュー内の前の PR」を積んだ一時ブランチ上で必須チェックを検証してからマージします。**この PR が main に入ってからでないと** ruleset で merge queue を有効化できません(逆順だとマージグループで CI が発火せず、必須チェックが永遠に未報告になりマージ不能)。

なので順序は: **この PR をマージ → ruleset に `merge_queue` ルール追加**。

## 設計判断
- ジョブの PR/キュー振り分けは**しない**。CI のクリティカルパスは実測 ~8分(`rust-build` → `cli-plugin-backend-e2e`)で、重いジョブを降ろしても短縮ゼロのため。14ジョブはそのまま `merge_group` でも走り、`protect main` の必須14チェックがキュー上で検証される。
- main/tag 限定ジョブ(rust-dist 等)はキューブランチでは ref ガードにより skip(従来通り)。

actionlint 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)