### PR TITLE
perf(viewer): fix texture-loading stalls (bounded retry, server-gated, off-thread decode)

### DIFF
--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -289,13 +289,18 @@ export function App() {
 
   // --- Derived values ---
   const textureBaseUrl = useMemo(() => {
+    // High-res textures are served by a connected orts server, which downloads
+    // and resizes them on demand. Without a live server — file replay, or no
+    // connection — stay on the bundled 2K base rather than fetching resolutions
+    // that may not exist (which otherwise stalls on big decodes / 404 retries).
+    if (!wsSource.isConnected) return undefined;
     try {
       const u = new URL(wsUrl.replace(/^ws/, "http"));
       return `${u.origin}/textures/`;
     } catch {
-      return `${import.meta.env.BASE_URL}textures/`;
+      return undefined;
     }
-  }, [wsUrl]);
+  }, [wsSource.isConnected, wsUrl]);
 
   const satelliteNames = useMemo(() => {
     if (!simInfo) return undefined;

--- a/viewer/src/components/CelestialBody.tsx
+++ b/viewer/src/components/CelestialBody.tsx
@@ -93,34 +93,53 @@ function TexturedBody({
     if (upgraded) return;
 
     let cancelled = false;
+    let inFlight = false;
     const basePath = textureBaseUrl ?? `${import.meta.env.BASE_URL}textures/`;
     const startIdx = FALLBACK_CHAIN.indexOf(targetResolution);
     const candidates = startIdx >= 0 ? FALLBACK_CHAIN.slice(startIdx) : [];
 
     async function tryUpgrade() {
-      for (const res of candidates) {
-        if (cancelled) return;
-        const url = `${basePath}${renderInfo.textureBaseName}_${res}.jpg`;
-        const newTex = await loadTexture(url);
-        if (cancelled) {
-          newTex?.dispose();
-          return;
+      // Don't stack a second load while one is in flight: each decodes and
+      // uploads a large texture synchronously on the main thread.
+      if (inFlight) return;
+      inFlight = true;
+      try {
+        for (const res of candidates) {
+          if (cancelled) return;
+          const url = `${basePath}${renderInfo.textureBaseName}_${res}.jpg`;
+          const newTex = await loadTexture(url);
+          if (cancelled) {
+            newTex?.dispose();
+            return;
+          }
+          if (newTex) {
+            setTexture((old) => {
+              old?.dispose();
+              return newTex;
+            });
+            setUpgraded(true);
+            return;
+          }
         }
-        if (newTex) {
-          setTexture((old) => {
-            old?.dispose();
-            return newTex;
-          });
-          setUpgraded(true);
-          return;
-        }
+      } finally {
+        inFlight = false;
       }
     }
     tryUpgrade();
 
-    // Periodic retry every 10s until upgrade succeeds or component unmounts.
+    // Bounded fallback poll (textureRevision bump is the primary re-trigger).
+    // Stop after MAX_RETRIES so a permanently unavailable resolution doesn't
+    // loop forever, and never re-upload while a load is already running.
+    let attempts = 0;
+    const MAX_RETRIES = 3;
     const timer = setInterval(() => {
-      if (!cancelled) tryUpgrade();
+      if (cancelled) return;
+      attempts += 1;
+      if (attempts > MAX_RETRIES) {
+        clearInterval(timer);
+        return;
+      }
+      tryUpgrade();
     }, 10_000);
 
     return () => {

--- a/viewer/src/components/CelestialBody.tsx
+++ b/viewer/src/components/CelestialBody.tsx
@@ -148,6 +148,9 @@ function TexturedBody({
     const MAX_RETRIES = 3;
     const timer = setInterval(() => {
       if (cancelled) return;
+      // A load is still in flight — skip without spending a retry, so a slow load
+      // (>10s) doesn't exhaust the budget on ticks that tryUpgrade would bail on.
+      if (inFlightRef.current) return;
       if (attempts >= MAX_RETRIES) {
         clearInterval(timer);
         return;

--- a/viewer/src/components/CelestialBody.tsx
+++ b/viewer/src/components/CelestialBody.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 import { type BodyRenderInfo, getBodyRenderInfo } from "../bodies.js";
 import { type TextureResolution, useTextureResolution } from "../hooks/useTextureResolution.js";
@@ -70,6 +70,9 @@ function TexturedBody({
   const [texture, setTexture] = useState<THREE.Texture | null>(null);
   const [baseLoaded, setBaseLoaded] = useState(false);
   const [upgraded, setUpgraded] = useState(false);
+  // Persisted across effect re-runs (e.g. textureRevision bumps) so upgrades
+  // never overlap, not just within a single effect execution.
+  const inFlightRef = useRef(false);
 
   // Load base texture
   useEffect(() => {
@@ -105,7 +108,6 @@ function TexturedBody({
     if (!textureBaseUrl) return;
 
     let cancelled = false;
-    let inFlight = false;
     const basePath = textureBaseUrl;
     const startIdx = FALLBACK_CHAIN.indexOf(targetResolution);
     const candidates = startIdx >= 0 ? FALLBACK_CHAIN.slice(startIdx) : [];
@@ -113,8 +115,8 @@ function TexturedBody({
     async function tryUpgrade() {
       // Don't stack a second load while one is in flight: each decodes and
       // uploads a large texture synchronously on the main thread.
-      if (inFlight) return;
-      inFlight = true;
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
       try {
         for (const res of candidates) {
           if (cancelled) return;
@@ -134,7 +136,7 @@ function TexturedBody({
           }
         }
       } finally {
-        inFlight = false;
+        inFlightRef.current = false;
       }
     }
     tryUpgrade();

--- a/viewer/src/components/CelestialBody.tsx
+++ b/viewer/src/components/CelestialBody.tsx
@@ -31,12 +31,21 @@ interface CelestialBodyProps {
 
 const FALLBACK_CHAIN: TextureResolution[] = ["16k", "8k", "4k"];
 
+// Decode off the main thread via createImageBitmap (see EarthBody). The bitmap
+// is pre-flipped to match TextureLoader; WebGL can't flip an ImageBitmap on
+// upload, so texture.flipY is off.
+const bitmapLoader = new THREE.ImageBitmapLoader();
+bitmapLoader.setOptions({ imageOrientation: "flipY" });
+
 function loadTexture(url: string): Promise<THREE.Texture | null> {
   return new Promise((resolve) => {
-    new THREE.TextureLoader().load(
+    bitmapLoader.load(
       url,
-      (tex) => {
+      (bitmap) => {
+        const tex = new THREE.Texture(bitmap);
         tex.colorSpace = THREE.SRGBColorSpace;
+        tex.flipY = false;
+        tex.needsUpdate = true;
         resolve(tex);
       },
       undefined,
@@ -91,10 +100,13 @@ function TexturedBody({
     if (!baseLoaded || !renderInfo.textureBaseName) return;
     if (!targetResolution || targetResolution === "2k") return;
     if (upgraded) return;
+    // Only upgrade when a real texture source is provided (a connected orts
+    // server, or an explicit base URL). No source → keep the bundled 2K.
+    if (!textureBaseUrl) return;
 
     let cancelled = false;
     let inFlight = false;
-    const basePath = textureBaseUrl ?? `${import.meta.env.BASE_URL}textures/`;
+    const basePath = textureBaseUrl;
     const startIdx = FALLBACK_CHAIN.indexOf(targetResolution);
     const candidates = startIdx >= 0 ? FALLBACK_CHAIN.slice(startIdx) : [];
 

--- a/viewer/src/components/CelestialBody.tsx
+++ b/viewer/src/components/CelestialBody.tsx
@@ -113,8 +113,8 @@ function TexturedBody({
     const candidates = startIdx >= 0 ? FALLBACK_CHAIN.slice(startIdx) : [];
 
     async function tryUpgrade() {
-      // Don't stack a second load while one is in flight: each decodes and
-      // uploads a large texture synchronously on the main thread.
+      // Don't stack a second load while one is in flight: decode is off-thread
+      // (ImageBitmapLoader) but the GPU upload is still synchronous on the main thread.
       if (inFlightRef.current) return;
       inFlightRef.current = true;
       try {
@@ -148,11 +148,11 @@ function TexturedBody({
     const MAX_RETRIES = 3;
     const timer = setInterval(() => {
       if (cancelled) return;
-      attempts += 1;
-      if (attempts > MAX_RETRIES) {
+      if (attempts >= MAX_RETRIES) {
         clearInterval(timer);
         return;
       }
+      attempts += 1;
       tryUpgrade();
     }, 10_000);
 

--- a/viewer/src/components/EarthBody.tsx
+++ b/viewer/src/components/EarthBody.tsx
@@ -201,6 +201,9 @@ export function EarthBody({
     const MAX_RETRIES = 3;
     const timer = setInterval(() => {
       if (cancelled) return;
+      // A load is still in flight — skip without spending a retry, so a slow load
+      // (>10s) doesn't exhaust the budget on ticks that tryUpgrade would bail on.
+      if (inFlightRef.current) return;
       if (attempts >= MAX_RETRIES) {
         clearInterval(timer);
         return;

--- a/viewer/src/components/EarthBody.tsx
+++ b/viewer/src/components/EarthBody.tsx
@@ -40,15 +40,25 @@ interface EarthBodyProps {
   textureBaseUrl?: string;
 }
 
+// Decode textures off the main thread via createImageBitmap, so a large texture
+// doesn't decode synchronously while uploading (the dominant source of frame
+// hitches on big textures). The bitmap is pre-flipped to match TextureLoader's
+// default; WebGL can't flip an ImageBitmap at upload, so texture.flipY is off.
+const bitmapLoader = new THREE.ImageBitmapLoader();
+bitmapLoader.setOptions({ imageOrientation: "flipY" });
+
 /**
  * Try loading a texture by URL. Returns the loaded texture or null on failure.
  */
 function loadTexture(url: string): Promise<THREE.Texture | null> {
   return new Promise((resolve) => {
-    new THREE.TextureLoader().load(
+    bitmapLoader.load(
       url,
-      (tex) => {
+      (bitmap) => {
+        const tex = new THREE.Texture(bitmap);
         tex.colorSpace = THREE.SRGBColorSpace;
+        tex.flipY = false;
+        tex.needsUpdate = true;
         resolve(tex);
       },
       undefined,
@@ -113,10 +123,13 @@ export function EarthBody({
       return;
     if (!materialRef.current) return;
     if (upgraded) return;
+    // Only upgrade when a real texture source is provided (a connected orts
+    // server, or an explicit base URL). No source → keep the bundled 2K.
+    if (!textureBaseUrl) return;
 
     let cancelled = false;
     let inFlight = false;
-    const basePath = textureBaseUrl ?? `${import.meta.env.BASE_URL}textures/`;
+    const basePath = textureBaseUrl;
 
     // Build fallback chain starting from target resolution
     const startIdx = FALLBACK_CHAIN.indexOf(targetResolution);

--- a/viewer/src/components/EarthBody.tsx
+++ b/viewer/src/components/EarthBody.tsx
@@ -86,6 +86,10 @@ export function EarthBody({
   const poleGroupRef = useRef<THREE.Group>(null);
   const [ready, setReady] = useState(false);
   const [upgraded, setUpgraded] = useState(false);
+  // Guards against overlapping high-res loads. A ref (not an effect-local) so it
+  // persists across effect re-runs — e.g. a textureRevision bump that re-runs the
+  // upgrade effect while a previous load is still decoding — not just within one run.
+  const inFlightRef = useRef(false);
 
   // 1. Load 2K textures manually (no Suspense — keeps Canvas interactive)
   // biome-ignore lint/correctness/useExhaustiveDependencies: uniform values are synced by separate effects below; recreating the material on every uniform change would reload textures unnecessarily.
@@ -128,7 +132,6 @@ export function EarthBody({
     if (!textureBaseUrl) return;
 
     let cancelled = false;
-    let inFlight = false;
     const basePath = textureBaseUrl;
 
     // Build fallback chain starting from target resolution
@@ -139,8 +142,8 @@ export function EarthBody({
       // Don't stack a second load while one is in flight: each load decodes and
       // uploads a large texture (synchronous on the main thread), so overlapping
       // attempts pile up into visible frame hitches.
-      if (inFlight) return;
-      inFlight = true;
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
       try {
         for (const res of candidates) {
           if (cancelled) return;
@@ -184,7 +187,7 @@ export function EarthBody({
         // No resolution available right now — 2K stays. A textureRevision bump
         // (server "textures_ready") re-runs this effect to try again.
       } finally {
-        inFlight = false;
+        inFlightRef.current = false;
       }
     }
 

--- a/viewer/src/components/EarthBody.tsx
+++ b/viewer/src/components/EarthBody.tsx
@@ -139,9 +139,9 @@ export function EarthBody({
     const candidates = startIdx >= 0 ? FALLBACK_CHAIN.slice(startIdx) : [];
 
     async function tryUpgrade() {
-      // Don't stack a second load while one is in flight: each load decodes and
-      // uploads a large texture (synchronous on the main thread), so overlapping
-      // attempts pile up into visible frame hitches.
+      // Don't stack a second load while one is in flight: decode is off-thread
+      // (ImageBitmapLoader) but the GPU upload of a large texture is still
+      // synchronous on the main thread, so overlapping loads pile up into hitches.
       if (inFlightRef.current) return;
       inFlightRef.current = true;
       try {
@@ -201,11 +201,11 @@ export function EarthBody({
     const MAX_RETRIES = 3;
     const timer = setInterval(() => {
       if (cancelled) return;
-      attempts += 1;
-      if (attempts > MAX_RETRIES) {
+      if (attempts >= MAX_RETRIES) {
         clearInterval(timer);
         return;
       }
+      attempts += 1;
       tryUpgrade();
     }, 10_000);
 

--- a/viewer/src/components/EarthBody.tsx
+++ b/viewer/src/components/EarthBody.tsx
@@ -115,6 +115,7 @@ export function EarthBody({
     if (upgraded) return;
 
     let cancelled = false;
+    let inFlight = false;
     const basePath = textureBaseUrl ?? `${import.meta.env.BASE_URL}textures/`;
 
     // Build fallback chain starting from target resolution
@@ -122,50 +123,74 @@ export function EarthBody({
     const candidates = startIdx >= 0 ? FALLBACK_CHAIN.slice(startIdx) : [];
 
     async function tryUpgrade() {
-      for (const res of candidates) {
-        if (cancelled) return;
+      // Don't stack a second load while one is in flight: each load decodes and
+      // uploads a large texture (synchronous on the main thread), so overlapping
+      // attempts pile up into visible frame hitches.
+      if (inFlight) return;
+      inFlight = true;
+      try {
+        for (const res of candidates) {
+          if (cancelled) return;
 
-        const dayUrl = `${basePath}${textureBaseName}_${res}.jpg`;
-        const nightUrl = `${basePath}${nightTextureBaseName}_${res}.jpg`;
+          const dayUrl = `${basePath}${textureBaseName}_${res}.jpg`;
+          const nightUrl = `${basePath}${nightTextureBaseName}_${res}.jpg`;
 
-        const [newDay, newNight] = await Promise.all([loadTexture(dayUrl), loadTexture(nightUrl)]);
+          const [newDay, newNight] = await Promise.all([
+            loadTexture(dayUrl),
+            loadTexture(nightUrl),
+          ]);
 
-        if (cancelled) {
+          if (cancelled) {
+            newDay?.dispose();
+            newNight?.dispose();
+            return;
+          }
+
+          // Both textures must load successfully for this resolution
+          if (newDay && newNight) {
+            if (materialRef.current) {
+              const oldDay = materialRef.current.uniforms.dayMap.value as THREE.Texture;
+              const oldNight = materialRef.current.uniforms.nightMap.value as THREE.Texture;
+
+              materialRef.current.uniforms.dayMap.value = newDay;
+              materialRef.current.uniforms.nightMap.value = newNight;
+              materialRef.current.needsUpdate = true;
+
+              // Dispose old textures to free GPU memory
+              oldDay.dispose();
+              oldNight.dispose();
+            }
+            setUpgraded(true);
+            return; // success
+          }
+
+          // Partial load: clean up and try next resolution
           newDay?.dispose();
           newNight?.dispose();
-          return;
         }
-
-        // Both textures must load successfully for this resolution
-        if (newDay && newNight) {
-          if (materialRef.current) {
-            const oldDay = materialRef.current.uniforms.dayMap.value as THREE.Texture;
-            const oldNight = materialRef.current.uniforms.nightMap.value as THREE.Texture;
-
-            materialRef.current.uniforms.dayMap.value = newDay;
-            materialRef.current.uniforms.nightMap.value = newNight;
-            materialRef.current.needsUpdate = true;
-
-            // Dispose old textures to free GPU memory
-            oldDay.dispose();
-            oldNight.dispose();
-          }
-          setUpgraded(true);
-          return; // success
-        }
-
-        // Partial load: clean up and try next resolution
-        newDay?.dispose();
-        newNight?.dispose();
+        // No resolution available right now — 2K stays. A textureRevision bump
+        // (server "textures_ready") re-runs this effect to try again.
+      } finally {
+        inFlight = false;
       }
-      // All resolutions failed — 2K fallback remains active
     }
 
     tryUpgrade();
 
-    // Periodic retry every 10s until upgrade succeeds or component unmounts.
+    // Bounded fallback poll. The textureRevision bump is the primary re-trigger;
+    // this just covers a missed signal. Stop after MAX_RETRIES so a permanently
+    // unavailable resolution doesn't loop forever (e.g. static hosting without
+    // the high-res files), and never re-upload while a load is already running.
+    let attempts = 0;
+    const MAX_RETRIES = 3;
     const timer = setInterval(() => {
-      if (!cancelled) tryUpgrade();
+      if (cancelled) return;
+      attempts += 1;
+      if (attempts > MAX_RETRIES) {
+        clearInterval(timer);
+        return;
+      }
+      tryUpgrade();
     }, 10_000);
 
     return () => {


### PR DESCRIPTION
## Problem

Satellite-centred view (and, more mildly, every view) periodically stalls — the
camera stops responding and animation freezes. Root cause is the texture
upgrade path:

- The high-res upgrade re-attempted on a blind 10s `setInterval` that never
  stopped while a target resolution was unavailable (e.g. static hosting lacking
  the 4k/8k files → a permanent 404 loop), and could start a new load while a
  previous one was still in flight.
- Each load decodes + uploads a large texture **synchronously on the main
  thread** (`THREE.TextureLoader` → HTMLImageElement → `gl.texImage2D`). Stacked
  or looping attempts pile up into frame hitches, worst in satellite-centred
  view where the resolution is forced to 16k (~29 MB for Earth day+night).

## Fix

1. **Bounded retry + in-flight guard** (`EarthBody`, `CelestialBody`): never
   start a new upgrade while one is running; stop the fallback poll after
   `MAX_RETRIES`. The `textureRevision` bump (server `textures_ready`) stays the
   primary re-trigger, so the app still upgrades when the server finishes.
2. **Server-gated upgrade** (`App.tsx` + both bodies): only fetch high-res when
   a real source is provided — `App.tsx` sets `textureBaseUrl` only while
   connected to an orts server (which downloads/resizes textures on demand).
   File replay / no connection stays on the bundled 2K.
3. **Off-thread decode** (`ImageBitmapLoader` / `createImageBitmap`): decode is
   no longer synchronous on the main thread; only the GPU upload remains. The
   bitmap is pre-flipped (`imageOrientation: "flipY"`) to preserve orientation —
   verified the Earth renders right-side up.

## Verification

- `tsc` clean, vitest 346 pass, biome clean (warn-level only).
- Headless diagnostic: satellite-centred view was ~8–11 fps with repeated
  >100 ms frame gaps and high-res textures re-requested every 10s; after the fix
  the retry loop is bounded and a single load no longer blocks on decode.
- flipY orientation verified by screenshot (continents right-side up).

## Notes / follow-ups

- Optional: suppress mipmaps on the largest textures to shave the remaining
  upload cost (kept on here to preserve quality).
- The embeddable `OrbitViewer` (separate viewer-as-library work) inherits the
  server-gated default — it won't auto-fetch high-res without an explicit
  `textureBaseUrl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
