### PR TITLE
refactor(orts): use checked_div in ComponentColumn::num_rows

### DIFF
--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -29,11 +29,11 @@ impl ComponentColumn {
     }
 
     pub fn num_rows(&self) -> usize {
-        if self.scalars_per_row == 0 {
-            0
-        } else {
-            self.data.len() / self.scalars_per_row
-        }
+        // checked_div yields None when scalars_per_row == 0 (avoids div-by-zero).
+        self.data
+            .len()
+            .checked_div(self.scalars_per_row)
+            .unwrap_or(0)
     }
 
     pub fn get_row(&self, index: usize) -> Option<&[f64]> {


### PR DESCRIPTION
## What

`ComponentColumn::num_rows` の手書き checked-div を `checked_div(...).unwrap_or(0)` に置き換える（挙動は完全に等価）。

```rust
// before
if self.scalars_per_row == 0 { 0 } else { self.data.len() / self.scalars_per_row }
// after
self.data.len().checked_div(self.scalars_per_row).unwrap_or(0)
```

## Why

clippy の `manual_checked_ops` lint（Rust 1.96 で追加）が指摘する箇所。来る **rust-toolchain 1.91 → 1.96 bump** で `cargo clippy -- -D warnings` が落ちる要因の一つ。

これを**単独で先に入れておく**ことで、toolchain bump の PR を「toolchain 変更＋trybuild スナップショット再生成（こちらは toolchain と束ねる必要がある）」だけに絞れる。`checked_div` は Rust 1.0 から stable なので、**現行 1.91 でもコンパイル・clippy 緑**（ローカル確認済み: `cargo clippy -p orts --lib -- -D warnings` 緑、record モジュールテスト 46 件 pass）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)