### PR TITLE
ci: run nos3-adcs-e2e on PRs using the debug CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,10 +345,13 @@ jobs:
   # NOS3 ADCS SILS E2E: builds the NOS3 generic_adcs WASM plugin
   # (C FFI via wasi-sdk) and verifies B-dot detumbling reduces angular
   # velocity. Separate job because it needs wasi-sdk for C cross-compilation.
+  # Runs on PRs using the debug CLI from rust-build (same pattern as
+  # cli-plugin-backend-e2e) so wasi-sdk bumps and the C plugin build are
+  # validated before merge rather than only post-merge. The B-dot check is
+  # a correctness assertion, so the slower debug binary is acceptable.
   nos3-adcs-e2e:
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [rust-dist]
+    needs: [rust-build]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -385,10 +388,10 @@ jobs:
           sudo mv "/tmp/wasi-sysroot-${WASI_SDK_VERSION}.0" /usr/share/wasi-sysroot
           echo "WASI_SYSROOT=/usr/share/wasi-sysroot" >> "$GITHUB_ENV"
 
-      - name: Download orts binary (release)
+      - name: Download orts binary (debug)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: orts-cli-release-x86_64-unknown-linux-gnu
+          name: orts-cli-debug
           path: ./bin
 
       - name: Make orts binary executable


### PR DESCRIPTION
## What

`nos3-adcs-e2e` を **PR でも実行**するように変更（main/tags ゲート削除）。リリース成果物(rust-dist, ~10分)依存から、**rust-build の debug CLI 成果物**（`cli-plugin-backend-e2e` と同パターン）に切り替え。

## Why — 「CI で意味のある検証ができていない」の解消

このジョブは **wasi-sdk の DL と C(wasi-sdk) プラグインビルドの唯一の検証者**なのに、main 限定のため **PR で一切走っていなかった**。例: wasi-sdk v33(#139) は sysroot アセット名変更（`+m`）で 404 するが、**マージ後にしか壊れが見えない**。PR で走らせれば事前に検知できる。

`test.sh` は `ORTS_BIN` を使い plugin も debug でビルドする設計なので debug バイナリで動作。B-dot 判定は correctness なので debug の遅さは許容。

## 速度

main 実測でジョブ自体は **~1m11s**。rust-build の後で並列実行され、律速 `cli-plugin-backend-e2e`(~6m49s) の陰に隠れるため **PR の総 wall-clock はほぼ不変**の見込み。**本 PR の CI run 自体が debug-sim 実時間の計測**になる（その数値を見てから merge 判断）。

## Note
計測目的。nos3-adcs-e2e の実所要を確認してからマージ可否を判断（むやみに遅くしない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)