### PR TITLE
chore(renovate): disable platformAutomerge for repo-default merge messages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>sksat/renovate-config"],
+  "platformAutomerge": false,
   "customManagers": [
     {
       "description": "Match '# renovate: datasource=... depName=...' followed by a VARNAME=value assignment in shell/CI",


### PR DESCRIPTION
## 背景

Renovate の auto-merge 済み依存 PR の merge commit が `chore(deps): … (#NN)` 形式になり、手動マージの `Merge pull request #NN from …`（repo の `merge_commit_title=MERGE_MESSAGE` 既定）と食い違っていた。

原因は **GitHub ネイティブ auto-merge（`platformAutomerge`）**。Renovate は `enablePullRequestAutoMerge` mutation に `commitHeadline`/`commitBody`（= `config.commitMessage` + ` (#NN)`）を渡すため、repo の既定メッセージを上書きしてしまう（[github/index.ts `tryPrAutomerge`](https://github.com/renovatebot/renovate/blob/main/lib/modules/platform/github/index.ts#L1862)）。`automergeCommitMessage` は `config.commitMessage` 直結で、automerge だけ抑止するピンポイント設定は存在しない。

## 変更

トップレベルに `"platformAutomerge": false` を追加。Renovate が自前マージ（`mergePr`, REST `PUT /pulls/{n}/merge`）に切り替わり、`commit_title`/`commit_message` を渡さない → GitHub が repo 既定（classic 形式）を使う → 手動マージと一致する。

## トレードオフ

- マージは GitHub 即時ではなく **Renovate の実行サイクル**で行われる（数十分程度遅れうる）。依存更新 automerge なので実害は小さい。
- 必須チェックの gating は両経路とも維持（`mergePr` も `Required status check is expected` で merge を見送る）。
- `automergeSchedule` が効くようになる副次効果あり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)