### PR TITLE
chore: update Rust toolchain to 1.96.0

### DIFF
--- a/arika/tests/trybuild/null_eop_in_iau2006.stderr
+++ b/arika/tests/trybuild/null_eop_in_iau2006.stderr
@@ -6,7 +6,11 @@ error[E0277]: the trait bound `NullEop: NutationCorrections` is not satisfied
    |              |
    |              required by a bound introduced by this call
    |
-   = help: the trait `NutationCorrections` is implemented for `EopTable`
+help: the trait `NutationCorrections` is implemented for `EopTable`
+  --> src/earth/eop/table.rs
+   |
+   | impl NutationCorrections for EopTable {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `cio_chain::<impl Rotation<arika::frame::Gcrs, arika::frame::Cirs>>::iau2006`
   --> src/earth/iau2006/cio_chain.rs
    |

--- a/arika/tests/trybuild/null_eop_in_iau2006_full_from_utc.stderr
+++ b/arika/tests/trybuild/null_eop_in_iau2006_full_from_utc.stderr
@@ -6,7 +6,11 @@ error[E0277]: the trait bound `NullEop: Ut1Offset` is not satisfied
    |              |
    |              required by a bound introduced by this call
    |
-   = help: the trait `Ut1Offset` is implemented for `EopTable`
+help: the trait `Ut1Offset` is implemented for `EopTable`
+  --> src/earth/eop/table.rs
+   |
+   | impl Ut1Offset for EopTable {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `cio_chain::<impl Rotation<arika::frame::Gcrs, arika::frame::Itrs>>::iau2006_full_from_utc`
   --> src/earth/iau2006/cio_chain.rs
    |
@@ -24,7 +28,11 @@ error[E0277]: the trait bound `NullEop: NutationCorrections` is not satisfied
    |              |
    |              required by a bound introduced by this call
    |
-   = help: the trait `NutationCorrections` is implemented for `EopTable`
+help: the trait `NutationCorrections` is implemented for `EopTable`
+  --> src/earth/eop/table.rs
+   |
+   | impl NutationCorrections for EopTable {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `cio_chain::<impl Rotation<arika::frame::Gcrs, arika::frame::Itrs>>::iau2006_full_from_utc`
   --> src/earth/iau2006/cio_chain.rs
    |
@@ -42,7 +50,11 @@ error[E0277]: the trait bound `NullEop: PolarMotion` is not satisfied
    |              |
    |              required by a bound introduced by this call
    |
-   = help: the trait `PolarMotion` is implemented for `EopTable`
+help: the trait `PolarMotion` is implemented for `EopTable`
+  --> src/earth/eop/table.rs
+   |
+   | impl PolarMotion for EopTable {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `cio_chain::<impl Rotation<arika::frame::Gcrs, arika::frame::Itrs>>::iau2006_full_from_utc`
   --> src/earth/iau2006/cio_chain.rs
    |

--- a/arika/tests/trybuild/null_eop_in_polar_motion.stderr
+++ b/arika/tests/trybuild/null_eop_in_polar_motion.stderr
@@ -6,7 +6,11 @@ error[E0277]: the trait bound `NullEop: PolarMotion` is not satisfied
    |              |
    |              required by a bound introduced by this call
    |
-   = help: the trait `PolarMotion` is implemented for `EopTable`
+help: the trait `PolarMotion` is implemented for `EopTable`
+  --> src/earth/eop/table.rs
+   |
+   | impl PolarMotion for EopTable {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `cio_chain::<impl Rotation<arika::frame::Tirs, arika::frame::Itrs>>::polar_motion`
   --> src/earth/iau2006/cio_chain.rs
    |

--- a/arika/tests/trybuild/null_eop_in_to_ut1.stderr
+++ b/arika/tests/trybuild/null_eop_in_to_ut1.stderr
@@ -6,7 +6,11 @@ error[E0277]: the trait bound `NullEop: Ut1Offset` is not satisfied
    |                    |
    |                    required by a bound introduced by this call
    |
-   = help: the trait `Ut1Offset` is implemented for `EopTable`
+help: the trait `Ut1Offset` is implemented for `EopTable`
+  --> src/earth/eop/table.rs
+   |
+   | impl Ut1Offset for EopTable {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `Epoch::to_ut1`
   --> src/epoch.rs
    |

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -488,7 +488,7 @@ pub fn write_satellite_csv(
         .iter()
         .filter(|(name, _)| !skip.contains(name))
         .collect();
-    extra_cols.sort_by(|(a, _), (b, _)| a.cmp(b));
+    extra_cols.sort_by_key(|(a, _)| *a);
 
     let id = sat_path.to_string();
     let id = id.rsplit('/').next().unwrap_or("default");

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## What

- `rust-toolchain.toml`: 1.91.0 → **1.96.0**
- `arika/tests/trybuild/*.stderr`（4件）を 1.96 で再生成

## Why

複数の依存更新が **rustc ≥ 1.92** を要求しており、toolchain bump がそれらの前提（キーストーン）:
- #78 wasmtime-wasi v44 **[security]**
- #141 wasmtime v45
- #142 cargo lock file maintenance

1.96 で壊れる箇所は2つだけ（#124 の CI 実行で確認済み）:
1. clippy `manual_checked_ops` @ `ComponentColumn::num_rows` → **#145 で先行修正・マージ済み**
2. arika trybuild の `.stderr` 不一致（rustc 1.96 が trait-bound 診断を「impl 箇所を `-->` で示す」形に変更）→ 本PRで再生成

## 検証（ローカル 1.96）

- `cargo test -p arika --test trybuild` 緑（再生成後一致）
- `cargo fmt --all -- --check` クリーン
- `cargo clippy -p arika --no-default-features` / `--features alloc` クリーン（#124 の lint job が到達しなかった variant）
- workspace 全体の clippy/build/test は CI に委譲（#124 実行時点で workspace clippy の指摘は manual_checked_ops の1件のみ＝#145 で解消済み）

Renovate の #124（toolchain だけの bump で clippy/trybuild 修正を伴わず落ちる）を置き換えるもの。

🤖 Generated with [Claude Code](https://claude.com/claude-code)