### PR TITLE
ci: pin cargo-component@0.21.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,7 @@ jobs:
       - name: Install cargo-component
         uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
-          tool: cargo-component
+          tool: cargo-component@0.21.1
 
       - name: Build guest WASM components
         run: |
@@ -365,7 +365,7 @@ jobs:
       - name: Install cargo-component
         uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
-          tool: cargo-component
+          tool: cargo-component@0.21.1
 
       - name: Install wasi-sysroot
         run: |
@@ -437,7 +437,7 @@ jobs:
       - name: Install cargo-component
         uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
-          tool: cargo-component
+          tool: cargo-component@0.21.1
 
       - name: Build guest WASM components
         run: |
@@ -633,7 +633,7 @@ jobs:
       - name: Install cargo-component
         uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
-          tool: cargo-component
+          tool: cargo-component@0.21.1
 
       - name: Build example WASM plugins
         run: |


### PR DESCRIPTION
## What

Pin the `cargo-component` taiki-e install to `@0.21.1` (×4 in ci.yml). This is the last unpinned CI tool install — `cross`/`cargo-about` were pinned in #60, `wasm-pack` in #72.

## Why this version

`0.21.1` is what taiki-e currently resolves to (latest), confirmed from a recent CI run's log — so this is a **pure pin, not a bump**, freezing the status quo for reproducibility.

Kept as a plain manual pin, consistent with the existing `cross@0.2.5` / `cargo-about@0.9.0` pins. (Renovate-managing the taiki-e `tool:` pins — cross/cargo-about/cargo-component — uniformly via a customManager could be a follow-up if desired; wasm-pack is already Renovate-tracked via #72 because it's a direct download.)

## Validation

`cargo-component` is installed by `rust-test-plugin-wasm` and `cli-plugin-backend-e2e`, which run on PRs, so green PR CI confirms `@0.21.1` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)