### PR TITLE
fix(dist): build gnu release binary with cross to lower glibc floor (2.39 → 2.18)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,15 @@
-# mold: sudo apt install mold (or pacman -S mold)
-# wild: cargo install wild-linker
-
+# Local dev fast-linking: clang as the linker driver + mold as the actual
+# linker (mold: sudo apt install mold / pacman -S mold). Purely a build-speed
+# convenience for incremental dev rebuilds.
+#
+# The linker is folded into `rustflags` (via -Clinker) on purpose: it makes
+# the whole thing a single knob. Any build that sets a non-empty global
+# RUSTFLAGS replaces this line entirely and falls back to the default
+# `cc`/gcc linker — no clang, no mold required. The release gnu binary is
+# built exactly that way inside an old-glibc `cross` container that has
+# neither clang nor mold; see Cross.toml and the rust-dist job in
+# .github/workflows/ci.yml.
 [target.x86_64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
-# wild (~2x faster than mold)
-#rustflags = ["-C", "link-args=--ld-path=wild"]
+rustflags = ["-Clinker=clang", "-Clink-arg=-fuse-ld=mold"]
+# wild (~2x faster than mold): cargo install wild-linker, then swap to:
+#rustflags = ["-Clinker=clang", "-Clink-arg=--ld-path=wild"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,14 +1,8 @@
-# Local dev fast-linking: clang as the linker driver + mold as the actual
-# linker (mold: sudo apt install mold / pacman -S mold). Purely a build-speed
-# convenience for incremental dev rebuilds.
-#
-# The linker is folded into `rustflags` (via -Clinker) on purpose: it makes
-# the whole thing a single knob. Any build that sets a non-empty global
-# RUSTFLAGS replaces this line entirely and falls back to the default
-# `cc`/gcc linker — no clang, no mold required. The release gnu binary is
-# built exactly that way inside an old-glibc `cross` container that has
-# neither clang nor mold; see Cross.toml and the rust-dist job in
-# .github/workflows/ci.yml.
+# Local dev fast-linking with mold (sudo apt install mold / pacman -S mold).
+# The linker is folded into `rustflags` (via -Clinker) on purpose: that makes
+# it a single knob — a non-empty global RUSTFLAGS replaces this whole line and
+# falls back to plain cc/gcc. The release gnu `cross` build relies on exactly
+# that (its container has no clang/mold); see Cross.toml.
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-Clinker=clang", "-Clink-arg=-fuse-ld=mold"]
 # wild (~2x faster than mold): cargo install wild-linker, then swap to:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,9 +490,18 @@ jobs:
           docker-images: true
           swap-storage: false
 
-      - name: Install mold linker
+      # The gnu binary is built with `cross` inside the released cross 0.2.5
+      # container (Ubuntu 16.04 / glibc 2.23) so the shipped binary's glibc
+      # floor is a pinned, host-independent value instead of whatever
+      # `ubuntu-latest` happens to ship (which produced GLIBC_2.39 binaries
+      # that failed on every distro older than Ubuntu 24.04). See Cross.toml.
+      # No host mold/clang is needed for this target anymore — linking happens
+      # inside the container with its gcc. musl stays a native static build.
+      - name: Install cross (gnu target)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: sudo apt-get install -y mold
+        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cross
 
       - name: Install musl toolchain
         if: matrix.target == 'x86_64-unknown-linux-musl'
@@ -514,7 +523,12 @@ jobs:
           shared-key: rust-release-${{ matrix.target }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Install cargo-about
+      # Host build (musl) needs cargo-about for the embedded third-party
+      # license notice. The gnu build gets cargo-about inside the cross
+      # container (Cross.toml `pre-build`), so it is not needed on the host
+      # for that target.
+      - name: Install cargo-about (musl host build)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
         uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
           tool: cargo-about
@@ -525,7 +539,23 @@ jobs:
           name: viewer-dist
           path: ./viewer/dist
 
-      - name: Build CLI with embedded viewer (release)
+      - name: Build CLI with embedded viewer (gnu, via cross)
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        env:
+          ORTS_REQUIRE_LICENSE_NOTICE: "1"
+          # .cargo/config.toml enables clang+mold for the gnu triple via a
+          # single `rustflags` line; the cross container has neither. A
+          # non-empty global RUSTFLAGS replaces that line wholesale, dropping
+          # clang+mold and falling back to the container's default cc/gcc
+          # linker. target-cpu=x86-64 is the default baseline — a no-op that
+          # also documents the portable CPU floor. (An empty RUSTFLAGS is
+          # ignored, and neither --config nor CARGO_TARGET_*_RUSTFLAGS override
+          # config-file rustflags.) Forwarded via Cross.toml build.env.passthrough.
+          RUSTFLAGS: "-Ctarget-cpu=x86-64"
+        run: cross build --locked --release -p orts-cli --target ${{ matrix.target }}
+
+      - name: Build CLI with embedded viewer (musl, native static)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
         env:
           ORTS_REQUIRE_LICENSE_NOTICE: "1"
         run: cargo build --locked --release -p orts-cli --target ${{ matrix.target }}
@@ -1154,8 +1184,8 @@ jobs:
           Download the tarball for your platform, verify with the \`.sha256\` sidecar, extract, and run \`./orts\`.
 
           Targets:
-          - \`x86_64-unknown-linux-gnu\` (glibc, dynamically linked)
-          - \`x86_64-unknown-linux-musl\` (musl, fully static)
+          - \`x86_64-unknown-linux-gnu\` (glibc, dynamically linked; built with \`cross\` against an old glibc, so it requires only glibc >= 2.18 — runs on Ubuntu 14.04+, Debian 8+, and any newer distro)
+          - \`x86_64-unknown-linux-musl\` (musl, fully static; runs on any Linux)
           BODY
           # Remove leading whitespace from heredoc indentation
           sed -i 's/^          //' /tmp/release-body.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,7 +501,10 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
-          tool: cross
+          # Pinned: this PR's point is a reproducible, host-independent gnu
+          # build, so the cross CLI version is fixed alongside the pinned
+          # container image in Cross.toml (0.2.5 is the current cross release).
+          tool: cross@0.2.5
 
       - name: Install musl toolchain
         if: matrix.target == 'x86_64-unknown-linux-musl'
@@ -531,7 +534,10 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-musl'
         uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
-          tool: cargo-about
+          # Pinned to match the in-container cargo-about used for the gnu
+          # build (Cross.toml), so both targets embed an identically-generated
+          # license notice. Keep these two versions in sync.
+          tool: cargo-about@0.9.0
 
       - name: Download viewer dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,13 +490,9 @@ jobs:
           docker-images: true
           swap-storage: false
 
-      # The gnu binary is built with `cross` inside the released cross 0.2.5
-      # container (Ubuntu 16.04 / glibc 2.23) so the shipped binary's glibc
-      # floor is a pinned, host-independent value instead of whatever
-      # `ubuntu-latest` happens to ship (which produced GLIBC_2.39 binaries
-      # that failed on every distro older than Ubuntu 24.04). See Cross.toml.
-      # No host mold/clang is needed for this target anymore — linking happens
-      # inside the container with its gcc. musl stays a native static build.
+      # gnu is built via `cross` so its glibc floor is pinned and
+      # host-independent (see Cross.toml); no host mold/clang needed. musl
+      # stays a native static build.
       - name: Install cross (gnu target)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
@@ -549,14 +545,10 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         env:
           ORTS_REQUIRE_LICENSE_NOTICE: "1"
-          # .cargo/config.toml enables clang+mold for the gnu triple via a
-          # single `rustflags` line; the cross container has neither. A
-          # non-empty global RUSTFLAGS replaces that line wholesale, dropping
-          # clang+mold and falling back to the container's default cc/gcc
-          # linker. target-cpu=x86-64 is the default baseline — a no-op that
-          # also documents the portable CPU floor. (An empty RUSTFLAGS is
-          # ignored, and neither --config nor CARGO_TARGET_*_RUSTFLAGS override
-          # config-file rustflags.) Forwarded via Cross.toml build.env.passthrough.
+          # .cargo/config.toml's clang+mold rustflags line can't run in the
+          # container; a non-empty RUSTFLAGS replaces it, falling back to
+          # cc/gcc. Must be non-empty (empty is ignored); target-cpu=x86-64 is
+          # the default baseline no-op. Forwarded via Cross.toml passthrough.
           RUSTFLAGS: "-Ctarget-cpu=x86-64"
         run: cross build --locked --release -p orts-cli --target ${{ matrix.target }}
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,43 +1,23 @@
-# cross configuration for building the release `orts` gnu binary.
-#
-# Why cross: the gnu binary was previously built directly on
-# `ubuntu-latest`, so its glibc floor was whatever that runner happened to
-# ship — at v0.2.0 that meant GLIBC_2.39 (Ubuntu 24.04), which fails to
-# start on Ubuntu 22.04/20.04, Debian 11/12, RHEL 8/9, Amazon Linux 2, etc.
-# Building inside a pinned cross image makes the floor a deliberate,
-# host-independent value.
-#
-# Image: cross 0.2.5 (the latest released cross) ships an Ubuntu 16.04 based
-# gnu image == glibc 2.23 + gcc 5.4. That floor comfortably covers the target
-# environments (>= Ubuntu 20.04 / Debian 11 / RHEL 8) and older. gcc 5.4 is
-# old but the whole dependency graph — including the only C/asm dependency,
-# `ring` — compiles cleanly with it. Pinned to the released tag (not the
-# moving `:main`/`:edge` Ubuntu-20.04 images) so the floor is reproducible.
+# Builds the release gnu binary in a pinned cross image so its glibc floor is
+# reproducible and host-independent (rationale in RELEASING.md). Released cross
+# 0.2.5's image is Ubuntu 16.04 = glibc 2.23 / gcc 5.4; the whole graph (incl.
+# ring) builds, and pinning the released tag — not the moving :edge — keeps the
+# floor stable.
 [target.x86_64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5"
 
-# The release build sets ORTS_REQUIRE_LICENSE_NOTICE=1, which makes
-# cli/build.rs hard-fail unless `cargo about` is available to generate the
-# embedded third-party license notice. cross runs the whole build inside the
-# container, so cargo-about must exist there too. Fetch the prebuilt static
-# musl binary (runs on the image's old glibc) instead of compiling it, and
-# verify it against its published SHA-256 before extracting (download to a
-# file first rather than piping, so a bad download fails loudly).
-#
-# Version pinned to match the host `cargo-about` install in the rust-dist
-# job (.github/workflows/ci.yml). Bump the version and the sha256 together —
-# the value is the `.sha256` sidecar at the same release URL. (Deliberately
-# not a renovate auto-bump target: the hash must change in lockstep.)
+# build.rs needs `cargo about` in the build env (it hard-fails under
+# ORTS_REQUIRE_LICENSE_NOTICE=1) and cross builds in-container, so fetch +
+# SHA-256 verify the prebuilt binary here. Pinned to the host install in
+# ci.yml; bump the version and hash together (hash = the .sha256 sidecar).
 pre-build = [
   "curl -fsSL -o /tmp/cargo-about.tar.gz https://github.com/EmbarkStudios/cargo-about/releases/download/0.9.0/cargo-about-0.9.0-x86_64-unknown-linux-musl.tar.gz && echo '7a1a1bfb3ae3b6feabe9e1d6147a6b34b85bd0339bfd8b0ec11b312dee10d99a  /tmp/cargo-about.tar.gz' | sha256sum -c - && tar -xzf /tmp/cargo-about.tar.gz -C /usr/local/bin --strip-components=1 --wildcards '*/cargo-about' && rm -f /tmp/cargo-about.tar.gz",
 ]
 
-# Forward the build's env into the container. The workspace .cargo/config.toml
-# enables clang+mold for the gnu triple via a single `rustflags` line, neither
-# of which exists in the cross image. The CI step sets a non-empty global
-# RUSTFLAGS, which replaces that line wholesale (an empty value is ignored, and
-# neither --config nor CARGO_TARGET_*_RUSTFLAGS override config-file rustflags)
-# — dropping clang+mold and falling back to the container's default cc/gcc.
+# .cargo/config.toml pins clang+mold for this triple; the container has
+# neither. The CI step's non-empty RUSTFLAGS replaces that rustflags line
+# (falling back to the container's cc/gcc) — forward it in, plus the
+# license-notice flag.
 [build.env]
 passthrough = [
   "ORTS_REQUIRE_LICENSE_NOTICE",

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,39 @@
+# cross configuration for building the release `orts` gnu binary.
+#
+# Why cross: the gnu binary was previously built directly on
+# `ubuntu-latest`, so its glibc floor was whatever that runner happened to
+# ship — at v0.2.0 that meant GLIBC_2.39 (Ubuntu 24.04), which fails to
+# start on Ubuntu 22.04/20.04, Debian 11/12, RHEL 8/9, Amazon Linux 2, etc.
+# Building inside a pinned cross image makes the floor a deliberate,
+# host-independent value.
+#
+# Image: cross 0.2.5 (the latest released cross) ships an Ubuntu 16.04 based
+# gnu image == glibc 2.23 + gcc 5.4. That floor comfortably covers the target
+# environments (>= Ubuntu 20.04 / Debian 11 / RHEL 8) and older. gcc 5.4 is
+# old but the whole dependency graph — including the only C/asm dependency,
+# `ring` — compiles cleanly with it. Pinned to the released tag (not the
+# moving `:main`/`:edge` Ubuntu-20.04 images) so the floor is reproducible.
+[target.x86_64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5"
+
+# The release build sets ORTS_REQUIRE_LICENSE_NOTICE=1, which makes
+# cli/build.rs hard-fail unless `cargo about` is available to generate the
+# embedded third-party license notice. cross runs the whole build inside the
+# container, so cargo-about must exist there too. Fetch the static musl
+# binary (runs on the image's old glibc) instead of compiling it.
+# renovate: datasource=github-releases depName=EmbarkStudios/cargo-about
+pre-build = [
+  "curl -fsSL https://github.com/EmbarkStudios/cargo-about/releases/download/0.9.0/cargo-about-0.9.0-x86_64-unknown-linux-musl.tar.gz | tar -xz -C /usr/local/bin --strip-components=1 --wildcards '*/cargo-about'",
+]
+
+# Forward the build's env into the container. The workspace .cargo/config.toml
+# enables clang+mold for the gnu triple via a single `rustflags` line, neither
+# of which exists in the cross image. The CI step sets a non-empty global
+# RUSTFLAGS, which replaces that line wholesale (an empty value is ignored, and
+# neither --config nor CARGO_TARGET_*_RUSTFLAGS override config-file rustflags)
+# — dropping clang+mold and falling back to the container's default cc/gcc.
+[build.env]
+passthrough = [
+  "ORTS_REQUIRE_LICENSE_NOTICE",
+  "RUSTFLAGS",
+]

--- a/Cross.toml
+++ b/Cross.toml
@@ -19,11 +19,17 @@ image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5"
 # The release build sets ORTS_REQUIRE_LICENSE_NOTICE=1, which makes
 # cli/build.rs hard-fail unless `cargo about` is available to generate the
 # embedded third-party license notice. cross runs the whole build inside the
-# container, so cargo-about must exist there too. Fetch the static musl
-# binary (runs on the image's old glibc) instead of compiling it.
-# renovate: datasource=github-releases depName=EmbarkStudios/cargo-about
+# container, so cargo-about must exist there too. Fetch the prebuilt static
+# musl binary (runs on the image's old glibc) instead of compiling it, and
+# verify it against its published SHA-256 before extracting (download to a
+# file first rather than piping, so a bad download fails loudly).
+#
+# Version pinned to match the host `cargo-about` install in the rust-dist
+# job (.github/workflows/ci.yml). Bump the version and the sha256 together —
+# the value is the `.sha256` sidecar at the same release URL. (Deliberately
+# not a renovate auto-bump target: the hash must change in lockstep.)
 pre-build = [
-  "curl -fsSL https://github.com/EmbarkStudios/cargo-about/releases/download/0.9.0/cargo-about-0.9.0-x86_64-unknown-linux-musl.tar.gz | tar -xz -C /usr/local/bin --strip-components=1 --wildcards '*/cargo-about'",
+  "curl -fsSL -o /tmp/cargo-about.tar.gz https://github.com/EmbarkStudios/cargo-about/releases/download/0.9.0/cargo-about-0.9.0-x86_64-unknown-linux-musl.tar.gz && echo '7a1a1bfb3ae3b6feabe9e1d6147a6b34b85bd0339bfd8b0ec11b312dee10d99a  /tmp/cargo-about.tar.gz' | sha256sum -c - && tar -xzf /tmp/cargo-about.tar.gz -C /usr/local/bin --strip-components=1 --wildcards '*/cargo-about' && rm -f /tmp/cargo-about.tar.gz",
 ]
 
 # Forward the build's env into the container. The workspace .cargo/config.toml

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -116,10 +116,10 @@ gh run watch
    `--release` で CLI binary をビルド (viewer SPA を embed)。
    **gnu は `cross` 経由** ([Cross.toml](Cross.toml)) で released cross 0.2.5 の
    Ubuntu 16.04 (glibc 2.23) イメージ内ビルド → glibc floor を host 非依存に固定
-   (実測 GLIBC_2.18)。コンテナには
-   clang/mold が無いので、CI step で `RUSTFLAGS=-Ctarget-cpu=x86-64`
-   (mold link-arg を落とす) と `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc`
-   を渡し、cargo-about は Cross.toml の `pre-build` でコンテナに入れる。
+   (実測 GLIBC_2.18)。コンテナには clang/mold が無いので、CI step で
+   `RUSTFLAGS=-Ctarget-cpu=x86-64` を渡して config の clang+mold を打ち消し
+   (rustflags 1行が丸ごと置換され、デフォルトの cc/gcc にフォールバック)、
+   cargo-about は Cross.toml の `pre-build` でコンテナに入れる。
    **musl は従来通りホストで native static ビルド**。
 2. **`build-example-plugins` job** — WASM plugin guest を全自動ビルド
 3. **`release` job** (needs: rust-dist, build-example-plugins, crate-package-verify,

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,13 @@ orts のリリース手順メモ。
    - `orts-{target}` (standalone stripped binary)
    - `README.md`, `LICENSE`
 
-   ターゲット: `x86_64-unknown-linux-gnu` (glibc), `x86_64-unknown-linux-musl` (static)
+   ターゲット: `x86_64-unknown-linux-gnu` (glibc, **`cross` の glibc 2.23 イメージ内
+   ビルド → 生成バイナリは glibc >= 2.18 を要求**), `x86_64-unknown-linux-musl`
+   (fully static)。gnu バイナリは以前 `ubuntu-latest` 直ビルドで glibc floor が
+   ランナー任せ (v0.2.0 は GLIBC_2.39 を要求し Ubuntu 24.04 未満で起動不可)
+   だったが、`cross` の released イメージ (Ubuntu 16.04 ベース, glibc 2.23) 内
+   ビルドに変更して floor を host 非依存に固定した (実測 GLIBC_2.18)。
+   詳細は [Cross.toml](Cross.toml)。
 
    draft release なので、人間が確認してから手動で publish する。
    cargo-binstall compatible。
@@ -107,14 +113,22 @@ gh run watch
 通常の CI job (lint, rust-test, viewer-build 等) に加えて:
 
 1. **`rust-dist` job** (matrix: gnu + musl, needs: rust-build, viewer-build) —
-   `--release` で CLI binary をビルド (viewer SPA を embed)
+   `--release` で CLI binary をビルド (viewer SPA を embed)。
+   **gnu は `cross` 経由** ([Cross.toml](Cross.toml)) で released cross 0.2.5 の
+   Ubuntu 16.04 (glibc 2.23) イメージ内ビルド → glibc floor を host 非依存に固定
+   (実測 GLIBC_2.18)。コンテナには
+   clang/mold が無いので、CI step で `RUSTFLAGS=-Ctarget-cpu=x86-64`
+   (mold link-arg を落とす) と `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc`
+   を渡し、cargo-about は Cross.toml の `pre-build` でコンテナに入れる。
+   **musl は従来通りホストで native static ビルド**。
 2. **`build-example-plugins` job** — WASM plugin guest を全自動ビルド
 3. **`release` job** (needs: rust-dist, build-example-plugins, crate-package-verify,
    npm-publish-dry-run, rust-test, rust-test-plugin-wasm, viewer-e2e,
    cli-plugin-backend-e2e) — 全テスト + 全検証が通った場合のみ tarball +
    checksum を作成し `softprops/action-gh-release` で **draft** GitHub Release を作成
 
-ターゲット: `x86_64-unknown-linux-gnu` (glibc) + `x86_64-unknown-linux-musl` (static)。
+ターゲット: `x86_64-unknown-linux-gnu` (glibc >= 2.18, `cross` ビルド) +
+`x86_64-unknown-linux-musl` (fully static)。
 
 ### Release の添付物 (各ターゲットについて)
 
@@ -143,8 +157,16 @@ gh release edit v0.1.0 --draft=false
 
 - **Version mismatch**: tag 名と `Cargo.toml` version が不一致 →
   release job 冒頭の verify step で早期 fail。version bump 忘れ。
-- **cargo-about が無い**: `cli/build.rs` が panic。CI runner 側で
-  `taiki-e/install-action` で install されるはず。
+- **cargo-about が無い**: `cli/build.rs` が panic (`ORTS_REQUIRE_LICENSE_NOTICE=1`
+  のため)。musl(ホストビルド)は `taiki-e/install-action`、gnu(cross)は
+  [Cross.toml](Cross.toml) の `pre-build` で install される。gnu で失敗する場合は
+  pre-build の cargo-about ダウンロード URL/バージョンを確認。
+- **gnu (cross) で `-fuse-ld=mold` / `linker clang not found`**: CI step の
+  `RUSTFLAGS` 上書きがコンテナに伝わっていない (`.cargo/config.toml` の
+  clang+mold が効いてしまっている)。Cross.toml の `build.env.passthrough` に
+  `RUSTFLAGS` があるか確認。local 再現: `CROSS_CONTAINER_ENGINE=podman
+  RUSTFLAGS=-Ctarget-cpu=x86-64 cross build --release -p orts-cli
+  --target x86_64-unknown-linux-gnu`。
 - **viewer build 失敗**: viewer-build job で fail、rust-dist は実行されない。
   local で `pnpm --filter orts-viewer build` を再現。
 - **example plugin build 失敗**: rust-dist job の cargo-component build step

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,13 +15,9 @@ orts のリリース手順メモ。
    - `orts-{target}` (standalone stripped binary)
    - `README.md`, `LICENSE`
 
-   ターゲット: `x86_64-unknown-linux-gnu` (glibc, **`cross` の glibc 2.23 イメージ内
-   ビルド → 生成バイナリは glibc >= 2.18 を要求**), `x86_64-unknown-linux-musl`
-   (fully static)。gnu バイナリは以前 `ubuntu-latest` 直ビルドで glibc floor が
-   ランナー任せ (v0.2.0 は GLIBC_2.39 を要求し Ubuntu 24.04 未満で起動不可)
-   だったが、`cross` の released イメージ (Ubuntu 16.04 ベース, glibc 2.23) 内
-   ビルドに変更して floor を host 非依存に固定した (実測 GLIBC_2.18)。
-   詳細は [Cross.toml](Cross.toml)。
+   ターゲット: `x86_64-unknown-linux-gnu` (glibc; `cross` ビルドで floor を
+   glibc >= 2.18 に pin) + `x86_64-unknown-linux-musl` (fully static)。
+   gnu の floor 固定の仕組みは [Cross.toml](Cross.toml) 参照。
 
    draft release なので、人間が確認してから手動で publish する。
    cargo-binstall compatible。
@@ -113,22 +109,14 @@ gh run watch
 通常の CI job (lint, rust-test, viewer-build 等) に加えて:
 
 1. **`rust-dist` job** (matrix: gnu + musl, needs: rust-build, viewer-build) —
-   `--release` で CLI binary をビルド (viewer SPA を embed)。
-   **gnu は `cross` 経由** ([Cross.toml](Cross.toml)) で released cross 0.2.5 の
-   Ubuntu 16.04 (glibc 2.23) イメージ内ビルド → glibc floor を host 非依存に固定
-   (実測 GLIBC_2.18)。コンテナには clang/mold が無いので、CI step で
-   `RUSTFLAGS=-Ctarget-cpu=x86-64` を渡して config の clang+mold を打ち消し
-   (rustflags 1行が丸ごと置換され、デフォルトの cc/gcc にフォールバック)、
-   cargo-about は Cross.toml の `pre-build` でコンテナに入れる。
-   **musl は従来通りホストで native static ビルド**。
+   `--release` で CLI binary をビルド (viewer SPA を embed)。**gnu は `cross`
+   経由** ([Cross.toml](Cross.toml)) で glibc floor を host 非依存に pin、
+   **musl はホストで native static ビルド**。
 2. **`build-example-plugins` job** — WASM plugin guest を全自動ビルド
 3. **`release` job** (needs: rust-dist, build-example-plugins, crate-package-verify,
    npm-publish-dry-run, rust-test, rust-test-plugin-wasm, viewer-e2e,
    cli-plugin-backend-e2e) — 全テスト + 全検証が通った場合のみ tarball +
    checksum を作成し `softprops/action-gh-release` で **draft** GitHub Release を作成
-
-ターゲット: `x86_64-unknown-linux-gnu` (glibc >= 2.18, `cross` ビルド) +
-`x86_64-unknown-linux-musl` (fully static)。
 
 ### Release の添付物 (各ターゲットについて)
 


### PR DESCRIPTION
## Problem

The prebuilt `x86_64-unknown-linux-gnu` release binary was built directly on `ubuntu-latest`, so its glibc floor was whatever that runner happened to ship. At v0.2.0 the binary required **`GLIBC_2.39`** (Ubuntu 24.04), failing to start on Ubuntu 22.04/20.04, Debian 11/12, RHEL 8/9, Amazon Linux 2, etc. with `version 'GLIBC_2.39' not found`. The floor was an implicit, drifting side effect of the runner.

## Fix

Build the gnu binary inside the **released cross 0.2.5 image** (Ubuntu 16.04 / glibc 2.23) so the floor is a deliberate, host-independent, reproducible value. The produced binary now requires only **`GLIBC_2.18`** — it runs on Ubuntu 14.04+, Debian 8+, and any newer distro. musl stays a native fully-static build.

### What changed
- **`Cross.toml`** (new) — pins the image and installs `cargo-about` in-container via `pre-build` (the release build sets `ORTS_REQUIRE_LICENSE_NOTICE=1`, so `cli/build.rs` requires cargo-about to embed the third-party license notice, and `cross` runs the whole build in the container).
- **`.github/workflows/ci.yml`** — `rust-dist` builds the gnu target via `cross`; drops the host mold install; scopes the host `cargo-about` install to musl; documents the floor in the release notes.
- **`.cargo/config.toml`** — folds the linker into a single `rustflags` line so one non-empty global `RUSTFLAGS` (`-Ctarget-cpu=x86-64`, the default baseline) switches off the clang+mold dev fast-linking inside the container (which has neither). **Local dev keeps clang+mold unchanged** — mold is the default, and only the no-mold case (cross) flips the single knob.
- **`RELEASING.md`** — documents the mechanism + failure handling.

## Validation

Built locally end-to-end with `cross` (via podman, forcing the `:0.2.5` image — equivalent to CI's released cross + Docker by the Cross.toml image pin):

- full release build (`ORTS_REQUIRE_LICENSE_NOTICE=1`) → **exit 0**
- entire graph incl. wasmtime / cranelift / rerun / `ring` (the only C/asm dep) compiles under gcc 5.4
- `cargo-about` runs in-container → **real** license notice embedded (286 license texts, not the stub)
- produced binary glibc floor = **`GLIBC_2.18`**, `orts --help` runs

## Notes

- **CI verification**: `rust-dist` runs on main push (not just tags), so this gets exercised in real CI after merge; `nos3-adcs-e2e` even downloads and runs the cross-built gnu binary. Only the tag-gated `release` job (tarball/sha256/draft) stays unexercised until a release tag. `rust-dist` is skipped on PRs, so it won't appear in this PR's checks.
- **gcc 5.4 escape hatch**: the whole graph builds fine today; if a future C dependency needs a newer toolchain, switch the `Cross.toml` image to the `:edge`/`:main` (Ubuntu 20.04 / gcc 9.4 / glibc 2.31) image (documented in `Cross.toml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
