### PR TITLE
ci(renovate): pin pnpm major via constraints

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>sksat/renovate-config"],
   "platformAutomerge": false,
+  "constraints": {
+    "pnpm": "10"
+  },
   "customManagers": [
     {
       "description": "Match '# renovate: datasource=... depName=...' followed by a VARNAME=value assignment in shell/CI",


### PR DESCRIPTION
## What

`renovate.json` に `constraints.pnpm: "10"` を追加し、Renovate が lockfile 更新/artifact 生成で使う pnpm を major 10 に固定する。

## Why

Renovate には pnpm のバージョン source が一切なかった（`packageManager` / `engines.pnpm` / `constraints` のいずれも未設定）。そのため Renovate は `pnpm-lock.yaml` の `lockfileVersion: 9.0` から版を推測するフォールバックに落ち、**pnpm 9 か 10 かが曖昧**だった。CI 自体は pnpm 10（`pnpm/action-setup` の `version: 10`）を使うため、この食い違いが複数の lockfile PR で多発していた **"Artifact file update failure" の有力な一因**。

`constraints`（範囲 `"10"`）を採用し、`packageManager` フィールドは使わない理由:
- `packageManager` は exact semver 必須（corepack が `pnpm@10` を拒否）→ pnpm の patch リリース毎に PR が出て煩い。
- `packageManager` は corepack 前提だが、corepack は Node.js v25+ で同梱配布が廃止された。`constraints` は corepack 非依存で将来も堅牢。

## Note

CI 側（`pnpm/action-setup version: 10`）は変更なし。本変更は Renovate の挙動のみに効く最小差分。

🤖 Generated with [Claude Code](https://claude.com/claude-code)