### PR TITLE
chore: add 7-day release-age cooldown (pnpm + renovate)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,11 @@ packages:
   - "docs"
   - "tobari/examples/web"
   - "starlight-rustdoc"
+
+# Supply-chain hardening: refuse to resolve a version published less than
+# 7 days ago (10080 minutes), so a compromised release has time to be
+# detected and yanked before it can enter the lockfile. Applies to
+# pnpm add/update and Renovate's lockfile regen; --frozen-lockfile installs
+# (CI) are unaffected. Use minimumReleaseAgeExclude to fast-track a package
+# when an urgent fix is needed. (pnpm 10.16+; pnpm 11 defaults this to 1 day.)
+minimumReleaseAge: 10080

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   "constraints": {
     "pnpm": "10"
   },
+  "minimumReleaseAge": "7 days",
   "customManagers": [
     {
       "description": "Match '# renovate: datasource=... depName=...' followed by a VARNAME=value assignment in shell/CI",
@@ -46,6 +47,7 @@
     "automerge": true
   },
   "vulnerabilityAlerts": {
-    "automerge": true
+    "automerge": true,
+    "minimumReleaseAge": "0 days"
   }
 }


### PR DESCRIPTION
## What

サプライチェーン対策として「**公開から7日未満の版は入れない**」cooldown を2層で追加。

- **pnpm** `minimumReleaseAge: 10080`（分=7日, `pnpm-workspace.yaml`）— install/update 時に新しすぎる版の resolve を拒否（`pnpm add/update`・Renovate の lockfile 再生成に作用。`--frozen-lockfile` の CI install は影響なし）。pnpm 10.16+ で有効、pnpm 11 は既定1日。
- **Renovate** `minimumReleaseAge: "7 days"` — 公開7日経過まで更新 PR を作らない（`internalChecksFilter` は既定 strict）。

## Security は即時

`vulnerabilityAlerts.minimumReleaseAge: "0 days"` で脆弱性修正は cooldown を回避し即適用。pnpm 側は緊急時 `minimumReleaseAgeExclude` で個別 fast-track 可。

## レビュー

code-review-gpt（codex）通過。初版は security override を数値 `0` にしていたが、Renovate の `minimumReleaseAge` は duration 文字列なので無効になる指摘を受け `"0 days"` に修正済み。`pnpm config get minimumReleaseAge` が 10080 を返すことも確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)