### PR TITLE
ci(renovate): group wasmtime crates so they bump in lockstep

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,12 @@
       ]
     },
     {
+      "description": "wasmtime and wasmtime-wasi release in lockstep and must share a major; group them so they bump together (a split bump leaves two wasmtime versions and fails to build)",
+      "matchManagers": ["cargo"],
+      "groupName": "wasmtime",
+      "matchPackageNames": ["/^wasmtime/"]
+    },
+    {
       "description": "Auto-merge patch-level updates once required CI checks pass",
       "matchUpdateTypes": ["patch"],
       "automerge": true


### PR DESCRIPTION
## What

`renovate.json` の packageRules に **wasmtime グループ**を追加（`/^wasmtime/` を `groupName: "wasmtime"` でまとめる）。

## Why

`wasmtime` と `wasmtime-wasi` は lockstep（同一 major 必須。wasmtime-wasi は内部で同版 wasmtime に依存）。Renovate は両者を独立依存として個別に bump するため、**split PR**（#78 wasmtime-wasi v44 / #141 wasmtime v45）が生まれ、それぞれ tree に wasmtime が2版残ってコンパイル不能になっていた。

グループ化すれば今後は**1つの PR でペア bump** され、この種の split は再発しない。

これを入れると Renovate は次回実行で #78/#141 を統合したグループ PR に作り直す見込み（中身は両方を同一最新版に）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)