### PR TITLE
fix(uneri): retry DuckDB-wasm init to absorb transient CDN failures

### DIFF
--- a/uneri/src/db/duckdb.ts
+++ b/uneri/src/db/duckdb.ts
@@ -3,7 +3,11 @@ import * as duckdb from "@duckdb/duckdb-wasm";
 let dbPromise: Promise<duckdb.AsyncDuckDB> | null = null;
 
 const MAX_ATTEMPTS = 3;
-const INIT_TIMEOUT_MS = 15000;
+// Generous backstop for a silently-dead/hung worker — kept long so it does NOT
+// abort a slow-but-healthy first load (large wasm fetch + compile on a slow
+// network/device). The worker `error` listener below fast-fails the common
+// CDN-unreachable case well before this fires.
+const INIT_TIMEOUT_MS = 45000;
 
 /**
  * One DuckDB-wasm instantiation attempt using the jsDelivr CDN bundles.
@@ -34,7 +38,14 @@ async function instantiateOnce(): Promise<duckdb.AsyncDuckDB> {
       };
       worker.addEventListener(
         "error",
-        () => settle(() => reject(new Error("DuckDB worker failed to load (CDN unreachable?)"))),
+        (ev: ErrorEvent) =>
+          settle(() =>
+            reject(
+              new Error(
+                `DuckDB worker failed to load (CDN unreachable?): ${ev.message || "unknown error"}`,
+              ),
+            ),
+          ),
         { once: true },
       );
       db.instantiate(bundle.mainModule, bundle.pthreadWorker).then(
@@ -72,7 +83,7 @@ export function initDuckDB(): Promise<duckdb.AsyncDuckDB> {
         }
       }
     }
-    throw lastError;
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
   })();
 
   // If every attempt failed, drop the cached rejected promise so a later

--- a/uneri/src/db/duckdb.ts
+++ b/uneri/src/db/duckdb.ts
@@ -2,30 +2,77 @@ import * as duckdb from "@duckdb/duckdb-wasm";
 
 let dbPromise: Promise<duckdb.AsyncDuckDB> | null = null;
 
+const MAX_ATTEMPTS = 3;
+const INIT_TIMEOUT_MS = 15000;
+
 /**
- * Initialize DuckDB-wasm (singleton). Uses jsDelivr CDN for WASM bundles.
+ * One DuckDB-wasm instantiation attempt using the jsDelivr CDN bundles.
+ *
+ * Rejects (rather than hanging) when the CDN worker/wasm can't be fetched: a
+ * failed `importScripts` kills the worker, after which `instantiate()` would
+ * otherwise wait forever for a dead worker to reply. A worker `error` event or
+ * an overall timeout both abort the attempt so the caller can retry.
+ */
+async function instantiateOnce(): Promise<duckdb.AsyncDuckDB> {
+  const bundle = await duckdb.selectBundle(duckdb.getJsDelivrBundles());
+
+  const workerUrl = URL.createObjectURL(
+    new Blob([`importScripts("${bundle.mainWorker!}");`], { type: "text/javascript" }),
+  );
+  const worker = new Worker(workerUrl);
+  const db = new duckdb.AsyncDuckDB(new duckdb.VoidLogger(), worker);
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`DuckDB init timed out after ${INIT_TIMEOUT_MS}ms`)),
+        INIT_TIMEOUT_MS,
+      );
+      const settle = (fn: () => void) => {
+        clearTimeout(timer);
+        fn();
+      };
+      worker.addEventListener(
+        "error",
+        () => settle(() => reject(new Error("DuckDB worker failed to load (CDN unreachable?)"))),
+        { once: true },
+      );
+      db.instantiate(bundle.mainModule, bundle.pthreadWorker).then(
+        () => settle(resolve),
+        (err) => settle(() => reject(err)),
+      );
+    });
+    return db;
+  } catch (e) {
+    worker.terminate();
+    throw e;
+  } finally {
+    URL.revokeObjectURL(workerUrl);
+  }
+}
+
+/**
+ * Initialize DuckDB-wasm (singleton), loading the worker/wasm from the jsDelivr
+ * CDN. Retries a few times so a transient CDN hiccup doesn't fail the whole
+ * session — a recurring source of viewer E2E flakiness (see #70).
  * Safe to call multiple times — returns the same promise.
  */
 export function initDuckDB(): Promise<duckdb.AsyncDuckDB> {
   if (dbPromise) return dbPromise;
 
   dbPromise = (async () => {
-    const JSDELIVR_BUNDLES = duckdb.getJsDelivrBundles();
-    const bundle = await duckdb.selectBundle(JSDELIVR_BUNDLES);
-
-    const workerUrl = URL.createObjectURL(
-      new Blob([`importScripts("${bundle.mainWorker!}");`], {
-        type: "text/javascript",
-      }),
-    );
-
-    const worker = new Worker(workerUrl);
-    const logger = new duckdb.VoidLogger();
-    const db = new duckdb.AsyncDuckDB(logger, worker);
-    await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
-
-    URL.revokeObjectURL(workerUrl);
-    return db;
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        return await instantiateOnce();
+      } catch (e) {
+        lastError = e;
+        if (attempt < MAX_ATTEMPTS) {
+          await new Promise((r) => setTimeout(r, attempt * 500));
+        }
+      }
+    }
+    throw lastError;
   })();
 
   return dbPromise;

--- a/uneri/src/db/duckdb.ts
+++ b/uneri/src/db/duckdb.ts
@@ -75,5 +75,12 @@ export function initDuckDB(): Promise<duckdb.AsyncDuckDB> {
     throw lastError;
   })();
 
+  // If every attempt failed, drop the cached rejected promise so a later
+  // call (e.g. after the user reconnects) retries from scratch instead of
+  // replaying the same rejection for the rest of the session.
+  dbPromise.catch(() => {
+    dbPromise = null;
+  });
+
   return dbPromise;
 }


### PR DESCRIPTION
## 背景（CI diagnostic で確定した真因）
viewer-e2e の `multi-satellite-nan` flake の正体は、**DuckDB-wasm が worker/wasm を jsDelivr CDN から実行時 fetch**していること（`getJsDelivrBundles()`）。CI が `cdn.jsdelivr.net` に届かない窓で worker init が失敗 → chart data が populate せず 30s timeout、という外部 CDN 到達性依存の flake。

CI で `--repeat-each 20` 計測して `net::ERR_ABORTED https://cdn.jsdelivr.net/.../duckdb-browser-eh.worker.js` を捕捉し確定（[#70 の調査コメント](https://github.com/sksat/orts/issues/70)）。local では jsDelivr に届くため非再現だった。

## 変更
`uneri/src/db/duckdb.ts` の `initDuckDB` を **3回リトライ + 短い backoff** に。CDN worker のロード失敗は worker が死んで `instantiate()` が**ハング**するので、各試行を **worker `error` イベント or 15s timeout** で打ち切ってから再試行する。

- **CDN は維持**（本番配信は変更なし。オフライン完結は別目的なので対象外）。
- transient な CDN blip を吸収し、#66 の Playwright `retries:2` と多層で flake を緩和。
- **plain TS なので lib build を壊さない**（`?url` ローカル同梱案は uneri の lib build が wasm を ~100MB inline 化して破綻したため不採用）。

## 検証
- `biome check` / `uneri build` OK（dist 通常サイズ ~338KB、100MB化なし）。
- ローカルで `multi-satellite-nan` happy path pass（~10s）。
- CDN 不達は local 再現困難なため、CI は #66 retries + 本リトライの多層で担保。

Refs #70
