### PR TITLE
fix(spacecraft): StateEffector を frame-generic 化して effector load の無検査 re-tag を除去

### DIFF
--- a/orts/src/effector.rs
+++ b/orts/src/effector.rs
@@ -7,6 +7,7 @@
 //! plant state.
 
 use arika::epoch::Epoch;
+use arika::frame::{self, SimpleEci};
 use utsuroi::{OdeState, Tolerances};
 
 use crate::model::ExternalLoads;
@@ -21,7 +22,17 @@ use crate::model::ExternalLoads;
 ///
 /// The `derivatives` method writes aux_rates into a caller-owned buffer
 /// to avoid allocation in the ODE hot path.
-pub trait StateEffector<S>: Send + Sync + std::any::Any {
+///
+/// The second type parameter `F` selects the inertial frame of the returned
+/// [`ExternalLoads`] (default `SimpleEci`), mirroring [`Model<S, F>`]. An
+/// effector contributes its loads directly in the host's frame, so the host
+/// never re-tags coordinates: torque-only effectors (reaction wheels) are
+/// `impl<S, F: Eci> StateEffector<S, F>` because body-frame torque is
+/// frame-independent, while a translational effector must produce its
+/// inertial acceleration in `F` explicitly (see issue #103).
+///
+/// [`Model<S, F>`]: crate::model::Model
+pub trait StateEffector<S, F: frame::Eci = SimpleEci>: Send + Sync + std::any::Any {
     /// Human-readable name for this effector (e.g., "reaction_wheels").
     fn name(&self) -> &str;
 
@@ -32,7 +43,8 @@ pub trait StateEffector<S>: Send + Sync + std::any::Any {
     ///
     /// `aux` is the current auxiliary state slice (length = `state_dim()`).
     /// `aux_rates` is the output buffer for derivatives (length = `state_dim()`).
-    /// Returns `ExternalLoads` contribution to the plant dynamics.
+    /// Returns the [`ExternalLoads<F>`] contribution to the plant dynamics,
+    /// already expressed in the host's inertial frame `F`.
     fn derivatives(
         &self,
         t: f64,
@@ -40,7 +52,7 @@ pub trait StateEffector<S>: Send + Sync + std::any::Any {
         aux: &[f64],
         aux_rates: &mut [f64],
         epoch: Option<&Epoch>,
-    ) -> ExternalLoads;
+    ) -> ExternalLoads<F>;
 
     /// Per-element (min, max) bounds for auxiliary state projection.
     ///

--- a/orts/src/spacecraft/dynamics.rs
+++ b/orts/src/spacecraft/dynamics.rs
@@ -4,7 +4,7 @@ use crate::effector::{AugmentedState, AuxRegistry, StateEffector};
 use crate::model::Model;
 use crate::orbital::gravity::GravityField;
 use arika::epoch::Epoch;
-use arika::frame::{Eci, SimpleEci, Vec3};
+use arika::frame::{Eci, SimpleEci};
 use nalgebra::Matrix3;
 use utsuroi::DynamicalSystem;
 
@@ -35,7 +35,7 @@ pub struct SpacecraftDynamics<G: GravityField, F: Eci = SimpleEci> {
     inertia: Matrix3<f64>,
     inertia_inv: Matrix3<f64>,
     models: Vec<Box<dyn Model<SpacecraftState<F>, F>>>,
-    effectors: Vec<Box<dyn StateEffector<SpacecraftState<F>>>>,
+    effectors: Vec<Box<dyn StateEffector<SpacecraftState<F>, F>>>,
     registry: AuxRegistry,
     epoch_0: Option<Epoch>,
     body_radius: Option<f64>,
@@ -79,10 +79,13 @@ impl<G: GravityField, F: Eci + 'static> SpacecraftDynamics<G, F> {
     /// Add a state effector (builder pattern).
     ///
     /// Effectors have auxiliary state (e.g. RW angular momentum) that
-    /// is integrated alongside the plant state.
+    /// is integrated alongside the plant state. The effector must produce
+    /// its loads in this system's inertial frame `F` (its
+    /// [`StateEffector::derivatives`] returns [`ExternalLoads<F>`]), so the
+    /// dynamics never re-tag coordinates. See issue #103.
     pub fn with_effector(
         mut self,
-        effector: impl StateEffector<SpacecraftState<F>> + 'static,
+        effector: impl StateEffector<SpacecraftState<F>, F> + 'static,
     ) -> Self {
         let dim = effector.state_dim();
         self.registry.register(effector.name(), dim);
@@ -122,7 +125,7 @@ impl<G: GravityField, F: Eci + 'static> SpacecraftDynamics<G, F> {
     }
 
     /// Downcast a state effector by index (immutable).
-    pub fn effector<T: StateEffector<SpacecraftState<F>> + 'static>(
+    pub fn effector<T: StateEffector<SpacecraftState<F>, F> + 'static>(
         &self,
         index: usize,
     ) -> Option<&T> {
@@ -132,7 +135,7 @@ impl<G: GravityField, F: Eci + 'static> SpacecraftDynamics<G, F> {
     }
 
     /// Downcast a state effector by index (mutable).
-    pub fn effector_mut<T: StateEffector<SpacecraftState<F>> + 'static>(
+    pub fn effector_mut<T: StateEffector<SpacecraftState<F>, F> + 'static>(
         &mut self,
         index: usize,
     ) -> Option<&mut T> {
@@ -142,7 +145,7 @@ impl<G: GravityField, F: Eci + 'static> SpacecraftDynamics<G, F> {
     }
 
     /// Find and downcast a state effector by name (immutable).
-    pub fn effector_by_name<T: StateEffector<SpacecraftState<F>> + 'static>(
+    pub fn effector_by_name<T: StateEffector<SpacecraftState<F>, F> + 'static>(
         &self,
         name: &str,
     ) -> Option<&T> {
@@ -155,7 +158,7 @@ impl<G: GravityField, F: Eci + 'static> SpacecraftDynamics<G, F> {
     }
 
     /// Find and downcast a state effector by name (mutable).
-    pub fn effector_by_name_mut<T: StateEffector<SpacecraftState<F>> + 'static>(
+    pub fn effector_by_name_mut<T: StateEffector<SpacecraftState<F>, F> + 'static>(
         &mut self,
         name: &str,
     ) -> Option<&mut T> {
@@ -252,26 +255,21 @@ impl<G: GravityField, F: Eci + 'static> DynamicalSystem for SpacecraftDynamics<G
             total += model.eval(t, &state.plant, epoch.as_ref());
         }
 
-        // Evaluate state effectors
-        // Note: StateEffector::derivatives returns ExternalLoads (= ExternalLoads<SimpleEci>).
-        // We convert to ExternalLoads<F> via raw vectors, which is safe because the
-        // underlying representation is identical (Vec3 is a newtype over Vector3<f64>).
+        // Evaluate state effectors.
+        //
+        // INVARIANT: a `StateEffector<S, F>` returns `ExternalLoads<F>` —
+        // already expressed in this system's inertial frame `F` — so loads
+        // accumulate directly with no coordinate re-tag. Torque-only
+        // effectors (reaction wheels) are `impl<.., F: Eci>` because
+        // body-frame torque is frame-independent; a translational effector
+        // must produce its inertial acceleration in `F` itself. This is what
+        // makes the SimpleEci→`F` mislabel from issue #103 unrepresentable.
         let mut aux_rates = vec![0.0; self.registry.total_dim()];
         for (i, eff) in self.effectors.iter().enumerate() {
             let entry = &self.registry.entries()[i];
             let aux_slice = &state.aux[entry.offset..entry.offset + entry.dim];
             let rates_slice = &mut aux_rates[entry.offset..entry.offset + entry.dim];
-            let eff_loads =
-                eff.derivatives(t, &state.plant, aux_slice, rates_slice, epoch.as_ref());
-            // TODO: StateEffector::derivatives returns ExternalLoads<SimpleEci>.
-            // When F != SimpleEci, this raw re-tag is only correct if the effector
-            // produces zero translational acceleration (torque-only, like RW).
-            // Making StateEffector frame-generic is needed for Gcrs effectors
-            // that contribute translational loads.
-            total.acceleration_inertial +=
-                Vec3::<F>::from_raw(*eff_loads.acceleration_inertial.inner());
-            total.torque_body += eff_loads.torque_body;
-            total.mass_rate += eff_loads.mass_rate;
+            total += eff.derivatives(t, &state.plant, aux_slice, rates_slice, epoch.as_ref());
         }
 
         // Total translational acceleration
@@ -810,5 +808,190 @@ mod tests {
             "spacecraft should react to RW torque"
         );
         assert!(result.is_finite());
+    }
+
+    // Step 8: frame-generic StateEffector (issue #103 fix)
+    //
+    // A `StateEffector<S, F>` returns `ExternalLoads<F>` — already in the
+    // host inertial frame — so the dynamics accumulate effector loads with
+    // no coordinate re-tag. Torque-only effectors work on any `F`; a
+    // translational effector produces its inertial acceleration in `F`
+    // itself (e.g. by rotating a body-frame thrust via
+    // `rotation_to_inertial::<F>`). This makes the old SimpleEci→`F`
+    // mislabel unrepresentable.
+
+    use crate::model::HasAttitude;
+    use arika::frame::{Body, Gcrs, Vec3 as FrameVec3};
+
+    /// Translational mock: contributes a constant acceleration already
+    /// expressed in the host frame `F`.
+    struct ConstAccelEffector {
+        accel: Vector3<f64>,
+    }
+
+    impl<S, F: Eci> StateEffector<S, F> for ConstAccelEffector {
+        fn name(&self) -> &str {
+            "const_accel"
+        }
+        fn state_dim(&self) -> usize {
+            0
+        }
+        fn derivatives(
+            &self,
+            _t: f64,
+            _state: &S,
+            _aux: &[f64],
+            _aux_rates: &mut [f64],
+            _epoch: Option<&Epoch>,
+        ) -> ExternalLoads<F> {
+            ExternalLoads::<F>::acceleration(self.accel)
+        }
+    }
+
+    /// Realistic translational mock: a body-frame thrust rotated into the
+    /// host inertial frame `F` — the correct pattern for a thruster effector
+    /// on any frame, with no silent re-tag.
+    struct BodyThrustEffector {
+        accel_body: Vector3<f64>,
+    }
+
+    impl<S: HasAttitude, F: Eci> StateEffector<S, F> for BodyThrustEffector {
+        fn name(&self) -> &str {
+            "body_thrust"
+        }
+        fn state_dim(&self) -> usize {
+            0
+        }
+        fn derivatives(
+            &self,
+            _t: f64,
+            state: &S,
+            _aux: &[f64],
+            _aux_rates: &mut [f64],
+            _epoch: Option<&Epoch>,
+        ) -> ExternalLoads<F> {
+            let a_body = FrameVec3::<Body>::from_raw(self.accel_body);
+            let a_inertial = state
+                .attitude()
+                .rotation_to_inertial::<F>()
+                .transform(&a_body);
+            ExternalLoads {
+                acceleration_inertial: a_inertial,
+                torque_body: FrameVec3::zeros(),
+                mass_rate: 0.0,
+            }
+        }
+    }
+
+    fn gcrs_spacecraft(attitude: AttitudeState) -> SpacecraftState<Gcrs> {
+        SpacecraftState {
+            orbit: crate::OrbitalState::new_in_frame(
+                Vector3::new(7000.0, 0.0, 0.0),
+                Vector3::new(0.0, 7.5, 0.0),
+            ),
+            attitude,
+            mass: 500.0,
+        }
+    }
+
+    #[test]
+    fn torque_only_effector_works_on_gcrs() {
+        // A torque-only effector (RW) registers and integrates on a
+        // non-SimpleEci system: the types now permit it because RW is
+        // `StateEffector<S, F>` for every `F`, and torque is frame-independent.
+        use crate::spacecraft::ReactionWheelAssembly;
+        let rw = ReactionWheelAssembly::three_axis(0.01, 1.0, 0.5);
+        let mut dyn_sc: SpacecraftDynamics<PointMass, Gcrs> =
+            SpacecraftDynamics::new(MU_EARTH, PointMass, symmetric_inertia(10.0)).with_effector(rw);
+        dyn_sc
+            .effector_mut::<ReactionWheelAssembly>(0)
+            .unwrap()
+            .command = crate::plugin::command::RwCommand::Torques(vec![0.01, 0.0, 0.0]);
+
+        let state = dyn_sc.initial_augmented_state(gcrs_spacecraft(AttitudeState::identity()));
+        let d = dyn_sc.derivatives(0.0, &state);
+
+        assert_eq!(d.aux.len(), 3);
+        // RW reaction torque produces a body angular acceleration, ...
+        assert!(d.plant.attitude.angular_velocity.magnitude() > 1e-9);
+        // ... and contributes zero inertial acceleration (gravity only).
+        let dyn_grav: SpacecraftDynamics<PointMass, Gcrs> =
+            SpacecraftDynamics::new(MU_EARTH, PointMass, symmetric_inertia(10.0));
+        let d_grav = dyn_grav.derivatives(
+            0.0,
+            &dyn_grav.initial_augmented_state(gcrs_spacecraft(AttitudeState::identity())),
+        );
+        assert!((d.plant.orbit.velocity() - d_grav.plant.orbit.velocity()).magnitude() < 1e-15);
+    }
+
+    #[test]
+    fn translational_effector_acceleration_applied_in_gcrs() {
+        // The effector's ExternalLoads<Gcrs> acceleration reaches the Gcrs
+        // translational EOM directly — no coordinate re-tag.
+        let accel = Vector3::new(1e-6, 2e-6, 3e-6);
+        let dyn_sc: SpacecraftDynamics<PointMass, Gcrs> =
+            SpacecraftDynamics::new(MU_EARTH, PointMass, symmetric_inertia(10.0))
+                .with_effector(ConstAccelEffector { accel });
+        let plant = gcrs_spacecraft(AttitudeState::identity());
+        let d = dyn_sc.derivatives(0.0, &dyn_sc.initial_augmented_state(plant.clone()));
+
+        let dyn_grav: SpacecraftDynamics<PointMass, Gcrs> =
+            SpacecraftDynamics::new(MU_EARTH, PointMass, symmetric_inertia(10.0));
+        let d_grav = dyn_grav.derivatives(0.0, &dyn_grav.initial_augmented_state(plant));
+
+        let diff = d.plant.orbit.velocity() - d_grav.plant.orbit.velocity();
+        assert!((diff - accel).magnitude() < 1e-15);
+    }
+
+    #[test]
+    fn body_thrust_effector_rotates_into_gcrs() {
+        // Regression guard for #103: a body-frame thrust is rotated into the
+        // host frame `F = Gcrs` via rotation_to_inertial::<F>, not re-tagged.
+        // 90° about +Z: body +X thrust → inertial +Y acceleration.
+        let half = std::f64::consts::FRAC_PI_2 / 2.0;
+        let attitude = AttitudeState {
+            quaternion: Vector4::new(half.cos(), 0.0, 0.0, half.sin()),
+            angular_velocity: Vector3::zeros(),
+        };
+        let dyn_sc: SpacecraftDynamics<PointMass, Gcrs> =
+            SpacecraftDynamics::new(MU_EARTH, PointMass, symmetric_inertia(10.0)).with_effector(
+                BodyThrustEffector {
+                    accel_body: Vector3::new(1e-6, 0.0, 0.0),
+                },
+            );
+        let plant = gcrs_spacecraft(attitude);
+        let d = dyn_sc.derivatives(0.0, &dyn_sc.initial_augmented_state(plant.clone()));
+
+        let dyn_grav: SpacecraftDynamics<PointMass, Gcrs> =
+            SpacecraftDynamics::new(MU_EARTH, PointMass, symmetric_inertia(10.0));
+        let d_grav = dyn_grav.derivatives(0.0, &dyn_grav.initial_augmented_state(plant));
+
+        let inertial_accel = d.plant.orbit.velocity() - d_grav.plant.orbit.velocity();
+        assert!(
+            inertial_accel[0].abs() < 1e-12,
+            "x ~0, got {}",
+            inertial_accel[0]
+        );
+        assert!(
+            (inertial_accel[1] - 1e-6).abs() < 1e-12,
+            "y = 1e-6, got {}",
+            inertial_accel[1]
+        );
+        assert!(inertial_accel[2].abs() < 1e-15);
+    }
+
+    #[test]
+    fn translational_effector_on_simple_eci_still_works() {
+        // Backward compatibility: the default `F = SimpleEci` path is unchanged.
+        let accel = Vector3::new(1e-6, 2e-6, 3e-6);
+        let dyn_sc = SpacecraftDynamics::new(MU_EARTH, PointMass, symmetric_inertia(10.0))
+            .with_effector(ConstAccelEffector { accel });
+        let d = dyn_sc.derivatives(0.0, &dyn_sc.initial_augmented_state(sample_spacecraft()));
+
+        let dyn_grav = SpacecraftDynamics::new(MU_EARTH, PointMass, symmetric_inertia(10.0));
+        let d_grav = dyn_grav.derivatives(0.0, &augment(sample_spacecraft()));
+
+        let diff = d.plant.orbit.velocity() - d_grav.plant.orbit.velocity();
+        assert!((diff - accel).magnitude() < 1e-15);
     }
 }

--- a/orts/src/spacecraft/reaction_wheel.rs
+++ b/orts/src/spacecraft/reaction_wheel.rs
@@ -15,6 +15,7 @@
 //! integrates wheel angular momentum.
 
 use arika::epoch::Epoch;
+use arika::frame::Eci;
 use nalgebra::Vector3;
 
 use super::ExternalLoads;
@@ -431,7 +432,11 @@ impl RwAssembly {
     }
 }
 
-impl<S: HasAttitude + Send + Sync> StateEffector<S> for RwAssembly {
+// Reaction wheels are frame-agnostic: their entire contribution is body-frame
+// reaction + gyroscopic torque, which is independent of the host inertial
+// frame `F`. The inertial acceleration is identically zero, so `RwAssembly`
+// implements `StateEffector<S, F>` for every `F: Eci`.
+impl<S: HasAttitude + Send + Sync, F: Eci> StateEffector<S, F> for RwAssembly {
     fn name(&self) -> &str {
         "reaction_wheels"
     }
@@ -463,7 +468,7 @@ impl<S: HasAttitude + Send + Sync> StateEffector<S> for RwAssembly {
         aux: &[f64],
         aux_rates: &mut [f64],
         _epoch: Option<&Epoch>,
-    ) -> ExternalLoads {
+    ) -> ExternalLoads<F> {
         let n = self.core.num_wheels();
         let omega = &state.attitude().angular_velocity;
         let momentum = self.core.momentum_slice(aux);
@@ -529,7 +534,8 @@ impl<S: HasAttitude + Send + Sync> StateEffector<S> for RwAssembly {
         // Gyroscopic coupling: −ω × H_rw
         let gyro = self.core.gyroscopic_torque(omega, momentum);
 
-        ExternalLoads::torque(reaction + gyro)
+        // Body-frame torque only; zero inertial acceleration in any frame `F`.
+        ExternalLoads::<F>::torque(reaction + gyro)
     }
 }
 
@@ -547,6 +553,18 @@ mod tests {
 
     fn test_state_at_rest() -> AttitudeState {
         AttitudeState::identity()
+    }
+
+    // `RwAssembly` is now `StateEffector<S, F>` for every frame `F`, so a bare
+    // `rw.derivatives(..)` is ambiguous in `F`. These single-frame tests pin
+    // `F = SimpleEci` via the return type.
+    fn rw_derivatives(
+        rw: &RwAssembly,
+        state: &AttitudeState,
+        aux: &[f64],
+        rates: &mut [f64],
+    ) -> ExternalLoads {
+        rw.derivatives(0.0, state, aux, rates, None)
     }
 
     // Core tests
@@ -840,7 +858,7 @@ mod tests {
         let state = test_state_at_rest();
         let aux = vec![0.0, 0.0, 0.0];
         let mut rates = vec![0.0, 0.0, 0.0];
-        let loads = rw.derivatives(0.0, &state, &aux, &mut rates, None);
+        let loads = rw_derivatives(&rw, &state, &aux, &mut rates);
         assert_eq!(rates, vec![0.0, 0.0, 0.0]);
         assert!(loads.torque_body.magnitude() < 1e-15);
     }
@@ -854,7 +872,7 @@ mod tests {
         let state = test_state_at_rest();
         let aux = vec![0.0, 0.0, 0.0];
         let mut rates = vec![0.0, 0.0, 0.0];
-        let loads = rw.derivatives(0.0, &state, &aux, &mut rates, None);
+        let loads = rw_derivatives(&rw, &state, &aux, &mut rates);
 
         // Z-wheel rate = -0.05
         assert!(rates[0].abs() < 1e-15);
@@ -874,7 +892,7 @@ mod tests {
         let state = test_state_at_rest();
         let aux = vec![0.0, 0.0, 0.0];
         let mut rates = vec![0.0, 0.0, 0.0];
-        rw.derivatives(0.0, &state, &aux, &mut rates, None);
+        rw_derivatives(&rw, &state, &aux, &mut rates);
 
         // Clamped to 0.1
         assert!((rates[0] - 0.1).abs() < 1e-15);
@@ -889,7 +907,7 @@ mod tests {
         let state = test_state_at_rest();
         let aux = vec![1.0, 0.0, 0.0];
         let mut rates = vec![0.0, 0.0, 0.0];
-        rw.derivatives(0.0, &state, &aux, &mut rates, None);
+        rw_derivatives(&rw, &state, &aux, &mut rates);
 
         assert!(rates[0].abs() < 1e-15);
     }
@@ -903,7 +921,7 @@ mod tests {
         let state = test_state_at_rest();
         let aux = vec![-1.0, 0.0, 0.0];
         let mut rates = vec![0.0, 0.0, 0.0];
-        rw.derivatives(0.0, &state, &aux, &mut rates, None);
+        rw_derivatives(&rw, &state, &aux, &mut rates);
 
         assert!(rates[0].abs() < 1e-15);
     }
@@ -917,7 +935,7 @@ mod tests {
         let state = test_state_at_rest();
         let aux = vec![1.0, 0.0, 0.0];
         let mut rates = vec![0.0, 0.0, 0.0];
-        rw.derivatives(0.0, &state, &aux, &mut rates, None);
+        rw_derivatives(&rw, &state, &aux, &mut rates);
 
         assert!((rates[0] - (-0.05)).abs() < 1e-15);
     }
@@ -932,7 +950,7 @@ mod tests {
         let state = test_state_at_rest();
         let aux = vec![0.0, 0.0, 0.0];
         let mut rates = vec![0.0, 0.0, 0.0];
-        let loads = rw.derivatives(0.0, &state, &aux, &mut rates, None);
+        let loads = rw_derivatives(&rw, &state, &aux, &mut rates);
 
         // At rest (no gyroscopic coupling), body torque should match desired
         let tb = loads.torque_body.into_inner();
@@ -1035,7 +1053,7 @@ mod tests {
         // aux = [h, τ_realized], both start at 0
         let aux = vec![0.0, 0.0];
         let mut rates = vec![0.0, 0.0];
-        let _loads = rw.derivatives(0.0, &state, &aux, &mut rates, None);
+        let _loads = rw_derivatives(&rw, &state, &aux, &mut rates);
 
         // dτ_realized/dt = (τ_target - τ_realized) / T_m = (0.1 - 0.0) / 0.05 = 2.0
         assert!((rates[1] - 2.0).abs() < 1e-12);
@@ -1055,7 +1073,7 @@ mod tests {
         // τ_realized has caught up to 0.06
         let aux = vec![0.0, 0.06];
         let mut rates = vec![0.0, 0.0];
-        let loads = rw.derivatives(0.0, &state, &aux, &mut rates, None);
+        let loads = rw_derivatives(&rw, &state, &aux, &mut rates);
 
         // dτ_realized/dt = (0.1 - 0.06) / 0.05 = 0.8
         assert!((rates[1] - 0.8).abs() < 1e-12);
@@ -1075,7 +1093,7 @@ mod tests {
         };
         let aux = vec![5.0, 0.0, 0.0];
         let mut rates = vec![0.0, 0.0, 0.0];
-        let loads = rw.derivatives(0.0, &state, &aux, &mut rates, None);
+        let loads = rw_derivatives(&rw, &state, &aux, &mut rates);
 
         // H_rw = [5, 0, 0], omega = [0, 0, 1]
         // gyro = -omega × H_rw = -[0,5,0] = [0,-5,0]


### PR DESCRIPTION
Closes #103

## 背景 (バグ)

`SpacecraftDynamics<G, F>` は `derivatives()` の hot loop で各 `StateEffector` の loads を

```rust
total.acceleration_inertial += Vec3::<F>::from_raw(*eff_loads.acceleration_inertial.inner());
```

と、effector が返す `ExternalLoads<SimpleEci>` の加速度を**無検査で host frame `F` に貼り替え**ていた。`F != SimpleEci` かつ effector が並進加速度を出すと、座標系を取り違えたまま積分される。現存 effector は `RwAssembly`（torque-only, 加速度ゼロ）のみなので**潜在バグ**だったが、thruster のような並進 effector を `Gcrs` 系に登録すると顕在化する。torque（Body frame）と mass_rate は frame 非依存で安全。

## 対応 (封じ込めでなく根本修正)

issue では「封じ込め（型 or 実行時 assert で誤用を禁止）」が小 PR として提案されていたが、**バグそのものを直す**方針に変更。

- **`StateEffector<S, F = SimpleEci>`** に frame-generic 化し、`derivatives -> ExternalLoads<F>` に（`Model<S, F>` と対称）。effector は最初から host frame の loads を返すので、`SpacecraftDynamics` は `total += eff.derivatives(...)` で直接加算 — **re-tag を削除**し、座標系取り違えを型レベルで表現不能にした。
- **`RwAssembly`** を `impl<S: HasAttitude + Send + Sync, F: Eci> StateEffector<S, F>` に。寄与は body-frame torque（frame 非依存）＋加速度ゼロなので全 inertial frame で健全。
- 将来の並進 effector は `AttitudeState::rotation_to_inertial::<F>` で F-frame 加速度を自前で構築する（body 推力 → F 慣性系）。
- default 型パラメータにより既存の `StateEffector<S>` 表記・`AugmentedAttitudeSystem` は **無変更で SimpleEci 動作を維持**（後方互換）。

## スコープ

#103 のバグ＝`StateEffector` の re-tag に限定。`drag` / `pd_controller` / `bdot` / `mtq` の `HasOrbit<Frame = SimpleEci>` 束縛は「黙って間違う」のではなく**型で弾く明示制約**なので別物（Gcrs 対応の feature 作業）として触っていない。

## テスト

`orts` lib に frame-generic な単体テストを追加（TDD）:

- `torque_only_effector_works_on_gcrs` — RW が非 SimpleEci 系で登録・積分でき、body torque を出し inertial 加速度ゼロ
- `translational_effector_acceleration_applied_in_gcrs` — 並進 effector の `ExternalLoads<Gcrs>` 加速度が re-tag なしで Gcrs EOM に反映
- `body_thrust_effector_rotates_into_gcrs` — body 推力が `rotation_to_inertial::<Gcrs>` で正しく回転（#103 再発防止）
- `translational_effector_on_simple_eci_still_works` — 既定 `F = SimpleEci` の後方互換

検証:
- `cargo test --workspace` — 全 suite green（0 failed）
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt --all` 済み
- 設計を smart-friend、実装を code-review-gpt で外部レビュー（指摘なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)