### PR TITLE
feat(utsuroi): implement Error trait for IntegrationError

### DIFF
--- a/utsuroi/src/error.rs
+++ b/utsuroi/src/error.rs
@@ -27,6 +27,28 @@ pub enum IntegrationError {
     StepSizeTooSmall { t: f64, dt: f64 },
 }
 
+impl core::fmt::Display for IntegrationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::NonFiniteState { t } => {
+                write!(f, "non-finite state (NaN or Inf) detected at t = {t}")
+            }
+            Self::StepSizeTooSmall { t, dt } => {
+                write!(
+                    f,
+                    "step size {dt} fell below the minimum threshold at t = {t}"
+                )
+            }
+        }
+    }
+}
+
+// `core::error::Error` (re-exported as `std::error::Error` since Rust 1.81) so the
+// error participates in `?` chains. No inner cause, so `source()` stays the default
+// `None`. Implemented by hand rather than via `thiserror` to keep utsuroi free of
+// proc-macro dependencies (it pulls in only nalgebra + libm).
+impl core::error::Error for IntegrationError {}
+
 /// Outcome of an integration with event detection.
 #[derive(Debug, Clone)]
 pub enum IntegrationOutcome<Y: OdeState, B> {
@@ -36,4 +58,54 @@ pub enum IntegrationOutcome<Y: OdeState, B> {
     Terminated { state: Y, t: f64, reason: B },
     /// Integration was aborted due to a numerical error.
     Error(IntegrationError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Compile-time proof that the bound holds in no_std too: we assert against
+    // `core::error::Error`, which is what `std::error::Error` re-exports since 1.81.
+    fn assert_error<E: core::error::Error>() {}
+
+    #[test]
+    fn implements_error_trait() {
+        assert_error::<IntegrationError>();
+    }
+
+    #[test]
+    fn display_mentions_cause_and_time() {
+        let msg = IntegrationError::NonFiniteState { t: 1.5 }.to_string();
+        assert!(msg.contains("1.5"), "display should report t: {msg}");
+        assert!(
+            msg.to_lowercase().contains("non-finite") || msg.to_lowercase().contains("nan"),
+            "display should explain the cause: {msg}"
+        );
+
+        let msg = IntegrationError::StepSizeTooSmall { t: 2.0, dt: 1e-15 }.to_string();
+        assert!(msg.contains('2'), "display should report t: {msg}");
+        assert!(
+            msg.to_lowercase().contains("step"),
+            "display should explain the cause: {msg}"
+        );
+    }
+
+    #[test]
+    fn no_inner_source() {
+        use std::error::Error;
+        assert!(
+            IntegrationError::NonFiniteState { t: 0.0 }
+                .source()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn propagates_with_question_mark() {
+        fn fallible() -> Result<(), Box<dyn std::error::Error>> {
+            Err(IntegrationError::StepSizeTooSmall { t: 0.0, dt: 0.0 })?;
+            Ok(())
+        }
+        assert!(fallible().is_err());
+    }
 }


### PR DESCRIPTION
## 概要

`#104` の項目1（4項目中）。utsuroi の `IntegrationError` に `std::error::Error` を実装し、`?` チェーンや `Box<dyn Error>` に乗せられるようにする。

## 背景

`IntegrationError` はこれまで `Debug + Clone + PartialEq` のみで `Error` を実装していなかったため、`?` で上位エラーへ伝播したり `dyn Error` として扱えなかった。

## 変更

- `impl core::fmt::Display`（原因 + 発生時刻 `t` を含む説明的メッセージ）
- `impl core::error::Error`（leaf error なので `source()` はデフォルトの `None`）

### 設計判断

- **手書き実装（thiserror 不採用）**: 内部 source を持たない 2 variant の leaf error で `#[from]`/`#[source]` の旨味がなく、utsuroi の「nalgebra + libm 以外の依存ゼロ」という軽量さを保つため proc-macro 依存を増やさない。
- **`core::error::Error` を使用**: Rust 1.81 以降 `std::error::Error` は `core::error::Error` の re-export。これにより feature gate なしで **std/no_std 両方**で `Error` として機能する。

## テスト（TDD）

- `core::error::Error` 実装のコンパイル時アサート（no_std でも成立する保証）
- Display メッセージが原因と `t` を含むこと
- `source()` が `None`
- `Box<dyn std::error::Error>` への `?` 伝播

## 検証（CI 相当）

- `cargo test -p utsuroi` … 120 passed
- `cargo clippy --locked -p utsuroi -- -D warnings` … clean
- `cargo clippy --locked -p utsuroi --no-default-features -- -D warnings`（no_std）… clean
- `cargo fmt -p utsuroi --check` … clean
- no_std / `wasm32-unknown-unknown` ビルド成功

挙動変更なし（追加のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)