### PR TITLE
ci: pin & verify wasm-pack via install-wasm-pack composite action

### DIFF
--- a/.github/actions/install-wasm-pack/action.yml
+++ b/.github/actions/install-wasm-pack/action.yml
@@ -1,0 +1,24 @@
+name: Install wasm-pack
+description: >-
+  Install a pinned, checksum-verified wasm-pack into $CARGO_HOME/bin. Replaces
+  the unpinned `curl … init.sh | sh` (which fetches whatever version that
+  script bakes in). Bump WP_VERSION and WP_SHA256 together — the release has no
+  .sha256 sidecar, so compute the hash from the asset when bumping.
+
+runs:
+  using: composite
+  steps:
+    - name: Download, verify, and install wasm-pack
+      shell: bash
+      run: |
+        set -euo pipefail
+        WP_VERSION=0.13.1
+        WP_SHA256=c539d91ccab2591a7e975bcf82c82e1911b03335c80aa83d67ad25ed2ad06539
+        url="https://github.com/wasm-bindgen/wasm-pack/releases/download/v${WP_VERSION}/wasm-pack-v${WP_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+        curl -fsSL -o /tmp/wasm-pack.tar.gz "$url"
+        echo "${WP_SHA256}  /tmp/wasm-pack.tar.gz" | sha256sum -c -
+        dest="${CARGO_HOME:-$HOME/.cargo}/bin"
+        mkdir -p "$dest"
+        tar -xzf /tmp/wasm-pack.tar.gz --strip-components=1 -C "$dest" --wildcards '*/wasm-pack'
+        rm -f /tmp/wasm-pack.tar.gz
+        wasm-pack --version

--- a/.github/actions/install-wasm-pack/action.yml
+++ b/.github/actions/install-wasm-pack/action.yml
@@ -1,9 +1,10 @@
 name: Install wasm-pack
 description: >-
-  Install a pinned, checksum-verified wasm-pack into $CARGO_HOME/bin. Replaces
-  the unpinned `curl … init.sh | sh` (which fetches whatever version that
-  script bakes in). Bump WP_VERSION and WP_SHA256 together — the release has no
-  .sha256 sidecar, so compute the hash from the asset when bumping.
+  Install a pinned, checksum-verified wasm-pack into $CARGO_HOME/bin, replacing
+  the unpinned `curl … init.sh | sh`. Renovate tracks WP_VERSION via the inline
+  annotation and opens bump PRs; WP_SHA256 must be updated in lockstep on a bump
+  (wasm-pack publishes no checksum, so compute it from the asset, e.g.
+  `curl -fsSL "$url" | sha256sum`).
 
 runs:
   using: composite
@@ -12,6 +13,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        # renovate: datasource=github-releases depName=wasm-bindgen/wasm-pack extractVersion=^v(?<version>.+)$
         WP_VERSION=0.13.1
         WP_SHA256=c539d91ccab2591a7e975bcf82c82e1911b03335c80aa83d67ad25ed2ad06539
         url="https://github.com/wasm-bindgen/wasm-pack/releases/download/v${WP_VERSION}/wasm-pack-v${WP_VERSION}-x86_64-unknown-linux-musl.tar.gz"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -720,7 +720,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        uses: ./.github/actions/install-wasm-pack
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -777,7 +777,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        uses: ./.github/actions/install-wasm-pack
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -876,7 +876,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        uses: ./.github/actions/install-wasm-pack
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
           shared-key: deploy-site
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        uses: ./.github/actions/install-wasm-pack
 
       - name: Build site
         run: pnpm build:site

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     {
       "description": "Match '# renovate: datasource=... depName=...' followed by a VARNAME=value assignment in shell/CI",
       "customType": "regex",
-      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$", "\\.sh$"],
+      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$", "^\\.github/actions/.*\\.ya?ml$", "\\.sh$"],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+extractVersion=(?<extractVersion>\\S+))?(?:\\s+versioning=(?<versioning>\\S+))?\\s*\\n\\s*\\w+=(?<currentValue>\\S+)"
       ]


### PR DESCRIPTION
## What

Add a reusable `.github/actions/install-wasm-pack` composite action that installs a **pinned, checksum-verified** wasm-pack, and use it in the four places that currently run the unpinned `curl … init.sh | sh` (viewer-build, viewer-e2e, tobari-example-web, deploy).

Split out from #72 so this self-contained change (new action + the wasm-pack pin) can land first; the trivial `cargo-component` pin will follow in its own PR.

## Why

- The `rustwasm` `init.sh` installs whatever version it bakes in — currently **0.13.1**, *not* the latest. That's effectively unpinned (the remote script controls the version) and unverified.
- Pinned here to **0.13.1**, the version CI already uses, so this is a **pure pin, not a bump** (latest is 0.15.0).
- `taiki-e/install-action` could not be used: its pinned version still points wasm-pack at the moved `drager/wasm-pack` repo, whose v0.13.1 asset 404s (the repo is now `wasm-bindgen/wasm-pack`). So the action does a direct, SHA-256-verified download from `wasm-bindgen/wasm-pack`.
- Version + hash live in one place (the action), so future bumps touch a single file.

## Validation

The download + sha256 verification + extraction was validated locally (wasm-pack 0.13.1 binary runs). On PRs, `viewer-build` / `viewer-e2e` / `tobari-example-web` install wasm-pack via this action, so green PR CI confirms it resolves and builds. (`deploy.yml` runs on push to main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
