### PR TITLE
feat(viewer): honour satellite-centred inertial vs local-orbital frames

### DIFF
--- a/viewer/src/components/FrameSelector.tsx
+++ b/viewer/src/components/FrameSelector.tsx
@@ -52,9 +52,15 @@ export function FrameSelector({
 
   function handleCenterChange(e: React.ChangeEvent<HTMLSelectElement>) {
     const newCenter = decodeCenterKey(e.target.value);
-    // Reset to inertial when switching to satellite (body_fixed not supported)
-    const newOrientation: FrameOrientation =
-      newCenter.type === "satellite" ? "inertial" : referenceFrame.orientation;
+    // Satellite centre defaults to LVLH (the classic "Earth below" view);
+    // body_fixed / local_orbital don't carry across centre kinds.
+    let newOrientation: FrameOrientation = referenceFrame.orientation;
+    if (newCenter.type === "satellite") {
+      if (newOrientation === "body_fixed") newOrientation = "local_orbital";
+      if (referenceFrame.center.type !== "satellite") newOrientation = "local_orbital";
+    } else if (newOrientation === "local_orbital") {
+      newOrientation = "inertial";
+    }
     onChange({ center: newCenter, orientation: newOrientation });
   }
 
@@ -83,25 +89,34 @@ export function FrameSelector({
 
       <div className={controlStyles.modeToggle} style={{ marginTop: "4px" }}>
         <button
+          type="button"
           className={`${controlStyles.modeToggleBtn} ${referenceFrame.orientation === "inertial" ? controlStyles.active : ""}`}
+          data-testid="frame-orientation-inertial"
           onClick={() => handleOrientationChange("inertial")}
         >
           {labels.inertial}
         </button>
-        <button
-          className={`${controlStyles.modeToggleBtn} ${referenceFrame.orientation === "body_fixed" ? controlStyles.active : ""}`}
-          onClick={() => handleOrientationChange("body_fixed")}
-          disabled={isSatCentered || !hasEpoch}
-          title={
-            isSatCentered
-              ? "Body-fixed not available for satellite center"
-              : !hasEpoch
-                ? "Requires epoch"
-                : ""
-          }
-        >
-          {labels.body_fixed}
-        </button>
+        {isSatCentered ? (
+          <button
+            type="button"
+            className={`${controlStyles.modeToggleBtn} ${referenceFrame.orientation === "local_orbital" ? controlStyles.active : ""}`}
+            data-testid="frame-orientation-lvlh"
+            onClick={() => handleOrientationChange("local_orbital")}
+          >
+            LVLH
+          </button>
+        ) : (
+          <button
+            type="button"
+            className={`${controlStyles.modeToggleBtn} ${referenceFrame.orientation === "body_fixed" ? controlStyles.active : ""}`}
+            data-testid="frame-orientation-body-fixed"
+            onClick={() => handleOrientationChange("body_fixed")}
+            disabled={!hasEpoch}
+            title={!hasEpoch ? "Requires epoch" : ""}
+          >
+            {labels.body_fixed}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -9,6 +9,7 @@ import {
   type DisplayScaleProfile,
   getDisplayScaleProfile,
 } from "../displayScale.js";
+import { resolveSceneFrame } from "../frameResolve.js";
 import { rotateZ } from "../frameTransform.js";
 import type { OrbitPoint } from "../orbit.js";
 import { DEFAULT_FRAME, isLegacyEcef, type ReferenceFrame } from "../referenceFrame.js";
@@ -403,39 +404,31 @@ export function OrbitSceneContents({
   // Effective scale radius: smaller when amplified, so positions appear larger
   const effectiveScaleRadius = centralBodyRadius / sceneAmplification;
 
-  // Compute origin position for satellite-centered view
-  const originPosition: [number, number, number] | null = useMemo(() => {
-    if (!isSatCentered || centeredSatId == null) return null;
-
-    const satPos = satellitePositions?.get(centeredSatId);
-    if (satPos) return [satPos.x, satPos.y, satPos.z];
-
-    return null;
-  }, [isSatCentered, centeredSatId, satellitePositions]);
-
-  // Compute origin velocity for LVLH axes
-  const originVelocity: [number, number, number] | null = useMemo(() => {
-    if (!isSatCentered || centeredSatId == null) return null;
-
-    const satPos = satellitePositions?.get(centeredSatId);
-    if (satPos) return [satPos.vx, satPos.vy, satPos.vz];
-
-    return null;
-  }, [isSatCentered, centeredSatId, satellitePositions]);
-
-  // Compute LVLH axes for body-frame transformation
-  const lvlhAxes: LvlhAxes | null = useMemo(
-    () => computeLvlhAxes(originPosition, originVelocity),
-    [originPosition, originVelocity],
+  // Resolve the frame semantics (origin, LVLH axes, camera behaviour) through
+  // the shared kernel — the one place that honours `orientation` (#90).
+  const { originPosition, originVelocity, lvlhAxes, lvlhActive, cameraTracking } = useMemo(
+    () =>
+      resolveSceneFrame(
+        referenceFrame,
+        (id) => {
+          const p = satellitePositions?.get(id);
+          return p ? { position: [p.x, p.y, p.z], velocity: [p.vx, p.vy, p.vz] } : null;
+        },
+        (id) => entityPathToBodyId(id) != null,
+      ),
+    [referenceFrame, satellitePositions],
   );
 
-  // LVLH body-frame mode: active when satellite-centered (not body entity) with valid axes.
-  // Body entities (Moon, Mars) use IAU rotation in ECI, not LVLH.
-  // TODO(#90): this is inferred purely from "satellite-centered + velocity"; it
-  // ignores any caller-selected orientation, so a satellite-centered *inertial*
-  // frame still renders as LVLH. Honouring inertial needs an explicit signal here.
-  const lvlhActive =
-    isSatCentered && centeredBodyId == null && lvlhAxes != null && originPosition != null;
+  // Dev/E2E-only: expose the resolved frame semantics so tests can assert
+  // inertial vs local-orbital behaviour without reading pixels.
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    const w = window as unknown as Record<string, unknown>;
+    w.__debug_scene_frame = { lvlhActive, cameraTracking, originPosition };
+    return () => {
+      delete w.__debug_scene_frame;
+    };
+  }, [lvlhActive, cameraTracking, originPosition]);
 
   // Determine sim time for sun direction from first available satellite position
   const firstPosition = satellitePositions
@@ -562,8 +555,10 @@ export function OrbitSceneContents({
         minDistance={displayProfile.minDistance}
         maxDistance={displayProfile.maxDistance}
       />
+      {/* Camera co-rotation only when the kernel asked for it (local-orbital
+          approximated by the camera); an inertial centre keeps star-fixed axes. */}
       <CameraLvlhTracker
-        originPosition={originPosition}
+        originPosition={cameraTracking ? originPosition : null}
         originVelocity={originVelocity}
         lvlhActive={lvlhActive}
       />

--- a/viewer/src/frameResolve.test.ts
+++ b/viewer/src/frameResolve.test.ts
@@ -74,6 +74,21 @@ describe("resolveSceneFrame — satellite centred, local_orbital", () => {
   });
 });
 
+describe("resolveSceneFrame — snapshot semantics", () => {
+  it("returns copies of the caller-owned tuples (in-place mutation can't alias)", () => {
+    const state = { position: [7000, 0, 0] as V3, velocity: [0, 7.5, 0] as V3 };
+    const f: ReferenceFrame = {
+      center: { type: "satellite", id: "a" },
+      orientation: "local_orbital",
+    };
+    const ctx = resolveSceneFrame(f, () => state, noBody);
+    state.position[0] = 9999; // caller reuses its array
+    state.velocity[1] = -1;
+    expect(ctx.originPosition).toEqual([7000, 0, 0]);
+    expect(ctx.originVelocity).toEqual([0, 7.5, 0]);
+  });
+});
+
 describe("resolveSceneFrame — satellite centred, inertial (#90)", () => {
   const f: ReferenceFrame = { center: { type: "satellite", id: "a" }, orientation: "inertial" };
 

--- a/viewer/src/frameResolve.test.ts
+++ b/viewer/src/frameResolve.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { resolveSceneFrame } from "./frameResolve.js";
+import type { ReferenceFrame } from "./referenceFrame.js";
+
+type V3 = [number, number, number];
+const entity = (map: Record<string, { position: V3; velocity: V3 | null }>) => (id: string) =>
+  map[id] ?? null;
+const noBody = () => false;
+
+const SAT = { position: [7000, 0, 0] as V3, velocity: [0, 7.5, 0] as V3 };
+
+describe("resolveSceneFrame — central body", () => {
+  it("inertial: no origin, no axes, nothing active", () => {
+    const f: ReferenceFrame = { center: { type: "central_body" }, orientation: "inertial" };
+    const ctx = resolveSceneFrame(f, entity({}), noBody);
+    expect(ctx).toEqual({
+      centeredSatId: null,
+      originPosition: null,
+      originVelocity: null,
+      lvlhAxes: null,
+      lvlhActive: false,
+      cameraTracking: false,
+    });
+  });
+
+  it("body_fixed: same nulls (ECEF is handled by the primitives, not the frame context)", () => {
+    const f: ReferenceFrame = { center: { type: "central_body" }, orientation: "body_fixed" };
+    const ctx = resolveSceneFrame(f, entity({}), noBody);
+    expect(ctx.lvlhActive).toBe(false);
+    expect(ctx.originPosition).toBeNull();
+  });
+});
+
+describe("resolveSceneFrame — satellite centred, local_orbital", () => {
+  const f: ReferenceFrame = {
+    center: { type: "satellite", id: "a" },
+    orientation: "local_orbital",
+  };
+
+  it("with velocity: data-LVLH active (axes set, no camera tracking)", () => {
+    const ctx = resolveSceneFrame(f, entity({ a: SAT }), noBody);
+    expect(ctx.centeredSatId).toBe("a");
+    expect(ctx.originPosition).toEqual([7000, 0, 0]);
+    expect(ctx.originVelocity).toEqual([0, 7.5, 0]);
+    expect(ctx.lvlhAxes?.radial[0]).toBeCloseTo(1);
+    expect(ctx.lvlhActive).toBe(true);
+    expect(ctx.cameraTracking).toBe(false); // rotation lives in the data, not the camera
+  });
+
+  it("without velocity: falls back to camera tracking (radial-up), data stays inertial", () => {
+    const ctx = resolveSceneFrame(
+      f,
+      entity({ a: { position: [7000, 0, 0], velocity: null } }),
+      noBody,
+    );
+    expect(ctx.originPosition).toEqual([7000, 0, 0]);
+    expect(ctx.lvlhAxes).toBeNull();
+    expect(ctx.lvlhActive).toBe(false);
+    expect(ctx.cameraTracking).toBe(true);
+  });
+
+  it("centred on a body entity (e.g. moon): no data-LVLH, camera co-rotates", () => {
+    const ctx = resolveSceneFrame(f, entity({ a: SAT }), () => true);
+    expect(ctx.lvlhAxes).toBeNull();
+    expect(ctx.lvlhActive).toBe(false);
+    expect(ctx.cameraTracking).toBe(true);
+  });
+
+  it("unknown entity: inert (no origin, nothing active)", () => {
+    const ctx = resolveSceneFrame(f, entity({}), noBody);
+    expect(ctx.originPosition).toBeNull();
+    expect(ctx.lvlhActive).toBe(false);
+    expect(ctx.cameraTracking).toBe(false);
+  });
+});
+
+describe("resolveSceneFrame — satellite centred, inertial (#90)", () => {
+  const f: ReferenceFrame = { center: { type: "satellite", id: "a" }, orientation: "inertial" };
+
+  it("origin set but axes star-fixed: no LVLH transform, no camera tracking", () => {
+    const ctx = resolveSceneFrame(f, entity({ a: SAT }), noBody);
+    expect(ctx.centeredSatId).toBe("a");
+    expect(ctx.originPosition).toEqual([7000, 0, 0]); // satellite at scene origin…
+    expect(ctx.lvlhAxes).toBeNull(); // …but axes stay inertial
+    expect(ctx.lvlhActive).toBe(false);
+    expect(ctx.cameraTracking).toBe(false); // camera must NOT co-rotate with the orbit
+  });
+
+  it("inertial on a body entity: also offset-only", () => {
+    const ctx = resolveSceneFrame(f, entity({ a: SAT }), () => true);
+    expect(ctx.originPosition).toEqual([7000, 0, 0]);
+    expect(ctx.lvlhActive).toBe(false);
+    expect(ctx.cameraTracking).toBe(false);
+  });
+});

--- a/viewer/src/frameResolve.ts
+++ b/viewer/src/frameResolve.ts
@@ -1,0 +1,91 @@
+/**
+ * Resolve a {@link ReferenceFrame} into everything the scene needs to render in
+ * it: the frame centre's state, the LVLH axes (when the data should be
+ * expressed in the local-orbital frame), and what the camera should do.
+ *
+ * This is the single place that decides the frame semantics (#90):
+ *
+ * - `central_body` centre — origin at the body; `body_fixed` rotation is
+ *   applied by the primitives themselves (ECEF transforms), not here.
+ * - satellite centre + `local_orbital` — the classic LVLH view: positions,
+ *   trails and attitudes are transformed into the orbit frame (`lvlhActive`).
+ *   When that's not possible (no velocity) or the centred entity is a celestial
+ *   body (which keeps its IAU orientation in inertial axes), the LVLH feel is
+ *   approximated by co-rotating the *camera* instead (`cameraTracking`).
+ * - satellite centre + `inertial` — the centred entity sits at the origin but
+ *   the axes stay star-fixed: data is offset only, and the camera must not
+ *   co-rotate with the orbit.
+ *
+ * Pure and renderer-agnostic so the semantics are unit-testable; both the app
+ * scene and the embeddable viewer resolve frames through this kernel.
+ */
+
+import type { ReferenceFrame } from "./referenceFrame.js";
+import { computeLvlhAxes, type LvlhAxes } from "./sceneFrame.js";
+
+/** Current state of a centred entity, in the central-body inertial frame [km, km/s]. */
+export interface FrameEntityState {
+  position: [number, number, number];
+  velocity: [number, number, number] | null;
+}
+
+/** Look up an entity's current state by id; null when unknown/not yet known. */
+export type FrameEntityLookup = (id: string) => FrameEntityState | null;
+
+/** Everything the scene graph needs to render in the resolved frame. */
+export interface SceneFrameContext {
+  /** Centred satellite/entity id, or null for a central-body centre. */
+  centeredSatId: string | null;
+  /** ECI position [km] of the frame centre, or null for the central body. */
+  originPosition: [number, number, number] | null;
+  /** ECI velocity [km/s] of the frame centre, when known. */
+  originVelocity: [number, number, number] | null;
+  /** LVLH axes when `lvlhActive`; null otherwise. */
+  lvlhAxes: LvlhAxes | null;
+  /** True when positions/trails/attitudes get the LVLH (data) transform. */
+  lvlhActive: boolean;
+  /** True when the camera should co-rotate / radial-track the centre instead. */
+  cameraTracking: boolean;
+}
+
+export function resolveSceneFrame(
+  frame: ReferenceFrame,
+  getEntity: FrameEntityLookup,
+  isBodyEntity: (id: string) => boolean,
+): SceneFrameContext {
+  const inert: SceneFrameContext = {
+    centeredSatId: null,
+    originPosition: null,
+    originVelocity: null,
+    lvlhAxes: null,
+    lvlhActive: false,
+    cameraTracking: false,
+  };
+
+  if (frame.center.type !== "satellite") return inert;
+
+  const id = frame.center.id;
+  const state = getEntity(id);
+  if (state == null) return { ...inert, centeredSatId: id };
+
+  const originPosition = state.position;
+  const originVelocity = state.velocity;
+  const localOrbital = frame.orientation === "local_orbital";
+
+  // Data-LVLH: only for a real satellite (bodies keep their IAU orientation in
+  // inertial axes) and only when the axes are computable from pos/vel.
+  const lvlhAxes =
+    localOrbital && !isBodyEntity(id) ? computeLvlhAxes(originPosition, originVelocity) : null;
+  const lvlhActive = lvlhAxes != null;
+
+  return {
+    centeredSatId: id,
+    originPosition,
+    originVelocity,
+    lvlhAxes,
+    lvlhActive,
+    // LVLH requested but not expressible in the data → approximate with the
+    // camera. An inertial centre never tracks: the axes stay star-fixed.
+    cameraTracking: localOrbital && !lvlhActive,
+  };
+}

--- a/viewer/src/frameResolve.ts
+++ b/viewer/src/frameResolve.ts
@@ -68,8 +68,13 @@ export function resolveSceneFrame(
   const state = getEntity(id);
   if (state == null) return { ...inert, centeredSatId: id };
 
-  const originPosition = state.position;
-  const originVelocity = state.velocity;
+  // Snapshot the caller-owned tuples: the context is returned from public API
+  // surfaces, and an embedder mutating its position array in place must not
+  // retroactively change an already-resolved frame.
+  const originPosition: [number, number, number] = [...state.position];
+  const originVelocity: [number, number, number] | null = state.velocity
+    ? [...state.velocity]
+    : null;
   const localOrbital = frame.orientation === "local_orbital";
 
   // Data-LVLH: only for a real satellite (bodies keep their IAU orientation in

--- a/viewer/src/lib/OrbitViewer.tsx
+++ b/viewer/src/lib/OrbitViewer.tsx
@@ -91,11 +91,9 @@ export function OrbitViewer({
   // Persistent per-satellite trail buffers (stable identity → incremental upload).
   const trailBuffers = useTrailBuffers(satellites);
 
-  // Map the public frame onto the renderer's internal ReferenceFrame; origin and
-  // LVLH axes are derived inside OrbitSceneContents from the satellite positions.
-  // TODO(#90): satellite-centred `inertial` and `localOrbital` both collapse to
-  // the same internal frame, and OrbitSceneContents always applies LVLH for a
-  // satellite-centred view — so the `inertial` option is currently ignored.
+  // Map the public frame onto the renderer's internal ReferenceFrame (incl.
+  // local_orbital); the scene resolves the geometry itself via the shared
+  // resolveSceneFrame kernel from the satellite positions it receives.
   const internalFrame = useMemo(
     () => resolveFrameContext(referenceFrame, () => undefined).referenceFrame,
     [referenceFrame],

--- a/viewer/src/lib/frameContext.test.ts
+++ b/viewer/src/lib/frameContext.test.ts
@@ -43,12 +43,26 @@ describe("resolveFrameContext — central body", () => {
 describe("resolveFrameContext — satellite centred", () => {
   const get = lookup({ a: sat([7000, 0, 0], [0, 7.5, 0]) });
 
-  it("inertial: origin at the satellite, no LVLH axes", () => {
+  it("inertial: origin at the satellite, no LVLH axes, internal orientation inertial", () => {
     const ctx = resolveFrameContext({ center: { satelliteId: "a" }, orientation: "inertial" }, get);
-    expect(ctx.referenceFrame.center).toEqual({ type: "satellite", id: "a" });
+    expect(ctx.referenceFrame).toEqual({
+      center: { type: "satellite", id: "a" },
+      orientation: "inertial",
+    });
     expect(ctx.originPosition).toEqual([7000, 0, 0]);
     expect(ctx.lvlhAxes).toBeNull();
     expect(ctx.localOrbitalFallback).toBe(false);
+  });
+
+  it("localOrbital: maps to the internal local_orbital orientation (#90)", () => {
+    const ctx = resolveFrameContext(
+      { center: { satelliteId: "a" }, orientation: "localOrbital" },
+      get,
+    );
+    expect(ctx.referenceFrame).toEqual({
+      center: { type: "satellite", id: "a" },
+      orientation: "local_orbital",
+    });
   });
 
   it("localOrbital: computes LVLH axes (radial = normalized position)", () => {

--- a/viewer/src/lib/frameContext.ts
+++ b/viewer/src/lib/frameContext.ts
@@ -3,13 +3,15 @@
  * primitives consume: an internal `ReferenceFrame`, the frame-centre's ECI
  * position, and (for local-orbital views) the LVLH axes.
  *
- * Pure and renderer-agnostic so the frame logic can be unit tested without a
- * canvas — and so the same kernel can back both the library viewer and the app's
- * richer Scene later.
+ * The mapping is the only logic that lives here; the frame *semantics*
+ * (origin, axes, what the camera does) are delegated to the shared
+ * `resolveSceneFrame` kernel that the scene itself renders from, so the
+ * library and the app cannot drift apart (#90).
  */
 
+import { resolveSceneFrame } from "../frameResolve.js";
 import type { ReferenceFrame } from "../referenceFrame.js";
-import { computeLvlhAxes, type LvlhAxes } from "../sceneFrame.js";
+import type { LvlhAxes } from "../sceneFrame.js";
 import type { Vec3, ViewerReferenceFrame } from "./types.js";
 
 /** Minimal satellite state the frame resolver needs. */
@@ -53,25 +55,29 @@ export function resolveFrameContext(
     };
   }
 
-  // Satellite-centred. The internal frame always uses "inertial" orientation:
-  // LVLH is driven by the presence of `lvlhAxes`, not the orientation field.
-  const id = frame.center.satelliteId;
-  const sat = getSatellite(id);
-  const originPosition = sat ? ([...sat.position] as [number, number, number]) : null;
-
-  let lvlhAxes: LvlhAxes | null = null;
-  let localOrbitalFallback = false;
-  if (frame.orientation === "localOrbital") {
-    lvlhAxes = sat ? computeLvlhAxes(sat.position, sat.velocity ?? null) : null;
-    // Flag the fallback only when we actually had a satellite to frame on.
-    if (lvlhAxes === null && sat) localOrbitalFallback = true;
-  }
+  // Satellite-centred: map the public orientation onto the internal one and
+  // let the shared kernel resolve the geometry. The public API has no body
+  // entities, so the body predicate is constantly false.
+  const localOrbital = frame.orientation === "localOrbital";
+  const referenceFrame: ReferenceFrame = {
+    center: { type: "satellite", id: frame.center.satelliteId },
+    orientation: localOrbital ? "local_orbital" : "inertial",
+  };
+  const ctx = resolveSceneFrame(
+    referenceFrame,
+    (id) => {
+      const sat = getSatellite(id);
+      return sat ? { position: sat.position, velocity: sat.velocity ?? null } : null;
+    },
+    () => false,
+  );
 
   return {
-    referenceFrame: { center: { type: "satellite", id }, orientation: "inertial" },
-    originPosition,
-    lvlhAxes,
+    referenceFrame,
+    originPosition: ctx.originPosition,
+    lvlhAxes: ctx.lvlhAxes,
     bodyFixed: false,
-    localOrbitalFallback,
+    // LVLH was requested but the axes weren't computable (no velocity).
+    localOrbitalFallback: localOrbital && !ctx.lvlhActive && ctx.originPosition != null,
   };
 }

--- a/viewer/src/lib/types.ts
+++ b/viewer/src/lib/types.ts
@@ -86,14 +86,13 @@ export interface CentralBody {
  * - `centralBody` + `inertial` — ECI-like, central body at the origin (default).
  * - `centralBody` + `bodyFixed` — body-fixed (ECEF-like); the body is static and
  *   positions rotate with it.
- * - `{ satelliteId }` + `inertial` — that satellite at the origin, inertial axes.
+ * - `{ satelliteId }` + `inertial` — that satellite at the origin with the axes
+ *   star-fixed: the central body appears to move around the satellite as it
+ *   orbits, and the camera does not co-rotate.
  * - `{ satelliteId }` + `localOrbital` — that satellite at the origin, LVLH axes
- *   (radial / along-track / cross-track). Requires the satellite's velocity;
- *   falls back to `inertial` if it's missing.
- *
- * KNOWN LIMITATION (#90): satellite-centred views currently always render in
- * LVLH when velocity is available — the `inertial` vs `localOrbital` choice is
- * not yet honoured for a satellite centre.
+ *   (radial / along-track / cross-track): the central body stays "below" as the
+ *   satellite orbits. Requires the satellite's velocity; without it the view
+ *   falls back to a radial-up camera follow.
  */
 export type ViewerReferenceFrame =
   | { center: "centralBody"; orientation?: "inertial" | "bodyFixed" }

--- a/viewer/src/referenceFrame.ts
+++ b/viewer/src/referenceFrame.ts
@@ -3,7 +3,9 @@
  *
  * A reference frame has two components:
  * - **center**: which object is at the origin (central body, satellite, etc.)
- * - **orientation**: how the axes are aligned (inertial or body-fixed)
+ * - **orientation**: how the axes are aligned — inertial, body-fixed (rotating
+ *   with the central body), or local-orbital (LVLH; following the centred
+ *   entity's orbit, only meaningful with a satellite centre)
  */
 
 /** Center of the reference frame (what object is at the origin). */
@@ -14,7 +16,7 @@ export type FrameCenter =
   | { type: "satellite"; id: string };
 
 /** Orientation of the reference frame axes. */
-export type FrameOrientation = "inertial" | "body_fixed";
+export type FrameOrientation = "inertial" | "body_fixed" | "local_orbital";
 
 /** Complete reference frame specification. */
 export interface ReferenceFrame {

--- a/viewer/tests/orbit-viewer-lib.spec.ts
+++ b/viewer/tests/orbit-viewer-lib.spec.ts
@@ -96,6 +96,42 @@ test("local-orbital (LVLH) frame renders without error", async ({ page }) => {
   expect((await readTrail(page))?.length).toBeGreaterThan(0);
 });
 
+test("satellite-centred inertial and LVLH are distinct frames (#90)", async ({ page }) => {
+  type SceneFrame = {
+    lvlhActive: boolean;
+    cameraTracking: boolean;
+    originPosition: [number, number, number] | null;
+  };
+  // The scene mounts inside the r3f reconciler, whose effects can flush after
+  // the page-level ones — wait for the global rather than reading immediately.
+  const readFrame = async () => {
+    await page.waitForFunction(
+      () => (window as unknown as { __debug_scene_frame?: unknown }).__debug_scene_frame != null,
+      undefined,
+      { timeout: 10000 },
+    );
+    return page.evaluate(
+      () => (window as unknown as { __debug_scene_frame?: SceneFrame }).__debug_scene_frame ?? null,
+    );
+  };
+
+  // LVLH: data is transformed into the orbit frame; the camera stays put.
+  await page.goto("/examples/orbit-viewer/?frame=lvlh&animate=0");
+  await waitForTrail(page);
+  const lvlh = await readFrame();
+  expect(lvlh?.lvlhActive).toBe(true);
+  expect(lvlh?.cameraTracking).toBe(false);
+
+  // Inertial: satellite is still centred, but axes stay star-fixed —
+  // no LVLH data transform and no camera co-rotation.
+  await page.goto("/examples/orbit-viewer/?frame=sat&animate=0");
+  await waitForTrail(page);
+  const inertial = await readFrame();
+  expect(inertial?.originPosition).not.toBeNull();
+  expect(inertial?.lvlhActive).toBe(false);
+  expect(inertial?.cameraTracking).toBe(false);
+});
+
 test("a marker-only satellite (no trail prop) gets no trail buffer", async ({ page }) => {
   await page.goto("/examples/orbit-viewer/?animate=0");
   await waitForTrail(page); // scene is up: the demo satellite's trail is filled


### PR DESCRIPTION
Fixes #90: a satellite-centred view always rendered as LVLH regardless of the
requested orientation — the public `inertial` vs `localOrbital` choice (and the
app's frame UI) couldn't actually change the rendering.

## Root cause

The internal `ReferenceFrame` had no way to express "local orbital": LVLH was
*inferred* from "the centre is a satellite", and frame geometry was derived in
two places (the lib's `resolveFrameContext` and `OrbitSceneContents`' inline
logic) that could drift apart.

## Approach

- **`local_orbital`** joins the internal `FrameOrientation`.
- **One kernel** — `resolveSceneFrame` (`frameResolve.ts`, pure, unit-tested) —
  decides the semantics for everyone:

  | frame | data transform | camera |
  |---|---|---|
  | satellite + `local_orbital` (velocity available) | LVLH (`lvlhActive`) | static |
  | satellite + `local_orbital` (body entity / no velocity) | offset only | co-rotates (`cameraTracking`) |
  | satellite + `inertial` | offset only | **static — star-fixed axes** |
  | central body (`inertial`/`body_fixed`) | as before | static |

- `OrbitSceneContents` resolves frames through the kernel and feeds the camera
  tracker only when asked; the lib's `resolveFrameContext` becomes a thin
  public→internal mapping that delegates to the same kernel. Frame resolution
  now lives in exactly one place.
- `FrameSelector`: selecting a satellite defaults to **LVLH** (the app's view is
  unchanged), and the orientation toggle becomes **Inertial / LVLH** — the new
  inertial mode is reachable from the app UI too.
- KNOWN LIMITATION / TODO(#90) notes removed; a dev-only `__debug_scene_frame`
  exposes the resolved semantics for E2E.

## Tests

- `resolveSceneFrame` unit tests (8) covering every row of the table above,
  incl. the #90 case (inertial ⇒ no LVLH transform, no camera co-rotation).
- Lib mapping tests updated (+ explicit `localOrbital → local_orbital`).
- vitest 394; E2E 9/9: `lvlh-orientation` (app behaviour preserved),
  `history-trail`, `multi-satellite-nan`, and a new spec asserting
  `?frame=sat` and `?frame=lvlh` resolve to distinct semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
