### PR TITLE
chore: add DeepWiki MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "deepwiki": {
+      "type": "http",
+      "url": "https://mcp.deepwiki.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## What

Add `.mcp.json` registering the **DeepWiki MCP server** so that anyone working on orts can query the repo's auto-generated wiki ([deepwiki.com/sksat/orts](https://deepwiki.com/sksat/orts)) directly from Claude Code.

```json
{
  "mcpServers": {
    "deepwiki": {
      "type": "http",
      "url": "https://mcp.deepwiki.com/mcp"
    }
  }
}
```

## Why

The repo already advertises DeepWiki via the README badge (`[![Ask DeepWiki]...]`). Wiring up the MCP server makes that queryable from the agent, not just the web UI. Project-scoped `.mcp.json` so it's shared with contributors.

## Notes

- **Transport**: Streamable HTTP (`type: "http"`, the current MCP spec recommendation). SSE (`/sse`) remains a fallback if a client/proxy can't speak Streamable HTTP.
- **No auth** — DeepWiki MCP works on public repos only.
- Tools exposed: `read_wiki_structure` / `read_wiki_contents` / `ask_question`, with the repo passed as `repoName="sksat/orts"`.
- First connection prompts to trust the project's MCP server (standard Claude Code safety gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)