### PR TITLE
feat(plugin): msg-io node messaging layer for FSW command & telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,7 @@ jobs:
             --test oracle_plugin_wasm_bdot \
             --test oracle_plugin_wasm_pd_rw \
             --test wasm_async_backend \
+            --test plugin_msg_commandable_mode \
             --test block_on_from_spawn_blocking
 
   # NOS3 ADCS SILS E2E: builds the NOS3 generic_adcs WASM plugin
@@ -441,7 +442,7 @@ jobs:
 
       - name: Build guest WASM components
         run: |
-          cd plugin-sdk/examples && cargo component build -p orts-example-plugin-pd-rw-control --release
+          cd plugin-sdk/examples && cargo component build -p orts-example-plugin-pd-rw-control -p orts-example-plugin-commandable-mode-ff --release
 
       - name: Download orts binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -460,6 +461,7 @@ jobs:
           cargo test --locked -p orts-cli --test serve_dynamic_controlled_add_e2e
           cargo test --locked -p orts-cli --test throughput_mode_speedup_e2e
           cargo test --locked -p orts-cli --test e2e test_controlled_simulation_via_config
+          cargo test --locked -p orts-cli --test plugin_msg_config_command_e2e
 
   # Build CLI with embedded viewer SPA in release profile.
   # Runs on main push (smoke test) AND tag push (release job consumes

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -581,6 +581,51 @@ per-tick 実測では sync / async の差は測定ノイズの範囲。async の
 - 安全: 平のシンクコード、`tokio::task::spawn_blocking` からの呼び出し
 - `orts serve` の sim loop は `spawn_blocking` で blocking thread に退避済みのため、async backend でも serve が正常動作する
 
+##### ノード間メッセージング (msg-io): 地上局 ↔ FSW + 衛星間
+
+FSW (WASM plugin) と地上局の間のコマンド/テレメトリ (C&T)、および将来の衛星間通信 (ISL) を運ぶ transport 層。`interface msg-io` として定義し、制御ループ (`tick-io`) とは独立させる。
+
+`tick-io` の `command` は「FSW → アクチュエータ」の制御出力で別物。`msg-io` は「地上局 ↔ FSW」「衛星 ↔ 衛星」のメッセージを運ぶ。
+
+###### レイヤリング
+
+transport は dumb pipe とし、配送とアドレッシングのみを担う（`payload` は解釈しない）。fire-and-forget / request-response / ack といった interaction model は **アプリ層**（`payload` の中身 + SDK ヘルパ）に置く。こうすると同じ WIT 契約の上に複数モデルを載せられ、モデルを差し替えても契約は不変（fire-and-forget ⇄ request-response の差し替えで WIT が変わらないことを example で確認）。
+
+###### データモデル
+
+論理型 `kind`（content-type、名前空間 + version 規約）と payload のエンコーディングを分離する:
+
+```wit
+type msg-kind = string;            // 例 "orts.cmd.set-mode.v1"
+variant value { boolean(bool), integer(s64), number(f64), text(string), bytes(list<u8>) }
+variant payload {                  // エンコーディングをユースケースで選択
+    key-value(list<named-value>),  //   構造化（スカラ型付き）
+    binary(list<u8>),              //   生バイナリ
+    json(string),
+}
+variant node-id { ground, satellite(u32) }
+record message  { src, dst, kind, host-seq: u64, deliver-tick: u64, payload }  // 受信（host が確定）
+record outbound { dst, kind, payload }                                         // 送信（guest 側は最小）
+```
+
+`kind` はエンコーディングに依らず常に付くので型を担い、`payload` variant でエンコーディングを選べる。型付き構造体が欲しい guest は SDK の serde 層で被せる。
+
+###### 配送意味論
+
+- **受信**: host が tick 境界でその tick の inbox を**凍結**し、guest は `recv-batch(max)` で drain する。tick 途中の新着は次 tick へ回るので、いつ・何回呼んでも観測は不変（決定論）。`tick-input` には載せず物理 snapshot を純粋に保ち、大量受信でも `max` で guest がペース制御できる。
+- **送信**: `send-message` は append。host が `src` を注入（なりすまし防止）し `host-seq`・`deliver-tick` を確定 stamp する。
+
+###### transport adapter
+
+core は host が所有する transport 非依存のキュー。各入力経路は adapter にすぎず、FSW から見れば由来は区別されない。`deliver` / `take_outbound` / `set_node_id` を `PluginController` trait のメソッド（default no-op、WASM backend が override）として公開し、run ループが `dyn PluginController` 経由で駆動する。
+
+- **config 時刻シーケンス** (`[[command]]`): `t` / `sat` / `kind` / `args` を宣言し、`CommandSchedule` が tick ごとに due なものを配送する。決定論的。
+- **WebSocket 対話**（将来）: viewer から運用コンソール。到着タイミング依存で非決定論。
+
+###### 決定論とリプレイ
+
+非決定論の発生源は WebSocket の対話入力のみ（到着が壁時計依存）。host が tick 境界で **gate** して `deliver-tick` に確定・記録すれば、それは config の `[[command]]` と同形の**コマンドタイムライン**になる。これを config transport で流し直すのが**リプレイ**。物理は元々決定論なので、入力（コマンド列）さえ tick 単位で再現すれば全体が bit-for-bit 再現する。`deliver-tick` / `host-seq` を envelope に持たせたのはこの記録のため。録った運用セッションがそのまま oracle / 回帰テストになる。
+
 ### ミッション規模と力学モデル
 
 問題のスケールに応じて適切なモデルを選択する設計。一つのモデルで全てをカバーしない。

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -598,7 +598,7 @@ FSW (WASM plugin) と地上局の間のコマンド/テレメトリ (C&T)、お�
 - **connection の属性**（host / kble / channel が決め、FSW は不知）:
   - **scope**: intra-node（同一機内）/ inter-node（別ノード・地上）。endpoint から導出される metadata 的軸。
   - **impairment**: lossless / impaired（欠落・遅延・エラー）。ただし**注入する層と粒度は shape に依存**（packet 単位 / byte span・gap / bit・frame）するので shape と完全には独立でない。
-  - **time model**: deterministic-tick（host が `deliver-tick` を確定）/ replay（記録再生）/ live（実時間）。impairment とは**独立の次元**。
+  - **time model**: deterministic-tick（host がどの tick で配送を確定するか）/ replay（記録再生）/ live（実時間）。impairment とは**独立の次元**。
 
 含意:
 - 同じ `stream-io` の口が、機内シリアル（intra・lossless、例 SpaceWire/UART）にも地上 RF リンク（inter・impaired）にも配線できる。byte-stream は inter-node 専用ではない。
@@ -622,16 +622,18 @@ variant payload {                  // エンコーディングをユースケー
     json(string),
 }
 variant node-id { ground, satellite(u32) }
-record message  { src, dst, kind, host-seq: u64, deliver-tick: u64, payload }  // 受信（host が確定）
-record outbound { dst, kind, payload }                                         // 送信（guest 側は最小）
+record message  { src, dst, kind, payload }  // 受信（src は host が確定）
+record outbound { dst, kind, payload }       // 送信（guest 側は最小）
 ```
+
+> envelope は最小限に保つ。決定論リプレイの全順序 anchor（host 採番 seq）・配送 tick・dedup 用 origin id といった host 採番メタは、それを読む consumer が現れるまで足さない（YAGNI）。
 
 `kind` はエンコーディングに依らず常に付くので型を担い、`payload` variant でエンコーディングを選べる。型付き構造体が欲しい guest は SDK の serde 層で被せる。
 
 ###### 配送意味論
 
 - **受信**: host が tick 境界でその tick の inbox を**凍結**し、guest は `recv-batch(max)` で drain する。tick 途中の新着は次 tick へ回るので、いつ・何回呼んでも観測は不変（決定論）。`tick-input` には載せず物理 snapshot を純粋に保ち、大量受信でも `max` で guest がペース制御できる。
-- **送信**: `send-message` は append。host が `src` を注入（なりすまし防止）し `host-seq`・`deliver-tick` を確定 stamp する。
+- **送信**: `send-message` は append。host が `src` を注入する（なりすまし防止）。
 
 ###### transport adapter
 
@@ -642,7 +644,7 @@ core は host が所有する transport 非依存のキュー。各入力経路�
 
 ###### 決定論とリプレイ
 
-非決定論の発生源は WebSocket の対話入力のみ（到着が壁時計依存）。host が tick 境界で **gate** して `deliver-tick` に確定・記録すれば、それは config の `[[command]]` と同形の**コマンドタイムライン**になる。これを config transport で流し直すのが**リプレイ**。物理は元々決定論なので、入力（コマンド列）さえ tick 単位で再現すれば全体が bit-for-bit 再現する。`deliver-tick` / `host-seq` を envelope に持たせたのはこの記録のため。録った運用セッションがそのまま oracle / 回帰テストになる。
+非決定論の発生源は WebSocket の対話入力のみ（到着が壁時計依存）。host が tick 境界で **gate** して「どの tick で何を配ったか」を確定・記録すれば、それは config の `[[command]]` と同形の**コマンドタイムライン**になる。これを config transport で流し直すのが**リプレイ**。物理は元々決定論なので、入力（コマンド列）さえ tick 単位で再現すれば全体が bit-for-bit 再現する。記録は config 形式のコマンドタイムライン側に持たせ、message envelope 自体には決定論メタを載せない（必要になれば前述の YAGNI 注記どおり後で足す）。録った運用セッションがそのまま oracle / 回帰テストになる。
 
 ### ミッション規模と力学モデル
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -587,6 +587,24 @@ FSW (WASM plugin) と地上局の間のコマンド/テレメトリ (C&T)、お�
 
 `tick-io` の `command` は「FSW → アクチュエータ」の制御出力で別物。`msg-io` は「地上局 ↔ FSW」「衛星 ↔ 衛星」のメッセージを運ぶ。
 
+###### 通信の概念モデル（component / port / connection）
+
+通信は常に **component ↔ component**。FSW が見る「口（port kind / I/O discipline）」と、その口が「何に配線されているか（connection）」を分けて考える。
+
+- **port kind**（FSW が見る面）:
+  - `tick-io` — tick 結合の **control plane**（FSW → アクチュエータ）。通信の shape ではない。
+  - `msg-io` — **node ↔ node の datagram service**。datagram shape + `node-id` 論理アドレス + host 確定配送から成る **network / service 抽象**（shape だけではない）。
+  - `stream-io`（将来）— 順序バイトの conduit。
+- **connection の属性**（host / kble / channel が決め、FSW は不知）:
+  - **scope**: intra-node（同一機内）/ inter-node（別ノード・地上）。endpoint から導出される metadata 的軸。
+  - **impairment**: lossless / impaired（欠落・遅延・エラー）。ただし**注入する層と粒度は shape に依存**（packet 単位 / byte span・gap / bit・frame）するので shape と完全には独立でない。
+  - **time model**: deterministic-tick（host が `deliver-tick` を確定）/ replay（記録再生）/ live（実時間）。impairment とは**独立の次元**。
+
+含意:
+- 同じ `stream-io` の口が、機内シリアル（intra・lossless、例 SpaceWire/UART）にも地上 RF リンク（inter・impaired）にも配線できる。byte-stream は inter-node 専用ではない。
+- `node` = component を内包する単位（衛星 / 地上局）。inter-node は物理的には通信機(transceiver) ↔ 媒体 ↔ 通信機 で、`msg-io` はそれを隠す network 抽象（link/physical 側は将来 `stream-io` / RF）。
+- これは config 軸を多数作る話ではなく **思考の枠**。orts は当面 `tick-io` / `msg-io` /（将来）`stream-io` の 3 口を実装する。
+
 ###### レイヤリング
 
 transport は dumb pipe とし、配送とアドレッシングのみを担う（`payload` は解釈しない）。fire-and-forget / request-response / ack といった interaction model は **アプリ層**（`payload` の中身 + SDK ヘルパ）に置く。こうすると同じ WIT 契約の上に複数モデルを載せられ、モデルを差し替えても契約は不変（fire-and-forget ⇄ request-response の差し替えで WIT が変わらないことを example で確認）。

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -587,10 +587,6 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
         }
         crate::sim::command_schedule::CommandSchedule::new(scheduled)
     };
-    // Host-assigned monotonic sequence + control-tick index, stamped onto
-    // each delivered command's envelope.
-    let mut command_host_seq: u64 = 0;
-    let mut tick_index: u64 = 0;
 
     // 初期状態を記録。
     for (i, sat) in satellites.iter().enumerate() {
@@ -614,13 +610,11 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
         let dt = dt_ctrl.min(duration - t);
 
         // 時刻指定コマンド: この制御 tick の終端 (t+dt) までに due なものを
-        // 配送する。host が src/host-seq/deliver-tick を確定 stamp する。
+        // 配送する。`src` は controller(host) が確定する。
         for sc in command_schedule.drain_due(t + dt) {
-            let mut msg = sc.message.clone();
-            msg.host_seq = command_host_seq;
-            msg.deliver_tick = tick_index;
-            command_host_seq += 1;
-            satellites[sc.sat_index].controller.deliver(msg);
+            satellites[sc.sat_index]
+                .controller
+                .deliver(sc.message.clone());
         }
 
         if parallel_step {
@@ -663,7 +657,6 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
         }
 
         t += dt;
-        tick_index += 1;
 
         if t >= next_output_t - 1e-12 {
             for (i, sat) in satellites.iter().enumerate() {

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -644,9 +644,17 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
         // controller が msg-io 未対応なら default 実装で空。
         for (i, sat) in satellites.iter_mut().enumerate() {
             for m in sat.controller.take_outbound() {
+                // Metadata at info; the full payload only at debug — payloads
+                // can be large (binary / file-transfer), so logging them every
+                // tick at info would be noisy and IO-heavy.
                 log::info!(
-                    "downlink t={:.3} sat={} kind={} payload={:?}",
+                    "downlink t={:.3} sat={} kind={}",
                     t + dt,
+                    params.satellites[i].id,
+                    m.kind
+                );
+                log::debug!(
+                    "downlink payload sat={} kind={}: {:?}",
                     params.satellites[i].id,
                     m.kind,
                     m.payload

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -552,6 +552,46 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
         }
     }
 
+    // 各コントローラのノード identity を設定（msg-io outbound の src として
+    // stamp される）。衛星はベクタ内の位置でアドレス付けする。
+    for (i, sat) in satellites.iter_mut().enumerate() {
+        sat.controller
+            .set_node_id(orts::plugin::NodeId::Satellite(i as u32));
+    }
+
+    // config の時刻指定コマンド (`[[command]]`) を時刻順キューに積む。
+    // host が tick ごとに due なものを配送する決定論的 transport adapter。
+    let mut command_schedule = {
+        use std::collections::HashMap;
+        let id_to_index: HashMap<&str, usize> = params
+            .satellites
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (s.id.as_str(), i))
+            .collect();
+        let mut scheduled = Vec::new();
+        for cmd in &params.commands {
+            let Some(&idx) = id_to_index.get(cmd.sat.as_str()) else {
+                eprintln!("command targets unknown satellite '{}'", cmd.sat);
+                std::process::exit(1);
+            };
+            let message = cmd.to_message(idx).unwrap_or_else(|e| {
+                eprintln!("invalid command: {e}");
+                std::process::exit(1);
+            });
+            scheduled.push(crate::sim::command_schedule::ScheduledCommand {
+                t: cmd.t,
+                sat_index: idx,
+                message,
+            });
+        }
+        crate::sim::command_schedule::CommandSchedule::new(scheduled)
+    };
+    // Host-assigned monotonic sequence + control-tick index, stamped onto
+    // each delivered command's envelope.
+    let mut command_host_seq: u64 = 0;
+    let mut tick_index: u64 = 0;
+
     // 初期状態を記録。
     for (i, sat) in satellites.iter().enumerate() {
         let tp = TimePoint::new().with_sim_time(0.0).with_step(0);
@@ -573,6 +613,16 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
     while t < duration - 1e-12 {
         let dt = dt_ctrl.min(duration - t);
 
+        // 時刻指定コマンド: この制御 tick の終端 (t+dt) までに due なものを
+        // 配送する。host が src/host-seq/deliver-tick を確定 stamp する。
+        for sc in command_schedule.drain_due(t + dt) {
+            let mut msg = sc.message.clone();
+            msg.host_seq = command_host_seq;
+            msg.deliver_tick = tick_index;
+            command_host_seq += 1;
+            satellites[sc.sat_index].controller.deliver(msg);
+        }
+
         if parallel_step {
             use rayon::prelude::*;
             satellites.par_iter_mut().for_each(|sat| {
@@ -590,7 +640,22 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
             }
         }
 
+        // FSW からの downlink（テレメトリ / ISL）を回収してログに出す。
+        // controller が msg-io 未対応なら default 実装で空。
+        for (i, sat) in satellites.iter_mut().enumerate() {
+            for m in sat.controller.take_outbound() {
+                log::info!(
+                    "downlink t={:.3} sat={} kind={} payload={:?}",
+                    t + dt,
+                    params.satellites[i].id,
+                    m.kind,
+                    m.payload
+                );
+            }
+        }
+
         t += dt;
+        tick_index += 1;
 
         if t >= next_output_t - 1e-12 {
             for (i, sat) in satellites.iter().enumerate() {

--- a/cli/src/commands/serve/mod.rs
+++ b/cli/src/commands/serve/mod.rs
@@ -74,6 +74,13 @@ async fn async_server(sim: &SimArgs, port: u16) {
         None
     };
 
+    // `orts serve` does not drive config `[[command]]` timelines (run-only);
+    // reject loudly instead of silently dropping scheduled uplinks.
+    if let Some(cfg) = &initial_config {
+        cfg.ensure_serve_supported()
+            .unwrap_or_else(|e| panic!("Error: {e}"));
+    }
+
     let texture_cache = Arc::new(TextureCache::new());
     let texture_request_tx =
         textures::spawn_texture_downloader(Arc::clone(&texture_cache), tx.clone());

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -96,8 +96,11 @@ fn args_to_payload(args: &serde_json::Value) -> Result<Payload, String> {
             J::Number(n) => {
                 if let Some(i) = n.as_i64() {
                     Value::Integer(i)
-                } else if let Some(u) = n.as_u64() {
-                    Value::Integer(u as i64)
+                } else if n.is_u64() {
+                    // Reached only for u64 > i64::MAX (`as_i64` handled the
+                    // rest), which always overflows s64. Reject rather than
+                    // wrap silently into a negative integer.
+                    return Err(format!("arg '{name}': integer {n} exceeds s64 (i64) range"));
                 } else if let Some(f) = n.as_f64() {
                     Value::Number(f)
                 } else {
@@ -1154,6 +1157,19 @@ args = { mode = "nadir", req-id = 7 }
             sat: "x".into(),
             kind: "k".into(),
             args: serde_json::json!({ "nested": { "a": 1 } }),
+        };
+        assert!(cmd.to_message(0).is_err());
+    }
+
+    #[test]
+    fn command_rejects_out_of_range_integer() {
+        // u64 > i64::MAX must be rejected, not silently wrapped to a
+        // negative s64 (WIT `value.integer` is s64).
+        let cmd = CommandConfig {
+            t: 0.0,
+            sat: "x".into(),
+            kind: "k".into(),
+            args: serde_json::json!({ "big": 9_223_372_036_854_775_808u64 }),
         };
         assert!(cmd.to_message(0).is_err());
     }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -6,6 +6,7 @@ use crate::cli::{AtmosphereChoice, IntegratorChoice};
 use crate::satellite::{OrbitSpec, SatelliteSpec};
 use crate::tle::fetch_tle_by_norad_id;
 use arika::body::KnownBody;
+use orts::plugin::{Message, NamedValue, NodeId, Payload, Value};
 use orts::tle::Tle;
 
 /// JSON/TOML/YAML simulation configuration.
@@ -30,6 +31,91 @@ pub struct SimConfig {
     pub duration: Option<f64>,
     #[serde(default)]
     pub satellites: Vec<SatelliteConfig>,
+    /// 時刻指定コマンドシーケンス（FSW への C&T アップリンク）。
+    /// 各エントリは指定 sim 時刻に対象衛星のコントローラへ配送される。
+    /// TOML では `[[command]]`（単数）/ `[[commands]]`（複数）の両方可。
+    #[serde(default, alias = "command")]
+    pub commands: Vec<CommandConfig>,
+}
+
+/// 時刻指定コマンド（config transport）。
+///
+/// `orts.toml` の `[[command]]` として宣言し、`t` 秒の時点で `sat` の
+/// コントローラ(FSW)へ `kind` + `args`(key-value payload) を配送する。
+/// host が配送 tick を確定するので決定論的。
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct CommandConfig {
+    /// 配送するシミュレーション時刻 \[s\]。
+    pub t: f64,
+    /// 配送先衛星 id（`[[satellites]]` の id と一致する必要がある）。
+    pub sat: String,
+    /// メッセージの論理型（content-type）。例 `"orts.cmd.set-mode.v1"`。
+    pub kind: String,
+    /// key-value payload 引数。TOML/JSON のスカラ値が型付き値に対応する
+    /// （string→text, integer→integer, float→number, bool→boolean）。
+    /// 省略時は空の key-value。
+    #[serde(default)]
+    pub args: serde_json::Value,
+}
+
+impl CommandConfig {
+    /// 配送先衛星インデックスを指定して host-native [`Message`] を組み立てる。
+    /// `host_seq` / `deliver_tick` は配送時に host が上書きする（ここでは 0）。
+    pub fn to_message(&self, sat_index: usize) -> Result<Message, String> {
+        let payload = args_to_payload(&self.args).map_err(|e| {
+            format!(
+                "command t={} sat='{}' kind='{}': {e}",
+                self.t, self.sat, self.kind
+            )
+        })?;
+        Ok(Message {
+            src: NodeId::Ground,
+            dst: NodeId::Satellite(sat_index as u32),
+            kind: self.kind.clone(),
+            host_seq: 0,
+            deliver_tick: 0,
+            payload,
+        })
+    }
+}
+
+/// `args`（JSON/TOML object）を key-value [`Payload`] に変換する。
+/// スカラ値のみ対応。null（省略）は空の key-value。
+fn args_to_payload(args: &serde_json::Value) -> Result<Payload, String> {
+    use serde_json::Value as J;
+    let map = match args {
+        J::Null => return Ok(Payload::KeyValue(Vec::new())),
+        J::Object(m) => m,
+        other => return Err(format!("args must be a table/object, got {other}")),
+    };
+    let mut kvs = Vec::with_capacity(map.len());
+    for (name, v) in map {
+        let value = match v {
+            J::Bool(b) => Value::Boolean(*b),
+            J::String(s) => Value::Text(s.clone()),
+            J::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    Value::Integer(i)
+                } else if let Some(u) = n.as_u64() {
+                    Value::Integer(u as i64)
+                } else if let Some(f) = n.as_f64() {
+                    Value::Number(f)
+                } else {
+                    return Err(format!("arg '{name}': unsupported number {n}"));
+                }
+            }
+            other => {
+                return Err(format!(
+                    "arg '{name}': unsupported value type {other} (only scalars allowed in args)"
+                ));
+            }
+        };
+        kvs.push(NamedValue {
+            name: name.clone(),
+            value,
+        });
+    }
+    Ok(Payload::KeyValue(kvs))
 }
 
 fn default_body() -> String {
@@ -587,6 +673,7 @@ mod tests {
             space_weather: None,
             duration: None,
             satellites: vec![],
+            commands: vec![],
         };
         assert!(matches!(config.integrator_choice(), IntegratorChoice::Rk4));
     }
@@ -606,6 +693,7 @@ mod tests {
             space_weather: None,
             duration: None,
             satellites: vec![],
+            commands: vec![],
         };
         assert!(matches!(
             config.atmosphere_choice(),
@@ -811,6 +899,7 @@ satellites:
                 mtq: None,
                 thruster: None,
             }],
+            commands: vec![],
         };
         let json = serde_json::to_string(&config).unwrap();
         let roundtrip: SimConfig = serde_json::from_str(&json).unwrap();
@@ -984,6 +1073,89 @@ satellites:
             && (*max_momentum - 1.0).abs() < 1e-9
             && (*max_torque - 0.5).abs() < 1e-9
         ));
+    }
+
+    #[test]
+    fn deserialize_commands() {
+        let toml = r#"
+[[satellites]]
+id = "sat-a"
+[satellites.orbit]
+type = "circular"
+altitude = 500
+
+[[command]]
+t = 300.0
+sat = "sat-a"
+kind = "orts.cmd.set-mode.v1"
+args = { mode = "nadir" }
+
+[[command]]
+t = 10.0
+sat = "sat-a"
+kind = "orts.cmd.ping.v1"
+"#;
+        let config: SimConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.commands.len(), 2);
+        // Raw declaration order preserved (scheduling sorts separately).
+        assert!((config.commands[0].t - 300.0).abs() < 1e-9);
+        assert_eq!(config.commands[0].sat, "sat-a");
+        assert_eq!(config.commands[0].kind, "orts.cmd.set-mode.v1");
+        // No args → null.
+        assert!(config.commands[1].args.is_null());
+    }
+
+    #[test]
+    fn commands_absent_by_default() {
+        let json = r#"{ "satellites": [] }"#;
+        let config: SimConfig = serde_json::from_str(json).unwrap();
+        assert!(config.commands.is_empty());
+    }
+
+    #[test]
+    fn command_to_message_builds_keyvalue_payload() {
+        let toml = r#"
+t = 1.0
+sat = "x"
+kind = "orts.cmd.set-mode.v1"
+args = { mode = "nadir", req-id = 7 }
+"#;
+        let cmd: CommandConfig = toml::from_str(toml).unwrap();
+        let msg = cmd.to_message(2).unwrap();
+        assert_eq!(msg.dst, NodeId::Satellite(2));
+        assert_eq!(msg.src, NodeId::Ground);
+        assert_eq!(msg.kind, "orts.cmd.set-mode.v1");
+        assert_eq!(
+            msg.payload.get("mode").and_then(Value::as_text),
+            Some("nadir")
+        );
+        assert_eq!(
+            msg.payload.get("req-id").and_then(Value::as_integer),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn command_empty_args_is_empty_keyvalue() {
+        let cmd = CommandConfig {
+            t: 0.0,
+            sat: "x".into(),
+            kind: "k".into(),
+            args: serde_json::Value::Null,
+        };
+        let msg = cmd.to_message(0).unwrap();
+        assert!(matches!(msg.payload, Payload::KeyValue(ref v) if v.is_empty()));
+    }
+
+    #[test]
+    fn command_rejects_non_scalar_arg() {
+        let cmd = CommandConfig {
+            t: 0.0,
+            sat: "x".into(),
+            kind: "k".into(),
+            args: serde_json::json!({ "nested": { "a": 1 } }),
+        };
+        assert!(cmd.to_message(0).is_err());
     }
 
     #[test]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -533,6 +533,25 @@ impl SimConfig {
         }
         Ok(())
     }
+
+    /// Reject configs that `orts serve` cannot honor.
+    ///
+    /// `[[command]]` timelines are an `orts run` (deterministic batch)
+    /// transport; the serve loop does not build/drain a `CommandSchedule`,
+    /// so a timeline would be silently dropped. Interactive commanding in
+    /// serve is the (future) WebSocket console, not a config timeline.
+    pub fn ensure_serve_supported(&self) -> Result<(), String> {
+        if !self.commands.is_empty() {
+            return Err(format!(
+                "config has {} `[[command]]` timeline entr{}: command timelines run under \
+                 `orts run`, not `orts serve` (they would be silently dropped). \
+                 Use `orts run` for scheduled commands.",
+                self.commands.len(),
+                if self.commands.len() == 1 { "y" } else { "ies" }
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -1159,6 +1178,37 @@ args = { mode = "nadir", req-id = 7 }
             args: serde_json::json!({ "nested": { "a": 1 } }),
         };
         assert!(cmd.to_message(0).is_err());
+    }
+
+    #[test]
+    fn serve_rejects_command_timeline() {
+        let toml = r#"
+[[satellites]]
+[satellites.orbit]
+type = "circular"
+altitude = 500
+
+[[command]]
+t = 1.0
+sat = "sat-0"
+kind = "orts.cmd.set-mode.v1"
+"#;
+        let config: SimConfig = toml::from_str(toml).unwrap();
+        // serve does not deliver config command timelines (run-only feature)
+        // → reject loudly instead of silently dropping them.
+        assert!(config.ensure_serve_supported().is_err());
+    }
+
+    #[test]
+    fn serve_accepts_config_without_commands() {
+        let toml = r#"
+[[satellites]]
+[satellites.orbit]
+type = "circular"
+altitude = 500
+"#;
+        let config: SimConfig = toml::from_str(toml).unwrap();
+        assert!(config.ensure_serve_supported().is_ok());
     }
 
     #[test]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -531,6 +531,16 @@ impl SimConfig {
             sat.validate()
                 .map_err(|e| format!("satellites[{i}]: {e}"))?;
         }
+        for (i, cmd) in self.commands.iter().enumerate() {
+            // A non-finite or negative `t` would never satisfy the
+            // schedule's `t <= t_due`, silently dropping the command.
+            if !cmd.t.is_finite() || cmd.t < 0.0 {
+                return Err(format!(
+                    "commands[{i}]: t must be finite and >= 0 (got {})",
+                    cmd.t
+                ));
+            }
+        }
         Ok(())
     }
 
@@ -1222,6 +1232,42 @@ altitude = 500
             args: serde_json::json!({ "big": 9_223_372_036_854_775_808u64 }),
         };
         assert!(cmd.to_message(0).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_non_finite_command_t() {
+        // A non-finite `t` (TOML allows `nan`/`inf`) sorts but never becomes
+        // `<= t_due`, so the command would be silently undelivered. Reject it.
+        let toml = r#"
+[[satellites]]
+[satellites.orbit]
+type = "circular"
+altitude = 500
+
+[[command]]
+t = nan
+sat = "sat-0"
+kind = "orts.cmd.set-mode.v1"
+"#;
+        let config: SimConfig = toml::from_str(toml).unwrap();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_negative_command_t() {
+        let toml = r#"
+[[satellites]]
+[satellites.orbit]
+type = "circular"
+altitude = 500
+
+[[command]]
+t = -1.0
+sat = "sat-0"
+kind = "orts.cmd.set-mode.v1"
+"#;
+        let config: SimConfig = toml::from_str(toml).unwrap();
+        assert!(config.validate().is_err());
     }
 
     #[test]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -60,7 +60,7 @@ pub struct CommandConfig {
 
 impl CommandConfig {
     /// 配送先衛星インデックスを指定して host-native [`Message`] を組み立てる。
-    /// `host_seq` / `deliver_tick` は配送時に host が上書きする（ここでは 0）。
+    /// `src` は配送時に host(controller) が確定する。
     pub fn to_message(&self, sat_index: usize) -> Result<Message, String> {
         let payload = args_to_payload(&self.args).map_err(|e| {
             format!(
@@ -72,8 +72,6 @@ impl CommandConfig {
             src: NodeId::Ground,
             dst: NodeId::Satellite(sat_index as u32),
             kind: self.kind.clone(),
-            host_seq: 0,
-            deliver_tick: 0,
             payload,
         })
     }

--- a/cli/src/sim/command_schedule.rs
+++ b/cli/src/sim/command_schedule.rs
@@ -17,8 +17,7 @@ pub struct ScheduledCommand {
     pub t: f64,
     /// 配送先衛星のインデックス（`SimParams::satellites` 内の位置）。
     pub sat_index: usize,
-    /// 配送するメッセージ。`host_seq` / `deliver_tick` は配送時に host が
-    /// 上書きする（ここではテンプレート）。
+    /// 配送するメッセージ。`src` は配送時に host が確定する。
     pub message: Message,
 }
 
@@ -66,8 +65,6 @@ mod tests {
                 src: NodeId::Ground,
                 dst: NodeId::Satellite(sat_index as u32),
                 kind: kind.to_string(),
-                host_seq: 0,
-                deliver_tick: 0,
                 payload: Payload::KeyValue(vec![]),
             },
         }

--- a/cli/src/sim/command_schedule.rs
+++ b/cli/src/sim/command_schedule.rs
@@ -1,0 +1,128 @@
+//! 時刻指定コマンドシーケンス（config transport）。
+//!
+//! `orts.toml` の `[[command]]` を時刻順のキューにし、シミュレーション時刻が
+//! 進むにつれて該当 tick の衛星コントローラへ配送する。host が「どの
+//! コマンドをどの tick に配るか」を確定するので **決定論的**で、同じ config は
+//! 同じ結果を再現する（WebSocket 対話 transport と対照的）。
+//!
+//! これは host 所有の transport-agnostic キューの一実装（adapter）。
+//! 配送先 FSW から見れば、WebSocket 由来か config 由来かは区別されない。
+
+use orts::plugin::Message;
+
+/// 1 件の時刻指定コマンド。
+#[derive(Debug, Clone)]
+pub struct ScheduledCommand {
+    /// 配送するシミュレーション時刻 \[s\]。
+    pub t: f64,
+    /// 配送先衛星のインデックス（`SimParams::satellites` 内の位置）。
+    pub sat_index: usize,
+    /// 配送するメッセージ。`host_seq` / `deliver_tick` は配送時に host が
+    /// 上書きする（ここではテンプレート）。
+    pub message: Message,
+}
+
+/// 時刻順に整列したコマンドキュー。カーソルで「未配送の先頭」を追う。
+pub struct CommandSchedule {
+    commands: Vec<ScheduledCommand>,
+    cursor: usize,
+}
+
+impl CommandSchedule {
+    /// コマンド列から構築する。`t` で安定ソートするので、同時刻のコマンドは
+    /// 宣言順を保つ（決定論）。
+    pub fn new(mut commands: Vec<ScheduledCommand>) -> Self {
+        commands.sort_by(|a, b| a.t.total_cmp(&b.t));
+        Self {
+            commands,
+            cursor: 0,
+        }
+    }
+
+    /// 時刻 `t_due` までに配送すべき（`t <= t_due`）コマンドを返し、カーソルを
+    /// 進める。各コマンドはちょうど 1 回だけ返る。
+    ///
+    /// run ループは各 tick の終端時刻（`t + dt`）を渡し、その tick で
+    /// 配送が確定したコマンドを得る。
+    pub fn drain_due(&mut self, t_due: f64) -> &[ScheduledCommand] {
+        let start = self.cursor;
+        while self.cursor < self.commands.len() && self.commands[self.cursor].t <= t_due {
+            self.cursor += 1;
+        }
+        &self.commands[start..self.cursor]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orts::plugin::{NodeId, Payload};
+
+    fn cmd(t: f64, sat_index: usize, kind: &str) -> ScheduledCommand {
+        ScheduledCommand {
+            t,
+            sat_index,
+            message: Message {
+                src: NodeId::Ground,
+                dst: NodeId::Satellite(sat_index as u32),
+                kind: kind.to_string(),
+                host_seq: 0,
+                deliver_tick: 0,
+                payload: Payload::KeyValue(vec![]),
+            },
+        }
+    }
+
+    #[test]
+    fn drain_due_yields_each_command_once_in_time_order() {
+        let mut sched = CommandSchedule::new(vec![
+            cmd(300.0, 0, "c.300"),
+            cmd(100.0, 0, "c.100"),
+            cmd(200.0, 0, "c.200"),
+        ]);
+
+        // Nothing due before t=100.
+        assert!(sched.drain_due(50.0).is_empty());
+        // t<=150 → only the t=100 command.
+        let due = sched.drain_due(150.0);
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].message.kind, "c.100");
+        // t<=300 → the remaining two, in time order, not re-yielding c.100.
+        let due: Vec<&str> = sched
+            .drain_due(300.0)
+            .iter()
+            .map(|c| c.message.kind.as_str())
+            .collect();
+        assert_eq!(due, vec!["c.200", "c.300"]);
+        // Exhausted.
+        assert!(sched.drain_due(1000.0).is_empty());
+    }
+
+    #[test]
+    fn equal_time_commands_keep_declaration_order() {
+        let mut sched = CommandSchedule::new(vec![
+            cmd(100.0, 0, "first"),
+            cmd(100.0, 1, "second"),
+            cmd(100.0, 0, "third"),
+        ]);
+        let order: Vec<&str> = sched
+            .drain_due(100.0)
+            .iter()
+            .map(|c| c.message.kind.as_str())
+            .collect();
+        assert_eq!(order, vec!["first", "second", "third"]);
+    }
+
+    #[test]
+    fn boundary_is_inclusive() {
+        let mut sched = CommandSchedule::new(vec![cmd(100.0, 0, "at-100")]);
+        // exactly t == t_due delivers.
+        assert_eq!(sched.drain_due(100.0).len(), 1);
+    }
+
+    #[test]
+    fn empty_schedule() {
+        let mut sched = CommandSchedule::new(vec![]);
+        assert!(sched.drain_due(1e9).is_empty());
+    }
+}

--- a/cli/src/sim/mod.rs
+++ b/cli/src/sim/mod.rs
@@ -1,3 +1,4 @@
+pub mod command_schedule;
 pub mod controlled;
 pub mod core;
 pub mod params;

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -109,6 +109,8 @@ pub struct SimParams {
     pub epoch: Option<Epoch>,
     pub duration: Option<f64>,
     pub satellites: Vec<SatelliteSpec>,
+    /// 時刻指定コマンドシーケンス（config transport）。CLI 引数経由では空。
+    pub commands: Vec<crate::config::CommandConfig>,
     pub integrator: IntegratorChoice,
     pub tolerances: Tolerances,
     pub atmosphere: AtmosphereChoice,
@@ -264,6 +266,8 @@ impl SimParams {
             epoch,
             duration: args.duration,
             satellites,
+            // CLI-arg path has no command timeline (config-file only).
+            commands: Vec::new(),
             integrator: args.integrator,
             tolerances: Tolerances {
                 atol: args.atol,
@@ -325,6 +329,7 @@ impl SimParams {
             epoch,
             duration: config.duration,
             satellites,
+            commands: config.commands.clone(),
             integrator: config.integrator_choice(),
             tolerances: Tolerances {
                 atol: config.integrator.atol,

--- a/cli/tests/plugin_msg_config_command_e2e.rs
+++ b/cli/tests/plugin_msg_config_command_e2e.rs
@@ -1,0 +1,181 @@
+//! CLI E2E: `orts run` with a config `[[command]]` timeline.
+//!
+//! Exercises the config command transport end-to-end through the real
+//! binary: TOML parsing (`[[command]]`), `CommandSchedule`, the run
+//! loop's per-tick `drain_due` → `controller.deliver`, the guest (FSW)
+//! processing the uplinked set-mode command, and the downlink drain
+//! (`take_outbound`). Asserts the run completes without error.
+//!
+//! Behavioral correctness of the command effect (the FSW actually
+//! switching mode, accept/reject) is covered by the orts-level E2E
+//! `orts/tests/plugin_msg_commandable_mode.rs`; this test guards the
+//! CLI wiring (config → schedule → run loop) against regressions.
+//!
+//! Skips cleanly when the guest wasm has not been built.
+
+#![cfg(feature = "plugin-wasm")]
+
+use std::io::Write;
+use std::process::Command;
+
+fn orts_binary() -> String {
+    if let Ok(path) = std::env::var("ORTS_BIN") {
+        return path;
+    }
+    option_env!("CARGO_BIN_EXE_orts")
+        .map(str::to_owned)
+        .expect("neither ORTS_BIN nor CARGO_BIN_EXE_orts is set")
+}
+
+/// Build a temp config with a commandable-mode FSW and a timed set-mode
+/// command. Returns `None` if the guest wasm is missing.
+fn build_config() -> Option<tempfile::NamedTempFile> {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let wasm_path = std::path::PathBuf::from(format!(
+        "{manifest_dir}/../plugin-sdk/examples/target/wasm32-wasip1/release/orts_example_plugin_commandable_mode_ff.wasm"
+    ));
+    if !wasm_path.exists() {
+        eprintln!(
+            "WASM not found: {}\nBuild: cd plugin-sdk/examples && cargo +1.91.0 component build -p orts-example-plugin-commandable-mode-ff --release",
+            wasm_path.display()
+        );
+        return None;
+    }
+    let wasm = wasm_path.display();
+
+    // Near-zero initial rate + a gyroscope so the FSW's nadir gate sees a
+    // settled spacecraft and accepts the set-mode command.
+    let toml = format!(
+        r#"body = "earth"
+dt = 0.5
+output_interval = 1.0
+duration = 3.0
+epoch = "2024-01-01T00:00:00Z"
+
+[[satellites]]
+id = "commanded"
+sensors = ["gyroscope"]
+
+[satellites.orbit]
+type = "circular"
+altitude = 500
+
+[satellites.attitude]
+inertia_diag = [10, 10, 10]
+mass = 100
+initial_quaternion = [1, 0, 0, 0]
+initial_angular_velocity = [0.001, 0, 0]
+
+[satellites.controller]
+type = "wasm"
+path = "{wasm}"
+
+[[command]]
+t = 1.0
+sat = "commanded"
+kind = "orts.cmd.set-mode.v1"
+args = {{ mode = "nadir" }}
+"#
+    );
+
+    let mut file = tempfile::Builder::new()
+        .suffix(".toml")
+        .tempfile()
+        .expect("create temp config");
+    file.write_all(toml.as_bytes()).expect("write config");
+    Some(file)
+}
+
+#[test]
+fn run_with_config_command_completes() {
+    let Some(cfg) = build_config() else {
+        return;
+    };
+    let path = cfg.path().to_string_lossy().to_string();
+
+    let output = Command::new(orts_binary())
+        .args([
+            "run",
+            "--config",
+            &path,
+            "--plugin-backend",
+            "sync",
+            "--output",
+            "stdout",
+            "--format",
+            "csv",
+        ])
+        .output()
+        .expect("failed to execute orts");
+
+    assert!(
+        output.status.success(),
+        "orts run with [[command]] failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // CSV produced → the controlled simulation actually ran to completion
+    // with the command timeline wired in.
+    assert!(!output.stdout.is_empty(), "expected CSV output, got none");
+}
+
+#[test]
+fn run_rejects_command_for_unknown_satellite() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let wasm_path = std::path::PathBuf::from(format!(
+        "{manifest_dir}/../plugin-sdk/examples/target/wasm32-wasip1/release/orts_example_plugin_commandable_mode_ff.wasm"
+    ));
+    if !wasm_path.exists() {
+        return;
+    }
+    let wasm = wasm_path.display();
+    // Command targets a satellite id that does not exist → run must fail.
+    let toml = format!(
+        r#"body = "earth"
+dt = 0.5
+duration = 1.0
+epoch = "2024-01-01T00:00:00Z"
+
+[[satellites]]
+id = "commanded"
+sensors = ["gyroscope"]
+
+[satellites.orbit]
+type = "circular"
+altitude = 500
+
+[satellites.attitude]
+inertia_diag = [10, 10, 10]
+mass = 100
+
+[satellites.controller]
+type = "wasm"
+path = "{wasm}"
+
+[[command]]
+t = 0.5
+sat = "does-not-exist"
+kind = "orts.cmd.set-mode.v1"
+args = {{ mode = "nadir" }}
+"#
+    );
+    let mut file = tempfile::Builder::new()
+        .suffix(".toml")
+        .tempfile()
+        .expect("temp config");
+    file.write_all(toml.as_bytes()).expect("write");
+    let path = file.path().to_string_lossy().to_string();
+
+    let output = Command::new(orts_binary())
+        .args(["run", "--config", &path, "--plugin-backend", "sync"])
+        .output()
+        .expect("execute orts");
+
+    assert!(
+        !output.status.success(),
+        "orts run should fail for a command targeting an unknown satellite"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("does-not-exist"),
+        "stderr should name the unknown satellite"
+    );
+}

--- a/orts/src/plugin/controller.rs
+++ b/orts/src/plugin/controller.rs
@@ -22,6 +22,7 @@
 
 use super::command::Command;
 use super::error::PluginError;
+use super::message::{Message, NodeId};
 use super::tick_input::TickInput;
 
 /// A controller backend exposed through the plugin layer.
@@ -117,4 +118,25 @@ pub trait PluginController: Send {
     fn restore_state(&mut self, _bytes: &[u8]) -> Result<(), PluginError> {
         Err(PluginError::UnsupportedOperation("restore_state"))
     }
+
+    // ─── msg-io transport (operator C&T / ISL) ──────────────────
+    //
+    // These let the host drive the controller's node-to-node messaging
+    // channel through `dyn PluginController` (config command timeline,
+    // WebSocket adapter, ...). Controllers without msg-io support use
+    // the default no-op impls; the WASM backends override them.
+
+    /// Queue an inbound message for delivery on the controller's **next**
+    /// `update()` tick. Default: drop it (no msg-io support).
+    fn deliver(&mut self, _msg: Message) {}
+
+    /// Drain the messages this controller has emitted since the last
+    /// call (telemetry / ISL downlink). Default: none.
+    fn take_outbound(&mut self) -> Vec<Message> {
+        Vec::new()
+    }
+
+    /// Set this controller's node identity, stamped as `src` on its
+    /// outbound messages. Default: no-op.
+    fn set_node_id(&mut self, _id: NodeId) {}
 }

--- a/orts/src/plugin/message.rs
+++ b/orts/src/plugin/message.rs
@@ -1,0 +1,229 @@
+//! ノード間メッセージング（運用 C&T + 将来の ISL）のホスト側型。
+//!
+//! WIT `msg-io` interface の transport 層に対応する host-native 型。
+//! `tick-io` の [`Command`](super::Command)（FSW→アクチュエータの制御出力）
+//! とは **別物**で、運用者(地上)↔FSW のコマンド/テレメトリ、および将来の
+//! 衛星間通信(ISL)を運ぶ。
+//!
+//! ## レイヤリング
+//!
+//! transport は **dumb pipe** であり payload の意味を解釈しない。
+//! request-response / fire-and-forget / ack / file-transfer といった
+//! interaction model は **アプリ層**（[`Payload`] の中身 + SDK ヘルパ）に
+//! 属する。`kind` は content-type / 次プロトコル識別子で、受信側がこれを
+//! 見て payload の解釈プロトコルを選ぶ。
+//!
+//! WIT 生成型はホスト側 wasm モジュール内に閉じている（sync / async で
+//! 別型になる）。ここで host-native 型を定義し、
+//! [`super::wasm::convert`] が WIT 型との相互変換を担う — 既存の
+//! [`Command`](super::Command) / [`TickInput`](super::TickInput) と同じ構造。
+
+/// ノードアドレス。運用者 C&T = [`NodeId::Ground`] ↔ [`NodeId::Satellite`]、
+/// ISL = `Satellite` ↔ `Satellite`。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeId {
+    /// 地上局 / 運用者。
+    Ground,
+    /// 衛星（ID）。
+    Satellite(u32),
+}
+
+/// 型付きスカラ値（[`Payload::KeyValue`] の要素値）。
+///
+/// `kind` が論理型を識別する一方、`key-value` の各値はこの variant で
+/// 型付けされる。`binary` / `json` payload では型付けは受信側プロトコルの
+/// 責務（transport は中身を解釈しない）。
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    /// 真偽値。
+    Boolean(bool),
+    /// 符号付き 64bit 整数。
+    Integer(i64),
+    /// 倍精度浮動小数点。
+    Number(f64),
+    /// UTF-8 文字列。
+    Text(String),
+    /// 生バイト列。
+    Bytes(Vec<u8>),
+}
+
+impl Value {
+    /// `Boolean` なら中身を返す。
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            Value::Boolean(b) => Some(*b),
+            _ => None,
+        }
+    }
+
+    /// `Integer` なら中身を返す。
+    pub fn as_integer(&self) -> Option<i64> {
+        match self {
+            Value::Integer(i) => Some(*i),
+            _ => None,
+        }
+    }
+
+    /// `Number` なら中身を返す。
+    pub fn as_number(&self) -> Option<f64> {
+        match self {
+            Value::Number(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    /// `Text` なら中身を返す。
+    pub fn as_text(&self) -> Option<&str> {
+        match self {
+            Value::Text(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// `Bytes` なら中身を返す。
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        match self {
+            Value::Bytes(b) => Some(b),
+            _ => None,
+        }
+    }
+}
+
+/// 名前付き値（key-value の 1 要素）。
+#[derive(Debug, Clone, PartialEq)]
+pub struct NamedValue {
+    /// キー名。
+    pub name: String,
+    /// 値。
+    pub value: Value,
+}
+
+/// メッセージ本体のエンコーディング。ユースケースで選択する。
+///
+/// 同一 `kind` では canonical encoding を 1 つに固定する規約
+/// （json / key-value / binary を同じ `kind` で混在させない）。
+#[derive(Debug, Clone, PartialEq)]
+pub enum Payload {
+    /// 構造化（スカラは型付き）。viewer/CLI/test から扱いやすい。
+    KeyValue(Vec<NamedValue>),
+    /// 生バイナリ（CCSDS 等、デコードは受信側 FSW）。
+    Binary(Vec<u8>),
+    /// JSON テキスト。transport は opaque 文字列として扱う。
+    Json(String),
+}
+
+impl Payload {
+    /// `(name, value)` のイテレータから [`Payload::KeyValue`] を構築する。
+    ///
+    /// 並び順は保持される（決定論的）。
+    pub fn key_value<I, S>(pairs: I) -> Self
+    where
+        I: IntoIterator<Item = (S, Value)>,
+        S: Into<String>,
+    {
+        Payload::KeyValue(
+            pairs
+                .into_iter()
+                .map(|(name, value)| NamedValue {
+                    name: name.into(),
+                    value,
+                })
+                .collect(),
+        )
+    }
+
+    /// key-value から名前で値を引く。
+    ///
+    /// `KeyValue` 以外、または該当キーがなければ `None`。同名キーが複数
+    /// ある場合は最初の 1 つを返す。
+    pub fn get(&self, name: &str) -> Option<&Value> {
+        match self {
+            Payload::KeyValue(kvs) => kvs.iter().find(|kv| kv.name == name).map(|kv| &kv.value),
+            _ => None,
+        }
+    }
+}
+
+/// 受信側へ届く完全なメッセージ。
+///
+/// `src` / `host_seq` / `deliver_tick` はホストが確定して埋める
+/// （ゲストは送信時にこれらを指定できない — なりすまし防止と決定論）。
+#[derive(Debug, Clone, PartialEq)]
+pub struct Message {
+    /// 送信元。ホストが注入。
+    pub src: NodeId,
+    /// 宛先。
+    pub dst: NodeId,
+    /// 論理型（content-type）。例 `"orts.cmd.set-mode.v1"`。
+    pub kind: String,
+    /// ホストが割り当てる決定論的な全順序の anchor。
+    pub host_seq: u64,
+    /// ホストが配送を確定した tick。
+    pub deliver_tick: u64,
+    /// 本体。
+    pub payload: Payload,
+}
+
+/// ゲスト（FSW）が送信するメッセージ。最小限。
+///
+/// `src` / `host_seq` / `deliver_tick` はホストが補完して [`Message`] になる。
+#[derive(Debug, Clone, PartialEq)]
+pub struct Outbound {
+    /// 宛先（地上なら [`NodeId::Ground`]、別衛星なら `Satellite(id)`）。
+    pub dst: NodeId,
+    /// 論理型（content-type）。
+    pub kind: String,
+    /// 本体。
+    pub payload: Payload,
+}
+
+impl Outbound {
+    /// 宛先 + kind + payload から構築する。
+    pub fn new(dst: NodeId, kind: impl Into<String>, payload: Payload) -> Self {
+        Self {
+            dst,
+            kind: kind.into(),
+            payload,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_value_preserves_order_and_lookup() {
+        let p = Payload::key_value([
+            ("mode", Value::Text("nadir".into())),
+            ("priority", Value::Integer(3)),
+        ]);
+        // 並び順保持
+        if let Payload::KeyValue(kvs) = &p {
+            assert_eq!(kvs[0].name, "mode");
+            assert_eq!(kvs[1].name, "priority");
+        } else {
+            panic!("expected KeyValue");
+        }
+        // 名前引き
+        assert_eq!(p.get("mode").and_then(Value::as_text), Some("nadir"));
+        assert_eq!(p.get("priority").and_then(Value::as_integer), Some(3));
+        assert!(p.get("missing").is_none());
+    }
+
+    #[test]
+    fn get_on_non_key_value_is_none() {
+        assert!(Payload::Binary(vec![1, 2, 3]).get("x").is_none());
+        assert!(Payload::Json("{}".into()).get("x").is_none());
+    }
+
+    #[test]
+    fn value_accessors_are_typed() {
+        assert_eq!(Value::Boolean(true).as_bool(), Some(true));
+        assert_eq!(Value::Number(1.5).as_number(), Some(1.5));
+        assert_eq!(Value::Text("hi".into()).as_text(), Some("hi"));
+        assert_eq!(Value::Bytes(vec![0xAB]).as_bytes(), Some(&[0xAB][..]));
+        // 型違いは None
+        assert_eq!(Value::Integer(7).as_number(), None);
+    }
+}

--- a/orts/src/plugin/message.rs
+++ b/orts/src/plugin/message.rs
@@ -146,8 +146,10 @@ impl Payload {
 
 /// 受信側へ届く完全なメッセージ。
 ///
-/// `src` / `host_seq` / `deliver_tick` はホストが確定して埋める
-/// （ゲストは送信時にこれらを指定できない — なりすまし防止と決定論）。
+/// `src` はホストが確定して埋める（ゲストは送信時に指定できない — なりすまし防止）。
+///
+/// NOTE: 将来、決定論リプレイの全順序 anchor や配送 tick などの host 採番メタを
+/// 足すことはありうるが、それを読む consumer が現れるまでは入れない（YAGNI）。
 #[derive(Debug, Clone, PartialEq)]
 pub struct Message {
     /// 送信元。ホストが注入。
@@ -156,17 +158,13 @@ pub struct Message {
     pub dst: NodeId,
     /// 論理型（content-type）。例 `"orts.cmd.set-mode.v1"`。
     pub kind: String,
-    /// ホストが割り当てる決定論的な全順序の anchor。
-    pub host_seq: u64,
-    /// ホストが配送を確定した tick。
-    pub deliver_tick: u64,
     /// 本体。
     pub payload: Payload,
 }
 
 /// ゲスト（FSW）が送信するメッセージ。最小限。
 ///
-/// `src` / `host_seq` / `deliver_tick` はホストが補完して [`Message`] になる。
+/// `src` はホストが補完して [`Message`] になる。
 #[derive(Debug, Clone, PartialEq)]
 pub struct Outbound {
     /// 宛先（地上なら [`NodeId::Ground`]、別衛星なら `Satellite(id)`）。

--- a/orts/src/plugin/mod.rs
+++ b/orts/src/plugin/mod.rs
@@ -29,6 +29,7 @@ pub mod actuators;
 pub mod command;
 pub mod controller;
 pub mod error;
+pub mod message;
 pub mod tick_input;
 
 #[cfg(feature = "plugin-wasm")]
@@ -38,6 +39,7 @@ pub use actuators::ActuatorBundle;
 pub use command::{Command, MtqCommand, RwCommand, ThrusterCommand};
 pub use controller::PluginController;
 pub use error::PluginError;
+pub use message::{Message, NamedValue, NodeId, Outbound, Payload, Value};
 pub use tick_input::{
     ActuatorTelemetry, AngularVelocityBody, AttitudeBodyToInertial, MagneticFieldBody, RwTelemetry,
     Sensors, SunDirectionBody, SunSensorOutput, TickInput,

--- a/orts/src/plugin/wasm/async_controller.rs
+++ b/orts/src/plugin/wasm/async_controller.rs
@@ -148,8 +148,6 @@ pub struct AsyncWasmController {
 
     // ─── msg-io transport state (mirror of sync backend) ────────
     node_id: NodeId,
-    host_seq: u64,
-    tick: u64,
     pending_inbound: Vec<Message>,
     outbound_buffer: Vec<Message>,
 }
@@ -258,8 +256,6 @@ impl AsyncWasmController {
             sample_period_s,
             name: format!("wasm-async:{label}"),
             node_id: NodeId::Satellite(0),
-            host_seq: 0,
-            tick: 0,
             pending_inbound: Vec::new(),
             outbound_buffer: Vec::new(),
         })
@@ -319,20 +315,16 @@ impl PluginController for AsyncWasmController {
             }
         })?;
 
-        // Stamp host-controlled envelope fields onto guest outbound.
+        // Inject the host-controlled `src` onto guest outbound (anti-spoof).
         for ob in outgoing {
             let ob: Outbound = convert::outbound_from_wit(ob);
             self.outbound_buffer.push(Message {
                 src: self.node_id,
                 dst: ob.dst,
                 kind: ob.kind,
-                host_seq: self.host_seq,
-                deliver_tick: self.tick,
                 payload: ob.payload,
             });
-            self.host_seq += 1;
         }
-        self.tick += 1;
 
         match command {
             Some(wit_cmd) => convert::command_from_wit(wit_cmd).map(Some),

--- a/orts/src/plugin/wasm/async_controller.rs
+++ b/orts/src/plugin/wasm/async_controller.rs
@@ -57,6 +57,7 @@
 //! `PluginController::update` is reached via a blocking-thread
 //! boundary.
 
+use std::collections::VecDeque;
 use std::sync::Arc;
 
 use tokio::sync::{mpsc, oneshot};
@@ -66,14 +67,14 @@ use wasmtime::component::Component;
 use super::async_bindings::Plugin as AsyncPlugin;
 use super::async_bindings::PluginPre as AsyncPluginPre;
 use super::async_bindings::orts::plugin::types as wit;
-use super::async_host_state::{AsyncHostState, GuestResponse};
+use super::async_host_state::{AsyncHostState, GuestResponse, TickPacket};
 use super::async_runtime::AsyncRuntime;
 use super::convert::r#async as convert;
 use super::engine::WasmEngine;
 
 use crate::plugin::controller::PluginController;
 use crate::plugin::tick_input::TickInput;
-use crate::plugin::{Command, PluginError};
+use crate::plugin::{Command, Message, NodeId, Outbound, PluginError};
 
 /// Pre-linked async bindings ready to spawn satellite tasks against.
 ///
@@ -140,10 +141,17 @@ impl AsyncPluginPreBuilt {
 /// `handle.block_on` to exchange messages with the task.
 pub struct AsyncWasmController {
     runtime: Arc<AsyncRuntime>,
-    input_tx: mpsc::Sender<Option<wit::TickInput>>,
+    input_tx: mpsc::Sender<Option<TickPacket>>,
     output_rx: mpsc::Receiver<GuestResponse>,
     sample_period_s: f64,
     name: String,
+
+    // ─── msg-io transport state (mirror of sync backend) ────────
+    node_id: NodeId,
+    host_seq: u64,
+    tick: u64,
+    pending_inbound: Vec<Message>,
+    outbound_buffer: Vec<Message>,
 }
 
 impl AsyncWasmController {
@@ -162,7 +170,7 @@ impl AsyncWasmController {
         let label = label.into();
         let config = config.to_string();
 
-        let (input_tx, input_rx) = mpsc::channel::<Option<wit::TickInput>>(1);
+        let (input_tx, input_rx) = mpsc::channel::<Option<TickPacket>>(1);
         let (output_tx, output_rx) = mpsc::channel::<GuestResponse>(1);
         let (meta_tx, meta_rx) = oneshot::channel::<Result<f64, String>>();
 
@@ -184,6 +192,8 @@ impl AsyncWasmController {
                 input_rx,
                 output_tx: output_tx.clone(),
                 pending_cmd: None,
+                inbox: VecDeque::new(),
+                outbox: Vec::new(),
                 is_first_wait: true,
             };
             let mut store = Store::new(engine.inner(), host_state);
@@ -247,7 +257,30 @@ impl AsyncWasmController {
             output_rx,
             sample_period_s,
             name: format!("wasm-async:{label}"),
+            node_id: NodeId::Satellite(0),
+            host_seq: 0,
+            tick: 0,
+            pending_inbound: Vec::new(),
+            outbound_buffer: Vec::new(),
         })
+    }
+
+    /// Queue an inbound message for delivery on the next `update()`
+    /// tick. See [`super::WasmController::deliver`].
+    pub fn deliver(&mut self, msg: Message) {
+        self.pending_inbound.push(msg);
+    }
+
+    /// Drain messages the guest has emitted so far. See
+    /// [`super::WasmController::take_outbound`].
+    pub fn take_outbound(&mut self) -> Vec<Message> {
+        std::mem::take(&mut self.outbound_buffer)
+    }
+
+    /// Set this controller's node identity (stamped as `src` on
+    /// outbound messages). Defaults to `NodeId::Satellite(0)`.
+    pub fn set_node_id(&mut self, id: NodeId) {
+        self.node_id = id;
     }
 }
 
@@ -262,12 +295,19 @@ impl PluginController for AsyncWasmController {
 
     fn update(&mut self, obs: &TickInput<'_>) -> Result<Option<Command>, PluginError> {
         let wit_obs = convert::tick_input_to_wit(obs);
+        let inbox: Vec<wit::Message> = std::mem::take(&mut self.pending_inbound)
+            .into_iter()
+            .map(convert::message_to_wit)
+            .collect();
         let input_tx = self.input_tx.clone();
         let output_rx = &mut self.output_rx;
 
-        self.runtime.handle().block_on(async move {
+        let (command, outgoing) = self.runtime.handle().block_on(async move {
             input_tx
-                .send(Some(wit_obs))
+                .send(Some(TickPacket {
+                    input: wit_obs,
+                    inbox,
+                }))
                 .await
                 .map_err(|_| PluginError::Runtime("async task dropped".to_string()))?;
             match output_rx
@@ -275,10 +315,7 @@ impl PluginController for AsyncWasmController {
                 .await
                 .ok_or_else(|| PluginError::Runtime("async task channel closed".to_string()))?
             {
-                GuestResponse::Command(Some(wit_cmd)) => {
-                    convert::command_from_wit(wit_cmd).map(Some)
-                }
-                GuestResponse::Command(None) => Ok(None),
+                GuestResponse::Tick { command, outgoing } => Ok((command, outgoing)),
                 GuestResponse::Done(Ok(())) => Err(PluginError::Runtime(
                     "guest run() returned early".to_string(),
                 )),
@@ -286,7 +323,27 @@ impl PluginController for AsyncWasmController {
                     Err(PluginError::Runtime(format!("guest error: {e}")))
                 }
             }
-        })
+        })?;
+
+        // Stamp host-controlled envelope fields onto guest outbound.
+        for ob in outgoing {
+            let ob: Outbound = convert::outbound_from_wit(ob);
+            self.outbound_buffer.push(Message {
+                src: self.node_id,
+                dst: ob.dst,
+                kind: ob.kind,
+                host_seq: self.host_seq,
+                deliver_tick: self.tick,
+                payload: ob.payload,
+            });
+            self.host_seq += 1;
+        }
+        self.tick += 1;
+
+        match command {
+            Some(wit_cmd) => convert::command_from_wit(wit_cmd).map(Some),
+            None => Ok(None),
+        }
     }
 }
 

--- a/orts/src/plugin/wasm/async_controller.rs
+++ b/orts/src/plugin/wasm/async_controller.rs
@@ -264,24 +264,6 @@ impl AsyncWasmController {
             outbound_buffer: Vec::new(),
         })
     }
-
-    /// Queue an inbound message for delivery on the next `update()`
-    /// tick. See [`super::WasmController::deliver`].
-    pub fn deliver(&mut self, msg: Message) {
-        self.pending_inbound.push(msg);
-    }
-
-    /// Drain messages the guest has emitted so far. See
-    /// [`super::WasmController::take_outbound`].
-    pub fn take_outbound(&mut self) -> Vec<Message> {
-        std::mem::take(&mut self.outbound_buffer)
-    }
-
-    /// Set this controller's node identity (stamped as `src` on
-    /// outbound messages). Defaults to `NodeId::Satellite(0)`.
-    pub fn set_node_id(&mut self, id: NodeId) {
-        self.node_id = id;
-    }
 }
 
 impl PluginController for AsyncWasmController {
@@ -291,6 +273,18 @@ impl PluginController for AsyncWasmController {
 
     fn sample_period(&self) -> f64 {
         self.sample_period_s
+    }
+
+    fn deliver(&mut self, msg: Message) {
+        self.pending_inbound.push(msg);
+    }
+
+    fn take_outbound(&mut self) -> Vec<Message> {
+        std::mem::take(&mut self.outbound_buffer)
+    }
+
+    fn set_node_id(&mut self, id: NodeId) {
+        self.node_id = id;
     }
 
     fn update(&mut self, obs: &TickInput<'_>) -> Result<Option<Command>, PluginError> {

--- a/orts/src/plugin/wasm/async_host_state.rs
+++ b/orts/src/plugin/wasm/async_host_state.rs
@@ -132,7 +132,9 @@ impl tick_io::Host for AsyncHostState {
         // the guest exits. `Some(packet)` freezes this tick's inbox.
         match self.input_rx.recv().await {
             Some(Some(packet)) => {
-                self.inbox = packet.inbox.into();
+                // Carry over undrained messages; append the newly delivered
+                // ones (backpressure per the msg-io contract).
+                self.inbox.extend(packet.inbox);
                 Some(packet.input)
             }
             Some(None) | None => None,

--- a/orts/src/plugin/wasm/async_host_state.rs
+++ b/orts/src/plugin/wasm/async_host_state.rs
@@ -8,23 +8,38 @@
 //! channels rather than `std::sync::mpsc`, so that the satellite
 //! task can yield to the runtime on every `wait_tick`.
 
+use std::collections::VecDeque;
+
 use tobari::magnetic::TiltedDipole;
 use tokio::sync::mpsc;
 
 use super::async_bindings::orts::plugin::host_env;
+use super::async_bindings::orts::plugin::msg_io;
 use super::async_bindings::orts::plugin::tick_io;
 use super::async_bindings::orts::plugin::types as wit;
+
+/// One tick's worth of host → guest input for the async backend.
+///
+/// Async mirror of [`super::sync_host_state::TickPacket`]: physical
+/// snapshot + the frozen msg-io inbox for this tick.
+pub(super) struct TickPacket {
+    pub input: wit::TickInput,
+    pub inbox: Vec<wit::Message>,
+}
 
 /// Response sent back to the outer `AsyncWasmController` via
 /// `output_tx`. Same shape as the sync variant — only the channel
 /// implementation differs.
 #[derive(Debug)]
 pub(super) enum GuestResponse {
-    /// A command captured from the previous tick. `None` means the
-    /// guest did not call `send_command` during that tick.
-    Command(Option<wit::Command>),
+    /// The outcome of one tick: the actuator command (possibly `None`)
+    /// plus every message emitted via `send-message` (append).
+    Tick {
+        command: Option<wit::Command>,
+        outgoing: Vec<wit::Outbound>,
+    },
     /// The guest's `run()` function returned or errored. No more
-    /// commands will be produced.
+    /// responses will be produced.
     Done(Result<(), String>),
 }
 
@@ -35,9 +50,13 @@ pub(super) struct AsyncHostState {
     pub(super) wasi: wasmtime_wasi::WasiCtx,
     pub(super) table: wasmtime_wasi::ResourceTable,
 
-    pub(super) input_rx: mpsc::Receiver<Option<wit::TickInput>>,
+    pub(super) input_rx: mpsc::Receiver<Option<TickPacket>>,
     pub(super) output_tx: mpsc::Sender<GuestResponse>,
     pub(super) pending_cmd: Option<wit::Command>,
+    /// Frozen msg-io inbox for the current tick (drained by `recv-batch`).
+    pub(super) inbox: VecDeque<wit::Message>,
+    /// Messages emitted via `send-message` this tick (append).
+    pub(super) outbox: Vec<wit::Outbound>,
     pub(super) is_first_wait: bool,
 }
 
@@ -99,17 +118,41 @@ impl tick_io::Host for AsyncHostState {
     /// the guest can exit its main loop cleanly.
     async fn wait_tick(&mut self) -> Option<wit::TickInput> {
         if !self.is_first_wait {
-            let cmd = self.pending_cmd.take();
-            let _ = self.output_tx.send(GuestResponse::Command(cmd)).await;
+            let command = self.pending_cmd.take();
+            let outgoing = std::mem::take(&mut self.outbox);
+            let _ = self
+                .output_tx
+                .send(GuestResponse::Tick { command, outgoing })
+                .await;
         } else {
             self.is_first_wait = false;
         }
-        self.input_rx.recv().await.flatten()
+        // `recv` yields `None` when the outer side drops the sender;
+        // an inner `None` is the explicit shutdown signal. Either way
+        // the guest exits. `Some(packet)` freezes this tick's inbox.
+        match self.input_rx.recv().await {
+            Some(Some(packet)) => {
+                self.inbox = packet.inbox.into();
+                Some(packet.input)
+            }
+            Some(None) | None => None,
+        }
     }
 
     async fn send_command(&mut self, cmd: wit::Command) {
         // Last-write-wins: if the guest calls send_command multiple
         // times in one tick, only the last one survives.
         self.pending_cmd = Some(cmd);
+    }
+}
+
+impl msg_io::Host for AsyncHostState {
+    async fn recv_batch(&mut self, max: u32) -> Vec<wit::Message> {
+        let n = (max as usize).min(self.inbox.len());
+        self.inbox.drain(..n).collect()
+    }
+
+    async fn send_message(&mut self, msg: wit::Outbound) {
+        self.outbox.push(msg);
     }
 }

--- a/orts/src/plugin/wasm/convert.rs
+++ b/orts/src/plugin/wasm/convert.rs
@@ -270,8 +270,6 @@ macro_rules! impl_convert {
                 src: node_id_to_wit(m.src),
                 dst: node_id_to_wit(m.dst),
                 kind: m.kind,
-                host_seq: m.host_seq,
-                deliver_tick: m.deliver_tick,
                 payload: payload_to_wit(m.payload),
             }
         }
@@ -488,16 +486,12 @@ pub mod sync {
                 src: NodeId::Ground,
                 dst: NodeId::Satellite(7),
                 kind: "orts.cmd.set-mode.v1".into(),
-                host_seq: 42,
-                deliver_tick: 100,
                 payload: Payload::key_value([("mode", Value::Text("nadir".into()))]),
             };
             let w = message_to_wit(m);
             assert!(matches!(w.src, wit::NodeId::Ground));
             assert!(matches!(w.dst, wit::NodeId::Satellite(7)));
             assert_eq!(w.kind, "orts.cmd.set-mode.v1");
-            assert_eq!(w.host_seq, 42);
-            assert_eq!(w.deliver_tick, 100);
             match &w.payload {
                 wit::Payload::KeyValue(kvs) => {
                     assert_eq!(kvs[0].name, "mode");

--- a/orts/src/plugin/wasm/convert.rs
+++ b/orts/src/plugin/wasm/convert.rs
@@ -24,6 +24,7 @@ macro_rules! impl_convert {
         use $crate::SpacecraftState;
         use $crate::attitude::AttitudeState;
         use $crate::orbital::OrbitalState;
+        use $crate::plugin::message::{Message, NamedValue, NodeId, Outbound, Payload, Value};
         use $crate::plugin::tick_input::{ActuatorTelemetry, Sensors, SunSensorOutput, TickInput};
         use $crate::plugin::{Command, MtqCommand, PluginError, RwCommand, ThrusterCommand};
 
@@ -191,6 +192,98 @@ macro_rules! impl_convert {
                 return Err(PluginError::BadCommand(format!("{result:?}")));
             }
             Ok(result)
+        }
+
+        // ───────────────────── messaging (msg-io) ─────────────────────
+        //
+        // transport 層は payload を解釈しないので、Command のような
+        // NaN ガードは行わない（メッセージは ODE に入らない opaque データ）。
+
+        fn node_id_to_wit(n: NodeId) -> wit::NodeId {
+            match n {
+                NodeId::Ground => wit::NodeId::Ground,
+                NodeId::Satellite(id) => wit::NodeId::Satellite(id),
+            }
+        }
+
+        fn node_id_from_wit(n: wit::NodeId) -> NodeId {
+            match n {
+                wit::NodeId::Ground => NodeId::Ground,
+                wit::NodeId::Satellite(id) => NodeId::Satellite(id),
+            }
+        }
+
+        fn value_to_wit(v: Value) -> wit::Value {
+            match v {
+                Value::Boolean(b) => wit::Value::Boolean(b),
+                Value::Integer(i) => wit::Value::Integer(i),
+                Value::Number(n) => wit::Value::Number(n),
+                Value::Text(s) => wit::Value::Text(s),
+                Value::Bytes(b) => wit::Value::Bytes(b),
+            }
+        }
+
+        fn value_from_wit(v: wit::Value) -> Value {
+            match v {
+                wit::Value::Boolean(b) => Value::Boolean(b),
+                wit::Value::Integer(i) => Value::Integer(i),
+                wit::Value::Number(n) => Value::Number(n),
+                wit::Value::Text(s) => Value::Text(s),
+                wit::Value::Bytes(b) => Value::Bytes(b),
+            }
+        }
+
+        fn payload_to_wit(p: Payload) -> wit::Payload {
+            match p {
+                Payload::KeyValue(kvs) => wit::Payload::KeyValue(
+                    kvs.into_iter()
+                        .map(|kv| wit::NamedValue {
+                            name: kv.name,
+                            value: value_to_wit(kv.value),
+                        })
+                        .collect(),
+                ),
+                Payload::Binary(b) => wit::Payload::Binary(b),
+                Payload::Json(s) => wit::Payload::Json(s),
+            }
+        }
+
+        fn payload_from_wit(p: wit::Payload) -> Payload {
+            match p {
+                wit::Payload::KeyValue(kvs) => Payload::KeyValue(
+                    kvs.into_iter()
+                        .map(|kv| NamedValue {
+                            name: kv.name,
+                            value: value_from_wit(kv.value),
+                        })
+                        .collect(),
+                ),
+                wit::Payload::Binary(b) => Payload::Binary(b),
+                wit::Payload::Json(s) => Payload::Json(s),
+            }
+        }
+
+        /// Convert a host [`Message`] to the WIT `message` record
+        /// (host → guest inbox, delivered via `recv-batch`).
+        pub fn message_to_wit(m: Message) -> wit::Message {
+            wit::Message {
+                src: node_id_to_wit(m.src),
+                dst: node_id_to_wit(m.dst),
+                kind: m.kind,
+                host_seq: m.host_seq,
+                deliver_tick: m.deliver_tick,
+                payload: payload_to_wit(m.payload),
+            }
+        }
+
+        /// Convert a WIT `outbound` record to the host [`Outbound`]
+        /// (guest → host, captured from `send-message`).
+        pub fn outbound_from_wit(o: wit::Outbound) -> Outbound {
+            Outbound {
+                dst: node_id_from_wit(o.dst),
+                kind: o.kind,
+                payload: payload_from_wit(o.payload),
+            }
         }
     };
 }
@@ -386,6 +479,67 @@ pub mod sync {
                 thruster: Some(wit::ThrusterCommand::Throttles(vec![f64::NAN, 0.5])),
             };
             assert!(command_from_wit(wit_cmd).is_err());
+        }
+
+        #[test]
+        fn message_to_wit_preserves_fields() {
+            use crate::plugin::message::{Message, NodeId, Payload, Value};
+            let m = Message {
+                src: NodeId::Ground,
+                dst: NodeId::Satellite(7),
+                kind: "orts.cmd.set-mode.v1".into(),
+                host_seq: 42,
+                deliver_tick: 100,
+                payload: Payload::key_value([("mode", Value::Text("nadir".into()))]),
+            };
+            let w = message_to_wit(m);
+            assert!(matches!(w.src, wit::NodeId::Ground));
+            assert!(matches!(w.dst, wit::NodeId::Satellite(7)));
+            assert_eq!(w.kind, "orts.cmd.set-mode.v1");
+            assert_eq!(w.host_seq, 42);
+            assert_eq!(w.deliver_tick, 100);
+            match &w.payload {
+                wit::Payload::KeyValue(kvs) => {
+                    assert_eq!(kvs[0].name, "mode");
+                    assert!(matches!(&kvs[0].value, wit::Value::Text(s) if s == "nadir"));
+                }
+                _ => panic!("expected KeyValue"),
+            }
+        }
+
+        #[test]
+        fn outbound_from_wit_preserves_fields() {
+            use crate::plugin::message::{NodeId, Value};
+            let w = wit::Outbound {
+                dst: wit::NodeId::Ground,
+                kind: "orts.tlm.mode.v1".to_string(),
+                payload: wit::Payload::KeyValue(vec![wit::NamedValue {
+                    name: "mode".to_string(),
+                    value: wit::Value::Text("detumble".to_string()),
+                }]),
+            };
+            let o = outbound_from_wit(w);
+            assert_eq!(o.dst, NodeId::Ground);
+            assert_eq!(o.kind, "orts.tlm.mode.v1");
+            assert_eq!(
+                o.payload.get("mode").and_then(Value::as_text),
+                Some("detumble")
+            );
+        }
+
+        #[test]
+        fn value_roundtrip_through_wit() {
+            use crate::plugin::message::Value;
+            for v in [
+                Value::Boolean(true),
+                Value::Integer(-9),
+                Value::Number(2.5),
+                Value::Text("x".into()),
+                Value::Bytes(vec![1, 2, 3]),
+            ] {
+                let back = value_from_wit(value_to_wit(v.clone()));
+                assert_eq!(back, v);
+            }
         }
 
         #[test]

--- a/orts/src/plugin/wasm/sync_controller.rs
+++ b/orts/src/plugin/wasm/sync_controller.rs
@@ -76,12 +76,6 @@ pub struct WasmController {
     /// This controller's node identity, stamped as `src` on outbound
     /// messages. Defaults to `NodeId::Satellite(0)`.
     node_id: NodeId,
-    /// Monotonic sequence counter assigned to outbound messages
-    /// (`host-seq`). Gives a deterministic total order.
-    host_seq: u64,
-    /// Tick counter, incremented once per `update()`. Stamped as
-    /// `deliver-tick` on outbound messages.
-    tick: u64,
     /// Inbound messages queued via [`Self::deliver`], frozen into the
     /// next tick's inbox on `update()`.
     pending_inbound: Vec<Message>,
@@ -146,8 +140,6 @@ impl WasmController {
             name: format!("wasm:{label}"),
             _current_mode: current_mode,
             node_id: NodeId::Satellite(0),
-            host_seq: 0,
-            tick: 0,
             pending_inbound: Vec::new(),
             outbound_buffer: Vec::new(),
         })
@@ -199,7 +191,7 @@ impl PluginController for WasmController {
     }
 
     /// Drain every message the guest has emitted so far. Each message
-    /// carries the host-stamped `src`, `host_seq`, and `deliver_tick`.
+    /// carries the host-stamped `src`.
     fn take_outbound(&mut self) -> Vec<Message> {
         std::mem::take(&mut self.outbound_buffer)
     }
@@ -239,23 +231,17 @@ impl PluginController for WasmController {
 
         match response {
             GuestResponse::Tick { command, outgoing } => {
-                // Stamp host-controlled envelope fields onto each guest
-                // outbound (src injection prevents spoofing; host_seq
-                // gives a deterministic total order; deliver_tick is the
-                // tick the message was produced on) and buffer it.
+                // Inject the host-controlled `src` onto each guest outbound
+                // (prevents the guest from spoofing its origin) and buffer it.
                 for ob in outgoing {
                     let ob: Outbound = convert::outbound_from_wit(ob);
                     self.outbound_buffer.push(Message {
                         src: self.node_id,
                         dst: ob.dst,
                         kind: ob.kind,
-                        host_seq: self.host_seq,
-                        deliver_tick: self.tick,
                         payload: ob.payload,
                     });
-                    self.host_seq += 1;
                 }
-                self.tick += 1;
 
                 match command {
                     Some(wit_cmd) => convert::command_from_wit(wit_cmd).map(Some),

--- a/orts/src/plugin/wasm/sync_controller.rs
+++ b/orts/src/plugin/wasm/sync_controller.rs
@@ -153,26 +153,6 @@ impl WasmController {
         })
     }
 
-    /// Queue an inbound message for delivery on the **next** `update()`
-    /// tick. Transport / test-API entry point: the host freezes the
-    /// queued set into that tick's frozen inbox (`recv-batch`).
-    pub fn deliver(&mut self, msg: Message) {
-        self.pending_inbound.push(msg);
-    }
-
-    /// Drain every message the guest has emitted so far. Transport /
-    /// test-API exit point: each message carries the host-stamped
-    /// `src`, `host_seq`, and `deliver_tick`.
-    pub fn take_outbound(&mut self) -> Vec<Message> {
-        std::mem::take(&mut self.outbound_buffer)
-    }
-
-    /// Set this controller's node identity (stamped as `src` on
-    /// outbound messages). Defaults to `NodeId::Satellite(0)`.
-    pub fn set_node_id(&mut self, id: NodeId) {
-        self.node_id = id;
-    }
-
     /// Pre-link a Component against the host imports.
     pub fn prepare(
         engine: &Arc<WasmEngine>,
@@ -209,6 +189,25 @@ impl PluginController for WasmController {
 
     fn sample_period(&self) -> f64 {
         self.sample_period
+    }
+
+    /// Queue an inbound message for delivery on the **next** `update()`
+    /// tick. The host freezes the queued set into that tick's frozen
+    /// inbox (`recv-batch`).
+    fn deliver(&mut self, msg: Message) {
+        self.pending_inbound.push(msg);
+    }
+
+    /// Drain every message the guest has emitted so far. Each message
+    /// carries the host-stamped `src`, `host_seq`, and `deliver_tick`.
+    fn take_outbound(&mut self) -> Vec<Message> {
+        std::mem::take(&mut self.outbound_buffer)
+    }
+
+    /// Set this controller's node identity (stamped as `src` on
+    /// outbound messages). Defaults to `NodeId::Satellite(0)`.
+    fn set_node_id(&mut self, id: NodeId) {
+        self.node_id = id;
     }
 
     fn update(&mut self, obs: &TickInput<'_>) -> Result<Option<Command>, PluginError> {

--- a/orts/src/plugin/wasm/sync_controller.rs
+++ b/orts/src/plugin/wasm/sync_controller.rs
@@ -49,18 +49,18 @@ use super::convert::sync as convert;
 use super::engine::WasmEngine;
 use super::sync_bindings::orts::plugin::types as wit;
 use super::sync_bindings::{Plugin, PluginPre};
-use super::sync_host_state::{GuestResponse, HostState};
+use super::sync_host_state::{GuestResponse, HostState, TickPacket};
 
 use crate::plugin::controller::PluginController;
 use crate::plugin::tick_input::TickInput;
-use crate::plugin::{Command, PluginError};
+use crate::plugin::{Command, Message, NodeId, Outbound, PluginError};
 
 /// A `PluginController` backed by a WebAssembly Component guest.
 pub struct WasmController {
     /// Worker thread handle. Joined on Drop.
     worker: Option<thread::JoinHandle<()>>,
-    /// Channel for sending tick inputs to the worker.
-    input_tx: Option<mpsc::SyncSender<wit::TickInput>>,
+    /// Channel for sending tick packets (input + frozen inbox) to the worker.
+    input_tx: Option<mpsc::SyncSender<TickPacket>>,
     /// Channel for receiving guest responses from the worker.
     output_rx: mpsc::Receiver<GuestResponse>,
     /// Cached sample period from the guest's `metadata()` export,
@@ -71,6 +71,23 @@ pub struct WasmController {
     /// Current mission mode name, refreshed by the worker thread.
     /// Not yet implemented — always `None` in the current design.
     _current_mode: Arc<Mutex<Option<String>>>,
+
+    // ─── msg-io transport state ─────────────────────────────────
+    /// This controller's node identity, stamped as `src` on outbound
+    /// messages. Defaults to `NodeId::Satellite(0)`.
+    node_id: NodeId,
+    /// Monotonic sequence counter assigned to outbound messages
+    /// (`host-seq`). Gives a deterministic total order.
+    host_seq: u64,
+    /// Tick counter, incremented once per `update()`. Stamped as
+    /// `deliver-tick` on outbound messages.
+    tick: u64,
+    /// Inbound messages queued via [`Self::deliver`], frozen into the
+    /// next tick's inbox on `update()`.
+    pending_inbound: Vec<Message>,
+    /// Outbound messages emitted by the guest, awaiting pickup via
+    /// [`Self::take_outbound`].
+    outbound_buffer: Vec<Message>,
 }
 
 impl WasmController {
@@ -89,7 +106,7 @@ impl WasmController {
         let pre = pre.clone();
 
         // Channels for outer ↔ worker communication.
-        let (input_tx, input_rx) = mpsc::sync_channel::<wit::TickInput>(1);
+        let (input_tx, input_rx) = mpsc::sync_channel::<TickPacket>(1);
         let (output_tx, output_rx) = mpsc::sync_channel::<GuestResponse>(1);
         // Separate metadata channel used only during startup so the
         // outer thread can synchronously wait for `metadata()` without
@@ -128,7 +145,32 @@ impl WasmController {
             sample_period,
             name: format!("wasm:{label}"),
             _current_mode: current_mode,
+            node_id: NodeId::Satellite(0),
+            host_seq: 0,
+            tick: 0,
+            pending_inbound: Vec::new(),
+            outbound_buffer: Vec::new(),
         })
+    }
+
+    /// Queue an inbound message for delivery on the **next** `update()`
+    /// tick. Transport / test-API entry point: the host freezes the
+    /// queued set into that tick's frozen inbox (`recv-batch`).
+    pub fn deliver(&mut self, msg: Message) {
+        self.pending_inbound.push(msg);
+    }
+
+    /// Drain every message the guest has emitted so far. Transport /
+    /// test-API exit point: each message carries the host-stamped
+    /// `src`, `host_seq`, and `deliver_tick`.
+    pub fn take_outbound(&mut self) -> Vec<Message> {
+        std::mem::take(&mut self.outbound_buffer)
+    }
+
+    /// Set this controller's node identity (stamped as `src` on
+    /// outbound messages). Defaults to `NodeId::Satellite(0)`.
+    pub fn set_node_id(&mut self, id: NodeId) {
+        self.node_id = id;
     }
 
     /// Pre-link a Component against the host imports.
@@ -172,22 +214,55 @@ impl PluginController for WasmController {
     fn update(&mut self, obs: &TickInput<'_>) -> Result<Option<Command>, PluginError> {
         let wit_obs = convert::tick_input_to_wit(obs);
 
+        // Freeze this tick's inbox: drain whatever was queued via
+        // `deliver()` and lower it into WIT messages.
+        let inbox: Vec<wit::Message> = std::mem::take(&mut self.pending_inbound)
+            .into_iter()
+            .map(convert::message_to_wit)
+            .collect();
+
         let input_tx = self
             .input_tx
             .as_ref()
             .ok_or_else(|| PluginError::Runtime("controller is shut down".to_string()))?;
 
         input_tx
-            .send(wit_obs)
+            .send(TickPacket {
+                input: wit_obs,
+                inbox,
+            })
             .map_err(|_| PluginError::Runtime("worker thread exited".to_string()))?;
 
-        match self
+        let response = self
             .output_rx
             .recv()
-            .map_err(|_| PluginError::Runtime("worker thread exited".to_string()))?
-        {
-            GuestResponse::Command(Some(wit_cmd)) => convert::command_from_wit(wit_cmd).map(Some),
-            GuestResponse::Command(None) => Ok(None),
+            .map_err(|_| PluginError::Runtime("worker thread exited".to_string()))?;
+
+        match response {
+            GuestResponse::Tick { command, outgoing } => {
+                // Stamp host-controlled envelope fields onto each guest
+                // outbound (src injection prevents spoofing; host_seq
+                // gives a deterministic total order; deliver_tick is the
+                // tick the message was produced on) and buffer it.
+                for ob in outgoing {
+                    let ob: Outbound = convert::outbound_from_wit(ob);
+                    self.outbound_buffer.push(Message {
+                        src: self.node_id,
+                        dst: ob.dst,
+                        kind: ob.kind,
+                        host_seq: self.host_seq,
+                        deliver_tick: self.tick,
+                        payload: ob.payload,
+                    });
+                    self.host_seq += 1;
+                }
+                self.tick += 1;
+
+                match command {
+                    Some(wit_cmd) => convert::command_from_wit(wit_cmd).map(Some),
+                    None => Ok(None),
+                }
+            }
             GuestResponse::Done(Ok(())) => Err(PluginError::Runtime(
                 "guest run() returned early".to_string(),
             )),
@@ -205,7 +280,7 @@ fn worker_main(
     pre: PluginPre<HostState>,
     label: String,
     config: String,
-    input_rx: mpsc::Receiver<wit::TickInput>,
+    input_rx: mpsc::Receiver<TickPacket>,
     output_tx: mpsc::SyncSender<GuestResponse>,
     metadata_tx: mpsc::SyncSender<Result<f64, String>>,
     current_mode: Arc<Mutex<Option<String>>>,

--- a/orts/src/plugin/wasm/sync_host_state.rs
+++ b/orts/src/plugin/wasm/sync_host_state.rs
@@ -84,10 +84,11 @@ pub struct HostState {
     /// Command captured from the most recent `send_command` call,
     /// forwarded to the outer thread on the next `wait_tick`.
     pending_cmd: Option<wit::Command>,
-    /// Frozen msg-io inbox for the current tick. Set on each
-    /// `wait_tick` from the incoming [`TickPacket`]; drained by
-    /// `recv-batch`. Leftover messages are dropped at the next tick
-    /// boundary (the outer side decides carry-over policy).
+    /// Frozen msg-io inbox for the current tick. On each `wait_tick`
+    /// the incoming [`TickPacket`]'s deliveries are appended; drained by
+    /// `recv-batch`. Messages left undrained carry over to the next tick
+    /// (appended before the new deliveries) — backpressure per the
+    /// msg-io contract.
     inbox: VecDeque<wit::Message>,
     /// Messages the guest emitted via `send-message` during the current
     /// tick (append). Forwarded to the outer thread on the next
@@ -202,9 +203,10 @@ impl tick_io::Host for HostState {
         // host function panicking.
         match self.input_rx.recv() {
             Ok(packet) => {
-                // Freeze this tick's inbox. Any messages left undrained
-                // from the previous tick are dropped here.
-                self.inbox = packet.inbox.into();
+                // Freeze this tick's inbox: append the newly delivered
+                // messages after any left undrained from the previous tick
+                // (carry-over / backpressure per the msg-io contract).
+                self.inbox.extend(packet.inbox);
                 Some(packet.input)
             }
             Err(_) => None,
@@ -241,6 +243,7 @@ impl msg_io::Host for HostState {
 mod tests {
     use super::host_env::Host as _;
     use super::msg_io::Host as _;
+    use super::tick_io::Host as _;
     use super::*;
 
     fn make_state() -> HostState {
@@ -259,6 +262,79 @@ mod tests {
             deliver_tick: 0,
             payload: wit::Payload::KeyValue(vec![]),
         }
+    }
+
+    fn dummy_tick_input() -> wit::TickInput {
+        wit::TickInput {
+            t: 0.0,
+            spacecraft: wit::SpacecraftState {
+                orbit: wit::OrbitalState {
+                    position: wit::PositionEciKm {
+                        x: 7000.0,
+                        y: 0.0,
+                        z: 0.0,
+                    },
+                    velocity: wit::VelocityEciKms {
+                        x: 0.0,
+                        y: 7.5,
+                        z: 0.0,
+                    },
+                },
+                attitude: wit::AttitudeState {
+                    orientation: wit::Quat {
+                        w: 1.0,
+                        x: 0.0,
+                        y: 0.0,
+                        z: 0.0,
+                    },
+                    angular_velocity: wit::Vec3 {
+                        x: 0.0,
+                        y: 0.0,
+                        z: 0.0,
+                    },
+                },
+                mass: 50.0,
+            },
+            epoch: None,
+            sensors: wit::Sensors {
+                magnetometers: vec![],
+                gyroscopes: vec![],
+                star_trackers: vec![],
+                sun_sensors: vec![],
+            },
+            actuators: wit::ActuatorTelemetry { rw: None },
+        }
+    }
+
+    #[test]
+    fn wait_tick_carries_over_undrained_inbox() {
+        let (input_tx, input_rx) = mpsc::channel::<TickPacket>();
+        let (output_tx, _output_rx) = mpsc::sync_channel::<GuestResponse>(4);
+        let current_mode = Arc::new(Mutex::new(None));
+        let mut state = HostState::new("test", input_rx, output_tx, current_mode);
+
+        // Tick 0 delivers two messages; the guest drains only one.
+        input_tx
+            .send(TickPacket {
+                input: dummy_tick_input(),
+                inbox: vec![test_message(0), test_message(1)],
+            })
+            .unwrap();
+        state.wait_tick();
+        assert_eq!(state.recv_batch(1).len(), 1); // host_seq 0 drained
+
+        // Tick 1 delivers one more; the undrained host_seq 1 must carry over,
+        // with the newly frozen delivery appended after it.
+        input_tx
+            .send(TickPacket {
+                input: dummy_tick_input(),
+                inbox: vec![test_message(2)],
+            })
+            .unwrap();
+        state.wait_tick();
+
+        let seqs: Vec<u64> = state.recv_batch(10).iter().map(|m| m.host_seq).collect();
+        assert_eq!(seqs, vec![1, 2]); // leftover first, then newly delivered
     }
 
     #[test]

--- a/orts/src/plugin/wasm/sync_host_state.rs
+++ b/orts/src/plugin/wasm/sync_host_state.rs
@@ -232,8 +232,7 @@ impl msg_io::Host for HostState {
     }
 
     /// Capture an outbound message (append). Forwarded to the outer
-    /// `update()` on the next `wait_tick`; `src` / `host-seq` /
-    /// `deliver-tick` are stamped by the host there.
+    /// `update()` on the next `wait_tick`; `src` is stamped by the host there.
     fn send_message(&mut self, msg: wit::Outbound) {
         self.outbox.push(msg);
     }
@@ -253,13 +252,13 @@ mod tests {
         HostState::new("test", input_rx, output_tx, current_mode)
     }
 
-    fn test_message(host_seq: u64) -> wit::Message {
+    /// `seq` is encoded into `kind` so tests can assert delivery order /
+    /// carry-over by message identity.
+    fn test_message(seq: u64) -> wit::Message {
         wit::Message {
             src: wit::NodeId::Ground,
             dst: wit::NodeId::Satellite(0),
-            kind: "test.cmd.v1".to_string(),
-            host_seq,
-            deliver_tick: 0,
+            kind: format!("test.cmd.{seq}"),
             payload: wit::Payload::KeyValue(vec![]),
         }
     }
@@ -321,9 +320,9 @@ mod tests {
             })
             .unwrap();
         state.wait_tick();
-        assert_eq!(state.recv_batch(1).len(), 1); // host_seq 0 drained
+        assert_eq!(state.recv_batch(1).len(), 1); // test.cmd.0 drained
 
-        // Tick 1 delivers one more; the undrained host_seq 1 must carry over,
+        // Tick 1 delivers one more; the undrained test.cmd.1 must carry over,
         // with the newly frozen delivery appended after it.
         input_tx
             .send(TickPacket {
@@ -333,8 +332,12 @@ mod tests {
             .unwrap();
         state.wait_tick();
 
-        let seqs: Vec<u64> = state.recv_batch(10).iter().map(|m| m.host_seq).collect();
-        assert_eq!(seqs, vec![1, 2]); // leftover first, then newly delivered
+        let kinds: Vec<String> = state
+            .recv_batch(10)
+            .iter()
+            .map(|m| m.kind.clone())
+            .collect();
+        assert_eq!(kinds, vec!["test.cmd.1", "test.cmd.2"]); // leftover first, then newly delivered
     }
 
     #[test]
@@ -346,12 +349,12 @@ mod tests {
         // First batch: 2 of 5, in order.
         let b1 = state.recv_batch(2);
         assert_eq!(b1.len(), 2);
-        assert_eq!(b1[0].host_seq, 0);
-        assert_eq!(b1[1].host_seq, 1);
+        assert_eq!(b1[0].kind, "test.cmd.0");
+        assert_eq!(b1[1].kind, "test.cmd.1");
         // max larger than remaining → take the rest.
         let b2 = state.recv_batch(10);
         assert_eq!(b2.len(), 3);
-        assert_eq!(b2[0].host_seq, 2);
+        assert_eq!(b2[0].kind, "test.cmd.2");
         // Exhausted.
         assert!(state.recv_batch(1).is_empty());
     }

--- a/orts/src/plugin/wasm/sync_host_state.rs
+++ b/orts/src/plugin/wasm/sync_host_state.rs
@@ -13,12 +13,14 @@
 //!   pending command is forwarded through `output_tx` and the outer
 //!   `update()` receives it.
 
+use std::collections::VecDeque;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
 use tobari::magnetic::TiltedDipole;
 
 use super::sync_bindings::orts::plugin::host_env;
+use super::sync_bindings::orts::plugin::msg_io;
 use super::sync_bindings::orts::plugin::tick_io;
 use super::sync_bindings::orts::plugin::types as wit;
 
@@ -26,17 +28,34 @@ use super::sync_bindings::orts::plugin::types as wit;
 // `add_to_linker` requires a blanket `types::Host` impl for the host state.
 impl wit::Host for HostState {}
 
+/// One tick's worth of host → guest input.
+///
+/// Carries the physical [`wit::TickInput`] snapshot **and** the frozen
+/// inbox of msg-io messages the host has decided to deliver this tick.
+/// Freezing happens at the tick boundary (when the outer `update()`
+/// sends this packet), which keeps `recv-batch` deterministic regardless
+/// of when the guest drains it.
+pub(super) struct TickPacket {
+    pub input: wit::TickInput,
+    pub inbox: Vec<wit::Message>,
+}
+
 /// Guest response delivered to the outer `update()` via `output_tx`.
 ///
 /// Sent by the worker thread at the start of each `wait_tick` call
 /// (except the very first one, which primes the guest with an initial
 /// input without producing a response).
 pub(super) enum GuestResponse {
-    /// A command from the previous tick (possibly `None` if the guest
-    /// didn't call `send_command` during that tick).
-    Command(Option<wit::Command>),
+    /// The outcome of one tick: the actuator command (possibly `None`
+    /// if the guest didn't call `send_command`) plus every message the
+    /// guest emitted via `send-message` during the tick (append
+    /// semantics — a `Vec`, possibly empty).
+    Tick {
+        command: Option<wit::Command>,
+        outgoing: Vec<wit::Outbound>,
+    },
     /// The guest's `run()` function returned or errored. No more
-    /// commands will be produced.
+    /// responses will be produced.
     Done(Result<(), String>),
 }
 
@@ -57,13 +76,23 @@ pub struct HostState {
     /// Resource table for WASI resources.
     table: wasmtime_wasi::ResourceTable,
 
-    /// Receiver for tick inputs from the outer `update()` call.
-    input_rx: mpsc::Receiver<wit::TickInput>,
-    /// Sender for guest responses (commands / done signal).
+    /// Receiver for tick packets (physical input + frozen inbox) from
+    /// the outer `update()` call.
+    input_rx: mpsc::Receiver<TickPacket>,
+    /// Sender for guest responses (tick result / done signal).
     output_tx: mpsc::SyncSender<GuestResponse>,
     /// Command captured from the most recent `send_command` call,
     /// forwarded to the outer thread on the next `wait_tick`.
     pending_cmd: Option<wit::Command>,
+    /// Frozen msg-io inbox for the current tick. Set on each
+    /// `wait_tick` from the incoming [`TickPacket`]; drained by
+    /// `recv-batch`. Leftover messages are dropped at the next tick
+    /// boundary (the outer side decides carry-over policy).
+    inbox: VecDeque<wit::Message>,
+    /// Messages the guest emitted via `send-message` during the current
+    /// tick (append). Forwarded to the outer thread on the next
+    /// `wait_tick` and then cleared.
+    outbox: Vec<wit::Outbound>,
     /// `true` until the first `wait_tick` call. The very first call
     /// must NOT send a response (there's nothing to report yet), it
     /// just blocks waiting for the first input.
@@ -79,7 +108,7 @@ pub struct HostState {
 impl HostState {
     pub(super) fn new(
         label: impl Into<String>,
-        input_rx: mpsc::Receiver<wit::TickInput>,
+        input_rx: mpsc::Receiver<TickPacket>,
         output_tx: mpsc::SyncSender<GuestResponse>,
         current_mode: Arc<Mutex<Option<String>>>,
     ) -> Self {
@@ -91,6 +120,8 @@ impl HostState {
             input_rx,
             output_tx,
             pending_cmd: None,
+            inbox: VecDeque::new(),
+            outbox: Vec::new(),
             is_first_wait: true,
             current_mode,
         }
@@ -153,11 +184,14 @@ impl tick_io::Host for HostState {
     /// signaling the guest to exit its main loop cleanly.
     fn wait_tick(&mut self) -> Option<wit::TickInput> {
         if !self.is_first_wait {
-            let cmd = self.pending_cmd.take();
+            let command = self.pending_cmd.take();
+            let outgoing = std::mem::take(&mut self.outbox);
             // If the outer side has dropped the receiver (Controller
             // was dropped), this send fails — that's fine, we'll
             // return None below and the guest will exit cleanly.
-            let _ = self.output_tx.send(GuestResponse::Command(cmd));
+            let _ = self
+                .output_tx
+                .send(GuestResponse::Tick { command, outgoing });
         } else {
             self.is_first_wait = false;
         }
@@ -166,7 +200,15 @@ impl tick_io::Host for HostState {
         // the outer WasmController) has been dropped. We translate this
         // into `None` so the guest can exit its main loop without the
         // host function panicking.
-        self.input_rx.recv().ok()
+        match self.input_rx.recv() {
+            Ok(packet) => {
+                // Freeze this tick's inbox. Any messages left undrained
+                // from the previous tick are dropped here.
+                self.inbox = packet.inbox.into();
+                Some(packet.input)
+            }
+            Err(_) => None,
+        }
     }
 
     fn send_command(&mut self, cmd: wit::Command) {
@@ -176,9 +218,29 @@ impl tick_io::Host for HostState {
     }
 }
 
+// ─── msg-io interface ───────────────────────────────────────────
+
+impl msg_io::Host for HostState {
+    /// Drain up to `max` messages from this tick's frozen inbox, in
+    /// host-assigned order. Returns an empty list once the inbox is
+    /// exhausted for the tick.
+    fn recv_batch(&mut self, max: u32) -> Vec<wit::Message> {
+        let n = (max as usize).min(self.inbox.len());
+        self.inbox.drain(..n).collect()
+    }
+
+    /// Capture an outbound message (append). Forwarded to the outer
+    /// `update()` on the next `wait_tick`; `src` / `host-seq` /
+    /// `deliver-tick` are stamped by the host there.
+    fn send_message(&mut self, msg: wit::Outbound) {
+        self.outbox.push(msg);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::host_env::Host as _;
+    use super::msg_io::Host as _;
     use super::*;
 
     fn make_state() -> HostState {
@@ -186,6 +248,64 @@ mod tests {
         let (output_tx, _) = mpsc::sync_channel(1);
         let current_mode = Arc::new(Mutex::new(None));
         HostState::new("test", input_rx, output_tx, current_mode)
+    }
+
+    fn test_message(host_seq: u64) -> wit::Message {
+        wit::Message {
+            src: wit::NodeId::Ground,
+            dst: wit::NodeId::Satellite(0),
+            kind: "test.cmd.v1".to_string(),
+            host_seq,
+            deliver_tick: 0,
+            payload: wit::Payload::KeyValue(vec![]),
+        }
+    }
+
+    #[test]
+    fn recv_batch_drains_frozen_inbox_in_order() {
+        let mut state = make_state();
+        for seq in 0..5u64 {
+            state.inbox.push_back(test_message(seq));
+        }
+        // First batch: 2 of 5, in order.
+        let b1 = state.recv_batch(2);
+        assert_eq!(b1.len(), 2);
+        assert_eq!(b1[0].host_seq, 0);
+        assert_eq!(b1[1].host_seq, 1);
+        // max larger than remaining → take the rest.
+        let b2 = state.recv_batch(10);
+        assert_eq!(b2.len(), 3);
+        assert_eq!(b2[0].host_seq, 2);
+        // Exhausted.
+        assert!(state.recv_batch(1).is_empty());
+    }
+
+    #[test]
+    fn recv_batch_zero_takes_nothing() {
+        let mut state = make_state();
+        state.inbox.push_back(test_message(0));
+        assert!(state.recv_batch(0).is_empty());
+        assert_eq!(state.inbox.len(), 1);
+    }
+
+    #[test]
+    fn send_message_appends_to_outbox() {
+        let mut state = make_state();
+        assert!(state.outbox.is_empty());
+        state.send_message(wit::Outbound {
+            dst: wit::NodeId::Ground,
+            kind: "test.tlm.v1".to_string(),
+            payload: wit::Payload::Json("{}".to_string()),
+        });
+        state.send_message(wit::Outbound {
+            dst: wit::NodeId::Ground,
+            kind: "test.tlm.v2".to_string(),
+            payload: wit::Payload::Binary(vec![1]),
+        });
+        // Append (not last-write-wins).
+        assert_eq!(state.outbox.len(), 2);
+        assert_eq!(state.outbox[0].kind, "test.tlm.v1");
+        assert_eq!(state.outbox[1].kind, "test.tlm.v2");
     }
 
     #[test]

--- a/orts/tests/plugin_msg_commandable_mode.rs
+++ b/orts/tests/plugin_msg_commandable_mode.rs
@@ -7,6 +7,9 @@
 //! 地上局 + router 役をテストが演じる（WebSocket / config 時刻シーケンスは
 //! 別の transport adapter として後付けする）。
 //!
+//! FSW 側には運用ガードが入っている: `nadir` 指向は機体が整定済み
+//! （|ω| < 0.05 rad/s）のときだけ許可され、tumbling 中は拒否される。
+//!
 //! **Prerequisites**: guest を先にビルドすること:
 //!
 //! ```sh
@@ -22,6 +25,7 @@
 
 use std::sync::Arc;
 
+use arika::frame::{Body, Vec3};
 use nalgebra::{Vector3, Vector4};
 use wasmtime::component::Component;
 
@@ -30,12 +34,18 @@ use orts::SpacecraftState;
 use orts::attitude::AttitudeState;
 use orts::plugin::wasm::{WasmController, WasmEngine};
 use orts::plugin::{
-    ActuatorTelemetry, Message, NodeId, Payload, PluginController, Sensors, TickInput, Value,
+    ActuatorTelemetry, AngularVelocityBody, Message, NodeId, Payload, PluginController, Sensors,
+    TickInput, Value,
 };
 
 const KIND_SET_MODE: &str = "orts.cmd.set-mode.v1";
 const KIND_MODE_TLM: &str = "orts.tlm.mode.v1";
 const KIND_SET_MODE_ACK: &str = "orts.ack.set-mode.v1";
+
+/// Angular rate below the FSW's nadir gate (0.05 rad/s): "settled".
+const SETTLED: f64 = 0.0;
+/// Angular rate above the gate: "still tumbling".
+const TUMBLING: f64 = 0.2;
 
 /// Load a guest component and build a `WasmController`, or soft-skip
 /// (return `None`) when the guest has not been built.
@@ -73,6 +83,18 @@ fn spacecraft() -> SpacecraftState {
     }
 }
 
+/// Sensors carrying a single gyro reading of the given body-x rate \[rad/s\].
+fn gyro_sensors(omega_x: f64) -> Sensors {
+    Sensors {
+        magnetometers: vec![],
+        gyroscopes: vec![AngularVelocityBody::new(Vec3::<Body>::new(
+            omega_x, 0.0, 0.0,
+        ))],
+        star_trackers: vec![],
+        sun_sensors: vec![],
+    }
+}
+
 /// Ground → satellite(0) set-mode command. The host re-stamps `src` /
 /// `host_seq` / `deliver_tick` on outbound; for inbound the test plays
 /// the router and sets them directly.
@@ -92,6 +114,10 @@ fn find<'a>(out: &'a [Message], kind: &str) -> Option<&'a Message> {
     out.iter().find(|m| m.kind == kind)
 }
 
+fn text<'a>(m: &'a Message, key: &str) -> Option<&'a str> {
+    m.payload.get(key).and_then(Value::as_text)
+}
+
 // ─────────────────────── fire-and-forget ───────────────────────
 
 #[test]
@@ -100,7 +126,7 @@ fn fire_and_forget_set_mode_is_confirmed_by_telemetry() {
         return;
     };
     let sc = spacecraft();
-    let sensors = Sensors::empty();
+    let sensors = gyro_sensors(SETTLED); // settled → nadir allowed
     let act = ActuatorTelemetry::default();
     let obs = TickInput {
         t: 0.0,
@@ -114,10 +140,7 @@ fn fire_and_forget_set_mode_is_confirmed_by_telemetry() {
     ctrl.update(&obs).expect("update tick 0");
     let out0 = ctrl.take_outbound();
     let tlm0 = find(&out0, KIND_MODE_TLM).expect("mode telemetry every tick");
-    assert_eq!(
-        tlm0.payload.get("mode").and_then(Value::as_text),
-        Some("detumble")
-    );
+    assert_eq!(text(tlm0, "mode"), Some("detumble"));
     // Host stamped the envelope: src injected, dst preserved.
     assert_eq!(tlm0.src, NodeId::Satellite(0));
     assert_eq!(tlm0.dst, NodeId::Ground);
@@ -131,13 +154,42 @@ fn fire_and_forget_set_mode_is_confirmed_by_telemetry() {
     let out1 = ctrl.take_outbound();
 
     // Ground "waits for telemetry": the mode tlm now reports nadir.
-    let tlm1 = find(&out1, KIND_MODE_TLM).expect("mode telemetry every tick");
     assert_eq!(
-        tlm1.payload.get("mode").and_then(Value::as_text),
+        text(find(&out1, KIND_MODE_TLM).unwrap(), "mode"),
         Some("nadir")
     );
     // Fire-and-forget: no ack message is produced.
     assert!(find(&out1, KIND_SET_MODE_ACK).is_none());
+}
+
+#[test]
+fn fire_and_forget_nadir_blocked_while_tumbling() {
+    let Some(mut ctrl) = load("orts_example_plugin_commandable_mode_ff") else {
+        return;
+    };
+    let sc = spacecraft();
+    let sensors = gyro_sensors(TUMBLING); // still tumbling → nadir gated
+    let act = ActuatorTelemetry::default();
+    let obs = TickInput {
+        t: 0.0,
+        spacecraft: &sc,
+        epoch: None,
+        sensors: &sensors,
+        actuators: &act,
+    };
+
+    ctrl.deliver(set_mode(Payload::key_value([(
+        "mode",
+        Value::Text("nadir".to_string()),
+    )])));
+    ctrl.update(&obs).expect("update");
+    let out = ctrl.take_outbound();
+
+    // Gate blocked the switch (silently); telemetry still reports detumble.
+    assert_eq!(
+        text(find(&out, KIND_MODE_TLM).unwrap(), "mode"),
+        Some("detumble")
+    );
 }
 
 #[test]
@@ -146,7 +198,7 @@ fn fire_and_forget_invalid_mode_is_silently_ignored() {
         return;
     };
     let sc = spacecraft();
-    let sensors = Sensors::empty();
+    let sensors = gyro_sensors(SETTLED);
     let act = ActuatorTelemetry::default();
     let obs = TickInput {
         t: 0.0,
@@ -164,9 +216,8 @@ fn fire_and_forget_invalid_mode_is_silently_ignored() {
     let out = ctrl.take_outbound();
 
     // Invalid mode ignored → telemetry still reports the unchanged default.
-    let tlm = find(&out, KIND_MODE_TLM).expect("mode telemetry");
     assert_eq!(
-        tlm.payload.get("mode").and_then(Value::as_text),
+        text(find(&out, KIND_MODE_TLM).unwrap(), "mode"),
         Some("detumble")
     );
 }
@@ -179,7 +230,7 @@ fn request_response_set_mode_acked_with_correlation() {
         return;
     };
     let sc = spacecraft();
-    let sensors = Sensors::empty();
+    let sensors = gyro_sensors(SETTLED); // settled → nadir accepted
     let act = ActuatorTelemetry::default();
     let obs = TickInput {
         t: 0.0,
@@ -203,16 +254,44 @@ fn request_response_set_mode_acked_with_correlation() {
         ack.payload.get("req-id").and_then(Value::as_integer),
         Some(7)
     );
-    assert_eq!(
-        ack.payload.get("status").and_then(Value::as_text),
-        Some("accepted")
-    );
-    assert_eq!(
-        ack.payload.get("mode").and_then(Value::as_text),
-        Some("nadir")
-    );
+    assert_eq!(text(ack, "status"), Some("accepted"));
+    assert_eq!(text(ack, "mode"), Some("nadir"));
     assert_eq!(ack.src, NodeId::Satellite(0));
     assert_eq!(ack.dst, NodeId::Ground);
+}
+
+#[test]
+fn request_response_nadir_rejected_while_tumbling() {
+    let Some(mut ctrl) = load("orts_example_plugin_commandable_mode_rr") else {
+        return;
+    };
+    let sc = spacecraft();
+    let sensors = gyro_sensors(TUMBLING); // still tumbling → nadir gated
+    let act = ActuatorTelemetry::default();
+    let obs = TickInput {
+        t: 0.0,
+        spacecraft: &sc,
+        epoch: None,
+        sensors: &sensors,
+        actuators: &act,
+    };
+
+    ctrl.deliver(set_mode(Payload::key_value([
+        ("req-id", Value::Integer(9)),
+        ("mode", Value::Text("nadir".to_string())),
+    ])));
+    ctrl.update(&obs).expect("update");
+    let out = ctrl.take_outbound();
+
+    let ack = find(&out, KIND_SET_MODE_ACK).expect("ack for the request");
+    assert_eq!(
+        ack.payload.get("req-id").and_then(Value::as_integer),
+        Some(9)
+    );
+    assert_eq!(text(ack, "status"), Some("rejected"));
+    assert_eq!(text(ack, "reason"), Some("still-tumbling"));
+    // Mode unchanged: the gate kept it in detumble.
+    assert_eq!(text(ack, "mode"), Some("detumble"));
 }
 
 #[test]
@@ -221,7 +300,7 @@ fn request_response_invalid_mode_is_rejected() {
         return;
     };
     let sc = spacecraft();
-    let sensors = Sensors::empty();
+    let sensors = gyro_sensors(SETTLED);
     let act = ActuatorTelemetry::default();
     let obs = TickInput {
         t: 0.0,
@@ -243,13 +322,8 @@ fn request_response_invalid_mode_is_rejected() {
         ack.payload.get("req-id").and_then(Value::as_integer),
         Some(8)
     );
-    assert_eq!(
-        ack.payload.get("status").and_then(Value::as_text),
-        Some("rejected")
-    );
+    assert_eq!(text(ack, "status"), Some("rejected"));
+    assert_eq!(text(ack, "reason"), Some("unknown-mode"));
     // Mode unchanged (still the default).
-    assert_eq!(
-        ack.payload.get("mode").and_then(Value::as_text),
-        Some("detumble")
-    );
+    assert_eq!(text(ack, "mode"), Some("detumble"));
 }

--- a/orts/tests/plugin_msg_commandable_mode.rs
+++ b/orts/tests/plugin_msg_commandable_mode.rs
@@ -1,0 +1,255 @@
+//! E2E: msg-io C&T チャネルで FSW (WASM guest) にモード切替コマンドを
+//! 送り、結果を受け取る。fire-and-forget と request-response の両プロトコルを
+//! 同じ `msg-io` transport の上で検証する。
+//!
+//! transport は host が所有する決定論的なキュー + テレメトリシンク。ここでは
+//! `WasmController::deliver` / `take_outbound` の **test-API transport** を使い、
+//! 地上局 + router 役をテストが演じる（WebSocket / config 時刻シーケンスは
+//! 別の transport adapter として後付けする）。
+//!
+//! **Prerequisites**: guest を先にビルドすること:
+//!
+//! ```sh
+//! cd plugin-sdk/examples
+//! cargo +1.91.0 component build \
+//!   -p orts-example-plugin-commandable-mode-ff \
+//!   -p orts-example-plugin-commandable-mode-rr --release
+//! ```
+//!
+//! guest 未ビルド時は soft-skip する（wasm ツールチェインのない CI ジョブ向け）。
+
+#![cfg(feature = "plugin-wasm")]
+
+use std::sync::Arc;
+
+use nalgebra::{Vector3, Vector4};
+use wasmtime::component::Component;
+
+use orts::OrbitalState;
+use orts::SpacecraftState;
+use orts::attitude::AttitudeState;
+use orts::plugin::wasm::{WasmController, WasmEngine};
+use orts::plugin::{
+    ActuatorTelemetry, Message, NodeId, Payload, PluginController, Sensors, TickInput, Value,
+};
+
+const KIND_SET_MODE: &str = "orts.cmd.set-mode.v1";
+const KIND_MODE_TLM: &str = "orts.tlm.mode.v1";
+const KIND_SET_MODE_ACK: &str = "orts.ack.set-mode.v1";
+
+/// Load a guest component and build a `WasmController`, or soft-skip
+/// (return `None`) when the guest has not been built.
+fn load(binary: &str) -> Option<WasmController> {
+    let path = format!(
+        "{}/../plugin-sdk/examples/target/wasm32-wasip1/release/{binary}.wasm",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(_) => {
+            eprintln!(
+                "WASM not found: {path}\n\
+                 Build: cd plugin-sdk/examples && cargo +1.91.0 component build -p {binary_pkg} --release\n\
+                 Skipping this test.",
+                binary_pkg = binary.replace('_', "-")
+            );
+            return None;
+        }
+    };
+    let engine = Arc::new(WasmEngine::new().expect("WasmEngine must init"));
+    let component = Component::new(engine.inner(), &bytes).expect("Component must compile");
+    let pre = WasmController::prepare(&engine, &component).expect("prepare must succeed");
+    Some(WasmController::new(&pre, "msg-test", "").expect("new must succeed"))
+}
+
+fn spacecraft() -> SpacecraftState {
+    SpacecraftState {
+        orbit: OrbitalState::new(Vector3::new(7000.0, 0.0, 0.0), Vector3::new(0.0, 7.5, 0.0)),
+        attitude: AttitudeState {
+            quaternion: Vector4::new(1.0, 0.0, 0.0, 0.0),
+            angular_velocity: Vector3::zeros(),
+        },
+        mass: 50.0,
+    }
+}
+
+/// Ground → satellite(0) set-mode command. The host re-stamps `src` /
+/// `host_seq` / `deliver_tick` on outbound; for inbound the test plays
+/// the router and sets them directly.
+fn set_mode(payload: Payload) -> Message {
+    Message {
+        src: NodeId::Ground,
+        dst: NodeId::Satellite(0),
+        kind: KIND_SET_MODE.to_string(),
+        host_seq: 0,
+        deliver_tick: 0,
+        payload,
+    }
+}
+
+/// Find the first message of `kind` in a drained outbound batch.
+fn find<'a>(out: &'a [Message], kind: &str) -> Option<&'a Message> {
+    out.iter().find(|m| m.kind == kind)
+}
+
+// ─────────────────────── fire-and-forget ───────────────────────
+
+#[test]
+fn fire_and_forget_set_mode_is_confirmed_by_telemetry() {
+    let Some(mut ctrl) = load("orts_example_plugin_commandable_mode_ff") else {
+        return;
+    };
+    let sc = spacecraft();
+    let sensors = Sensors::empty();
+    let act = ActuatorTelemetry::default();
+    let obs = TickInput {
+        t: 0.0,
+        spacecraft: &sc,
+        epoch: None,
+        sensors: &sensors,
+        actuators: &act,
+    };
+
+    // tick 0: no uplink → FSW downlinks its default mode.
+    ctrl.update(&obs).expect("update tick 0");
+    let out0 = ctrl.take_outbound();
+    let tlm0 = find(&out0, KIND_MODE_TLM).expect("mode telemetry every tick");
+    assert_eq!(
+        tlm0.payload.get("mode").and_then(Value::as_text),
+        Some("detumble")
+    );
+    // Host stamped the envelope: src injected, dst preserved.
+    assert_eq!(tlm0.src, NodeId::Satellite(0));
+    assert_eq!(tlm0.dst, NodeId::Ground);
+
+    // Uplink set-mode nadir (fire-and-forget), then step.
+    ctrl.deliver(set_mode(Payload::key_value([(
+        "mode",
+        Value::Text("nadir".to_string()),
+    )])));
+    ctrl.update(&obs).expect("update tick 1");
+    let out1 = ctrl.take_outbound();
+
+    // Ground "waits for telemetry": the mode tlm now reports nadir.
+    let tlm1 = find(&out1, KIND_MODE_TLM).expect("mode telemetry every tick");
+    assert_eq!(
+        tlm1.payload.get("mode").and_then(Value::as_text),
+        Some("nadir")
+    );
+    // Fire-and-forget: no ack message is produced.
+    assert!(find(&out1, KIND_SET_MODE_ACK).is_none());
+}
+
+#[test]
+fn fire_and_forget_invalid_mode_is_silently_ignored() {
+    let Some(mut ctrl) = load("orts_example_plugin_commandable_mode_ff") else {
+        return;
+    };
+    let sc = spacecraft();
+    let sensors = Sensors::empty();
+    let act = ActuatorTelemetry::default();
+    let obs = TickInput {
+        t: 0.0,
+        spacecraft: &sc,
+        epoch: None,
+        sensors: &sensors,
+        actuators: &act,
+    };
+
+    ctrl.deliver(set_mode(Payload::key_value([(
+        "mode",
+        Value::Text("bogus".to_string()),
+    )])));
+    ctrl.update(&obs).expect("update");
+    let out = ctrl.take_outbound();
+
+    // Invalid mode ignored → telemetry still reports the unchanged default.
+    let tlm = find(&out, KIND_MODE_TLM).expect("mode telemetry");
+    assert_eq!(
+        tlm.payload.get("mode").and_then(Value::as_text),
+        Some("detumble")
+    );
+}
+
+// ─────────────────────── request-response ───────────────────────
+
+#[test]
+fn request_response_set_mode_acked_with_correlation() {
+    let Some(mut ctrl) = load("orts_example_plugin_commandable_mode_rr") else {
+        return;
+    };
+    let sc = spacecraft();
+    let sensors = Sensors::empty();
+    let act = ActuatorTelemetry::default();
+    let obs = TickInput {
+        t: 0.0,
+        spacecraft: &sc,
+        epoch: None,
+        sensors: &sensors,
+        actuators: &act,
+    };
+
+    // Request set-mode nadir with correlation id 7.
+    ctrl.deliver(set_mode(Payload::key_value([
+        ("req-id", Value::Integer(7)),
+        ("mode", Value::Text("nadir".to_string())),
+    ])));
+    ctrl.update(&obs).expect("update");
+    let out = ctrl.take_outbound();
+
+    let ack = find(&out, KIND_SET_MODE_ACK).expect("ack for the request");
+    // correlation id echoed back.
+    assert_eq!(
+        ack.payload.get("req-id").and_then(Value::as_integer),
+        Some(7)
+    );
+    assert_eq!(
+        ack.payload.get("status").and_then(Value::as_text),
+        Some("accepted")
+    );
+    assert_eq!(
+        ack.payload.get("mode").and_then(Value::as_text),
+        Some("nadir")
+    );
+    assert_eq!(ack.src, NodeId::Satellite(0));
+    assert_eq!(ack.dst, NodeId::Ground);
+}
+
+#[test]
+fn request_response_invalid_mode_is_rejected() {
+    let Some(mut ctrl) = load("orts_example_plugin_commandable_mode_rr") else {
+        return;
+    };
+    let sc = spacecraft();
+    let sensors = Sensors::empty();
+    let act = ActuatorTelemetry::default();
+    let obs = TickInput {
+        t: 0.0,
+        spacecraft: &sc,
+        epoch: None,
+        sensors: &sensors,
+        actuators: &act,
+    };
+
+    ctrl.deliver(set_mode(Payload::key_value([
+        ("req-id", Value::Integer(8)),
+        ("mode", Value::Text("bogus".to_string())),
+    ])));
+    ctrl.update(&obs).expect("update");
+    let out = ctrl.take_outbound();
+
+    let ack = find(&out, KIND_SET_MODE_ACK).expect("ack for the request");
+    assert_eq!(
+        ack.payload.get("req-id").and_then(Value::as_integer),
+        Some(8)
+    );
+    assert_eq!(
+        ack.payload.get("status").and_then(Value::as_text),
+        Some("rejected")
+    );
+    // Mode unchanged (still the default).
+    assert_eq!(
+        ack.payload.get("mode").and_then(Value::as_text),
+        Some("detumble")
+    );
+}

--- a/orts/tests/plugin_msg_commandable_mode.rs
+++ b/orts/tests/plugin_msg_commandable_mode.rs
@@ -95,16 +95,13 @@ fn gyro_sensors(omega_x: f64) -> Sensors {
     }
 }
 
-/// Ground → satellite(0) set-mode command. The host re-stamps `src` /
-/// `host_seq` / `deliver_tick` on outbound; for inbound the test plays
-/// the router and sets them directly.
+/// Ground → satellite(0) set-mode command. The host injects `src` on
+/// outbound; for inbound the test plays the router and sets it directly.
 fn set_mode(payload: Payload) -> Message {
     Message {
         src: NodeId::Ground,
         dst: NodeId::Satellite(0),
         kind: KIND_SET_MODE.to_string(),
-        host_seq: 0,
-        deliver_tick: 0,
         payload,
     }
 }

--- a/orts/wit/v0/orts.wit
+++ b/orts/wit/v0/orts.wit
@@ -247,6 +247,91 @@ interface types {
         /// 正の有限値でなければならない。
         sample-period-s: f64,
     }
+
+    // ─── ノード間メッセージング (C&T / ISL) ─────────────────────────
+    //
+    // `tick-io` の `command`（FSW→アクチュエータの制御出力）とは別物。
+    // こちらは運用者(地上)↔FSW のコマンド/テレメトリ、および将来の
+    // 衛星間通信(ISL)を運ぶ **transport 層**。dumb pipe であり、
+    // request-response / ack / fire-and-forget / file-transfer といった
+    // interaction model は **アプリ層（payload の中身 + SDK ヘルパ）** に
+    // 押し出す。transport は中身の意味を解釈しない。
+
+    /// メッセージの論理型（content-type / 次プロトコル識別子）。
+    ///
+    /// エンコーディングに依らず常に付く = 「型」。名前空間 + version を
+    /// 必須とする規約: 例 `"orts.cmd.set-mode.v1"`, `"mission.adcs.hk.v2"`。
+    /// 受信側（FSW / 地上）はこの値で payload の解釈プロトコルを選ぶ。
+    type msg-kind = string;
+
+    /// 型付きスカラ値。`payload` の `key-value` 表現で使う。
+    variant value {
+        boolean(bool),
+        integer(s64),
+        number(f64),
+        text(string),
+        bytes(list<u8>),
+    }
+
+    /// 名前付き値（key-value の 1 要素）。
+    record named-value {
+        name: string,
+        value: value,
+    }
+
+    /// メッセージ本体のエンコーディング。ユースケースで選択する。
+    ///
+    /// 同一 `msg-kind` では canonical encoding を 1 つに固定する規約
+    /// （json / key-value / binary を同じ kind で混在させない）。
+    variant payload {
+        /// 構造化（スカラは型付き）。viewer/CLI/test から扱いやすい。
+        key-value(list<named-value>),
+        /// 生バイナリ（CCSDS 等、デコードは受信側 FSW）。
+        binary(list<u8>),
+        /// JSON テキスト。transport は opaque 文字列として扱う。
+        json(string),
+    }
+
+    /// ノードアドレス。運用者 C&T = `ground` ↔ `satellite`、
+    /// ISL = `satellite` ↔ `satellite`。
+    variant node-id {
+        /// 地上局 / 運用者。
+        ground,
+        /// 衛星（ID）。
+        satellite(u32),
+    }
+
+    /// transport が **受信側へ届ける** 完全なメッセージ。
+    ///
+    /// `src` / `host-seq` / `deliver-tick` はホストが確定して埋める
+    /// （ゲストは送信時にこれらを指定できない。なりすまし防止と決定論）。
+    record message {
+        /// 送信元。ホストが注入。
+        src: node-id,
+        /// 宛先。
+        dst: node-id,
+        /// 論理型（content-type）。
+        kind: msg-kind,
+        /// ホストが割り当てる決定論的な全順序の anchor。
+        /// 安定ソート・重複排除・ログ突合に使える。
+        host-seq: u64,
+        /// ホストが配送を確定した tick（WS 到着 / ISL 遅延 / config
+        /// 時刻シーケンスを全てここに吸収する）。
+        deliver-tick: u64,
+        /// 本体。
+        payload: payload,
+    }
+
+    /// ゲスト（FSW）が **送信する** メッセージ。最小限。
+    /// `src` / `host-seq` / `deliver-tick` はホストが補完する。
+    record outbound {
+        /// 宛先（地上なら `ground`、別衛星なら `satellite(id)`）。
+        dst: node-id,
+        /// 論理型（content-type）。
+        kind: msg-kind,
+        /// 本体。
+        payload: payload,
+    }
 }
 
 /// ゲストがホストに対して呼び出せるサービス（host import）。
@@ -303,6 +388,33 @@ interface tick-io {
     send-command: func(cmd: command);
 }
 
+/// ノード間メッセージング（運用 C&T + 将来の ISL）の transport 層。
+///
+/// `tick-io` の制御ループとは独立。ゲストは `update` / `run` の tick 内で
+/// `recv-batch` で受信箱を drain し、`send-message` で送信する。
+///
+/// ## 決定論と "frozen inbox"
+///
+/// ホストは tick 境界で「その tick に配るメッセージ集合」を凍結する。
+/// `recv-batch` はその凍結済み列の先頭から最大 `max` 件を pop する。
+/// tick の途中に届いた新着は次 tick の受信箱へ回るため、ゲストが
+/// `recv-batch` をいつ・何回呼んでも観測は不変（A 意味論）。
+/// drain しきらなかった分は次 tick へ持ち越す（backpressure）。
+///
+/// `tick-input` には載せない。物理 snapshot を純粋に保ち、大量受信
+/// （ファイル転送等）でも `max` でゲストがペース制御できるようにするため。
+interface msg-io {
+    use types.{message, outbound};
+
+    /// 現在 tick の凍結受信箱から最大 `max` 件を取り出す。
+    /// 返り値が空なら、この tick の受信箱は空になった。
+    recv-batch: func(max: u32) -> list<message>;
+
+    /// メッセージを送信する。append 意味論（`send-command` の
+    /// last-write-wins とは異なり、1 tick 内の複数送信は全て保持される）。
+    send-message: func(msg: outbound);
+}
+
 /// プラグイン。ゲストがメインループを持ち、ホストは tick-io で駆動する。
 ///
 /// コールバック型（`init` + 毎 tick `update`）のゲストも SDK の
@@ -324,6 +436,7 @@ world plugin {
 
     import host-env;
     import tick-io;
+    import msg-io;
 
     /// メタデータを取得する。config の早期検証を兼ねる。
     /// 不正な config の場合は `Err` を返すこと。

--- a/orts/wit/v0/orts.wit
+++ b/orts/wit/v0/orts.wit
@@ -308,8 +308,11 @@ interface types {
 
     /// transport が **受信側へ届ける** 完全なメッセージ。
     ///
-    /// `src` / `host-seq` / `deliver-tick` はホストが確定して埋める
-    /// （ゲストは送信時にこれらを指定できない。なりすまし防止と決定論）。
+    /// `src` はホストが注入する（ゲストは送信時に指定できない＝なりすまし防止）。
+    ///
+    /// NOTE: 将来、決定論リプレイの全順序 anchor（host 採番 seq）・配送 tick・
+    /// dedup 用の origin id といった host 採番メタを足すことはありうるが、
+    /// それを読む consumer が現れるまでは入れない（YAGNI）。
     record message {
         /// 送信元。ホストが注入。
         src: node-id,
@@ -317,18 +320,12 @@ interface types {
         dst: node-id,
         /// 論理型（content-type）。
         kind: msg-kind,
-        /// ホストが割り当てる決定論的な全順序の anchor。
-        /// 安定ソート・重複排除・ログ突合に使える。
-        host-seq: u64,
-        /// ホストが配送を確定した tick（WS 到着 / ISL 遅延 / config
-        /// 時刻シーケンスを全てここに吸収する）。
-        deliver-tick: u64,
         /// 本体。
         payload: payload,
     }
 
     /// ゲスト（FSW）が **送信する** メッセージ。最小限。
-    /// `src` / `host-seq` / `deliver-tick` はホストが補完する。
+    /// `src` はホストが補完する（`message` になる）。
     record outbound {
         /// 宛先（地上なら `ground`、別衛星なら `satellite(id)`）。
         dst: node-id,
@@ -407,7 +404,7 @@ interface tick-io {
 ///
 /// scope（intra / inter-node）や将来のリンク impairment（欠落・遅延）は、この
 /// channel が「何に配線されているか」の属性であり host が決める。決定論（host が
-/// `deliver-tick` を確定）は **time model** で、impairment とは別の次元。
+/// どの tick で配送を確定するか）は **time model** で、impairment とは別の次元。
 ///
 /// ## 決定論と "frozen inbox"
 ///

--- a/orts/wit/v0/orts.wit
+++ b/orts/wit/v0/orts.wit
@@ -292,8 +292,13 @@ interface types {
         json(string),
     }
 
-    /// ノードアドレス。運用者 C&T = `ground` ↔ `satellite`、
-    /// ISL = `satellite` ↔ `satellite`。
+    /// ノードアドレス（network 層の論理アドレス）。
+    ///
+    /// node = **コンポーネントを内包する単位**（衛星 / 地上局）。機内の
+    /// コンポーネント（アクチュエータ / センサ / 通信機）は node ではない。
+    /// 運用者 C&T = `ground` ↔ `satellite`、ISL = `satellite` ↔ `satellite`。
+    /// inter-node は物理的には通信機(transceiver) ↔ 媒体 ↔ 通信機 だが、`msg-io`
+    /// はそれを隠して node ↔ node に見せる network 抽象。
     variant node-id {
         /// 地上局 / 運用者。
         ground,
@@ -372,6 +377,11 @@ interface host-env {
 ///
 /// ゲストは `wait-tick` で中断し、ホストが次の tick で再開する。
 /// `send-command` でコマンドをホストに送る。
+///
+/// 位置づけ: `tick-io` は **tick 結合の control plane**（FSW → アクチュエータ）。
+/// ここでの `command` は**アクチュエータ制御出力**で、`msg-io` が運ぶ運用
+/// メッセージ (telecommand) とは別物。通信の「形(shape)」ではなく、同期 tick 内の
+/// 型付き制御出力である点に注意。
 interface tick-io {
     use types.{tick-input, command};
 
@@ -388,10 +398,16 @@ interface tick-io {
     send-command: func(cmd: command);
 }
 
-/// ノード間メッセージング（運用 C&T + 将来の ISL）の transport 層。
+/// ノード間メッセージング（運用 C&T + 将来の ISL）。
 ///
-/// `tick-io` の制御ループとは独立。ゲストは `update` / `run` の tick 内で
-/// `recv-batch` で受信箱を drain し、`send-message` で送信する。
+/// datagram shape + `node-id` 論理アドレス + host 確定配送（決定論）から成る
+/// **network / service 抽象**（単なる byte 配送路ではない）。`tick-io`（制御）
+/// とは独立。ゲストは `update` / `run` の tick 内で `recv-batch` で受信箱を
+/// drain し、`send-message` で送信する。
+///
+/// scope（intra / inter-node）や将来のリンク impairment（欠落・遅延）は、この
+/// channel が「何に配線されているか」の属性であり host が決める。決定論（host が
+/// `deliver-tick` を確定）は **time model** で、impairment とは別の次元。
 ///
 /// ## 決定論と "frozen inbox"
 ///

--- a/plugin-sdk/examples/Cargo.lock
+++ b/plugin-sdk/examples/Cargo.lock
@@ -352,6 +352,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "orts-example-plugin-commandable-mode-ff"
+version = "0.0.0"
+dependencies = [
+ "orts-plugin-sdk",
+]
+
+[[package]]
+name = "orts-example-plugin-commandable-mode-rr"
+version = "0.0.0"
+dependencies = [
+ "orts-plugin-sdk",
+]
+
+[[package]]
 name = "orts-example-plugin-constellation-phasing"
 version = "0.0.0"
 dependencies = [

--- a/plugin-sdk/examples/Cargo.toml
+++ b/plugin-sdk/examples/Cargo.toml
@@ -7,6 +7,8 @@ members = [
     "detumble-nadir",
     "pd-rw-unloading",
     "transfer-burn-with-tcm",
+    "commandable-mode-ff",
+    "commandable-mode-rr",
 ]
 # nos3-adcs is excluded from the workspace because its build.rs requires
 # network access (git clone of nasa-itc/generic_adcs). Build it separately:

--- a/plugin-sdk/examples/commandable-mode-ff/Cargo.toml
+++ b/plugin-sdk/examples/commandable-mode-ff/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "orts-example-plugin-commandable-mode-ff"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+orts-plugin-sdk = { workspace = true }
+
+[lib]
+crate-type = ["cdylib"]

--- a/plugin-sdk/examples/commandable-mode-ff/src/lib.rs
+++ b/plugin-sdk/examples/commandable-mode-ff/src/lib.rs
@@ -1,9 +1,14 @@
 //! Commandable mode switching — **fire-and-forget** C&T プロトコル。
 //!
-//! 地上が `orts.cmd.set-mode.v1` を撃ちっぱなしで送り、FSW は受理して
-//! 内部モードを切り替えるだけ（応答は返さない）。確認は、FSW が毎 tick
-//! downlink する `orts.tlm.mode.v1` テレメトリを **地上が観測** して行う
+//! 地上が `orts.cmd.set-mode.v1` を撃ちっぱなしで送り、FSW は受理可能なら
+//! 内部モードを切り替える（応答は返さない）。確認は、FSW が毎 tick downlink
+//! する `orts.tlm.mode.v1` テレメトリを **地上が観測** して行う
 //! （verify-by-telemetry）。
+//!
+//! 受理には運用ガードが入る: `nadir` 指向は機体が整定済み（|ω| < ゲート）の
+//! ときだけ許可。tumbling 中の nadir 指令は **黙って無視** され、地上は
+//! モードテレメトリが変わらないことで失敗を推測する（fire-and-forget なので
+//! reason は返さない）。
 //!
 //! request-response 版 (`commandable-mode-rr`) と同じ `msg-io` transport の
 //! 上に載っており、違いは **アプリ層プロトコルだけ** — こちらは応答を返さず、
@@ -16,13 +21,13 @@ use orts_plugin_sdk::bindings::orts::plugin::types::{Command, TickInput};
 use orts_plugin_sdk::msg::{self, NodeId, Value};
 use orts_plugin_sdk::{Plugin, orts_plugin};
 
-/// この FSW が受理する有効なモード名。
-const VALID_MODES: [&str; 2] = ["detumble", "nadir"];
-
 /// 地上 → FSW: モード切替コマンド。
 const KIND_SET_MODE: &str = "orts.cmd.set-mode.v1";
 /// FSW → 地上: 現在モードのテレメトリ（fire-and-forget の確認手段）。
 const KIND_MODE_TLM: &str = "orts.tlm.mode.v1";
+
+/// nadir 受理に必要な角速度ゲート \[rad/s\]。rr 版と同じ閾値。
+const NADIR_RATE_GATE_RAD_S: f64 = 0.05;
 
 struct Controller {
     sample_period: f64,
@@ -42,14 +47,16 @@ impl Plugin<TickInput, Command> for Controller {
         })
     }
 
-    fn update(&mut self, _input: &TickInput) -> Result<Option<Command>, String> {
+    fn update(&mut self, input: &TickInput) -> Result<Option<Command>, String> {
         // 1) この tick に届いた uplink コマンドを処理する。
-        //    fire-and-forget なので応答は返さない。
+        //    fire-and-forget なので応答は返さない。受理可能なときだけ遷移し、
+        //    失敗（不正モード / tumbling 中の nadir）は黙殺する。
         for m in msg::recv_all() {
             if m.kind == KIND_SET_MODE
                 && let Some(target) = msg::get_text(&m.payload, "mode")
+                && can_enter(target, input)
             {
-                handle_set_mode(&mut self.mode, target);
+                self.mode = target.to_string();
             }
         }
 
@@ -70,17 +77,29 @@ impl Plugin<TickInput, Command> for Controller {
     }
 }
 
-/// set-mode コマンドの処理 — この FSW の business logic。
+/// 目標モードへ遷移してよいか — この FSW の business logic
+/// （fire-and-forget なので bool だけ。reason は返さない）。
 ///
-/// fire-and-forget では応答を返さないので、地上は「テレメトリでモードが
-/// 変わったか」でしか結果を知れない。よって不正なモード名は黙って無視する
-/// （= テレメトリのモードが変わらないことで、地上は失敗を推測する）。
-///
-/// 運用判断の余地: 有効モード集合、遷移可否（例 tumbling 中に nadir 直行を
-/// 許すか）、無視 vs ログ出力。ここではシンプルに「既知モードなら遷移」。
-fn handle_set_mode(current: &mut String, target: &str) {
-    if VALID_MODES.contains(&target) {
-        *current = target.to_string();
+/// - `detumble`: 常に可。
+/// - `nadir`: 機体が整定済み（|ω| < ゲート）のときのみ。tumbling 中は不可。
+/// - 未知モード: 不可。
+fn can_enter(target: &str, input: &TickInput) -> bool {
+    match target {
+        "detumble" => true,
+        "nadir" => settled(input),
+        _ => false,
+    }
+}
+
+/// 角速度が nadir ゲート未満（整定済み）か。ジャイロ読み値が無ければ
+/// レート未確認として保守的に「未整定」とみなす。
+fn settled(input: &TickInput) -> bool {
+    match input.sensors.gyroscopes.first() {
+        Some(g) => {
+            let w2 = g.x * g.x + g.y * g.y + g.z * g.z;
+            w2 < NADIR_RATE_GATE_RAD_S * NADIR_RATE_GATE_RAD_S
+        }
+        None => false,
     }
 }
 

--- a/plugin-sdk/examples/commandable-mode-ff/src/lib.rs
+++ b/plugin-sdk/examples/commandable-mode-ff/src/lib.rs
@@ -1,0 +1,87 @@
+//! Commandable mode switching — **fire-and-forget** C&T プロトコル。
+//!
+//! 地上が `orts.cmd.set-mode.v1` を撃ちっぱなしで送り、FSW は受理して
+//! 内部モードを切り替えるだけ（応答は返さない）。確認は、FSW が毎 tick
+//! downlink する `orts.tlm.mode.v1` テレメトリを **地上が観測** して行う
+//! （verify-by-telemetry）。
+//!
+//! request-response 版 (`commandable-mode-rr`) と同じ `msg-io` transport の
+//! 上に載っており、違いは **アプリ層プロトコルだけ** — こちらは応答を返さず、
+//! correlation も持たない。
+//!
+//! C&T の流れを示すのが主題なので、姿勢制御そのものは no-op（前回値を
+//! ZOH 保持）に留めている。
+
+use orts_plugin_sdk::bindings::orts::plugin::types::{Command, TickInput};
+use orts_plugin_sdk::msg::{self, NodeId, Value};
+use orts_plugin_sdk::{Plugin, orts_plugin};
+
+/// この FSW が受理する有効なモード名。
+const VALID_MODES: [&str; 2] = ["detumble", "nadir"];
+
+/// 地上 → FSW: モード切替コマンド。
+const KIND_SET_MODE: &str = "orts.cmd.set-mode.v1";
+/// FSW → 地上: 現在モードのテレメトリ（fire-and-forget の確認手段）。
+const KIND_MODE_TLM: &str = "orts.tlm.mode.v1";
+
+struct Controller {
+    sample_period: f64,
+    mode: String,
+}
+
+impl Plugin<TickInput, Command> for Controller {
+    fn sample_period(&self) -> f64 {
+        self.sample_period
+    }
+
+    fn init(_config: &str) -> Result<Self, String> {
+        Ok(Self {
+            sample_period: 1.0,
+            // 初期モードは detumble。地上の set-mode で切り替わる。
+            mode: "detumble".to_string(),
+        })
+    }
+
+    fn update(&mut self, _input: &TickInput) -> Result<Option<Command>, String> {
+        // 1) この tick に届いた uplink コマンドを処理する。
+        //    fire-and-forget なので応答は返さない。
+        for m in msg::recv_all() {
+            if m.kind == KIND_SET_MODE
+                && let Some(target) = msg::get_text(&m.payload, "mode")
+            {
+                handle_set_mode(&mut self.mode, target);
+            }
+        }
+
+        // 2) 現在モードを毎 tick downlink する。地上はこのテレメトリが
+        //    目標モードになるまで wait して、コマンドの効果を確認する。
+        msg::send_to(
+            NodeId::Ground,
+            KIND_MODE_TLM,
+            msg::key_value([("mode", Value::Text(self.mode.clone()))]),
+        );
+
+        // 制御出力はこの例の主題ではない（前回値を ZOH 保持）。
+        Ok(None)
+    }
+
+    fn current_mode(&self) -> Option<&str> {
+        Some(&self.mode)
+    }
+}
+
+/// set-mode コマンドの処理 — この FSW の business logic。
+///
+/// fire-and-forget では応答を返さないので、地上は「テレメトリでモードが
+/// 変わったか」でしか結果を知れない。よって不正なモード名は黙って無視する
+/// （= テレメトリのモードが変わらないことで、地上は失敗を推測する）。
+///
+/// 運用判断の余地: 有効モード集合、遷移可否（例 tumbling 中に nadir 直行を
+/// 許すか）、無視 vs ログ出力。ここではシンプルに「既知モードなら遷移」。
+fn handle_set_mode(current: &mut String, target: &str) {
+    if VALID_MODES.contains(&target) {
+        *current = target.to_string();
+    }
+}
+
+orts_plugin!(Controller, mode);

--- a/plugin-sdk/examples/commandable-mode-rr/Cargo.toml
+++ b/plugin-sdk/examples/commandable-mode-rr/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "orts-example-plugin-commandable-mode-rr"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+orts-plugin-sdk = { workspace = true }
+
+[lib]
+crate-type = ["cdylib"]

--- a/plugin-sdk/examples/commandable-mode-rr/src/lib.rs
+++ b/plugin-sdk/examples/commandable-mode-rr/src/lib.rs
@@ -1,0 +1,91 @@
+//! Commandable mode switching — **request-response** C&T プロトコル。
+//!
+//! 地上が `orts.cmd.set-mode.v1` を送る際、payload に `req-id` を入れる。
+//! FSW は受理/拒否を判定し、`orts.ack.set-mode.v1` を **同じ req-id を
+//! echo** して返す。correlation は transport ではなく **アプリ層**（payload
+//! の中身）で持つ — これがレイヤ分離の要点。
+//!
+//! fire-and-forget 版 (`commandable-mode-ff`) と同じ `msg-io` transport の
+//! 上に載っており、違いは「応答を返すか／correlation を持つか」だけ。
+
+use orts_plugin_sdk::bindings::orts::plugin::types::{Command, TickInput};
+use orts_plugin_sdk::msg::{self, NodeId, Payload, Value};
+use orts_plugin_sdk::{Plugin, orts_plugin};
+
+/// この FSW が受理する有効なモード名。
+const VALID_MODES: [&str; 2] = ["detumble", "nadir"];
+
+/// 地上 → FSW: モード切替リクエスト（payload に `req-id`）。
+const KIND_SET_MODE: &str = "orts.cmd.set-mode.v1";
+/// FSW → 地上: リクエストへの応答（同じ `req-id` を echo）。
+const KIND_SET_MODE_ACK: &str = "orts.ack.set-mode.v1";
+
+struct Controller {
+    sample_period: f64,
+    mode: String,
+}
+
+impl Plugin<TickInput, Command> for Controller {
+    fn sample_period(&self) -> f64 {
+        self.sample_period
+    }
+
+    fn init(_config: &str) -> Result<Self, String> {
+        Ok(Self {
+            sample_period: 1.0,
+            mode: "detumble".to_string(),
+        })
+    }
+
+    fn update(&mut self, _input: &TickInput) -> Result<Option<Command>, String> {
+        // この tick に届いたリクエストを処理し、それぞれに応答を返す。
+        for m in msg::recv_all() {
+            if m.kind == KIND_SET_MODE {
+                handle_set_mode(&mut self.mode, &m.payload);
+            }
+        }
+        Ok(None)
+    }
+
+    fn current_mode(&self) -> Option<&str> {
+        Some(&self.mode)
+    }
+}
+
+/// set-mode リクエストを処理し、correlation 付きで応答する
+/// — この FSW の business logic。
+///
+/// request-response では、受理でも拒否でも **必ず ack を返す**。
+/// ack は payload に元リクエストの `req-id` を echo するので、地上は
+/// 「どのコマンドの結果か」を対応付けられる。
+///
+/// 運用判断の余地: 有効モード集合、遷移可否ルール、reject 理由コードの
+/// 詳細度、req-id 欠落時の扱い。ここでは最小形に留めている。
+fn handle_set_mode(current: &mut String, payload: &Payload) {
+    // correlation id。欠落していても動く（その場合は -1 を echo）。
+    let req_id = match msg::get(payload, "req-id") {
+        Some(Value::Integer(id)) => *id,
+        _ => -1,
+    };
+    let target = msg::get_text(payload, "mode").unwrap_or("");
+
+    let (status, applied): (&str, String) = if VALID_MODES.contains(&target) {
+        *current = target.to_string();
+        ("accepted", current.clone())
+    } else {
+        // 拒否: モードは変えず、現在モードを返す。
+        ("rejected", current.clone())
+    };
+
+    msg::send_to(
+        NodeId::Ground,
+        KIND_SET_MODE_ACK,
+        msg::key_value([
+            ("req-id", Value::Integer(req_id)),
+            ("status", Value::Text(status.to_string())),
+            ("mode", Value::Text(applied)),
+        ]),
+    );
+}
+
+orts_plugin!(Controller, mode);

--- a/plugin-sdk/examples/commandable-mode-rr/src/lib.rs
+++ b/plugin-sdk/examples/commandable-mode-rr/src/lib.rs
@@ -5,6 +5,10 @@
 //! echo** して返す。correlation は transport ではなく **アプリ層**（payload
 //! の中身）で持つ — これがレイヤ分離の要点。
 //!
+//! 受理判定には運用ガードを入れている: `nadir` 指向は機体が整定済み
+//! （|ω| < ゲート）のときだけ許可し、tumbling 中は拒否する（detumble を
+//! 先に通させる ADCS 安全インターロック）。reject 時は `reason` を返す。
+//!
 //! fire-and-forget 版 (`commandable-mode-ff`) と同じ `msg-io` transport の
 //! 上に載っており、違いは「応答を返すか／correlation を持つか」だけ。
 
@@ -12,13 +16,14 @@ use orts_plugin_sdk::bindings::orts::plugin::types::{Command, TickInput};
 use orts_plugin_sdk::msg::{self, NodeId, Payload, Value};
 use orts_plugin_sdk::{Plugin, orts_plugin};
 
-/// この FSW が受理する有効なモード名。
-const VALID_MODES: [&str; 2] = ["detumble", "nadir"];
-
 /// 地上 → FSW: モード切替リクエスト（payload に `req-id`）。
 const KIND_SET_MODE: &str = "orts.cmd.set-mode.v1";
 /// FSW → 地上: リクエストへの応答（同じ `req-id` を echo）。
 const KIND_SET_MODE_ACK: &str = "orts.ack.set-mode.v1";
+
+/// nadir 受理に必要な角速度ゲート \[rad/s\]。これを上回る間は tumbling と
+/// みなして nadir 指令を拒否する。実機では機体ごとに config で調整する想定。
+const NADIR_RATE_GATE_RAD_S: f64 = 0.05;
 
 struct Controller {
     sample_period: f64,
@@ -37,11 +42,11 @@ impl Plugin<TickInput, Command> for Controller {
         })
     }
 
-    fn update(&mut self, _input: &TickInput) -> Result<Option<Command>, String> {
+    fn update(&mut self, input: &TickInput) -> Result<Option<Command>, String> {
         // この tick に届いたリクエストを処理し、それぞれに応答を返す。
         for m in msg::recv_all() {
             if m.kind == KIND_SET_MODE {
-                handle_set_mode(&mut self.mode, &m.payload);
+                self.handle_set_mode(&m.payload, input);
             }
         }
         Ok(None)
@@ -52,40 +57,73 @@ impl Plugin<TickInput, Command> for Controller {
     }
 }
 
-/// set-mode リクエストを処理し、correlation 付きで応答する
-/// — この FSW の business logic。
-///
-/// request-response では、受理でも拒否でも **必ず ack を返す**。
-/// ack は payload に元リクエストの `req-id` を echo するので、地上は
-/// 「どのコマンドの結果か」を対応付けられる。
-///
-/// 運用判断の余地: 有効モード集合、遷移可否ルール、reject 理由コードの
-/// 詳細度、req-id 欠落時の扱い。ここでは最小形に留めている。
-fn handle_set_mode(current: &mut String, payload: &Payload) {
-    // correlation id。欠落していても動く（その場合は -1 を echo）。
-    let req_id = match msg::get(payload, "req-id") {
-        Some(Value::Integer(id)) => *id,
-        _ => -1,
-    };
-    let target = msg::get_text(payload, "mode").unwrap_or("");
+impl Controller {
+    /// set-mode リクエストを処理し、correlation 付き ack を返す
+    /// — この FSW の business logic。
+    ///
+    /// request-response では、受理でも拒否でも **必ず ack を返す**。ack は
+    /// 元リクエストの `req-id` を echo するので、地上は「どのコマンドの結果か」
+    /// を対応付けられる。reject 時は `reason` も載せる。
+    fn handle_set_mode(&mut self, payload: &Payload, input: &TickInput) {
+        // correlation id。欠落していても動く（その場合は -1 を echo）。
+        let req_id = match msg::get(payload, "req-id") {
+            Some(Value::Integer(id)) => *id,
+            _ => -1,
+        };
+        let target = msg::get_text(payload, "mode").unwrap_or("");
 
-    let (status, applied): (&str, String) = if VALID_MODES.contains(&target) {
-        *current = target.to_string();
-        ("accepted", current.clone())
-    } else {
-        // 拒否: モードは変えず、現在モードを返す。
-        ("rejected", current.clone())
-    };
+        let (status, reason) = evaluate_transition(target, input);
+        if status == "accepted" {
+            self.mode = target.to_string();
+        }
 
-    msg::send_to(
-        NodeId::Ground,
-        KIND_SET_MODE_ACK,
-        msg::key_value([
-            ("req-id", Value::Integer(req_id)),
-            ("status", Value::Text(status.to_string())),
-            ("mode", Value::Text(applied)),
-        ]),
-    );
+        msg::send_to(
+            NodeId::Ground,
+            KIND_SET_MODE_ACK,
+            msg::key_value([
+                ("req-id", Value::Integer(req_id)),
+                ("status", Value::Text(status.to_string())),
+                ("reason", Value::Text(reason.to_string())),
+                // 受理なら新モード、拒否なら現モード（変更なし）。
+                ("mode", Value::Text(self.mode.clone())),
+            ]),
+        );
+    }
+}
+
+/// 運用ガード本体 — 目標モードへの遷移可否と理由を返す。
+///
+/// - `detumble`: 常に受理。
+/// - `nadir`: 機体が整定済み（|ω| < ゲート）のときのみ受理。tumbling 中は
+///   `"still-tumbling"` で拒否（detumble を先に通させる安全インターロック）。
+/// - 未知モード: `"unknown-mode"` で拒否。
+///
+/// 運用判断の余地: ゲート閾値、ガード対象の遷移、理由コード体系。ここは
+/// あなたのドメイン（ADCS 運用）で調整する想定の差し替え点。
+fn evaluate_transition(target: &str, input: &TickInput) -> (&'static str, &'static str) {
+    match target {
+        "detumble" => ("accepted", ""),
+        "nadir" => {
+            if settled(input) {
+                ("accepted", "")
+            } else {
+                ("rejected", "still-tumbling")
+            }
+        }
+        _ => ("rejected", "unknown-mode"),
+    }
+}
+
+/// 角速度が nadir ゲート未満（整定済み）か。ジャイロ読み値が無ければ
+/// レート未確認として保守的に「未整定」とみなす。
+fn settled(input: &TickInput) -> bool {
+    match input.sensors.gyroscopes.first() {
+        Some(g) => {
+            let w2 = g.x * g.x + g.y * g.y + g.z * g.z;
+            w2 < NADIR_RATE_GATE_RAD_S * NADIR_RATE_GATE_RAD_S
+        }
+        None => false,
+    }
 }
 
 orts_plugin!(Controller, mode);

--- a/plugin-sdk/src/lib.rs
+++ b/plugin-sdk/src/lib.rs
@@ -55,6 +55,7 @@ extern crate alloc;
 
 pub mod bindings;
 pub mod mode;
+pub mod msg;
 
 use alloc::string::String;
 

--- a/plugin-sdk/src/msg.rs
+++ b/plugin-sdk/src/msg.rs
@@ -1,0 +1,103 @@
+//! ノード間メッセージング（運用 C&T + 将来の ISL）のゲスト側ヘルパ。
+//!
+//! WIT `msg-io` interface への薄いラッパ + key-value [`Payload`] の構築/
+//! 読み出しヘルパ。`tick-io` の制御ループ（[`Plugin::update`](crate::Plugin)
+//! / `send-command`）とは独立して、`update` / `run` の tick 内から呼べる。
+//!
+//! ## レイヤリング
+//!
+//! transport（`msg-io`）は dumb pipe で、payload の意味を解釈しない。
+//! fire-and-forget / request-response / ack といった interaction model は
+//! **このアプリ層で組み立てる**（`kind` の規約 + payload の中身）。
+//! 同じ transport の上で両モデルを実装できる:
+//!
+//! - **fire-and-forget**: コマンドを送って応答を期待しない。確認は別途
+//!   流れるテレメトリを観測して行う（`examples/commandable-mode-ff`）。
+//! - **request-response**: payload に correlation id を入れ、応答が echo
+//!   する（`examples/commandable-mode-rr`）。
+//!
+//! どちらも `kind` は名前空間 + version 規約に従う
+//! （例 `"orts.cmd.set-mode.v1"` / `"orts.tlm.mode.v1"`）。
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::bindings::orts::plugin::msg_io;
+pub use crate::bindings::orts::plugin::types::{
+    Message, NamedValue, NodeId, Outbound, Payload, Value,
+};
+
+/// 現在 tick の凍結受信箱から最大 `max` 件取り出す。
+///
+/// 返り値が空なら、この tick の受信箱は空になった。ホストは tick 境界で
+/// 受信箱を凍結するので、いつ・何回呼んでも観測は決定論的。
+pub fn recv_batch(max: u32) -> Vec<Message> {
+    msg_io::recv_batch(max)
+}
+
+/// 現在 tick の受信箱を全部 drain する。
+///
+/// 内部で [`recv_batch`] を空になるまで繰り返す。1 tick に大量受信が
+/// 想定される場合（ファイル転送等）は、代わりに [`recv_batch`] で件数を
+/// 絞ってペース制御すること。
+pub fn recv_all() -> Vec<Message> {
+    let mut all = Vec::new();
+    loop {
+        let batch = msg_io::recv_batch(64);
+        if batch.is_empty() {
+            break;
+        }
+        all.extend(batch);
+    }
+    all
+}
+
+/// メッセージを送信する（append 意味論 — 1 tick 内の複数送信は全て届く）。
+pub fn send(msg: &Outbound) {
+    msg_io::send_message(msg);
+}
+
+/// 宛先 + kind + payload から送信する簡易ヘルパ。
+pub fn send_to(dst: NodeId, kind: impl Into<String>, payload: Payload) {
+    msg_io::send_message(&Outbound {
+        dst,
+        kind: kind.into(),
+        payload,
+    });
+}
+
+/// `(name, value)` のイテレータから key-value [`Payload`] を構築する。
+/// 並び順は保持される（決定論的）。
+pub fn key_value<I, S>(pairs: I) -> Payload
+where
+    I: IntoIterator<Item = (S, Value)>,
+    S: Into<String>,
+{
+    Payload::KeyValue(
+        pairs
+            .into_iter()
+            .map(|(name, value)| NamedValue {
+                name: name.into(),
+                value,
+            })
+            .collect(),
+    )
+}
+
+/// key-value [`Payload`] から名前で値を引く。
+///
+/// `KeyValue` 以外、または該当キーがなければ `None`。
+pub fn get<'a>(payload: &'a Payload, name: &str) -> Option<&'a Value> {
+    match payload {
+        Payload::KeyValue(kvs) => kvs.iter().find(|kv| kv.name == name).map(|kv| &kv.value),
+        _ => None,
+    }
+}
+
+/// key-value [`Payload`] から名前で文字列値を引く近道。
+pub fn get_text<'a>(payload: &'a Payload, name: &str) -> Option<&'a str> {
+    match get(payload, name) {
+        Some(Value::Text(s)) => Some(s),
+        _ => None,
+    }
+}

--- a/plugin-sdk/wit/v0/orts.wit
+++ b/plugin-sdk/wit/v0/orts.wit
@@ -247,6 +247,91 @@ interface types {
         /// 正の有限値でなければならない。
         sample-period-s: f64,
     }
+
+    // ─── ノード間メッセージング (C&T / ISL) ─────────────────────────
+    //
+    // `tick-io` の `command`（FSW→アクチュエータの制御出力）とは別物。
+    // こちらは運用者(地上)↔FSW のコマンド/テレメトリ、および将来の
+    // 衛星間通信(ISL)を運ぶ **transport 層**。dumb pipe であり、
+    // request-response / ack / fire-and-forget / file-transfer といった
+    // interaction model は **アプリ層（payload の中身 + SDK ヘルパ）** に
+    // 押し出す。transport は中身の意味を解釈しない。
+
+    /// メッセージの論理型（content-type / 次プロトコル識別子）。
+    ///
+    /// エンコーディングに依らず常に付く = 「型」。名前空間 + version を
+    /// 必須とする規約: 例 `"orts.cmd.set-mode.v1"`, `"mission.adcs.hk.v2"`。
+    /// 受信側（FSW / 地上）はこの値で payload の解釈プロトコルを選ぶ。
+    type msg-kind = string;
+
+    /// 型付きスカラ値。`payload` の `key-value` 表現で使う。
+    variant value {
+        boolean(bool),
+        integer(s64),
+        number(f64),
+        text(string),
+        bytes(list<u8>),
+    }
+
+    /// 名前付き値（key-value の 1 要素）。
+    record named-value {
+        name: string,
+        value: value,
+    }
+
+    /// メッセージ本体のエンコーディング。ユースケースで選択する。
+    ///
+    /// 同一 `msg-kind` では canonical encoding を 1 つに固定する規約
+    /// （json / key-value / binary を同じ kind で混在させない）。
+    variant payload {
+        /// 構造化（スカラは型付き）。viewer/CLI/test から扱いやすい。
+        key-value(list<named-value>),
+        /// 生バイナリ（CCSDS 等、デコードは受信側 FSW）。
+        binary(list<u8>),
+        /// JSON テキスト。transport は opaque 文字列として扱う。
+        json(string),
+    }
+
+    /// ノードアドレス。運用者 C&T = `ground` ↔ `satellite`、
+    /// ISL = `satellite` ↔ `satellite`。
+    variant node-id {
+        /// 地上局 / 運用者。
+        ground,
+        /// 衛星（ID）。
+        satellite(u32),
+    }
+
+    /// transport が **受信側へ届ける** 完全なメッセージ。
+    ///
+    /// `src` / `host-seq` / `deliver-tick` はホストが確定して埋める
+    /// （ゲストは送信時にこれらを指定できない。なりすまし防止と決定論）。
+    record message {
+        /// 送信元。ホストが注入。
+        src: node-id,
+        /// 宛先。
+        dst: node-id,
+        /// 論理型（content-type）。
+        kind: msg-kind,
+        /// ホストが割り当てる決定論的な全順序の anchor。
+        /// 安定ソート・重複排除・ログ突合に使える。
+        host-seq: u64,
+        /// ホストが配送を確定した tick（WS 到着 / ISL 遅延 / config
+        /// 時刻シーケンスを全てここに吸収する）。
+        deliver-tick: u64,
+        /// 本体。
+        payload: payload,
+    }
+
+    /// ゲスト（FSW）が **送信する** メッセージ。最小限。
+    /// `src` / `host-seq` / `deliver-tick` はホストが補完する。
+    record outbound {
+        /// 宛先（地上なら `ground`、別衛星なら `satellite(id)`）。
+        dst: node-id,
+        /// 論理型（content-type）。
+        kind: msg-kind,
+        /// 本体。
+        payload: payload,
+    }
 }
 
 /// ゲストがホストに対して呼び出せるサービス（host import）。
@@ -303,6 +388,33 @@ interface tick-io {
     send-command: func(cmd: command);
 }
 
+/// ノード間メッセージング（運用 C&T + 将来の ISL）の transport 層。
+///
+/// `tick-io` の制御ループとは独立。ゲストは `update` / `run` の tick 内で
+/// `recv-batch` で受信箱を drain し、`send-message` で送信する。
+///
+/// ## 決定論と "frozen inbox"
+///
+/// ホストは tick 境界で「その tick に配るメッセージ集合」を凍結する。
+/// `recv-batch` はその凍結済み列の先頭から最大 `max` 件を pop する。
+/// tick の途中に届いた新着は次 tick の受信箱へ回るため、ゲストが
+/// `recv-batch` をいつ・何回呼んでも観測は不変（A 意味論）。
+/// drain しきらなかった分は次 tick へ持ち越す（backpressure）。
+///
+/// `tick-input` には載せない。物理 snapshot を純粋に保ち、大量受信
+/// （ファイル転送等）でも `max` でゲストがペース制御できるようにするため。
+interface msg-io {
+    use types.{message, outbound};
+
+    /// 現在 tick の凍結受信箱から最大 `max` 件を取り出す。
+    /// 返り値が空なら、この tick の受信箱は空になった。
+    recv-batch: func(max: u32) -> list<message>;
+
+    /// メッセージを送信する。append 意味論（`send-command` の
+    /// last-write-wins とは異なり、1 tick 内の複数送信は全て保持される）。
+    send-message: func(msg: outbound);
+}
+
 /// プラグイン。ゲストがメインループを持ち、ホストは tick-io で駆動する。
 ///
 /// コールバック型（`init` + 毎 tick `update`）のゲストも SDK の
@@ -324,6 +436,7 @@ world plugin {
 
     import host-env;
     import tick-io;
+    import msg-io;
 
     /// メタデータを取得する。config の早期検証を兼ねる。
     /// 不正な config の場合は `Err` を返すこと。

--- a/plugin-sdk/wit/v0/orts.wit
+++ b/plugin-sdk/wit/v0/orts.wit
@@ -308,8 +308,11 @@ interface types {
 
     /// transport が **受信側へ届ける** 完全なメッセージ。
     ///
-    /// `src` / `host-seq` / `deliver-tick` はホストが確定して埋める
-    /// （ゲストは送信時にこれらを指定できない。なりすまし防止と決定論）。
+    /// `src` はホストが注入する（ゲストは送信時に指定できない＝なりすまし防止）。
+    ///
+    /// NOTE: 将来、決定論リプレイの全順序 anchor（host 採番 seq）・配送 tick・
+    /// dedup 用の origin id といった host 採番メタを足すことはありうるが、
+    /// それを読む consumer が現れるまでは入れない（YAGNI）。
     record message {
         /// 送信元。ホストが注入。
         src: node-id,
@@ -317,18 +320,12 @@ interface types {
         dst: node-id,
         /// 論理型（content-type）。
         kind: msg-kind,
-        /// ホストが割り当てる決定論的な全順序の anchor。
-        /// 安定ソート・重複排除・ログ突合に使える。
-        host-seq: u64,
-        /// ホストが配送を確定した tick（WS 到着 / ISL 遅延 / config
-        /// 時刻シーケンスを全てここに吸収する）。
-        deliver-tick: u64,
         /// 本体。
         payload: payload,
     }
 
     /// ゲスト（FSW）が **送信する** メッセージ。最小限。
-    /// `src` / `host-seq` / `deliver-tick` はホストが補完する。
+    /// `src` はホストが補完する（`message` になる）。
     record outbound {
         /// 宛先（地上なら `ground`、別衛星なら `satellite(id)`）。
         dst: node-id,
@@ -407,7 +404,7 @@ interface tick-io {
 ///
 /// scope（intra / inter-node）や将来のリンク impairment（欠落・遅延）は、この
 /// channel が「何に配線されているか」の属性であり host が決める。決定論（host が
-/// `deliver-tick` を確定）は **time model** で、impairment とは別の次元。
+/// どの tick で配送を確定するか）は **time model** で、impairment とは別の次元。
 ///
 /// ## 決定論と "frozen inbox"
 ///

--- a/plugin-sdk/wit/v0/orts.wit
+++ b/plugin-sdk/wit/v0/orts.wit
@@ -292,8 +292,13 @@ interface types {
         json(string),
     }
 
-    /// ノードアドレス。運用者 C&T = `ground` ↔ `satellite`、
-    /// ISL = `satellite` ↔ `satellite`。
+    /// ノードアドレス（network 層の論理アドレス）。
+    ///
+    /// node = **コンポーネントを内包する単位**（衛星 / 地上局）。機内の
+    /// コンポーネント（アクチュエータ / センサ / 通信機）は node ではない。
+    /// 運用者 C&T = `ground` ↔ `satellite`、ISL = `satellite` ↔ `satellite`。
+    /// inter-node は物理的には通信機(transceiver) ↔ 媒体 ↔ 通信機 だが、`msg-io`
+    /// はそれを隠して node ↔ node に見せる network 抽象。
     variant node-id {
         /// 地上局 / 運用者。
         ground,
@@ -372,6 +377,11 @@ interface host-env {
 ///
 /// ゲストは `wait-tick` で中断し、ホストが次の tick で再開する。
 /// `send-command` でコマンドをホストに送る。
+///
+/// 位置づけ: `tick-io` は **tick 結合の control plane**（FSW → アクチュエータ）。
+/// ここでの `command` は**アクチュエータ制御出力**で、`msg-io` が運ぶ運用
+/// メッセージ (telecommand) とは別物。通信の「形(shape)」ではなく、同期 tick 内の
+/// 型付き制御出力である点に注意。
 interface tick-io {
     use types.{tick-input, command};
 
@@ -388,10 +398,16 @@ interface tick-io {
     send-command: func(cmd: command);
 }
 
-/// ノード間メッセージング（運用 C&T + 将来の ISL）の transport 層。
+/// ノード間メッセージング（運用 C&T + 将来の ISL）。
 ///
-/// `tick-io` の制御ループとは独立。ゲストは `update` / `run` の tick 内で
-/// `recv-batch` で受信箱を drain し、`send-message` で送信する。
+/// datagram shape + `node-id` 論理アドレス + host 確定配送（決定論）から成る
+/// **network / service 抽象**（単なる byte 配送路ではない）。`tick-io`（制御）
+/// とは独立。ゲストは `update` / `run` の tick 内で `recv-batch` で受信箱を
+/// drain し、`send-message` で送信する。
+///
+/// scope（intra / inter-node）や将来のリンク impairment（欠落・遅延）は、この
+/// channel が「何に配線されているか」の属性であり host が決める。決定論（host が
+/// `deliver-tick` を確定）は **time model** で、impairment とは別の次元。
 ///
 /// ## 決定論と "frozen inbox"
 ///


### PR DESCRIPTION
## Summary

FSW (WASM plugin) と地上局/衛星の間でコマンド送信・テレメトリ受信を行うための **`msg-io` ノード間メッセージング層**を追加する。既存の制御ループ (`tick-io`、FSW→アクチュエータ) とは独立した経路で、運用 C&T（コマンド/テレメトリ）と将来の衛星間通信 (ISL) を運ぶ。

設計の核は **dumb transport + アプリ層プロトコル**: transport (`msg-io`) は配送とアドレッシングだけを担う datagram で、fire-and-forget / request-response / ack といった interaction model は payload 規約 + SDK ヘルパ（アプリ層）に置く。これにより同じ WIT 契約の上で複数モデルを実装でき、モデルを差し替えても契約は不変。詳細は `DESIGN.md` の「ノード間メッセージング (msg-io)」節を参照。

## できるようになること

- 地上局→FSW の**型付きコマンド送信**（config `[[command]]` タイムラインで、指定 sim 時刻に決定論的配送）
- FSW→地上局の**テレメトリ/メッセージ送信**（`send-message` → host 回収、downlink ログ）
- FSW 側の**受信**（`recv-batch` で受信箱を drain、未処理は次 tick へ carry-over = backpressure・決定論）
- **型付きペイロード**（`kind` content-type + `key-value` / `binary` / `json`）と**ノードアドレス**（`ground` ↔ `satellite(id)`）
- **fire-and-forget / request-response の両パターン**を同じ WIT 契約の上で実証（example 2 本、detumble→nadir モード遷移ガード付き）
- sync / async 両 WASM backend で動作

## レイヤリング

```
アプリ層 (payload 規約 + SDK ヘルパ): fire-and-forget / request-response / ack / file-transfer
──────────────────────────────────────────────────────────────────
msg-io transport (dumb pipe / datagram): 配送 + アドレス (kind / payload / node-id)
──────────────────────────────────────────────────────────────────
host: どの tick で配送を確定するか (config 時刻 / test-API / 将来 WebSocket)
```

## 主な変更

- **WIT** (`orts/wit/v0/orts.wit`): `interface msg-io`（`recv-batch` / `send-message`）+ 型（`msg-kind` / `value` / `payload` / `node-id` / `message` / `outbound`）。envelope は `message { src, dst, kind, payload }`（`src` は host 注入＝なりすまし防止）。
- **orts core**: host-native `message.rs`、sync/async 両 backend の frozen inbox + outbox（tick 境界で凍結 + carry-over）、`PluginController` trait に `deliver` / `take_outbound` / `set_node_id`（default no-op、WASM backend が override）。
- **plugin-sdk**: guest 向け `msg` モジュール（`recv_batch` / `send` / `key_value` 等）、commandable-mode の ff / rr example 2 本。
- **CLI**: config `[[command]]` タイムライン transport（`CommandSchedule` が tick ごとに due なコマンドを配送、決定論的）。`orts serve` は対話モードのため `[[command]]` を拒否（silent drop 防止）。
- **DESIGN.md**: msg-io 設計節 + 通信の概念モデル（component↔component / port kind = `tick-io`・`msg-io`・将来 `stream-io` / connection 属性 = scope・impairment・time model）。

## レビュー反映（最終状態）

- carry-over inbox / 範囲外整数 reject（Copilot）
- `orts serve` での `[[command]]` 拒否（code-review-gpt）
- 概念モデルを WIT / DESIGN に明文化（smart-friend）
- **`host_seq` / `deliver_tick` を envelope から削除**（最終 Copilot 指摘）: consumer 不在の投機フィールドで実質常に 0 だったため YAGNI で除去し `src` のみ残す。将来 replay / dedup / 全順序 anchor 用に host 採番メタを足しうる旨をコメントとして残置。

## Tests

- 単体: host-native ↔ WIT 変換、`recv-batch` drain 順序 / carry-over、`send-message` append、`CommandSchedule` due 判定、`CommandConfig` パース + payload 変換 + `t` 検証。
- E2E (実 wasm guest): `orts/tests/plugin_msg_commandable_mode.rs` 6 件（ff/rr 両プロトコル + 遷移ゲート）、CLI `[[command]]` タイムライン (`cli/tests/plugin_msg_config_command_e2e.rs`)。
- CI 必須チェック 14 本すべて green、`cargo fmt --check` / `cargo clippy --workspace -- -D warnings` 通過。

## このPRでは入れていない（今後）

- **対話 transport**: WebSocket（viewer 運用コンソール）/ stdin — 同期的 request-response や走行中の対話コマンドはこれ待ち
- **ISL 実配送**: sat↔sat アドレスは振れるが、LOS / 距離 / light-time 遅延 / 欠落の配送モデルは未実装
- **stream-io（バイトストリーム）/ arkedge/kble 統合 / RF 下位レイヤ**: DESIGN に概念のみ
- **リンク impairment**（欠落・遅延・エラー注入）、priority / ttl / QoS
- **replay ツール**（record/replay）、current-mode の out-of-band 取得（`#[allow(dead_code)] // TODO`）
- **命名整理**: `tick-io` の `command`（アクチュエータ出力）→ `actuator-command` リネーム（#77）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
