### PR TITLE
ci(viewer-e2e): gate on WS streaming readiness instead of port-open (#65)

### DIFF
--- a/.github/scripts/wait-ws-stream.mjs
+++ b/.github/scripts/wait-ws-stream.mjs
@@ -1,0 +1,92 @@
+// Wait until the orts WebSocket server is actually *streaming* simulation data,
+// i.e. a connected client receives a `state` message — not merely that the TCP
+// port is open.
+//
+// The previous CI gate (`nc -z localhost 9001`) passed as soon as the port was
+// bound (`TcpListener::bind`), which happens before `axum::serve` starts and
+// before the simulation manager is spawned/initialized. On connect the server
+// only emits `info`/`state` after a `GetStatus` round-trip to that manager, so
+// a client connecting in the gap receives nothing — the source of the flaky
+// `viewer-e2e` WS tests. See https://github.com/sksat/orts/issues/65.
+//
+// Uses Node's global WebSocket (Node >= 22; repo pins 24.x), so no dependency.
+//
+// Usage: node .github/scripts/wait-ws-stream.mjs [ws-url]
+//   env WS_WAIT_TIMEOUT_MS (default 60000) — overall budget before failing.
+
+const url = process.argv[2] ?? "ws://localhost:9001/ws";
+const parsedTimeout = Number(process.env.WS_WAIT_TIMEOUT_MS ?? 60000);
+// Fall back to the default for a non-numeric / non-positive override, otherwise
+// setTimeout(..., NaN) would fire immediately and the probe would falsely fail.
+const overallTimeoutMs =
+  Number.isFinite(parsedTimeout) && parsedTimeout > 0 ? parsedTimeout : 60000;
+const retryDelayMs = 1000;
+const deadline = Date.now() + overallTimeoutMs;
+
+let attempt = 0;
+let done = false;
+
+function finish(code, msg) {
+  if (done) return;
+  done = true;
+  if (code === 0) console.log(msg);
+  else console.error(msg);
+  process.exit(code);
+}
+
+setTimeout(
+  () =>
+    finish(1, `timed out after ${overallTimeoutMs}ms waiting for a 'state' message from ${url}`),
+  overallTimeoutMs,
+).unref();
+
+function connectOnce() {
+  if (done) return;
+  attempt++;
+  const ws = new WebSocket(url);
+
+  ws.addEventListener("message", (e) => {
+    let msg;
+    try {
+      msg = JSON.parse(e.data);
+    } catch {
+      return; // ignore non-JSON frames
+    }
+    // `state` confirms the simulation manager is initialized and broadcasting,
+    // which is the readiness signal the E2E tests actually depend on.
+    if (msg?.type === "state") {
+      try {
+        ws.close();
+      } catch {}
+      finish(0, `ready: received 'state' from ${url} (attempt ${attempt})`);
+    }
+  });
+
+  // Connection refused / dropped before streaming: server not accepting yet —
+  // retry until the overall deadline. A failed attempt fires `error` then
+  // `close`, so guard with `retried` to schedule at most one retry per attempt;
+  // otherwise overlapping connectOnce() calls would pile up extra sockets.
+  let retried = false;
+  const retry = () => {
+    if (done || retried) return;
+    retried = true;
+    try {
+      ws.close();
+    } catch {}
+    if (Date.now() >= deadline) {
+      finish(1, `timed out waiting for 'state' from ${url}`);
+      return;
+    }
+    setTimeout(connectOnce, retryDelayMs);
+  };
+  ws.addEventListener("error", retry);
+  ws.addEventListener("close", retry);
+}
+
+// Global WebSocket exists on Node >= 22 (repo pins 24.x). Fail with a clear
+// message rather than a bare ReferenceError if ever run on an older runtime.
+if (typeof WebSocket === "undefined") {
+  finish(1, "global WebSocket is unavailable; this probe requires Node >= 22");
+}
+
+connectOnce();

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -908,17 +908,12 @@ jobs:
       - name: Start WebSocket server
         run: ./bin/orts serve --sat altitude=400 --dt 1 --output-interval 10 &
 
-      - name: Wait for WebSocket server
-        run: |
-          for _ in $(seq 1 60); do
-            if nc -z localhost 9001 2>/dev/null; then
-              echo "WebSocket server ready"
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "WebSocket server failed to start"
-          exit 1
+      - name: Wait for WebSocket server to stream
+        # `nc -z` only checks the port is bound (TcpListener::bind), which happens
+        # before the simulation manager is ready to stream. Wait until a client
+        # actually receives a `state` message so tests don't connect too early.
+        # See issue #65.
+        run: node .github/scripts/wait-ws-stream.mjs ws://localhost:9001/ws
 
       - name: Start Vite dev server
         run: VITE_WS_URL=ws://localhost:9001/ws pnpm --filter orts-viewer dev &

--- a/viewer/playwright.config.ts
+++ b/viewer/playwright.config.ts
@@ -5,6 +5,9 @@ const VIEWER_PORT = Number(process.env.VIEWER_PORT ?? 15173);
 export default defineConfig({
   testDir: "./tests",
   timeout: 60000,
+  // Live-server E2E is inherently subject to transient timing; retry on CI so a
+  // single flaky miss doesn't fail the whole job. See issue #65.
+  retries: process.env.CI ? 2 : 0,
   use: {
     baseURL: `http://localhost:${VIEWER_PORT}`,
     headless: true,

--- a/viewer/tests/ws-connect.spec.ts
+++ b/viewer/tests/ws-connect.spec.ts
@@ -92,11 +92,14 @@ test("raw WebSocket connects and receives messages", async ({ page }) => {
         }
       });
 
+      // Give-up cap, aligned with the other WS tests (10/20/30s) rather than a
+      // tight 5s. The test still resolves as soon as messages arrive; CI
+      // readiness is ensured separately by the streaming probe. See issue #65.
       setTimeout(() => {
         events.push(`timeout:readyState=${ws.readyState}`);
         ws.close();
         resolve(events.join(" | "));
-      }, 5000);
+      }, 15000);
     });
   }, wsUrl);
 


### PR DESCRIPTION
Fixes the flaky `viewer-e2e` WS tests investigated in #65.

## 根本原因

CI は `nc -z localhost 9001` で readiness を判定していたが、これは **TCP ポートが bind された時点**（`TcpListener::bind`, `cli/src/commands/serve/mod.rs`）で通る。これは `axum::serve` 開始・`simulation_manager` spawn より**前**。接続時、connection handler は `SimCommand::GetStatus` を manager に送って応答を待ってから `info`/`state` を送る（`cli/src/commands/serve/connection.rs`）ため、manager 初期化前に接続したクライアントは何も受け取れず、WS テスト（特に 5 秒待ちの raw WS テスト）が flake していた。

## 変更（issue #65 の修正案 1〜3）

1. **readiness を「配信開始」で判定**: `.github/scripts/wait-ws-stream.mjs` を追加。実際に WS 接続し **最初の `state` メッセージを受信するまで待つ**（Node global WebSocket、接続不可なら 60s budget まで retry）。`nc -z` ステップを置換。
2. **CI リトライ**: `playwright.config.ts` に `retries: process.env.CI ? 2 : 0`。
3. **raw WS テストの give-up 上限を 5s → 15s** に揃える（他テストは 10/20/30s。実メッセージ受信は元から assert 済みで、固定窓だけ緩める）。

## 検証

- `node --check` / `biome check` クリーン（既存の `noNonNullAssertion` warning は変更箇所外・非失敗）
- プローブをローカル実機でスモークテスト:
  - 成功パス: `orts serve` 起動 → `ready: received 'state' ... (attempt 1)` → exit 0
  - 失敗パス: 無リッスンのポート → retry の後 exit 1（クラッシュなし）

## 補足

issue #65 の修正案 4（サーバ側で readiness ログ `WebSocket endpoint: ...` を初回 `state` 配信まで遅延させ、ローカル/CI 双方の待ちを正しくする）は**侵襲的なので本 PR では見送り**。恒久対策として #65 に残してあります（不要なら #65 はこの PR マージ後にクローズ可）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
