### PR TITLE
refactor(tobari): rename fetch feature to fetch-cssi, keep fetch as umbrella

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,14 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 
 ## [Unreleased]
 
+### `tobari` (Rust, crates.io)
+
+#### Changed
+- CSSI 宇宙天気ダウンロードの feature `fetch` を `fetch-cssi` にリネーム。
+  `fetch-<source>` 規約(`fetch-igrf`、arika の `fetch-horizons`)に揃えた。
+  `fetch` は全 `fetch-*` 源を束ねる傘 feature として存続するため、
+  `features = ["fetch"]` は引き続きビルド可能(加えて `fetch-igrf` も有効化)。
+
 ## [0.2.0](https://github.com/sksat/orts/releases/tag/v0.2.0) - 2026-04-20
 
 リリースブログ記事: [orts: 人工衛星シミュレーションプラットフォームを作りました](https://sksat.hatenablog.com/entry/orts-release)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ section is subdivided by package.
 
 ## [Unreleased]
 
+### `tobari` (Rust, crates.io)
+
+#### Changed
+- Renamed the CSSI space-weather download feature `fetch` to `fetch-cssi`,
+  matching the `fetch-<source>` convention (`fetch-igrf`, and `arika`'s
+  `fetch-horizons`). `fetch` is retained as an umbrella feature that enables
+  every `fetch-*` source, so `features = ["fetch"]` keeps building (and now
+  also pulls in `fetch-igrf`).
+
 ## [0.2.0](https://github.com/sksat/orts/releases/tag/v0.2.0) - 2026-04-20
 
 Release blog post: [orts: 人工衛星シミュレーションプラットフォームを作りました](https://sksat.hatenablog.com/entry/orts-release)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,7 +30,7 @@ plugin-wasm-async = ["plugin-wasm", "orts/plugin-wasm-async"]
 [dependencies]
 nalgebra.workspace = true
 utsuroi.workspace = true
-tobari = { workspace = true, features = ["fetch"] }
+tobari = { workspace = true, features = ["fetch-cssi"] }
 arika.workspace = true
 orts.workspace = true
 log = "0.4.29"

--- a/orts/Cargo.toml
+++ b/orts/Cargo.toml
@@ -43,7 +43,7 @@ tokio = { version = "1", default-features = false, features = [
 ], optional = true }
 
 [features]
-fetch-weather = ["tobari/fetch"]
+fetch-weather = ["tobari/fetch-cssi"]
 fetch-horizons = ["arika/fetch-horizons"]
 # Phase P1: load WASM Component guest controllers at runtime via
 # wasmtime + Pulley interpreter. See `orts::plugin::wasm`.

--- a/tobari/Cargo.toml
+++ b/tobari/Cargo.toml
@@ -38,8 +38,12 @@ ureq.workspace = true
 default = ["std", "fetch-igrf"]
 std = ["alloc", "nalgebra/std", "arika/std"]
 alloc = []
-fetch = ["std", "dep:ureq"]
+# CelesTrak CSSI space-weather HTTP download + cache.
+fetch-cssi = ["std", "dep:ureq"]
 fetch-igrf = []
+# Umbrella enabling every `fetch-*` data source. Kept for back-compat: external
+# users who selected the old `fetch` feature still build (and now also get IGRF).
+fetch = ["fetch-cssi", "fetch-igrf"]
 
 [dev-dependencies]
 serde = { workspace = true }

--- a/tobari/src/cssi.rs
+++ b/tobari/src/cssi.rs
@@ -439,9 +439,9 @@ impl SpaceWeatherProvider for CssiSpaceWeather {
     }
 }
 
-// fetch feature: HTTP download + cache
+// fetch-cssi feature: HTTP download + cache
 
-#[cfg(feature = "fetch")]
+#[cfg(feature = "fetch-cssi")]
 mod fetch_impl {
     use super::*;
     use std::time::{Duration, SystemTime};

--- a/tobari/src/lib.rs
+++ b/tobari/src/lib.rs
@@ -22,8 +22,8 @@
 //!
 //! The [`space_weather`] module defines [`SpaceWeather`] conditions and the
 //! [`SpaceWeatherProvider`] trait for supplying time-varying solar/geomagnetic data.
-//! [`CssiSpaceWeather`] parses CelesTrak CSSI-format files and (with the `fetch`
-//! feature) downloads them automatically with local caching.
+//! [`CssiSpaceWeather`] parses CelesTrak CSSI-format files and (with the
+//! `fetch-cssi` feature) downloads them automatically with local caching.
 //!
 //! ## Data attribution
 //!


### PR DESCRIPTION
## 概要

`#104` の項目2（4項目中）。tobari の取得系 feature 命名を `fetch-<source>` 規約に統一する。

## 背景

取得系 feature の命名が不揃いだった:
- arika: `fetch-horizons`（JPL Horizons）
- tobari: `fetch-igrf`（IGRF 係数）
- tobari: **`fetch`**（CSSI 宇宙天気）← これだけ source 名がない

## 変更（@sksat の傘 feature 案を採用）

- `fetch` → **`fetch-cssi`** にリネーム（`fetch-<source>` 規約に整合）
- `fetch` を**全 `fetch-*` 源を束ねる傘 feature** として再定義: `fetch = ["fetch-cssi", "fetch-igrf"]`
  - → `fetch` という名前が存続するので、外部の `features = ["fetch"]` は壊れない（加えて `fetch-igrf` も有効化されるだけ＝additive）
- 下流の feature マッピングを精密化: orts `fetch-weather` と orts-cli は `tobari/fetch-cssi` を直接選択（宇宙天気 = CSSI）
- `cssi.rs` / `lib.rs` の cfg・コメント・doc を `fetch-cssi` に更新
- CHANGELOG（EN/JA）の [Unreleased] に追記

## 検証（TDD: feature 存在の red→green）

各 feature tier で `cargo check` 成功:
- `--no-default-features`（no_std, CI 相当） / default / `--features fetch-cssi` / `--features fetch`（傘）
- 下流: `orts --features fetch-weather`、`orts-cli`
- wasm32: `tobari-wasm`（fetch を使わない）
- `cargo clippy -p tobari --features fetch-cssi -- -D warnings` … clean / `cargo fmt --check` … clean
- `cargo test -p tobari --features fetch-cssi` … 全通過

**傘配線の決定的証明**: `fetch-cssi` のみが有効化する `dep:ureq` が、`--features fetch` で依存ツリーに出現（2 ノード）し、default では 0 ノード。→ 傘 `fetch` が確かに `fetch-cssi` を引き込んでいる。

挙動変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)