### PR TITLE
ci(release): move the GitHub Release body to a template file

### DIFF
--- a/.github/release-body.md.tmpl
+++ b/.github/release-body.md.tmpl
@@ -1,0 +1,23 @@
+## What's Changed
+
+{{CHANGELOG_EN}}
+
+<details><summary>日本語 / Japanese</summary>
+
+{{CHANGELOG_JA}}
+
+</details>
+
+## Installation (cargo-binstall)
+
+```
+cargo binstall --git https://github.com/sksat/orts orts-cli --version {{VERSION}}
+```
+
+## Manual install
+
+Download the tarball for your platform, verify with the `.sha256` sidecar, extract, and run `./orts`.
+
+Targets:
+- `x86_64-unknown-linux-gnu` (glibc, dynamically linked; built with `cross` against an old glibc, so it requires only glibc >= 2.18 — runs on Ubuntu 14.04+, Debian 8+, and any newer distro)
+- `x86_64-unknown-linux-musl` (musl, fully static; runs on any Linux)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1023,10 +1023,10 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          # Non-cone mode so individual files — including the .github/ release
-          # body template — are checked out by exact path. Leading `/` anchors
-          # each pattern to the repo root (cone mode only takes directories, so
-          # it would not pull the template).
+          # Non-cone mode so individual files are checked out by exact path,
+          # including `.github/release-body.md.tmpl`. Leading `/` anchors each
+          # pattern to the repo root (cone mode only takes directories, so it
+          # would not pull the template).
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             /README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1023,12 +1023,18 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          # Non-cone mode so individual files — including the .github/ release
+          # body template — are checked out by exact path. Leading `/` anchors
+          # each pattern to the repo root (cone mode only takes directories, so
+          # it would not pull the template).
+          sparse-checkout-cone-mode: false
           sparse-checkout: |
-            README.md
-            LICENSE
-            Cargo.toml
-            CHANGELOG.md
-            CHANGELOG.ja.md
+            /README.md
+            /LICENSE
+            /Cargo.toml
+            /CHANGELOG.md
+            /CHANGELOG.ja.md
+            /.github/release-body.md.tmpl
 
       - name: Extract version from tag
         id: version
@@ -1163,10 +1169,11 @@ jobs:
           cp .github/release-body.md.tmpl /tmp/release-body.md
           sed -i "s/{{VERSION}}/${VERSION}/g" /tmp/release-body.md
           # Inject the extracted changelogs verbatim in place of the
-          # placeholder lines (sed `r` copies the file as-is, so its markdown
-          # and backticks are not re-interpreted).
-          sed -i -e '/{{CHANGELOG_EN}}/{r /tmp/changelog-en.txt' -e 'd}' /tmp/release-body.md
-          sed -i -e '/{{CHANGELOG_JA}}/{r /tmp/changelog-ja.txt' -e 'd}' /tmp/release-body.md
+          # placeholder lines: for the matched line, `r` queues the file
+          # (copied as-is, so its markdown/backticks are not re-interpreted)
+          # and `d` drops the placeholder.
+          sed -i -e '/{{CHANGELOG_EN}}/{' -e 'r /tmp/changelog-en.txt' -e 'd' -e '}' /tmp/release-body.md
+          sed -i -e '/{{CHANGELOG_JA}}/{' -e 'r /tmp/changelog-ja.txt' -e 'd' -e '}' /tmp/release-body.md
 
       - name: Create draft GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1160,33 +1160,13 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
-          cat > /tmp/release-body.md <<BODY
-          ## What's Changed
-
-          $(cat /tmp/changelog-en.txt)
-
-          <details><summary>日本語 / Japanese</summary>
-
-          $(cat /tmp/changelog-ja.txt)
-
-          </details>
-
-          ## Installation (cargo-binstall)
-
-          \`\`\`
-          cargo binstall --git https://github.com/sksat/orts orts-cli --version ${VERSION}
-          \`\`\`
-
-          ## Manual install
-
-          Download the tarball for your platform, verify with the \`.sha256\` sidecar, extract, and run \`./orts\`.
-
-          Targets:
-          - \`x86_64-unknown-linux-gnu\` (glibc, dynamically linked; built with \`cross\` against an old glibc, so it requires only glibc >= 2.18 — runs on Ubuntu 14.04+, Debian 8+, and any newer distro)
-          - \`x86_64-unknown-linux-musl\` (musl, fully static; runs on any Linux)
-          BODY
-          # Remove leading whitespace from heredoc indentation
-          sed -i 's/^          //' /tmp/release-body.md
+          cp .github/release-body.md.tmpl /tmp/release-body.md
+          sed -i "s/{{VERSION}}/${VERSION}/g" /tmp/release-body.md
+          # Inject the extracted changelogs verbatim in place of the
+          # placeholder lines (sed `r` copies the file as-is, so its markdown
+          # and backticks are not re-interpreted).
+          sed -i -e '/{{CHANGELOG_EN}}/{r /tmp/changelog-en.txt' -e 'd}' /tmp/release-body.md
+          sed -i -e '/{{CHANGELOG_JA}}/{r /tmp/changelog-ja.txt' -e 'd}' /tmp/release-body.md
 
       - name: Create draft GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0


### PR DESCRIPTION
## What

Move the GitHub Release body out of the `release` job's inline heredoc into a dedicated template file, `.github/release-body.md.tmpl`.

Follow-up to the cross/glibc-floor work in #60 (suggested there but deliberately deferred to a separate PR).

## Why

The body was a heredoc embedded in `ci.yml`, which forced:
- backtick-escaping everywhere (`` \`\`\` ``, `` \`.sha256\` ``, …),
- a `sed 's/^          //'` hack to strip the YAML/heredoc indentation.

A real `.md` file has literal backticks and no indentation games, and the body is now editable/reviewable as markdown instead of buried in shell.

## How

- `.github/release-body.md.tmpl` holds the static content with placeholders: `{{VERSION}}`, `{{CHANGELOG_EN}}`, `{{CHANGELOG_JA}}`.
- The `Build release body` step assembles it: `sed` substitutes `{{VERSION}}`, and `sed`'s `r` command injects the extracted changelogs **verbatim** at the placeholder lines (so changelog markdown/backticks are not re-interpreted).

## Validation

The `release` job only runs on a `v*` tag, so neither PR nor main CI exercises this path. Validated **locally** instead: ran both the new template assembly and the old heredoc against the same sample `VERSION` + changelog inputs — the output is **byte-identical** (`diff` empty), and no `{{…}}` placeholders remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
