### PR TITLE
feat(serve): log "Streaming started" once initial state is broadcast

### DIFF
--- a/cli/src/commands/serve/manager.rs
+++ b/cli/src/commands/serve/manager.rs
@@ -817,11 +817,12 @@ impl SimLoopContext {
             let _ = tx.send(msg);
         }
 
-        // Honest readiness signal: the simulation has emitted its initial
-        // state(s), so clients connecting now will receive data. Logged only
-        // when at least one satellite state was actually broadcast — never in
-        // idle serve mode, nor for an empty start awaiting AddSatellite.
-        let satellite_count = group.len();
+        // Readiness signal: the simulation has computed its initial state(s)
+        // and the step loop is about to stream updates. (Clients that connect
+        // later receive initial data via GetStatus / history replay, not this
+        // startup broadcast.) Logged only when >=1 satellite state exists —
+        // never in idle serve mode, nor for an empty start awaiting AddSatellite.
+        let satellite_count = metas.len();
         if satellite_count > 0 {
             eprintln!("Streaming started: {satellite_count} satellite(s)");
         }

--- a/cli/src/commands/serve/manager.rs
+++ b/cli/src/commands/serve/manager.rs
@@ -817,6 +817,11 @@ impl SimLoopContext {
             let _ = tx.send(msg);
         }
 
+        // Honest readiness signal: the simulation has emitted its initial
+        // state(s), so clients connecting now will receive data. Only logged
+        // when a simulation actually starts (never in idle serve mode).
+        eprintln!("Streaming started: {} satellite(s)", group.len());
+
         Ok(SimLoopContext {
             params,
             group,

--- a/cli/src/commands/serve/manager.rs
+++ b/cli/src/commands/serve/manager.rs
@@ -818,9 +818,13 @@ impl SimLoopContext {
         }
 
         // Honest readiness signal: the simulation has emitted its initial
-        // state(s), so clients connecting now will receive data. Only logged
-        // when a simulation actually starts (never in idle serve mode).
-        eprintln!("Streaming started: {} satellite(s)", group.len());
+        // state(s), so clients connecting now will receive data. Logged only
+        // when at least one satellite state was actually broadcast — never in
+        // idle serve mode, nor for an empty start awaiting AddSatellite.
+        let satellite_count = group.len();
+        if satellite_count > 0 {
+            eprintln!("Streaming started: {satellite_count} satellite(s)");
+        }
 
         Ok(SimLoopContext {
             params,


### PR DESCRIPTION
#65 の残っていたサーバ側項目（item 4: readiness ログを honest に）を、idle を壊さない形で実装。

## 変更
`orts serve` の simulation manager が**初期 `state` を broadcast した直後**に1行ログ:
```
Streaming started: N satellite(s)
```
[serve/manager.rs](cli/src/commands/serve/manager.rs) の初期 state 送出直後（`SimLoopContext` セットアップ内）。

## 設計（ダウンサイドなし）
- **sim が実際に起動した時だけ**出力（auto-start でも start コマンドでも）。**idle `orts serve` では出ない**（state が無いので正しい）。
- **純粋な追加**: 既存の `WebSocket endpoint: ws://…` 行は据え置き。idle モードでの告知・ポート探索（[ws-connect.spec.ts:33](viewer/tests/ws-connect.spec.ts#L33) がこの行をパース）はそのまま維持。
- 既存行の削除・遅延・抑止は一切なし。

## #65 item 4 との関係
当初の item 4 は「endpoint 行を初回 state まで遅延」だったが、**idle では state が来ない＝endpoint 行が永遠に出ない**ため不可。代わりに「streaming 開始」を**別シグナルとして追加**する形に refine した。viewer-e2e の WS flake 自体は #66 の CI streaming probe で解決済みなので、本 PR は honest なログの追加（診断性向上）が主目的。

## 検証
- `cargo fmt --all --check` OK
- `cargo clippy -p orts-cli -- -D warnings` OK（警告ゼロ）

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

