### PR TITLE
fix(viewer): default WS URL to CLI default on static deploys

### DIFF
--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -21,12 +21,16 @@ import { DEFAULT_FRAME, type ReferenceFrame } from "./referenceFrame.js";
 import { useSourceRuntime } from "./sources/useSourceRuntime.js";
 import { useWebSocketSource, WS_SOURCE_ID } from "./sources/useWebSocketSource.js";
 import { resolveTextureBaseUrl } from "./textureBaseUrl.js";
+import { resolveDefaultWsUrl } from "./utils/defaultWsUrl.js";
 import { planInitialRangeQuery } from "./utils/initialRangeQuery.js";
 import { readTimeRangeParam, writeTimeRangeParam } from "./utils/urlParams.js";
 
-const DEFAULT_WS_URL: string =
-  import.meta.env.VITE_WS_URL ??
-  `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/ws`;
+const DEFAULT_WS_URL: string = resolveDefaultWsUrl({
+  explicitWsUrl: import.meta.env.VITE_WS_URL,
+  baseUrl: import.meta.env.BASE_URL,
+  protocol: window.location.protocol,
+  host: window.location.host,
+});
 
 // Build-time texture base URL — present when VITE_TEXTURE_BASE_URL is set at Vite startup.
 const VITE_TEXTURE_BASE_URL = import.meta.env.VITE_TEXTURE_BASE_URL;

--- a/viewer/src/utils/defaultWsUrl.test.ts
+++ b/viewer/src/utils/defaultWsUrl.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { CLI_DEFAULT_WS_URL, resolveDefaultWsUrl } from "./defaultWsUrl.js";
+
+describe("resolveDefaultWsUrl", () => {
+  it("returns the explicit VITE_WS_URL override when set", () => {
+    expect(
+      resolveDefaultWsUrl({
+        explicitWsUrl: "ws://example.test:1234/ws",
+        baseUrl: "/",
+        protocol: "https:",
+        host: "sksat.github.io",
+      }),
+    ).toBe("ws://example.test:1234/ws");
+  });
+
+  it("lets the explicit override win even on a static sub-path deploy", () => {
+    expect(
+      resolveDefaultWsUrl({
+        explicitWsUrl: "wss://relay.example/ws",
+        baseUrl: "/orts/viewer/",
+        protocol: "https:",
+        host: "sksat.github.io",
+      }),
+    ).toBe("wss://relay.example/ws");
+  });
+
+  it("treats an empty explicit override as unset", () => {
+    expect(
+      resolveDefaultWsUrl({
+        explicitWsUrl: "",
+        baseUrl: "/",
+        protocol: "http:",
+        host: "localhost:9001",
+      }),
+    ).toBe("ws://localhost:9001/ws");
+  });
+
+  it("derives from the page origin when co-served from the root (orts serve)", () => {
+    expect(
+      resolveDefaultWsUrl({
+        baseUrl: "/",
+        protocol: "http:",
+        host: "localhost:9001",
+      }),
+    ).toBe("ws://localhost:9001/ws");
+  });
+
+  it("preserves the served port when co-served on a non-default port", () => {
+    expect(
+      resolveDefaultWsUrl({
+        baseUrl: "/",
+        protocol: "http:",
+        host: "localhost:8080",
+      }),
+    ).toBe("ws://localhost:8080/ws");
+  });
+
+  it("uses wss when co-served over https (remote orts serve)", () => {
+    expect(
+      resolveDefaultWsUrl({
+        baseUrl: "/",
+        protocol: "https:",
+        host: "orts.example.com",
+      }),
+    ).toBe("wss://orts.example.com/ws");
+  });
+
+  it("falls back to the CLI default on a static sub-path deploy (GitHub Pages)", () => {
+    // GitHub Pages serves the viewer at a non-root base; the WS server is the
+    // user's local `orts serve`, not the Pages host.
+    expect(
+      resolveDefaultWsUrl({
+        baseUrl: "/orts/viewer/",
+        protocol: "https:",
+        host: "sksat.github.io",
+      }),
+    ).toBe(CLI_DEFAULT_WS_URL);
+  });
+
+  it("allows overriding the local CLI default", () => {
+    expect(
+      resolveDefaultWsUrl({
+        baseUrl: "/orts/viewer/",
+        protocol: "https:",
+        host: "sksat.github.io",
+        localCliWsUrl: "ws://127.0.0.1:7777/ws",
+      }),
+    ).toBe("ws://127.0.0.1:7777/ws");
+  });
+
+  it("exposes the CLI default matching `orts serve` (port 9001)", () => {
+    expect(CLI_DEFAULT_WS_URL).toBe("ws://localhost:9001/ws");
+  });
+});

--- a/viewer/src/utils/defaultWsUrl.ts
+++ b/viewer/src/utils/defaultWsUrl.ts
@@ -1,0 +1,50 @@
+/**
+ * The WebSocket endpoint `orts serve` advertises by default
+ * (`ws://localhost:9001/ws`, matching the CLI's `--port 9001` default).
+ *
+ * Used as the connection default for static deployments (e.g. GitHub Pages)
+ * where the page host is not the telemetry server — the user runs `orts serve`
+ * locally and the viewer dials back to it.
+ */
+export const CLI_DEFAULT_WS_URL = "ws://localhost:9001/ws";
+
+export interface ResolveDefaultWsUrlInput {
+  /** Build-time override (`import.meta.env.VITE_WS_URL`). Wins when non-empty. */
+  explicitWsUrl?: string;
+  /** Vite base path (`import.meta.env.BASE_URL`); `"/"` unless a sub-path build. */
+  baseUrl: string;
+  /** Page protocol (`window.location.protocol`), e.g. `"https:"`. */
+  protocol: string;
+  /** Page host incl. port (`window.location.host`), e.g. `"localhost:9001"`. */
+  host: string;
+  /** Override for the static-deploy fallback; defaults to {@link CLI_DEFAULT_WS_URL}. */
+  localCliWsUrl?: string;
+}
+
+/**
+ * Resolve the default WebSocket URL the viewer connects to on startup.
+ *
+ * Precedence:
+ * 1. An explicit `VITE_WS_URL` build override always wins.
+ * 2. A non-root `baseUrl` marks a static sub-path deploy (only the GitHub Pages
+ *    build sets `VITE_BASE_PATH`). There the page host is *not* the WS server,
+ *    so dial the CLI default — the user's local `orts serve`. This is a
+ *    project-local build contract, not a general "base path ⇒ WS location"
+ *    rule: were `orts serve` ever to host the viewer under a sub-path, this
+ *    would need revisiting (set `VITE_WS_URL` for such deploys).
+ * 3. Otherwise the viewer is co-served by `orts serve` at the origin root
+ *    (locally or on a remote box, since serve binds `0.0.0.0`), so derive the
+ *    URL from the page origin — preserving a non-default `--port`.
+ */
+export function resolveDefaultWsUrl({
+  explicitWsUrl,
+  baseUrl,
+  protocol,
+  host,
+  localCliWsUrl = CLI_DEFAULT_WS_URL,
+}: ResolveDefaultWsUrlInput): string {
+  if (explicitWsUrl) return explicitWsUrl;
+  if (baseUrl !== "/") return localCliWsUrl;
+  const wsProtocol = protocol === "https:" ? "wss:" : "ws:";
+  return `${wsProtocol}//${host}/ws`;
+}


### PR DESCRIPTION
## 背景 / 問題

GitHub Pages にデプロイされた viewer (`https://…github.io/orts/viewer/`) が、存在しない `wss://…github.io/ws` に接続しようとしていた。

原因: `viewer/src/App.tsx` の `DEFAULT_WS_URL` が `window.location.host` から WS URL を導出していたため、ページ host (`*.github.io`) をそのまま WS サーバ所在として扱っていた。静的ホスティングでは WS サーバはユーザ手元の `orts serve` であって Pages host ではない。

## 変更

判定を純粋関数 `resolveDefaultWsUrl()` (`viewer/src/utils/defaultWsUrl.ts`) に切り出し、優先順位を整理:

1. `VITE_WS_URL` の明示 override が最優先
2. **非ルート base** (`import.meta.env.BASE_URL !== "/"`) = 静的サブパスデプロイ → CLI デフォルト `ws://localhost:9001/ws` (`orts serve --port 9001` と一致)。`VITE_BASE_PATH` を立てるのは GitHub Pages build (`deploy.yml`) だけ
3. それ以外 (orts serve 埋め込み build, base=`/`) → 従来どおりページオリジンから導出。ローカル/リモート co-serve、非デフォルト `--port` も維持

「base path = WS サーバ所在」という一般則ではなく **このプロジェクト固有のビルド契約** であることを docコメントに明記(将来 orts serve をサブパスで co-serve するなら要見直し)。`VITE_WS_URL` は引き続き escape hatch。

## テスト / 検証

- 新規ユニットテスト 9 件 — 全分岐を `window` 非依存で網羅 (TDD: red → green)
- viewer 全ユニットテスト **394/394 pass**、`tsc --noEmit` OK、Biome 新規2ファイル clean
- `VITE_BASE_PATH=/orts/viewer/` で production build → バンドルに `ws://localhost:9001/ws` が入り `github.io` リテラルが無いことを確認

## 補足

mixed-content: `https://…github.io` → `ws://localhost:9001/ws` はモダンブラウザが `localhost` を potentially-trustworthy 扱いするため通る(現状の壊れた挙動より厳密に改善)。本番ブラウザでの実挙動は別途 E2E で確認するとより安心。

🤖 Generated with [Claude Code](https://claude.com/claude-code)