### PR TITLE
fix(cli): skip high-res texture download in e2e tests to remove flakiness

### DIFF
--- a/cli/src/commands/serve/textures.rs
+++ b/cli/src/commands/serve/textures.rs
@@ -278,6 +278,16 @@ pub fn spawn_texture_downloader(
 ) -> TextureRequestSender {
     let (tx, mut rx) = mpsc::channel::<Vec<String>>(8);
 
+    // Headless/e2e runs can opt out of fetching the high-res source textures
+    // (the Earth source alone is 21600×10800). Downloading and decoding them
+    // competes for CPU with the simulation loop, which makes timing-sensitive
+    // e2e tests flaky, so those tests set ORTS_DISABLE_TEXTURE_DOWNLOAD=1.
+    // Embedded 2k textures are still served regardless of this flag.
+    if std::env::var_os("ORTS_DISABLE_TEXTURE_DOWNLOAD").is_some() {
+        tokio::spawn(async move { while rx.recv().await.is_some() {} });
+        return tx;
+    }
+
     tokio::spawn(async move {
         let dir = &cache.cache_dir;
         if let Err(e) = std::fs::create_dir_all(dir) {

--- a/cli/tests/serve_dynamic_controlled_add_e2e.rs
+++ b/cli/tests/serve_dynamic_controlled_add_e2e.rs
@@ -119,6 +119,7 @@ impl Server {
     fn spawn_with_config(port: u16, config_path: &str) -> Self {
         let binary = orts_binary();
         let mut child = Command::new(&binary)
+            .env("ORTS_DISABLE_TEXTURE_DOWNLOAD", "1")
             .args([
                 "serve",
                 "--port",

--- a/cli/tests/spa_e2e.rs
+++ b/cli/tests/spa_e2e.rs
@@ -31,6 +31,7 @@ impl Server {
         let binary = env!("CARGO_BIN_EXE_orts");
         let args = vec!["serve".to_string(), "--port".to_string(), port.to_string()];
         let mut child = Command::new(binary)
+            .env("ORTS_DISABLE_TEXTURE_DOWNLOAD", "1")
             .args(&args)
             .stdout(Stdio::null())
             .stderr(Stdio::piped())

--- a/cli/tests/ws_e2e.rs
+++ b/cli/tests/ws_e2e.rs
@@ -36,6 +36,7 @@ impl Server {
             args.push(sat.to_string());
         }
         let mut child = Command::new(binary)
+            .env("ORTS_DISABLE_TEXTURE_DOWNLOAD", "1")
             .args(&args)
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
@@ -80,6 +81,7 @@ impl Server {
         let binary = env!("CARGO_BIN_EXE_orts");
         let args = vec!["serve".to_string(), "--port".to_string(), port.to_string()];
         let mut child = Command::new(binary)
+            .env("ORTS_DISABLE_TEXTURE_DOWNLOAD", "1")
             .args(&args)
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
@@ -534,6 +536,7 @@ async fn test_websocket_no_history_detail_sent() {
     // empty HistoryDetailComplete marker immediately).
     let binary = env!("CARGO_BIN_EXE_orts");
     let mut child = Command::new(binary)
+        .env("ORTS_DISABLE_TEXTURE_DOWNLOAD", "1")
         .args([
             "serve",
             "--port",
@@ -633,6 +636,7 @@ async fn test_websocket_history_overview_payload_is_bounded() {
     // dt=1 output_interval=1 accumulates 1 history point per wall-clock second.
     let binary = env!("CARGO_BIN_EXE_orts");
     let mut child = Command::new(binary)
+        .env("ORTS_DISABLE_TEXTURE_DOWNLOAD", "1")
         .args([
             "serve",
             "--port",


### PR DESCRIPTION
## 背景
`rust-test`(必須チェックの1つ)が断続的に落ちていた。原因は `cli/tests/ws_e2e.rs` の `test_websocket_no_history_detail_sent` 等の **20秒タイムアウト**。

`orts serve` は起動時に背景タスクで高解像度テクスチャ(地球の元画像だけで **21600×10800**)を DL + デコード/リサイズする。ロードの高い CI ランナー(14ジョブ並列)ではこれがシミュレーションループと CPU を奪い合い、「20秒以内に ~100 個の `state` メッセージを読む」タイミング依存テストが間欠的にタイムアウトしていた。`/tmp/orts/textures` 固定キャッシュは CI では常に cold なので毎回発生し得る。

## 修正
- `spawn_texture_downloader` を **`ORTS_DISABLE_TEXTURE_DOWNLOAD`** でゲート。セット時は背景タスクがリクエストを drain するだけで DL しない。**埋め込み2kテクスチャは引き続き配信**。
- `orts serve` を起動する **CLI e2e**(ws_e2e / spa_e2e / serve_dynamic、計6箇所)でこの env を設定。
- **viewer-e2e(Playwright)には付けない** → `texture-lazy-load.spec.ts` の `textures_ready` / 高解像度配信アサートは従来通り DL を検証。

## 検証(ローカル)
- `ws_e2e` **13/13 pass**(旧 flaky テストは ~6s で完了、stderr に `Downloading` 無し)
- `spa_e2e` **5/5 pass**(`/textures/earth_2k.jpg` = 埋め込み、DL 無効でも 200)
- CI 相当 clippy(`cargo clippy -p orts-cli --locked`)clean

## 補足(スコープ外)
`cargo clippy --all-targets` でテストコードに既存 lint 2件("length comparison to one" / "loop variable index")があるが、**origin/main にも存在**し、CI の lint(`--workspace`、テスト非対象)では検出されない既存issue。本PRでは触れていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)