### PR TITLE
refactor(viewer): SunLighting 分離 + App.tsx 薄化 (#96 残スコープ)

### DIFF
--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -6,15 +6,14 @@ import { initArika } from "./wasm/arikaInit.js";
 const arikaReady = initArika();
 
 import type { TimeRange } from "@sksat/uneri";
-import styles from "./App.module.css";
-import { FrameSelector } from "./components/FrameSelector.js";
 import { GraphPanel } from "./components/GraphPanel.js";
 import { PlaybackBar } from "./components/PlaybackBar.js";
+import { SceneOverlay } from "./components/SceneOverlay.js";
 import { SimConfigModal } from "./components/SimConfigModal.js";
-import { SimInfoBar } from "./components/SimInfoBar.js";
 import { StatusBar } from "./components/StatusBar.js";
 import { CSV_SOURCE_ID, RRD_SOURCE_ID, useFileSource } from "./hooks/useFileSource.js";
 import { useRealtimePlayback } from "./hooks/useRealtimePlayback.js";
+import { useSimInfoDerived } from "./hooks/useSimInfoDerived.js";
 import { useSimulationData } from "./hooks/useSimulationData.js";
 import type { ClientMessage } from "./protocol/generated/ClientMessage.js";
 import { DEFAULT_FRAME, type ReferenceFrame } from "./referenceFrame.js";
@@ -306,16 +305,9 @@ export function App() {
     };
   }, [textureBaseUrl]);
 
-  const satelliteNames = useMemo(() => {
-    if (!simInfo) return undefined;
-    const m = new Map<string, string | null>();
-    for (const sat of simInfo.satellites) m.set(sat.id, sat.name);
-    return m;
-  }, [simInfo]);
-
-  const centralBody = simInfo?.central_body ?? "earth";
-  const centralBodyRadius = simInfo?.central_body_radius ?? 6378.137;
-  const epochJd = simInfo?.epoch_jd ?? undefined;
+  // Values derived from the simulation metadata (with absent-simInfo defaults).
+  const { centralBody, centralBodyRadius, epochJd, satelliteNames, activePerturbations } =
+    useSimInfoDerived(simInfo);
 
   // Total points across all satellite buffers.
   // chartBufferVersion bumps on data ingest AND on resetBuffers (clear),
@@ -329,16 +321,6 @@ export function App() {
   }, [chartBufferVersion]);
 
   const showPlaybackBar = totalPoints > 0;
-
-  // Union of active perturbation names across all satellites
-  const activePerturbations = useMemo(() => {
-    if (!simInfo) return [];
-    const set = new Set<string>();
-    for (const sat of simInfo.satellites) {
-      for (const p of sat.perturbations) set.add(p);
-    }
-    return [...set];
-  }, [simInfo]);
 
   // Auto-close SimConfig modal when leaving idle state or disconnecting
   useEffect(() => {
@@ -389,29 +371,17 @@ export function App() {
 
       {/* 3D Scene (row 2, column 1) */}
       <div className="scene-container">
-        {/* Scene overlay: frame selector + sim info (top-left of canvas) */}
-        <div className={styles.sceneOverlay}>
-          <FrameSelector
-            referenceFrame={referenceFrame}
-            onChange={setReferenceFrame}
-            satellites={simInfo?.satellites}
-            hasEpoch={epochJd != null}
-            centralBody={centralBody}
-          />
-          {fileSource.orbitInfo && (
-            <div className={styles.orbitInfo} data-testid="orbit-info-file">
-              {fileSource.orbitInfo}
-            </div>
-          )}
-          {simInfo && (
-            <SimInfoBar
-              simInfo={simInfo}
-              totalPoints={totalPoints}
-              epochJd={epochJd}
-              activePerturbations={activePerturbations}
-            />
-          )}
-        </div>
+        <SceneOverlay
+          referenceFrame={referenceFrame}
+          onReferenceFrameChange={setReferenceFrame}
+          satellites={simInfo?.satellites}
+          centralBody={centralBody}
+          epochJd={epochJd}
+          orbitInfo={fileSource.orbitInfo}
+          simInfo={simInfo}
+          totalPoints={totalPoints}
+          activePerturbations={activePerturbations}
+        />
 
         <Scene
           trailBuffers={trailBuffersMap}

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -10,26 +10,17 @@ import {
   getDisplayScaleProfile,
 } from "../displayScale.js";
 import { resolveSceneFrame } from "../frameResolve.js";
-import { rotateZ } from "../frameTransform.js";
 import type { OrbitPoint } from "../orbit.js";
 import { DEFAULT_FRAME, isLegacyEcef, type ReferenceFrame } from "../referenceFrame.js";
 import { getSatelliteModelConfig } from "../satelliteModels.js";
 import { computeCameraUp, computeLvlhAxes, type LvlhAxes, SCENE_UP } from "../sceneFrame.js";
 import type { TrailBuffer } from "../utils/TrailBuffer.js";
-import {
-  body_orientation,
-  earth_rotation_angle,
-  eci_to_ecef,
-  sun_direction_from_body,
-  sun_distance_from_body,
-} from "../wasm/arikaInit.js";
+import { body_orientation, earth_rotation_angle, eci_to_ecef } from "../wasm/arikaInit.js";
 import { CelestialBody } from "./CelestialBody.js";
 import { OrbitTrail } from "./OrbitTrail.js";
 import { buildRenderEntries } from "./renderEntries.js";
 import { Satellite } from "./Satellite.js";
-
-// Default sun direction when no epoch is provided: ECI +X (vernal equinox).
-const DEFAULT_SUN_DIRECTION = new THREE.Vector3(1, 0, 0);
+import { AMBIENT_INTENSITY, SunLighting, useSunLighting } from "./SunLighting.js";
 
 /** Color palette for multiple satellites. */
 const SATELLITE_COLORS = [0x00ff88, 0xff4488, 0x44aaff, 0xffaa44, 0xaa44ff];
@@ -437,53 +428,24 @@ export function OrbitSceneContents({
   const simTime = firstPosition?.t ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 
-  // Sun direction in body-centered inertial frame (via WASM)
-  const sunDirectionEci = useMemo(() => {
-    if (epochJd == null) return DEFAULT_SUN_DIRECTION;
-    const dir = sun_direction_from_body(centralBody, epochJd, quantizedSimTime);
-    return new THREE.Vector3(dir[0], dir[1], dir[2]);
-  }, [centralBody, epochJd, quantizedSimTime]);
-
-  // Sun intensity: inverse square law based on body-Sun distance
-  const AU_KM = 149_597_870.7;
-  const sunIntensity = useMemo(() => {
-    if (epochJd == null) return 1.0;
-    const distKm = sun_distance_from_body(centralBody, epochJd, quantizedSimTime);
-    return (AU_KM / distKm) ** 2;
-  }, [centralBody, epochJd, quantizedSimTime]);
-
   // Earth rotation angle (ERA) via WASM — updates every frame via simTime (not quantized)
   const era = useMemo(() => {
     if (epochJd == null) return undefined;
     return earth_rotation_angle(epochJd, simTime);
   }, [epochJd, simTime]);
 
-  // Sun direction in the display frame
-  const sunDirection = useMemo(() => {
-    if (lvlhActive && lvlhAxes) {
-      // LVLH: rotate sun direction into satellite body frame
-      const s = sunDirectionEci;
-      const ax = lvlhAxes;
-      return new THREE.Vector3(
-        ax.inTrack[0] * s.x + ax.inTrack[1] * s.y + ax.inTrack[2] * s.z,
-        ax.crossTrack[0] * s.x + ax.crossTrack[1] * s.y + ax.crossTrack[2] * s.z,
-        ax.radial[0] * s.x + ax.radial[1] * s.y + ax.radial[2] * s.z,
-      );
-    }
-    if (!isEcef || era == null) return sunDirectionEci;
-    // ECEF: rotate sun direction by -ERA to match Earth-fixed frame
-    const [sx, sy, sz] = rotateZ(sunDirectionEci.x, sunDirectionEci.y, sunDirectionEci.z, -era);
-    return new THREE.Vector3(sx, sy, sz);
-  }, [sunDirectionEci, isEcef, era, lvlhActive, lvlhAxes]);
-
-  const lightDistance = sceneAmplification * 10;
-  const lightPosition = useMemo<[number, number, number]>(() => {
-    return [
-      sunDirection.x * lightDistance,
-      sunDirection.y * lightDistance,
-      sunDirection.z * lightDistance,
-    ];
-  }, [sunDirection, lightDistance]);
+  // Sun direction + intensity (display frame). Shared by the lights and by the
+  // lit bodies below, so the scene holds them and passes them down explicitly.
+  const { sunDirection, sunIntensity, lightPosition } = useSunLighting({
+    centralBody,
+    epochJd,
+    quantizedSimTime,
+    isEcef,
+    era,
+    lvlhActive,
+    lvlhAxes,
+    sceneAmplification,
+  });
 
   // Earth rotation angle for the mesh: ERA in ECI, 0 in ECEF (Earth is static)
   const earthRotation = isEcef ? 0 : era;
@@ -563,8 +525,7 @@ export function OrbitSceneContents({
         lvlhActive={lvlhActive}
       />
 
-      <ambientLight intensity={0.15} />
-      <directionalLight intensity={3.0 * sunIntensity} position={lightPosition} />
+      <SunLighting intensity={sunIntensity} position={lightPosition} />
 
       {/* Centered satellite/body: always exactly at world origin (0,0,0). */}
       {centeredSatId != null &&
@@ -625,7 +586,7 @@ export function OrbitSceneContents({
           rotationAngle={earthRotation}
           lvlhPosition={lvlhActive ? bodyLvlhPosition : null}
           lvlhQuaternion={lvlhActive ? bodyLvlhQuaternion : null}
-          ambientIntensity={0.15}
+          ambientIntensity={AMBIENT_INTENSITY}
           sunIntensity={sunIntensity}
           physicalScale={physicalScale}
           textureRevision={textureRevision}

--- a/viewer/src/components/SceneOverlay.tsx
+++ b/viewer/src/components/SceneOverlay.tsx
@@ -1,0 +1,62 @@
+import styles from "../App.module.css";
+import type { SatelliteInfo, SimInfo } from "../hooks/useWebSocket.js";
+import type { ReferenceFrame } from "../referenceFrame.js";
+import { FrameSelector } from "./FrameSelector.js";
+import { SimInfoBar } from "./SimInfoBar.js";
+
+export interface SceneOverlayProps {
+  referenceFrame: ReferenceFrame;
+  onReferenceFrameChange: (frame: ReferenceFrame) => void;
+  /** Satellites available for the frame selector (from simInfo or replay). */
+  satellites: SatelliteInfo[] | undefined;
+  centralBody: string;
+  epochJd: number | undefined;
+  /** File-source orbit summary line; empty string when no file is loaded. */
+  orbitInfo: string;
+  /** Live simulation metadata; null hides the info bar. */
+  simInfo: SimInfo | null;
+  totalPoints: number;
+  activePerturbations: string[];
+}
+
+/**
+ * Top-left canvas overlay: frame selector, optional file-orbit summary, and the
+ * simulation info bar. Grouped out of App so the orchestrator stays focused on
+ * data flow rather than canvas chrome layout.
+ */
+export function SceneOverlay({
+  referenceFrame,
+  onReferenceFrameChange,
+  satellites,
+  centralBody,
+  epochJd,
+  orbitInfo,
+  simInfo,
+  totalPoints,
+  activePerturbations,
+}: SceneOverlayProps) {
+  return (
+    <div className={styles.sceneOverlay}>
+      <FrameSelector
+        referenceFrame={referenceFrame}
+        onChange={onReferenceFrameChange}
+        satellites={satellites}
+        hasEpoch={epochJd != null}
+        centralBody={centralBody}
+      />
+      {orbitInfo && (
+        <div className={styles.orbitInfo} data-testid="orbit-info-file">
+          {orbitInfo}
+        </div>
+      )}
+      {simInfo && (
+        <SimInfoBar
+          simInfo={simInfo}
+          totalPoints={totalPoints}
+          epochJd={epochJd}
+          activePerturbations={activePerturbations}
+        />
+      )}
+    </div>
+  );
+}

--- a/viewer/src/components/SunLighting.tsx
+++ b/viewer/src/components/SunLighting.tsx
@@ -1,0 +1,115 @@
+import { useMemo } from "react";
+import * as THREE from "three";
+import type { LvlhAxes } from "../sceneFrame.js";
+import { inverseSquareIntensity, sunDirectionInDisplayFrame } from "../sunLighting.js";
+import { sun_direction_from_body, sun_distance_from_body } from "../wasm/arikaInit.js";
+
+// Default sun direction when no epoch is provided: ECI +X (vernal equinox).
+const DEFAULT_SUN_DIRECTION_ECI: [number, number, number] = [1, 0, 0];
+
+/** Directional light distance from the origin, as a multiple of sceneAmplification. */
+const LIGHT_DISTANCE_FACTOR = 10;
+
+/** Ambient light intensity. Shared with the lit bodies' ambient term. */
+export const AMBIENT_INTENSITY = 0.15;
+
+/** Directional intensity at 1 AU, before the inverse-square distance scale. */
+const BASE_DIRECTIONAL_INTENSITY = 3.0;
+
+export interface SunLightingParams {
+  centralBody: string;
+  epochJd?: number | null;
+  /** Sim time, quantised (e.g. to 60s) to limit WASM recomputation. */
+  quantizedSimTime: number;
+  /** True when the display frame is Earth-fixed (ECEF). */
+  isEcef: boolean;
+  /** Earth rotation angle (radians); undefined when no epoch. */
+  era: number | undefined;
+  /** True when LVLH (local-orbital) rotation lives in the data. */
+  lvlhActive: boolean;
+  lvlhAxes: LvlhAxes | null;
+  /** Environment scale-up factor for satellite-centred views. */
+  sceneAmplification: number;
+}
+
+export interface SunLightingState {
+  /** Sun direction in the active display frame. */
+  sunDirection: THREE.Vector3;
+  /** Inverse-square intensity scale relative to 1 AU. */
+  sunIntensity: number;
+  /** Directional light position (sun direction scaled out by the light distance). */
+  lightPosition: [number, number, number];
+}
+
+/**
+ * Compute sun direction + intensity for the scene via the arika WASM model.
+ *
+ * `sunDirection`/`sunIntensity` are consumed both by {@link SunLighting} and by
+ * the lit bodies (CelestialBody/SecondaryBody), so the scene holds them and
+ * threads them down explicitly — there is no implicit lighting context (which
+ * would also leak into the embeddable OrbitViewer's prop-driven scene graph).
+ */
+export function useSunLighting({
+  centralBody,
+  epochJd,
+  quantizedSimTime,
+  isEcef,
+  era,
+  lvlhActive,
+  lvlhAxes,
+  sceneAmplification,
+}: SunLightingParams): SunLightingState {
+  // Sun direction in the body-centred inertial frame (ECI), via WASM.
+  const sunDirectionEci = useMemo<[number, number, number]>(() => {
+    if (epochJd == null) return DEFAULT_SUN_DIRECTION_ECI;
+    const dir = sun_direction_from_body(centralBody, epochJd, quantizedSimTime);
+    return [dir[0], dir[1], dir[2]];
+  }, [centralBody, epochJd, quantizedSimTime]);
+
+  // Sun intensity: inverse-square law based on the body-Sun distance.
+  const sunIntensity = useMemo(() => {
+    if (epochJd == null) return 1.0;
+    return inverseSquareIntensity(sun_distance_from_body(centralBody, epochJd, quantizedSimTime));
+  }, [centralBody, epochJd, quantizedSimTime]);
+
+  // Sun direction rotated into the active display frame.
+  const sunDirection = useMemo(
+    () =>
+      new THREE.Vector3(
+        ...sunDirectionInDisplayFrame(sunDirectionEci, { isEcef, era, lvlhActive, lvlhAxes }),
+      ),
+    [sunDirectionEci, isEcef, era, lvlhActive, lvlhAxes],
+  );
+
+  const lightDistance = sceneAmplification * LIGHT_DISTANCE_FACTOR;
+  const lightPosition = useMemo<[number, number, number]>(
+    () => [
+      sunDirection.x * lightDistance,
+      sunDirection.y * lightDistance,
+      sunDirection.z * lightDistance,
+    ],
+    [sunDirection, lightDistance],
+  );
+
+  return { sunDirection, sunIntensity, lightPosition };
+}
+
+/**
+ * Scene lighting: a fixed ambient term plus a sun-tracking directional light.
+ * Pair with {@link useSunLighting} for the position/intensity inputs.
+ */
+export function SunLighting({
+  intensity,
+  position,
+}: {
+  /** Inverse-square sun intensity scale (from {@link useSunLighting}). */
+  intensity: number;
+  position: [number, number, number];
+}) {
+  return (
+    <>
+      <ambientLight intensity={AMBIENT_INTENSITY} />
+      <directionalLight intensity={BASE_DIRECTIONAL_INTENSITY * intensity} position={position} />
+    </>
+  );
+}

--- a/viewer/src/hooks/useSimInfoDerived.ts
+++ b/viewer/src/hooks/useSimInfoDerived.ts
@@ -1,0 +1,12 @@
+import { useMemo } from "react";
+import { type DerivedSimInfo, deriveSimInfo } from "../simInfoDerived.js";
+import type { SimInfo } from "./useWebSocket.js";
+
+/**
+ * Memoised {@link deriveSimInfo}. Recomputes only when `simInfo` identity
+ * changes, so the returned `satelliteNames` map stays referentially stable for
+ * the scene between renders.
+ */
+export function useSimInfoDerived(simInfo: SimInfo | null): DerivedSimInfo {
+  return useMemo(() => deriveSimInfo(simInfo), [simInfo]);
+}

--- a/viewer/src/simInfoDerived.test.ts
+++ b/viewer/src/simInfoDerived.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { SatelliteInfo, SimInfo } from "./hooks/useWebSocket.js";
+import { deriveSimInfo } from "./simInfoDerived.js";
+
+const sat = (over: Partial<SatelliteInfo> & { id: string }): SatelliteInfo => ({
+  name: null,
+  altitude: 0,
+  period: 0,
+  perturbations: [],
+  ...over,
+});
+
+const simInfo = (over: Partial<SimInfo>): SimInfo => ({
+  mu: 0,
+  dt: 1,
+  output_interval: 1,
+  stream_interval: 1,
+  central_body: "earth",
+  central_body_radius: 6378.137,
+  epoch_jd: null,
+  satellites: [],
+  ...over,
+});
+
+describe("deriveSimInfo", () => {
+  it("returns app defaults when simInfo is null", () => {
+    expect(deriveSimInfo(null)).toEqual({
+      centralBody: "earth",
+      centralBodyRadius: 6378.137,
+      epochJd: undefined,
+      satelliteNames: undefined,
+      activePerturbations: [],
+    });
+  });
+
+  it("maps each satellite id to its name (null names preserved)", () => {
+    const d = deriveSimInfo(
+      simInfo({
+        satellites: [sat({ id: "a", name: "Alpha" }), sat({ id: "b", name: null })],
+      }),
+    );
+    expect(d.satelliteNames).toEqual(
+      new Map([
+        ["a", "Alpha"],
+        ["b", null],
+      ]),
+    );
+  });
+
+  it("unions perturbation names across satellites, de-duplicated", () => {
+    const d = deriveSimInfo(
+      simInfo({
+        satellites: [
+          sat({ id: "a", perturbations: ["drag", "srp"] }),
+          sat({ id: "b", perturbations: ["srp", "j2"] }),
+        ],
+      }),
+    );
+    expect(new Set(d.activePerturbations)).toEqual(new Set(["drag", "srp", "j2"]));
+    expect(d.activePerturbations).toHaveLength(3);
+  });
+
+  it("passes through central body, radius and epoch (null epoch → undefined)", () => {
+    const withEpoch = deriveSimInfo(
+      simInfo({ central_body: "mars", central_body_radius: 3389.5, epoch_jd: 2451545.0 }),
+    );
+    expect(withEpoch.centralBody).toBe("mars");
+    expect(withEpoch.centralBodyRadius).toBe(3389.5);
+    expect(withEpoch.epochJd).toBe(2451545.0);
+
+    expect(deriveSimInfo(simInfo({ epoch_jd: null })).epochJd).toBeUndefined();
+  });
+
+  it("returns an empty perturbation list (not undefined) for a satellite-less sim", () => {
+    expect(deriveSimInfo(simInfo({ satellites: [] })).activePerturbations).toEqual([]);
+  });
+});

--- a/viewer/src/simInfoDerived.ts
+++ b/viewer/src/simInfoDerived.ts
@@ -1,0 +1,51 @@
+/**
+ * Values the app derives from the simulation metadata (`SimInfo`), with the
+ * absent-simInfo defaults resolved in one place.
+ *
+ * Pure and React-free so it can be unit-tested directly; {@link useSimInfoDerived}
+ * wraps it in a `useMemo` for referential stability across renders.
+ */
+import type { SimInfo } from "./hooks/useWebSocket.js";
+
+export interface DerivedSimInfo {
+  /** Central body id (default "earth" when no simInfo). */
+  centralBody: string;
+  /** Central body radius in km (default Earth equatorial radius). */
+  centralBodyRadius: number;
+  /** Epoch as Julian Date, or undefined when unset. */
+  epochJd: number | undefined;
+  /** Per-satellite id → name; undefined when no simInfo. */
+  satelliteNames: Map<string, string | null> | undefined;
+  /** De-duplicated union of active perturbation names across all satellites. */
+  activePerturbations: string[];
+}
+
+/** Default central body radius (Earth equatorial radius, km). */
+const DEFAULT_CENTRAL_BODY_RADIUS = 6378.137;
+
+export function deriveSimInfo(simInfo: SimInfo | null): DerivedSimInfo {
+  if (!simInfo) {
+    return {
+      centralBody: "earth",
+      centralBodyRadius: DEFAULT_CENTRAL_BODY_RADIUS,
+      epochJd: undefined,
+      satelliteNames: undefined,
+      activePerturbations: [],
+    };
+  }
+
+  const satelliteNames = new Map<string, string | null>();
+  const perturbations = new Set<string>();
+  for (const satellite of simInfo.satellites) {
+    satelliteNames.set(satellite.id, satellite.name);
+    for (const p of satellite.perturbations) perturbations.add(p);
+  }
+
+  return {
+    centralBody: simInfo.central_body,
+    centralBodyRadius: simInfo.central_body_radius,
+    epochJd: simInfo.epoch_jd ?? undefined,
+    satelliteNames,
+    activePerturbations: [...perturbations],
+  };
+}

--- a/viewer/src/sunLighting.test.ts
+++ b/viewer/src/sunLighting.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import type { LvlhAxes } from "./sceneFrame.js";
+import { AU_KM, inverseSquareIntensity, sunDirectionInDisplayFrame } from "./sunLighting.js";
+
+type Vec3 = [number, number, number];
+const dot = (a: Vec3, b: Vec3): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+const mag = (v: Vec3): number => Math.sqrt(dot(v, v));
+
+describe("inverseSquareIntensity", () => {
+  it("is 1.0 at exactly 1 AU", () => {
+    expect(inverseSquareIntensity(AU_KM)).toBeCloseTo(1.0, 12);
+  });
+
+  it("follows the inverse-square law (2 AU → 1/4, 0.5 AU → 4)", () => {
+    expect(inverseSquareIntensity(2 * AU_KM)).toBeCloseTo(0.25, 12);
+    expect(inverseSquareIntensity(0.5 * AU_KM)).toBeCloseTo(4.0, 12);
+  });
+
+  it("clamps non-positive distance to unit intensity (no Infinity/NaN)", () => {
+    expect(inverseSquareIntensity(0)).toBe(1.0);
+    expect(inverseSquareIntensity(-1)).toBe(1.0);
+  });
+});
+
+describe("sunDirectionInDisplayFrame", () => {
+  const ECI_SUN: Vec3 = [0.6, 0, 0.8];
+
+  it("returns the ECI direction unchanged for an inertial frame", () => {
+    expect(
+      sunDirectionInDisplayFrame(ECI_SUN, {
+        isEcef: false,
+        era: 1.234,
+        lvlhActive: false,
+        lvlhAxes: null,
+      }),
+    ).toEqual(ECI_SUN);
+  });
+
+  it("returns the ECI direction unchanged for ECEF when ERA is unavailable", () => {
+    expect(
+      sunDirectionInDisplayFrame(ECI_SUN, {
+        isEcef: true,
+        era: null,
+        lvlhActive: false,
+        lvlhAxes: null,
+      }),
+    ).toEqual(ECI_SUN);
+  });
+
+  it("rotates by -ERA about Z for the ECEF (Earth-fixed) frame", () => {
+    // ERA = +π/2: an ECI +X sun maps to -Y in the Earth-fixed frame.
+    const out = sunDirectionInDisplayFrame([1, 0, 0], {
+      isEcef: true,
+      era: Math.PI / 2,
+      lvlhActive: false,
+      lvlhAxes: null,
+    });
+    expect(out[0]).toBeCloseTo(0, 12);
+    expect(out[1]).toBeCloseTo(-1, 12);
+    expect(out[2]).toBeCloseTo(0, 12);
+  });
+
+  it("projects the sun onto the LVLH basis [inTrack, crossTrack, radial]", () => {
+    // Permuted orthonormal basis: ECI +X lands on the radial (3rd) component.
+    const axes: LvlhAxes = {
+      inTrack: [0, 1, 0],
+      crossTrack: [0, 0, 1],
+      radial: [1, 0, 0],
+    };
+    const out = sunDirectionInDisplayFrame([1, 0, 0], {
+      isEcef: false,
+      era: undefined,
+      lvlhActive: true,
+      lvlhAxes: axes,
+    });
+    expect(out[0]).toBeCloseTo(0, 12);
+    expect(out[1]).toBeCloseTo(0, 12);
+    expect(out[2]).toBeCloseTo(1, 12);
+  });
+
+  it("LVLH takes precedence over the ECEF branch", () => {
+    const axes: LvlhAxes = {
+      inTrack: [1, 0, 0],
+      crossTrack: [0, 1, 0],
+      radial: [0, 0, 1],
+    };
+    // isEcef + era set, but lvlhActive wins → identity basis leaves it unchanged.
+    expect(
+      sunDirectionInDisplayFrame(ECI_SUN, {
+        isEcef: true,
+        era: Math.PI / 3,
+        lvlhActive: true,
+        lvlhAxes: axes,
+      }),
+    ).toEqual(ECI_SUN);
+  });
+
+  it("preserves magnitude under the orthonormal LVLH projection", () => {
+    const axes = {
+      inTrack: [0, 1, 0],
+      crossTrack: [0, 0, 1],
+      radial: [1, 0, 0],
+    } satisfies LvlhAxes;
+    const out = sunDirectionInDisplayFrame(ECI_SUN, {
+      isEcef: false,
+      era: undefined,
+      lvlhActive: true,
+      lvlhAxes: axes,
+    });
+    expect(mag(out as Vec3)).toBeCloseTo(mag(ECI_SUN), 12);
+  });
+
+  it("falls back to ECI when lvlhActive is true but axes are null", () => {
+    expect(
+      sunDirectionInDisplayFrame(ECI_SUN, {
+        isEcef: false,
+        era: undefined,
+        lvlhActive: true,
+        lvlhAxes: null,
+      }),
+    ).toEqual(ECI_SUN);
+  });
+});

--- a/viewer/src/sunLighting.ts
+++ b/viewer/src/sunLighting.ts
@@ -1,0 +1,69 @@
+/**
+ * Pure sun-lighting math, separated from the React/Three scene so it can be
+ * unit-tested without a renderer or the arika WASM module.
+ *
+ * The WASM calls (sun direction/distance from a body) and Three.js wiring live
+ * in the {@link useSunLighting} hook; everything here is a plain function of
+ * its inputs.
+ */
+import { rotateZ } from "./frameTransform.js";
+import type { LvlhAxes } from "./sceneFrame.js";
+
+/** One astronomical unit in kilometres. */
+export const AU_KM = 149_597_870.7;
+
+/** Display-frame transform options for the sun direction. */
+export interface SunDisplayFrameOptions {
+  /** True when the display frame is Earth-fixed (ECEF). */
+  isEcef: boolean;
+  /** Earth rotation angle (radians); null/undefined when unavailable. */
+  era: number | null | undefined;
+  /** True when LVLH (local-orbital) rotation is applied to the data. */
+  lvlhActive: boolean;
+  /** LVLH basis when active; null falls back to the inertial/ECEF branch. */
+  lvlhAxes: LvlhAxes | null;
+}
+
+/**
+ * Transform a sun direction from the body-centred inertial frame (ECI) into the
+ * active display frame.
+ *
+ * - LVLH (`lvlhActive` with axes): project onto the LVLH basis
+ *   `[inTrack, crossTrack, radial]` so the sun tracks the satellite body frame.
+ * - ECEF (`isEcef`, `era` given): rotate by `-era` about Z to match Earth-fixed.
+ * - Otherwise: return the ECI direction unchanged.
+ *
+ * Works on and returns `[x, y, z]` tuples; the caller wraps the result in a
+ * `THREE.Vector3` at the React boundary.
+ */
+export function sunDirectionInDisplayFrame(
+  sunEci: [number, number, number],
+  { isEcef, era, lvlhActive, lvlhAxes }: SunDisplayFrameOptions,
+): [number, number, number] {
+  const [sx, sy, sz] = sunEci;
+
+  if (lvlhActive && lvlhAxes) {
+    const { inTrack, crossTrack, radial } = lvlhAxes;
+    return [
+      inTrack[0] * sx + inTrack[1] * sy + inTrack[2] * sz,
+      crossTrack[0] * sx + crossTrack[1] * sy + crossTrack[2] * sz,
+      radial[0] * sx + radial[1] * sy + radial[2] * sz,
+    ];
+  }
+
+  if (!isEcef || era == null) return [sx, sy, sz];
+
+  // ECEF: rotate the sun direction by -ERA to match the Earth-fixed frame.
+  return rotateZ(sx, sy, sz, -era);
+}
+
+/**
+ * Sun illumination scale from the inverse-square law, normalised to 1.0 at 1 AU.
+ *
+ * Guards against non-positive distances (which never occur for a real body-Sun
+ * distance) so a bad input can't produce Infinity/NaN intensity.
+ */
+export function inverseSquareIntensity(distKm: number): number {
+  if (!(distKm > 0)) return 1.0;
+  return (AU_KM / distKm) ** 2;
+}


### PR DESCRIPTION
クローズ済み #96 の「未消化 nice-to-have」を実装する。本丸(Scene.tsx 分解)は PR #89/#108 で実装済み・#96 はクローズ済みで、本 PR はそのクローズコメントに残した follow-up に対応する。

## 方針: SimInfoContext は導入しない(原案の再評価)

#96 当初案の「`SimInfoContext` 等の軽い Context 導入で prop drilling 削減」は再評価の結果、**目標(App.tsx 薄化/重複削減)は正当だが手段(Context)はこの構造に対して過剰**と判断した。

- 決め手: 派生値の最大消費者 `OrbitSceneContents` は embeddable `lib/OrbitViewer` が **props 駆動する公開 API** であり、app の Context の射程外。Context を scene に届かせると viewer-as-library の分離(#96 が解消したもの)を壊す。
- 当初の「prop drilling」は *直接の子に多数 props を渡す*(正常)ことを指しており、*中間層を貫通する drilling* は存在しなかった。
- → Provider は作らず、純粋関数 + フック抽出と sub-layout 抽出で薄化する。

(設計は smart-friend / 外部 AI レビューにも相談済み)

## 変更内容

### Phase 1 — SunLighting 分離
- `sunLighting.ts`: 純粋関数 `sunDirectionInDisplayFrame`(LVLH/ECEF/ECI 変換) + `inverseSquareIntensity`(逆二乗則)を切り出し。THREE/WASM/React 非依存で renderer 無しに単体テスト可能(回転変換という最もバグの出やすい箇所を TDD 対象に)。
- `components/SunLighting.tsx`: `useSunLighting` フックが WASM 呼び出し + 純粋関数を束ねて `{sunDirection, sunIntensity, lightPosition}` を返す。presentational `<SunLighting>` は ambient + directional light を描くだけ。
- `OrbitSceneContents` はフックの戻り値を従来どおり子(CelestialBody 等)へ prop で渡す(陰影にも要るため Context にしない)。ambient intensity の magic number を `AMBIENT_INTENSITY` に集約。

### Phase 2 — App.tsx 薄化
- `simInfoDerived.ts`: 純粋関数 `deriveSimInfo(simInfo)` が centralBody / centralBodyRadius / epochJd / satelliteNames / activePerturbations を「simInfo 不在時の既定値」込みで 1 箇所に集約。
- `hooks/useSimInfoDerived.ts`: `deriveSimInfo` を `useMemo` でラップし `satelliteNames` の参照安定性を保つ。
- `components/SceneOverlay.tsx`: top-left canvas overlay(frame selector + file-orbit 表示 + sim info bar)を抽出。スタイルは `ConnectionPanel` と同様に共有 `App.module.css` を使用(DOM 不変)。
- App.tsx **483 → 453 行**。

## 検証
- `tsc`(viewer)クリーン / `vite` 本番ビルド成功
- viewer 単体テスト **409 件パス**(新規 TDD 15 件: sunLighting 10 + deriveSimInfo 5)
- `biome check .` **zero delta**(base と完全一致、追加の error/warning 0)
- Playwright E2E **8 件パス**: `orbit-viewer-lib`(embeddable scene = OrbitSceneContents + SunLighting), `lvlh-orientation`(scene quaternion 不変), `csv-file-load`(SceneOverlay の orbit-info 経路)
- 外部 AI コードレビュー(codex/gpt-5.5): "clean refactor without changing behavior, no actionable correctness issues"

振る舞い不変の faithful extraction。

🤖 Generated with [Claude Code](https://claude.com/claude-code)