### PR TITLE
fix(viewer): restore high-res textures in static deployment (#105)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,8 +36,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install mold linker
-        run: sudo apt-get install -y mold
+      - name: Install mold linker and ImageMagick
+        run: sudo apt-get install -y mold imagemagick
+
+      - name: Cache viewer textures (4k/8k)
+        id: texture-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: viewer/public/textures
+          key: viewer-textures-${{ hashFiles('tools/fetch-textures.sh') }}
+
+      - name: Fetch viewer textures (4k/8k — skips mars to avoid 12 GB source)
+        if: steps.texture-cache.outputs.cache-hit != 'true'
+        run: ./tools/fetch-textures.sh --resolution 4k --body earth,moon,sun && ./tools/fetch-textures.sh --resolution 8k --body earth,moon,sun
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
             viewer/public/textures/moon_4k.jpg
             viewer/public/textures/moon_8k.jpg
             viewer/public/textures/sun_4k.jpg
-          key: viewer-textures-${{ hashFiles('tools/fetch-textures.sh') }}-${{ runner.os }}
+          key: viewer-textures-${{ hashFiles('tools/fetch-textures.sh', '.github/workflows/deploy.yml') }}-${{ runner.os }}
 
       - name: Fetch viewer textures (4k/8k — skips mars to avoid 12 GB source)
         if: steps.texture-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Fetch viewer textures (4k/8k — skips mars to avoid 12 GB source)
         if: steps.texture-cache.outputs.cache-hit != 'true'
-        run: ./tools/fetch-textures.sh --resolution 4k --body earth,moon,sun && ./tools/fetch-textures.sh --resolution 8k --body earth,moon,sun
+        run: ./tools/fetch-textures.sh --resolution 4k --body earth,moon,sun && ./tools/fetch-textures.sh --resolution 8k --body earth,moon
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,7 @@ jobs:
         run: pnpm build:site
         env:
           VITE_BASE_PATH: /orts/viewer/
+          VITE_TEXTURE_BASE_URL: /orts/viewer/textures/
           PUBLIC_GA_MEASUREMENT_ID: ${{ vars.GA_MEASUREMENT_ID }}
           VITE_GA_MEASUREMENT_ID: ${{ vars.GA_MEASUREMENT_ID }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,8 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      VITE_BASE_PATH: /orts/viewer/
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -83,8 +85,7 @@ jobs:
       - name: Build site
         run: pnpm build:site
         env:
-          VITE_BASE_PATH: /orts/viewer/
-          VITE_TEXTURE_BASE_URL: /orts/viewer/textures/
+          VITE_TEXTURE_BASE_URL: ${{ env.VITE_BASE_PATH }}textures/
           PUBLIC_GA_MEASUREMENT_ID: ${{ vars.GA_MEASUREMENT_ID }}
           VITE_GA_MEASUREMENT_ID: ${{ vars.GA_MEASUREMENT_ID }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install mold linker and ImageMagick
-        run: sudo apt-get update && sudo apt-get install -y mold imagemagick
+      - name: Install mold linker
+        run: sudo apt-get update && sudo apt-get install -y mold
 
       - name: Cache viewer textures (4k/8k)
         id: texture-cache
@@ -54,6 +54,10 @@ jobs:
             viewer/public/textures/moon_8k.jpg
             viewer/public/textures/sun_4k.jpg
           key: viewer-textures-${{ hashFiles('tools/fetch-textures.sh', '.github/workflows/deploy.yml') }}-${{ runner.os }}
+
+      - name: Install ImageMagick (texture conversion — cache miss only)
+        if: steps.texture-cache.outputs.cache-hit != 'true'
+        run: sudo apt-get install -y imagemagick
 
       - name: Fetch viewer textures (4k/8k — skips mars to avoid 12 GB source)
         if: steps.texture-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,14 +37,21 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install mold linker and ImageMagick
-        run: sudo apt-get install -y mold imagemagick
+        run: sudo apt-get update && sudo apt-get install -y mold imagemagick
 
       - name: Cache viewer textures (4k/8k)
         id: texture-cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: viewer/public/textures
-          key: viewer-textures-${{ hashFiles('tools/fetch-textures.sh') }}
+          path: |
+            viewer/public/textures/earth_4k.jpg
+            viewer/public/textures/earth_night_4k.jpg
+            viewer/public/textures/earth_8k.jpg
+            viewer/public/textures/earth_night_8k.jpg
+            viewer/public/textures/moon_4k.jpg
+            viewer/public/textures/moon_8k.jpg
+            viewer/public/textures/sun_4k.jpg
+          key: viewer-textures-${{ hashFiles('tools/fetch-textures.sh') }}-${{ runner.os }}
 
       - name: Fetch viewer textures (4k/8k — skips mars to avoid 12 GB source)
         if: steps.texture-cache.outputs.cache-hit != 'true'

--- a/tools/fetch-textures.sh
+++ b/tools/fetch-textures.sh
@@ -80,9 +80,11 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Returns 0 if the given body should be processed.
+# Normalises case and strips spaces so --body "Earth, Moon" works as expected.
 include_body() {
-  local body="$1"
-  [[ "$BODIES" == "all" ]] || [[ ",$BODIES," == *",$body,"* ]]
+  local body="${1,,}"
+  local bodies="${BODIES,,}"; bodies="${bodies// /}"
+  [[ "$bodies" == "all" ]] || [[ ",$bodies," == *",$body,"* ]]
 }
 
 # --- Check prerequisites ---
@@ -107,7 +109,7 @@ fi
 download() {
   local url="$1" dest="$2"
   echo "  Downloading $(basename "$dest")..."
-  curl -fSL --progress-bar -o "$dest" "$url"
+  curl -fSL --retry 3 --retry-delay 5 --progress-bar -o "$dest" "$url"
 }
 
 resize_jpeg() {

--- a/tools/fetch-textures.sh
+++ b/tools/fetch-textures.sh
@@ -130,8 +130,10 @@ fi
 
 download() {
   local url="$1" dest="$2"
+  local tmp="$TEMP_DIR/$(basename "$dest").partial"
   echo "  Downloading $(basename "$dest")..."
-  curl -fSL --retry 3 --retry-delay 5 --progress-bar -o "$dest" "$url"
+  curl -fSL --retry 3 --retry-delay 5 --progress-bar -o "$tmp" "$url"
+  mv "$tmp" "$dest"
 }
 
 resize_jpeg() {

--- a/tools/fetch-textures.sh
+++ b/tools/fetch-textures.sh
@@ -54,8 +54,8 @@ FORCE=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --resolution) RESOLUTION="$2"; shift 2 ;;
-    --body)       BODIES="$2"; shift 2 ;;
+    --resolution) [[ $# -ge 2 ]] || { echo "Error: --resolution requires a value" >&2; exit 1; }; RESOLUTION="$2"; shift 2 ;;
+    --body)       [[ $# -ge 2 ]] || { echo "Error: --body requires a value" >&2; exit 1; }; BODIES="$2"; shift 2 ;;
     --force)      FORCE=true; shift ;;
     -h|--help)
       echo "Usage: $0 [--resolution 2k|4k|8k|16k|all] [--body earth,moon,mars,sun|all] [--force]"

--- a/tools/fetch-textures.sh
+++ b/tools/fetch-textures.sh
@@ -82,7 +82,7 @@ done
 # Returns 0 if the given body should be processed.
 include_body() {
   local body="$1"
-  [[ "$BODIES" == "all" ]] || echo ",$BODIES," | grep -q ",$body,"
+  [[ "$BODIES" == "all" ]] || [[ ",$BODIES," == *",$body,"* ]]
 }
 
 # --- Check prerequisites ---

--- a/tools/fetch-textures.sh
+++ b/tools/fetch-textures.sh
@@ -86,7 +86,8 @@ case "$RESOLUTION" in
 esac
 
 # Validate --body entries
-_bodies_norm="${BODIES,,}"; _bodies_norm="${_bodies_norm// /}"
+_bodies_norm=$(tr '[:upper:]' '[:lower:]' <<< "$BODIES")
+_bodies_norm="${_bodies_norm// /}"
 IFS=',' read -ra _BODY_LIST <<< "$_bodies_norm"
 for _b in "${_BODY_LIST[@]}"; do
   case "$_b" in
@@ -102,8 +103,9 @@ unset _bodies_norm _BODY_LIST _b
 # Returns 0 if the given body should be processed.
 # Normalises case and strips spaces so --body "Earth, Moon" works as expected.
 include_body() {
-  local body="${1,,}"
-  local bodies="${BODIES,,}"; bodies="${bodies// /}"
+  local body; body=$(tr '[:upper:]' '[:lower:]' <<< "$1")
+  local bodies; bodies=$(tr '[:upper:]' '[:lower:]' <<< "$BODIES")
+  bodies="${bodies// /}"
   [[ "$bodies" == "all" ]] || [[ ",$bodies," == *",$body,"* ]]
 }
 

--- a/tools/fetch-textures.sh
+++ b/tools/fetch-textures.sh
@@ -49,14 +49,16 @@ SUN_SOURCE_URL="https://svs.gsfc.nasa.gov/vis/a030000/a030300/a030362/euvi_aia30
 # --- Parse arguments ---
 
 RESOLUTION="all"
+BODIES="all"
 FORCE=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --resolution) RESOLUTION="$2"; shift 2 ;;
+    --body)       BODIES="$2"; shift 2 ;;
     --force)      FORCE=true; shift ;;
     -h|--help)
-      echo "Usage: $0 [--resolution 2k|4k|8k|16k|all] [--force]"
+      echo "Usage: $0 [--resolution 2k|4k|8k|16k|all] [--body earth,moon,mars,sun|all] [--force]"
       echo ""
       echo "Downloads NASA/USGS textures and converts to power-of-two JPEG."
       echo ""
@@ -68,12 +70,20 @@ while [[ $# -gt 0 ]]; do
       echo ""
       echo "Options:"
       echo "  --resolution  Which resolutions to download: 2k, 4k, 8k, 16k, or all (default: all)"
+      echo "  --body        Comma-separated list of bodies: earth,moon,mars,sun or all (default: all)"
+      echo "                Tip: omit mars to skip the 12GB source download required for mars 4k/8k/16k"
       echo "  --force       Re-download even if files already exist"
       exit 0
       ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
 done
+
+# Returns 0 if the given body should be processed.
+include_body() {
+  local body="$1"
+  [[ "$BODIES" == "all" ]] || echo ",$BODIES," | grep -q ",$body,"
+}
 
 # --- Check prerequisites ---
 
@@ -327,11 +337,13 @@ process_sun() {
   fi
 }
 
-process_day
-process_night
-process_moon
-process_mars
-process_sun
+if include_body earth; then
+  process_day
+  process_night
+fi
+if include_body moon; then process_moon; fi
+if include_body mars; then process_mars; fi
+if include_body sun;  then process_sun;  fi
 
 echo ""
 echo "==> All done! Texture files in $TEXTURE_DIR:"

--- a/tools/fetch-textures.sh
+++ b/tools/fetch-textures.sh
@@ -86,15 +86,18 @@ case "$RESOLUTION" in
 esac
 
 # Validate --body entries
-IFS=',' read -ra _BODY_LIST <<< "${BODIES,,}"
+_bodies_norm="${BODIES,,}"; _bodies_norm="${_bodies_norm// /}"
+IFS=',' read -ra _BODY_LIST <<< "$_bodies_norm"
 for _b in "${_BODY_LIST[@]}"; do
-  _b="${_b// /}"
   case "$_b" in
     earth|moon|mars|sun|all) ;;
     *) echo "Error: unknown body '$_b' (expected: earth,moon,mars,sun or all)" >&2; exit 1 ;;
   esac
 done
-unset _BODY_LIST _b
+if [[ "$_bodies_norm" != "all" ]] && [[ ",$_bodies_norm," == *",all,"* ]]; then
+  echo "Error: 'all' cannot be combined with specific bodies; use '--body all' alone" >&2; exit 1
+fi
+unset _bodies_norm _BODY_LIST _b
 
 # Returns 0 if the given body should be processed.
 # Normalises case and strips spaces so --body "Earth, Moon" works as expected.

--- a/tools/fetch-textures.sh
+++ b/tools/fetch-textures.sh
@@ -79,6 +79,23 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Validate --resolution
+case "$RESOLUTION" in
+  2k|4k|8k|16k|all) ;;
+  *) echo "Error: unknown resolution '$RESOLUTION' (expected: 2k|4k|8k|16k|all)" >&2; exit 1 ;;
+esac
+
+# Validate --body entries
+IFS=',' read -ra _BODY_LIST <<< "${BODIES,,}"
+for _b in "${_BODY_LIST[@]}"; do
+  _b="${_b// /}"
+  case "$_b" in
+    earth|moon|mars|sun|all) ;;
+    *) echo "Error: unknown body '$_b' (expected: earth,moon,mars,sun or all)" >&2; exit 1 ;;
+  esac
+done
+unset _BODY_LIST _b
+
 # Returns 0 if the given body should be processed.
 # Normalises case and strips spaces so --body "Earth, Moon" works as expected.
 include_body() {

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -291,7 +291,7 @@ export function App() {
   // Derived values
   const textureBaseUrl = useMemo(
     () => resolveTextureBaseUrl(wsSource.isConnected, wsUrl, VITE_TEXTURE_BASE_URL),
-    [wsSource.isConnected, wsUrl],
+    [wsSource.isConnected, wsUrl, VITE_TEXTURE_BASE_URL],
   );
 
   useEffect(() => {

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -28,7 +28,7 @@ const DEFAULT_WS_URL: string =
   import.meta.env.VITE_WS_URL ??
   `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/ws`;
 
-// Build-time texture base URL (static deployments only). Undefined in dev/embed.
+// Build-time texture base URL — present when VITE_TEXTURE_BASE_URL is set at Vite startup.
 const VITE_TEXTURE_BASE_URL = import.meta.env.VITE_TEXTURE_BASE_URL;
 
 export function App() {

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -299,7 +299,9 @@ export function App() {
     // set VITE_TEXTURE_BASE_URL at build time (e.g. /orts/viewer/textures/).
     // Without the env var — local dev without a server, third-party embeds —
     // we keep the bundled 2K and avoid probing paths that likely don't exist.
-    return import.meta.env.VITE_TEXTURE_BASE_URL ?? undefined;
+    const raw = import.meta.env.VITE_TEXTURE_BASE_URL;
+    if (!raw) return undefined;
+    return raw.endsWith("/") ? raw : `${raw}/`;
   }, [wsSource.isConnected, wsUrl]);
 
   const satelliteNames = useMemo(() => {

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -20,6 +20,7 @@ import type { ClientMessage } from "./protocol/generated/ClientMessage.js";
 import { DEFAULT_FRAME, type ReferenceFrame } from "./referenceFrame.js";
 import { useSourceRuntime } from "./sources/useSourceRuntime.js";
 import { useWebSocketSource, WS_SOURCE_ID } from "./sources/useWebSocketSource.js";
+import { resolveTextureBaseUrl } from "./textureBaseUrl.js";
 import { planInitialRangeQuery } from "./utils/initialRangeQuery.js";
 import { readTimeRangeParam, writeTimeRangeParam } from "./utils/urlParams.js";
 
@@ -285,24 +286,19 @@ export function App() {
   }, [fileSource.fileSourceActive, wsSource.isConnected, noAutoConnect]);
 
   // Derived values
-  const textureBaseUrl = useMemo(() => {
-    // Prefer WS server when connected — it fetches and resizes textures on demand.
-    if (wsSource.isConnected) {
-      try {
-        const u = new URL(wsUrl.replace(/^ws/, "http"));
-        return `${u.origin}/textures/`;
-      } catch {
-        return undefined;
-      }
-    }
-    // Static deployments that ship high-res textures alongside the viewer can
-    // set VITE_TEXTURE_BASE_URL at build time (e.g. /orts/viewer/textures/).
-    // Without the env var — local dev without a server, third-party embeds —
-    // we keep the bundled 2K and avoid probing paths that likely don't exist.
-    const raw = import.meta.env.VITE_TEXTURE_BASE_URL?.trim();
-    if (!raw) return undefined;
-    return raw.endsWith("/") ? raw : `${raw}/`;
-  }, [wsSource.isConnected, wsUrl]);
+  const textureBaseUrl = useMemo(
+    () => resolveTextureBaseUrl(wsSource.isConnected, wsUrl, import.meta.env.VITE_TEXTURE_BASE_URL),
+    [wsSource.isConnected, wsUrl],
+  );
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    const w = window as unknown as Record<string, unknown>;
+    w.__debug_texture_base_url = textureBaseUrl;
+    return () => {
+      delete w.__debug_texture_base_url;
+    };
+  }, [textureBaseUrl]);
 
   const satelliteNames = useMemo(() => {
     if (!simInfo) return undefined;

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -286,17 +286,20 @@ export function App() {
 
   // Derived values
   const textureBaseUrl = useMemo(() => {
-    // High-res textures are served by a connected orts server, which downloads
-    // and resizes them on demand. Without a live server — file replay, or no
-    // connection — stay on the bundled 2K base rather than fetching resolutions
-    // that may not exist (which otherwise stalls on big decodes / 404 retries).
-    if (!wsSource.isConnected) return undefined;
-    try {
-      const u = new URL(wsUrl.replace(/^ws/, "http"));
-      return `${u.origin}/textures/`;
-    } catch {
-      return undefined;
+    // Prefer WS server when connected — it fetches and resizes textures on demand.
+    if (wsSource.isConnected) {
+      try {
+        const u = new URL(wsUrl.replace(/^ws/, "http"));
+        return `${u.origin}/textures/`;
+      } catch {
+        return undefined;
+      }
     }
+    // Static deployments that ship high-res textures alongside the viewer can
+    // set VITE_TEXTURE_BASE_URL at build time (e.g. /orts/viewer/textures/).
+    // Without the env var — local dev without a server, third-party embeds —
+    // we keep the bundled 2K and avoid probing paths that likely don't exist.
+    return import.meta.env.VITE_TEXTURE_BASE_URL ?? undefined;
   }, [wsSource.isConnected, wsUrl]);
 
   const satelliteNames = useMemo(() => {

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -299,7 +299,7 @@ export function App() {
     // set VITE_TEXTURE_BASE_URL at build time (e.g. /orts/viewer/textures/).
     // Without the env var — local dev without a server, third-party embeds —
     // we keep the bundled 2K and avoid probing paths that likely don't exist.
-    const raw = import.meta.env.VITE_TEXTURE_BASE_URL;
+    const raw = import.meta.env.VITE_TEXTURE_BASE_URL?.trim();
     if (!raw) return undefined;
     return raw.endsWith("/") ? raw : `${raw}/`;
   }, [wsSource.isConnected, wsUrl]);

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -28,6 +28,9 @@ const DEFAULT_WS_URL: string =
   import.meta.env.VITE_WS_URL ??
   `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/ws`;
 
+// Build-time texture base URL (static deployments only). Undefined in dev/embed.
+const VITE_TEXTURE_BASE_URL = import.meta.env.VITE_TEXTURE_BASE_URL;
+
 export function App() {
   // WASM initialization (must complete before rendering ECEF transforms)
   const [wasmReady, setWasmReady] = useState(false);
@@ -287,7 +290,7 @@ export function App() {
 
   // Derived values
   const textureBaseUrl = useMemo(
-    () => resolveTextureBaseUrl(wsSource.isConnected, wsUrl, import.meta.env.VITE_TEXTURE_BASE_URL),
+    () => resolveTextureBaseUrl(wsSource.isConnected, wsUrl, VITE_TEXTURE_BASE_URL),
     [wsSource.isConnected, wsUrl],
   );
 

--- a/viewer/src/textureBaseUrl.test.ts
+++ b/viewer/src/textureBaseUrl.test.ts
@@ -9,9 +9,9 @@ describe("resolveTextureBaseUrl", () => {
   });
 
   it("WS takes priority over env var when connected", () => {
-    expect(
-      resolveTextureBaseUrl(true, "ws://example.com/ws", "/orts/viewer/textures/"),
-    ).toBe("http://example.com/textures/");
+    expect(resolveTextureBaseUrl(true, "ws://example.com/ws", "/orts/viewer/textures/")).toBe(
+      "http://example.com/textures/",
+    );
   });
 
   it("falls back to envBaseUrl when disconnected", () => {

--- a/viewer/src/textureBaseUrl.test.ts
+++ b/viewer/src/textureBaseUrl.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { resolveTextureBaseUrl } from "./textureBaseUrl.js";
+
+describe("resolveTextureBaseUrl", () => {
+  it("returns WS server origin when connected", () => {
+    expect(resolveTextureBaseUrl(true, "ws://example.com:9001/ws", undefined)).toBe(
+      "http://example.com:9001/textures/",
+    );
+  });
+
+  it("WS takes priority over env var when connected", () => {
+    expect(
+      resolveTextureBaseUrl(true, "ws://example.com/ws", "/orts/viewer/textures/"),
+    ).toBe("http://example.com/textures/");
+  });
+
+  it("falls back to envBaseUrl when disconnected", () => {
+    expect(resolveTextureBaseUrl(false, "", "/orts/viewer/textures/")).toBe(
+      "/orts/viewer/textures/",
+    );
+  });
+
+  it("adds trailing slash when envBaseUrl is missing it", () => {
+    expect(resolveTextureBaseUrl(false, "", "/orts/viewer/textures")).toBe(
+      "/orts/viewer/textures/",
+    );
+  });
+
+  it("trims whitespace from envBaseUrl", () => {
+    expect(resolveTextureBaseUrl(false, "", "  /orts/viewer/textures/  ")).toBe(
+      "/orts/viewer/textures/",
+    );
+  });
+
+  it("returns undefined when disconnected and envBaseUrl is absent", () => {
+    expect(resolveTextureBaseUrl(false, "", undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when disconnected and envBaseUrl is whitespace-only", () => {
+    expect(resolveTextureBaseUrl(false, "", "   ")).toBeUndefined();
+  });
+});

--- a/viewer/src/textureBaseUrl.ts
+++ b/viewer/src/textureBaseUrl.ts
@@ -1,0 +1,26 @@
+/**
+ * Resolve the base URL for texture fetches.
+ *
+ * Priority:
+ *  1. WS server origin (when connected) — server resizes on demand.
+ *  2. Build-time VITE_TEXTURE_BASE_URL (static deployments that ship
+ *     high-res textures alongside the viewer bundle).
+ *  3. undefined — keep bundled 2K textures; do not probe unknown paths.
+ */
+export function resolveTextureBaseUrl(
+  isConnected: boolean,
+  wsUrl: string,
+  envBaseUrl: string | undefined,
+): string | undefined {
+  if (isConnected) {
+    try {
+      const u = new URL(wsUrl.replace(/^ws/, "http"));
+      return `${u.origin}/textures/`;
+    } catch {
+      return undefined;
+    }
+  }
+  const raw = envBaseUrl?.trim();
+  if (!raw) return undefined;
+  return raw.endsWith("/") ? raw : `${raw}/`;
+}

--- a/viewer/src/vite-env.d.ts
+++ b/viewer/src/vite-env.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_WS_URL?: string;
+  readonly VITE_TEXTURE_BASE_URL?: string;
+  readonly VITE_GA_MEASUREMENT_ID?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/viewer/tests/texture-base-url.spec.ts
+++ b/viewer/tests/texture-base-url.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+// Verify the textureBaseUrl resolution for the static-deployment path (#105).
+//
+// The VITE_TEXTURE_BASE_URL env var is a build-time constant (undefined in the
+// Vite dev server), so we test two things:
+//
+// (a) No env var + no WS → textureBaseUrl is undefined (2K bundled textures).
+//     Covered here via window.__debug_texture_base_url (DEV-mode only hook).
+//
+// (b) Env var set + no WS → textureBaseUrl derived from env var.
+//     Covered by unit tests in src/textureBaseUrl.test.ts (vi.stubEnv friendly).
+
+test("textureBaseUrl is undefined when disconnected and VITE_TEXTURE_BASE_URL is not set", async ({
+  page,
+}) => {
+  await page.goto("/?noAutoConnect=1");
+
+  // Wait for the React app to mount (canvas appears when Three.js scene initialises).
+  await page.waitForSelector("canvas", { timeout: 15000 });
+
+  const url = await page.evaluate(
+    () => (window as unknown as Record<string, unknown>).__debug_texture_base_url,
+  );
+  expect(url).toBeUndefined();
+});

--- a/viewer/tests/texture-base-url.spec.ts
+++ b/viewer/tests/texture-base-url.spec.ts
@@ -1,20 +1,16 @@
 import { expect, test } from "@playwright/test";
+import { resolveTextureBaseUrl } from "../src/textureBaseUrl.js";
 
 // Verify the textureBaseUrl resolution for the static-deployment path (#105).
 //
-// VITE_TEXTURE_BASE_URL is read at Vite startup: it is defined only when the
-// env var is set before `vite` (or `vite build`) runs. In the default test
-// environment the env var is absent, so the var resolves to undefined.
+// VITE_TEXTURE_BASE_URL is read at Vite startup and can be set in any mode
+// (dev, build, or custom). The expected value is derived from
+// process.env.VITE_TEXTURE_BASE_URL so the test remains correct whether or
+// not the env var is present in the test environment.
 //
-// (a) No env var + no WS → textureBaseUrl is undefined (2K bundled textures).
-//     Covered here via window.__debug_texture_base_url (DEV-mode only hook).
-//
-// (b) Env var set + no WS → textureBaseUrl derived from env var.
-//     Covered by unit tests in src/textureBaseUrl.test.ts.
+// The "env var set" path is covered by unit tests in src/textureBaseUrl.test.ts.
 
-test("textureBaseUrl is undefined when disconnected and VITE_TEXTURE_BASE_URL is not set", async ({
-  page,
-}) => {
+test("textureBaseUrl matches VITE_TEXTURE_BASE_URL when disconnected", async ({ page }) => {
   await page.goto("/?noAutoConnect=1");
 
   // Wait for the React app to mount (canvas appears when Three.js scene initialises).
@@ -31,5 +27,9 @@ test("textureBaseUrl is undefined when disconnected and VITE_TEXTURE_BASE_URL is
   const url = await page.evaluate(
     () => (window as unknown as Record<string, unknown>).__debug_texture_base_url,
   );
-  expect(url).toBeUndefined();
+
+  // Derive expected value the same way the app does — handles the case where
+  // a developer or CI has VITE_TEXTURE_BASE_URL set in their environment.
+  const expected = resolveTextureBaseUrl(false, "", process.env.VITE_TEXTURE_BASE_URL);
+  expect(url).toBe(expected);
 });

--- a/viewer/tests/texture-base-url.spec.ts
+++ b/viewer/tests/texture-base-url.spec.ts
@@ -2,14 +2,15 @@ import { expect, test } from "@playwright/test";
 
 // Verify the textureBaseUrl resolution for the static-deployment path (#105).
 //
-// The VITE_TEXTURE_BASE_URL env var is a build-time constant (undefined in the
-// Vite dev server), so we test two things:
+// VITE_TEXTURE_BASE_URL is read at Vite startup: it is defined only when the
+// env var is set before `vite` (or `vite build`) runs. In the default test
+// environment the env var is absent, so the var resolves to undefined.
 //
 // (a) No env var + no WS → textureBaseUrl is undefined (2K bundled textures).
 //     Covered here via window.__debug_texture_base_url (DEV-mode only hook).
 //
 // (b) Env var set + no WS → textureBaseUrl derived from env var.
-//     Covered by unit tests in src/textureBaseUrl.test.ts (vi.stubEnv friendly).
+//     Covered by unit tests in src/textureBaseUrl.test.ts.
 
 test("textureBaseUrl is undefined when disconnected and VITE_TEXTURE_BASE_URL is not set", async ({
   page,
@@ -18,6 +19,14 @@ test("textureBaseUrl is undefined when disconnected and VITE_TEXTURE_BASE_URL is
 
   // Wait for the React app to mount (canvas appears when Three.js scene initialises).
   await page.waitForSelector("canvas", { timeout: 15000 });
+
+  // The debug hook is installed by a useEffect; wait for it to appear so we
+  // don't assert before the effect has run (a missing key and undefined both
+  // evaluate to undefined, which would cause a false positive).
+  await page.waitForFunction(
+    () => "__debug_texture_base_url" in (window as unknown as Record<string, unknown>),
+    { timeout: 5000 },
+  );
 
   const url = await page.evaluate(
     () => (window as unknown as Record<string, unknown>).__debug_texture_base_url,

--- a/viewer/tests/texture-base-url.spec.ts
+++ b/viewer/tests/texture-base-url.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from "@playwright/test";
-import { resolveTextureBaseUrl } from "../src/textureBaseUrl.js";
 
 // Verify the textureBaseUrl resolution for the static-deployment path (#105).
 //
@@ -28,8 +27,9 @@ test("textureBaseUrl matches VITE_TEXTURE_BASE_URL when disconnected", async ({ 
     () => (window as unknown as Record<string, unknown>).__debug_texture_base_url,
   );
 
-  // Derive expected value the same way the app does — handles the case where
-  // a developer or CI has VITE_TEXTURE_BASE_URL set in their environment.
-  const expected = resolveTextureBaseUrl(false, "", process.env.VITE_TEXTURE_BASE_URL);
+  // Inline the same normalization the app uses — avoids importing src code
+  // into a Node/Playwright context where .js→.ts rewriting may not apply.
+  const rawEnv = process.env.VITE_TEXTURE_BASE_URL?.trim();
+  const expected = rawEnv ? (rawEnv.endsWith("/") ? rawEnv : `${rawEnv}/`) : undefined;
   expect(url).toBe(expected);
 });


### PR DESCRIPTION
## Summary

- `VITE_TEXTURE_BASE_URL` env var を `App.tsx` の `textureBaseUrl` memo に追加
- WS 未接続時にこの env var が設定されていれば静的テクスチャを使用
- `vite-env.d.ts` に全カスタム env var (`VITE_WS_URL` / `VITE_TEXTURE_BASE_URL` / `VITE_GA_MEASUREMENT_ID`) の型定義を追加
- `deploy.yml` で以下の変更を実施:
  - `VITE_BASE_PATH` を job-level env に移動し `VITE_TEXTURE_BASE_URL` を導出（二重管理を解消）
  - ImageMagick・mold をインストール
  - `actions/cache` で 4k/8k テクスチャをキャッシュ（キーは fetch-textures.sh と deploy.yml のハッシュ）
  - キャッシュミス時に 4k/8k テクスチャを CI でダウンロード（Mars 12GB ソースは除外）
- `tools/fetch-textures.sh` に `--body` オプション追加・`include_body` を純 bash 実装・curl retry

## Background

#88 がテクスチャアップグレードを「WS サーバー接続時のみ」に制限した結果、`viewer/public/textures/earth_16k.jpg` が同梱されているにもかかわらず GitHub Pages の静的デプロイが常に 2K で表示されていた (#105)。

## Behaviour

| ケース | 変更前 | 変更後 |
|-------|-------|-------|
| WS 接続中 | サーバー URL 使用 | 同じ |
| 静的デプロイ (GitHub Pages) | 2K 固定 | 4k/8k/16k にアップグレード |
| サードパーティ embed (env var なし) | 2K 固定 | 2K 固定 (変化なし) |
| ローカル dev (未接続) | 2K 固定 | 2K 固定 (env var なし) |

## Operational impact

- deploy ジョブに ImageMagick インストールと最大 2 回の NASA テクスチャ取得ステップが追加
- キャッシュヒット時はネットワークアクセスなし（初回のみ ~数百 MB ダウンロード）
- Mars の 4k/8k/16k は 12GB GeoTIFF が必要なため CI では除外（`--body earth,moon,sun`）

## Test plan

- [ ] `VITE_TEXTURE_BASE_URL=/orts/viewer/textures/ pnpm dev` で地球テクスチャが 16k にアップグレードされることを確認
- [ ] env var なしの dev サーバーで 2K のまま変化がないことを確認
- [ ] deploy.yml の変更が CI で正常にビルドされることを確認

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)