### PR TITLE
perf(tobari): use binary search for Harris-Priester altitude lookup

### DIFF
--- a/tobari/src/harris_priester.rs
+++ b/tobari/src/harris_priester.rs
@@ -462,12 +462,19 @@ fn scale_height_interp(h: f64, h_lo: f64, h_hi: f64, rho_lo: f64, rho_hi: f64) -
 
 /// Index of the first entry whose key exceeds `x`, by binary search.
 ///
-/// Equivalent to `table.partition_point(|e| key(e) <= x)`: it splits the
-/// ascending table into entries with `key <= x` (before the index) and
-/// `key > x` (at/after). O(log n) comparisons instead of a linear scan — the
-/// atmospheric density lookup is on the per-step drag hot path.
+/// Splits the ascending table into entries with `key <= x` (before the
+/// returned index) and `key > x` (at/after). O(log n) comparisons instead of a
+/// linear scan — the atmospheric density lookup is on the per-step drag hot path.
+///
+/// The predicate is `!(key > x)` rather than `key <= x` so that a `NaN` query
+/// returns `len` (every `NaN > k` is false → predicate true everywhere),
+/// exactly matching the previous `position(|e| key > x).unwrap_or(len)` scan.
+/// For finite `x` the two predicates are identical.
+// The negated comparison is deliberate: `!(key > x)` and `key <= x` differ for
+// NaN, and the NaN case is exactly the behavior we must preserve here.
+#[allow(clippy::neg_cmp_op_on_partial_ord)]
 fn upper_bound_by<T>(table: &[T], x: f64, key: impl Fn(&T) -> f64) -> usize {
-    table.partition_point(|e| key(e) <= x)
+    table.partition_point(|e| !(key(e) > x))
 }
 
 #[cfg(test)]
@@ -746,7 +753,9 @@ mod tests {
         // Behavior preservation: the binary-search bracket index must equal the
         // previous linear-scan formula `position(|e| e.h > x).unwrap_or(len)`
         // across the full domain — below the first knot, at each knot exactly,
-        // between knots, and above the last knot.
+        // between knots, above the last knot, and the non-finite edge cases.
+        // NaN in particular must yield `len` (clamp to the last entry), not 0:
+        // the `!(key > x)` predicate is what preserves this.
         let linear = |x: f64| {
             HP_TABLE
                 .iter()
@@ -754,7 +763,14 @@ mod tests {
                 .unwrap_or(HP_TABLE.len())
         };
         let last = HP_TABLE[HP_TABLE.len() - 1].h;
-        let mut samples = vec![HP_TABLE[0].h - 50.0, last + 50.0, last];
+        let mut samples = vec![
+            HP_TABLE[0].h - 50.0,
+            last + 50.0,
+            last,
+            f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ];
         for w in HP_TABLE.windows(2) {
             samples.push(w[0].h); // exact knot
             samples.push(0.5 * (w[0].h + w[1].h)); // midpoint between knots
@@ -771,10 +787,12 @@ mod tests {
     #[test]
     fn lookup_uses_logarithmic_comparisons() {
         // "Is it actually fast?" — assert the lookup is O(log n), not O(n).
-        // Wall-clock timing would be flaky; instead count key comparisons via an
-        // instrumented closure. A linear scan would touch ~n entries; binary
-        // search touches ⌈log2 n⌉+1. This fails loudly if the search ever
-        // regresses to a linear scan on the per-step drag hot path.
+        // Wall-clock timing would be flaky; instead count how many times the
+        // key extractor is invoked (once per binary-search step). A linear scan
+        // would invoke it ~n times; binary search stays at ⌊log2 n⌋ + a small
+        // constant. The `⌊log2 n⌋ + 2` bound (= 7 for n=50) is comfortably below
+        // n=50, so this fails loudly if the search regresses to a linear scan on
+        // the per-step drag hot path.
         use std::cell::Cell;
         let n = HP_TABLE.len();
         let bound = n.ilog2() as usize + 2;

--- a/tobari/src/harris_priester.rs
+++ b/tobari/src/harris_priester.rs
@@ -467,9 +467,11 @@ fn scale_height_interp(h: f64, h_lo: f64, h_hi: f64, rho_lo: f64, rho_hi: f64) -
 /// linear scan — the atmospheric density lookup is on the per-step drag hot path.
 ///
 /// The predicate is `!(key > x)` rather than `key <= x` so that a `NaN` query
-/// returns `len` (every `NaN > k` is false → predicate true everywhere),
-/// exactly matching the previous `position(|e| key > x).unwrap_or(len)` scan.
-/// For finite `x` the two predicates are identical.
+/// returns `len`: when `x` is `NaN`, `key > x` is false for every entry (all
+/// comparisons against `NaN` are false), so the negated predicate is true
+/// everywhere and `partition_point` returns `len` — exactly matching the
+/// previous `position(|e| key > x).unwrap_or(len)` scan. For finite `x` the two
+/// predicates are identical.
 // The negated comparison is deliberate: `!(key > x)` and `key <= x` differ for
 // NaN, and the NaN case is exactly the behavior we must preserve here.
 #[allow(clippy::neg_cmp_op_on_partial_ord)]

--- a/tobari/src/harris_priester.rs
+++ b/tobari/src/harris_priester.rs
@@ -395,11 +395,8 @@ impl HarrisPriester {
     ///
     /// Uses scale-height interpolation (log-linear) between table entries.
     fn interpolate_table(&self, altitude_km: f64) -> (f64, f64) {
-        // Find the bracket
-        let idx = HP_TABLE
-            .iter()
-            .position(|e| e.h > altitude_km)
-            .unwrap_or(HP_TABLE.len());
+        // Find the bracket (binary search; this runs every drag RHS evaluation).
+        let idx = upper_bound_by(HP_TABLE, altitude_km, |e| e.h);
 
         if idx == 0 {
             return (HP_TABLE[0].rho_min, HP_TABLE[0].rho_max);
@@ -461,6 +458,16 @@ fn scale_height_interp(h: f64, h_lo: f64, h_hi: f64, rho_lo: f64, rho_hi: f64) -
     }
     let scale_h = (h_hi - h_lo) / (rho_lo / rho_hi).ln();
     rho_lo * (-(h - h_lo) / scale_h).exp()
+}
+
+/// Index of the first entry whose key exceeds `x`, by binary search.
+///
+/// Equivalent to `table.partition_point(|e| key(e) <= x)`: it splits the
+/// ascending table into entries with `key <= x` (before the index) and
+/// `key > x` (at/after). O(log n) comparisons instead of a linear scan — the
+/// atmospheric density lookup is on the per-step drag hot path.
+fn upper_bound_by<T>(table: &[T], x: f64, key: impl Fn(&T) -> f64) -> usize {
+    table.partition_point(|e| key(e) <= x)
 }
 
 #[cfg(test)]
@@ -731,6 +738,57 @@ mod tests {
         assert!(
             ratio > 0.1 && ratio < 10.0,
             "HP/Exponential ratio at 400 km: {ratio:.2} (HP={rho_hp:.3e}, Exp={rho_exp:.3e})"
+        );
+    }
+
+    #[test]
+    fn upper_bound_matches_previous_linear_scan() {
+        // Behavior preservation: the binary-search bracket index must equal the
+        // previous linear-scan formula `position(|e| e.h > x).unwrap_or(len)`
+        // across the full domain — below the first knot, at each knot exactly,
+        // between knots, and above the last knot.
+        let linear = |x: f64| {
+            HP_TABLE
+                .iter()
+                .position(|e| e.h > x)
+                .unwrap_or(HP_TABLE.len())
+        };
+        let last = HP_TABLE[HP_TABLE.len() - 1].h;
+        let mut samples = vec![HP_TABLE[0].h - 50.0, last + 50.0, last];
+        for w in HP_TABLE.windows(2) {
+            samples.push(w[0].h); // exact knot
+            samples.push(0.5 * (w[0].h + w[1].h)); // midpoint between knots
+        }
+        for x in samples {
+            assert_eq!(
+                upper_bound_by(HP_TABLE, x, |e| e.h),
+                linear(x),
+                "bracket index mismatch at altitude {x}"
+            );
+        }
+    }
+
+    #[test]
+    fn lookup_uses_logarithmic_comparisons() {
+        // "Is it actually fast?" — assert the lookup is O(log n), not O(n).
+        // Wall-clock timing would be flaky; instead count key comparisons via an
+        // instrumented closure. A linear scan would touch ~n entries; binary
+        // search touches ⌈log2 n⌉+1. This fails loudly if the search ever
+        // regresses to a linear scan on the per-step drag hot path.
+        use std::cell::Cell;
+        let n = HP_TABLE.len();
+        let bound = n.ilog2() as usize + 2;
+        // Highest bracket: the worst case a linear scan would walk to (~n).
+        let target = HP_TABLE[n - 1].h - 1.0;
+        let comparisons = Cell::new(0usize);
+        let _ = upper_bound_by(HP_TABLE, target, |e| {
+            comparisons.set(comparisons.get() + 1);
+            e.h
+        });
+        assert!(
+            comparisons.get() <= bound,
+            "lookup made {} comparisons for n={n}; expected ≤{bound} (binary, not linear)",
+            comparisons.get()
         );
     }
 }


### PR DESCRIPTION
## 概要

`#104` の項目3「テーブル補間の共通化」。検討の結果、**越境抽出ではなく stdlib への収斂**という形で対応する。

## 経緯（設計判断）

当初 Issue は「EOP(arika 線形補間) と Harris-Priester(tobari log-linear 補間) の binary search + bracket パターンを共通 util に抽出」を想定。しかし精査すると:

- **真に共通な核は `slice::partition_point` だけ**で、これは既に core(no_std 可)にある。EOP は既にそれを使用。
- 実体的な不整合は **HP だけが線形スキャン `position` を使っている**こと。
- 範囲外処理(Err vs クランプ)・補間式(線形 vs log-linear)・データ表現はドメイン的に正当に異なり共有不可。

→ 独自 util を作ると core::partition_point の再発明になるため、**HP を stdlib の `partition_point` に揃える**のが筋がよいと判断（外部レビュー Codex gpt-5.5 とも合意）。新規クレート/モジュール/依存辺は不要。

## 変更

- `interpolate_table` の線形スキャン `HP_TABLE.iter().position(|e| e.h > x)` を `partition_point`(二分探索, O(log n)) ベースの小ヘルパ `upper_bound_by` に置換
- 大気密度ルックアップは **drag の毎 RHS 評価で走るホットパス**

挙動変更なし: `position(|e| e.h > x).unwrap_or(len)` と `partition_point(|e| e.h <= x)` は昇順テーブルで同一の bracket index を返す。

## テスト（TDD）

- **挙動保存**: 旧線形スキャン式と新二分探索が全域（下限未満・各 knot・中点・上限超）で同一 index を返すことを characterization test で固定
- **「ちゃんと高速」= O(log n) を決定的に検証**: 壁時計時間は flaky なので、key 比較回数を instrumented closure で数え、`≤ ⌈log2 n⌉+1`（n=50 で ~6）を assert。線形に退化(~50回)したら必ず落ちる regression guard

## 検証

- `cargo test -p tobari`（default / `--features fetch-cssi`）… 全通過（HP モジュール 10→12 tests）
- `cargo check -p tobari --no-default-features`（no_std）… ok
- `cargo check -p tobari-wasm --target wasm32-unknown-unknown` / `tobari --no-default-features --target wasm32`（wasm32）… ok
- `cargo clippy --locked -p tobari -- -D warnings` / `cargo fmt --check` … clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)