### PR TITLE
feat(viewer): make central bodies extensible (custom body definitions)

### DIFF
--- a/viewer/examples/orbit-viewer/main.tsx
+++ b/viewer/examples/orbit-viewer/main.tsx
@@ -33,7 +33,6 @@ const EPOCH_JD = 2451545.0; // J2000
 
 /** A user-defined central body (no texture → flat colour; rotation is not modelled). */
 const CUSTOM_BODY: BodyDefinition = {
-  id: "kerbin",
   name: "Kerbin",
   radiusKm: 6000,
   fallbackColor: 0x33aa55,

--- a/viewer/examples/orbit-viewer/main.tsx
+++ b/viewer/examples/orbit-viewer/main.tsx
@@ -8,6 +8,7 @@
  * Query params:
  *   ?frame=eci|ecef|sat|lvlh   reference frame (default eci)
  *   ?animate=0                 freeze (deterministic for E2E)
+ *   ?body=earth|custom         central body (custom = a user-defined planet)
  *
  * Exposes `window.__example` (advanceTime / appendTrail) so the E2E can drive
  * state changes and assert the trail buffer stays stable.
@@ -16,6 +17,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 import {
+  type BodyDefinition,
   OrbitViewer,
   type SatelliteState,
   type TrailPoint,
@@ -28,6 +30,15 @@ const MU = 398600.4418; // km^3/s^2
 const ORBIT_RADIUS_KM = 7378; // ~1000 km altitude
 const STEP_SECONDS = 30;
 const EPOCH_JD = 2451545.0; // J2000
+
+/** A user-defined central body (no texture → flat colour; rotation is not modelled). */
+const CUSTOM_BODY: BodyDefinition = {
+  id: "kerbin",
+  name: "Kerbin",
+  radiusKm: 6000,
+  fallbackColor: 0x33aa55,
+  emissiveColor: 0x113322,
+};
 
 /** Deterministic circular equatorial orbit state at step `i`. */
 function orbitStep(i: number): { position: Vec3; velocity: Vec3 } {
@@ -58,6 +69,12 @@ function Example() {
   const [timeOffset, setTimeOffset] = useState(0); // extra sim time (for the E2E hook)
   const frame = useMemo(frameFromQuery, []);
   const animate = useMemo(() => new URLSearchParams(location.search).get("animate") !== "0", []);
+  // Custom central body via the public `bodies` prop; centralBody.radiusKm is
+  // omitted so it's resolved from the definition.
+  const useCustomBody = useMemo(
+    () => new URLSearchParams(location.search).get("body") === "custom",
+    [],
+  );
 
   // Advance along the orbit ~16x/s: the satellite moves and the trail grows.
   useEffect(() => {
@@ -92,7 +109,8 @@ function Example() {
 
   return (
     <OrbitViewer
-      centralBody={{ id: "earth", radiusKm: EARTH_RADIUS_KM }}
+      centralBody={useCustomBody ? { id: "kerbin" } : { id: "earth", radiusKm: EARTH_RADIUS_KM }}
+      bodies={useCustomBody ? { kerbin: CUSTOM_BODY } : undefined}
       satellites={satellites}
       referenceFrame={frame}
       epochJd={EPOCH_JD}

--- a/viewer/src/bodies.test.ts
+++ b/viewer/src/bodies.test.ts
@@ -1,33 +1,78 @@
 import * as THREE from "three";
 import { describe, expect, it } from "vitest";
-import { entityPathToBodyId, getBodyRadius } from "./bodies.js";
+import {
+  type BodyDefinition,
+  DEFAULT_BODIES,
+  entityPathToBodyId,
+  getBodyRadius,
+  getBodyRenderInfo,
+  resolveBodyDefinitions,
+} from "./bodies.js";
 
-describe("entityPathToBodyId", () => {
-  it("returns null for satellite paths", () => {
-    expect(entityPathToBodyId("/world/sat/iss")).toBeNull();
-    expect(entityPathToBodyId("/world/sat/apollo11")).toBeNull();
+const DEFAULTS = resolveBodyDefinitions();
+
+describe("resolveBodyDefinitions", () => {
+  it("returns the built-in bodies when given nothing", () => {
+    expect(Object.keys(DEFAULTS).sort()).toEqual(["earth", "mars", "moon", "sun"]);
   });
 
-  it("returns body id for known body paths", () => {
-    expect(entityPathToBodyId("/world/moon")).toBe("moon");
-    expect(entityPathToBodyId("/world/sun")).toBe("sun");
-    expect(entityPathToBodyId("/world/mars")).toBe("mars");
-    expect(entityPathToBodyId("/world/earth")).toBe("earth");
+  it("adds a custom body while keeping the defaults", () => {
+    const pluto: BodyDefinition = { id: "pluto", radiusKm: 1188.3, fallbackColor: 0x8a7f72 };
+    const defs = resolveBodyDefinitions({ pluto });
+    expect(defs.pluto).toBe(pluto);
+    expect(defs.earth).toBe(DEFAULT_BODIES.earth); // defaults preserved
   });
 
-  it("returns null for unknown body paths", () => {
-    expect(entityPathToBodyId("/world/pluto")).toBeNull();
+  it("overrides a default body by id (shallow, whole-definition replace)", () => {
+    const earth: BodyDefinition = { id: "earth", radiusKm: 1, fallbackColor: 0x111111 };
+    const defs = resolveBodyDefinitions({ earth });
+    expect(defs.earth).toBe(earth);
+    expect(getBodyRadius("earth", defs)).toBe(1);
   });
 });
 
-describe("getBodyRadius", () => {
-  it("returns radius for known bodies", () => {
-    expect(getBodyRadius("moon")).toBeCloseTo(1737.4, 0);
-    expect(getBodyRadius("earth")).toBeCloseTo(6378.137, 0);
+describe("entityPathToBodyId", () => {
+  it("returns null for satellite paths", () => {
+    expect(entityPathToBodyId("/world/sat/iss", DEFAULTS)).toBeNull();
+    expect(entityPathToBodyId("/world/sat/apollo11", DEFAULTS)).toBeNull();
   });
 
-  it("returns null for unknown bodies", () => {
-    expect(getBodyRadius("pluto")).toBeNull();
+  it("returns body id for known body paths", () => {
+    expect(entityPathToBodyId("/world/moon", DEFAULTS)).toBe("moon");
+    expect(entityPathToBodyId("/world/earth", DEFAULTS)).toBe("earth");
+  });
+
+  it("returns null for bodies not in the given set", () => {
+    expect(entityPathToBodyId("/world/pluto", DEFAULTS)).toBeNull();
+  });
+
+  it("recognises a custom body once it's in the definitions", () => {
+    const defs = resolveBodyDefinitions({ pluto: { id: "pluto", radiusKm: 1188.3 } });
+    expect(entityPathToBodyId("/world/pluto", defs)).toBe("pluto");
+  });
+});
+
+describe("getBodyRadius / getBodyRenderInfo", () => {
+  it("returns radius for known bodies", () => {
+    expect(getBodyRadius("moon", DEFAULTS)).toBeCloseTo(1737.4, 0);
+    expect(getBodyRadius("earth", DEFAULTS)).toBeCloseTo(6378.137, 0);
+  });
+
+  it("returns null radius for bodies not in the set", () => {
+    expect(getBodyRadius("pluto", DEFAULTS)).toBeNull();
+  });
+
+  it("falls back to a grey unknown body for render info", () => {
+    const info = getBodyRenderInfo("pluto", DEFAULTS);
+    expect(info.id).toBe("unknown");
+    expect(info.texture?.day ?? null).toBeNull();
+  });
+
+  it("returns the custom render definition when present", () => {
+    const defs = resolveBodyDefinitions({
+      pluto: { id: "pluto", radiusKm: 1188.3, texture: { day: "https://cdn/pluto.jpg" } },
+    });
+    expect(getBodyRenderInfo("pluto", defs).texture?.day).toBe("https://cdn/pluto.jpg");
   });
 });
 

--- a/viewer/src/bodies.test.ts
+++ b/viewer/src/bodies.test.ts
@@ -17,14 +17,14 @@ describe("resolveBodyDefinitions", () => {
   });
 
   it("adds a custom body while keeping the defaults", () => {
-    const pluto: BodyDefinition = { id: "pluto", radiusKm: 1188.3, fallbackColor: 0x8a7f72 };
+    const pluto: BodyDefinition = { radiusKm: 1188.3, fallbackColor: 0x8a7f72 };
     const defs = resolveBodyDefinitions({ pluto });
     expect(defs.pluto).toBe(pluto);
     expect(defs.earth).toBe(DEFAULT_BODIES.earth); // defaults preserved
   });
 
   it("overrides a default body by id (shallow, whole-definition replace)", () => {
-    const earth: BodyDefinition = { id: "earth", radiusKm: 1, fallbackColor: 0x111111 };
+    const earth: BodyDefinition = { radiusKm: 1, fallbackColor: 0x111111 };
     const defs = resolveBodyDefinitions({ earth });
     expect(defs.earth).toBe(earth);
     expect(getBodyRadius("earth", defs)).toBe(1);
@@ -47,7 +47,7 @@ describe("entityPathToBodyId", () => {
   });
 
   it("recognises a custom body once it's in the definitions", () => {
-    const defs = resolveBodyDefinitions({ pluto: { id: "pluto", radiusKm: 1188.3 } });
+    const defs = resolveBodyDefinitions({ pluto: { radiusKm: 1188.3 } });
     expect(entityPathToBodyId("/world/pluto", defs)).toBe("pluto");
   });
 });
@@ -64,13 +64,13 @@ describe("getBodyRadius / getBodyRenderInfo", () => {
 
   it("falls back to a grey unknown body for render info", () => {
     const info = getBodyRenderInfo("pluto", DEFAULTS);
-    expect(info.id).toBe("unknown");
+    expect(info.fallbackColor).toBe(0x666666); // the grey UNKNOWN_BODY
     expect(info.texture?.day ?? null).toBeNull();
   });
 
   it("returns the custom render definition when present", () => {
     const defs = resolveBodyDefinitions({
-      pluto: { id: "pluto", radiusKm: 1188.3, texture: { day: "https://cdn/pluto.jpg" } },
+      pluto: { radiusKm: 1188.3, texture: { day: "https://cdn/pluto.jpg" } },
     });
     expect(getBodyRenderInfo("pluto", defs).texture?.day).toBe("https://cdn/pluto.jpg");
   });

--- a/viewer/src/bodies.ts
+++ b/viewer/src/bodies.ts
@@ -16,7 +16,11 @@
 export interface BodyTexture {
   /** Day-side texture URL/path, or null/omitted for a flat fallback colour. */
   day?: string | null;
-  /** Night-side (city lights) texture URL/path. */
+  /**
+   * Night-side (city lights) texture URL/path. Currently only the built-in
+   * Earth renders a day/night terminator; for other bodies this is ignored
+   * (they render with `day` as a flat-lit sphere).
+   */
   night?: string | null;
   /**
    * Base name for an orts server's multi-resolution upgrade (e.g. "earth" →

--- a/viewer/src/bodies.ts
+++ b/viewer/src/bodies.ts
@@ -1,111 +1,144 @@
-/** Rendering properties for a known celestial body. */
-export interface BodyRenderInfo {
-  id: string;
-  name: string;
-  /** Path to texture image (relative to public/), or null for fallback color. */
-  texturePath: string | null;
-  /** Path to night-side texture (city lights), or null if not applicable. */
-  nightTexturePath: string | null;
-  /** Base name for multi-resolution textures (e.g., "earth" → earth_2k.jpg, earth_4k.jpg). */
-  textureBaseName?: string;
-  /** Base name for multi-resolution night textures. */
-  nightTextureBaseName?: string;
-  /** Fallback solid color (hex) when no texture is available/loaded. */
-  fallbackColor: number;
-  /** Emissive color for lit materials. */
-  emissiveColor: number;
-  /** Whether this body emits its own light (e.g., Sun). */
-  isSelfLuminous: boolean;
+/**
+ * Central / secondary body definitions for the 3D scene.
+ *
+ * Bodies are *data*, not hardcoded: {@link DEFAULT_BODIES} ships Earth / Moon /
+ * Sun / Mars, and a consumer can add or override any body by passing its own
+ * definitions (merged over the defaults via {@link resolveBodyDefinitions}).
+ * The lookups below are pure functions of a definitions map, so a scene only
+ * ever sees the bodies it was given — no module-global registry.
+ *
+ * Note: physically-correct Sun direction and body rotation come from the arika
+ * WASM model, which only knows a fixed set of bodies. A *custom* body renders
+ * (radius, texture, colour) but does not get physical lighting/rotation.
+ */
+
+/** Texture sources for a body. Provide direct URLs/paths via `day`/`night`. */
+export interface BodyTexture {
+  /** Day-side texture URL/path, or null/omitted for a flat fallback colour. */
+  day?: string | null;
+  /** Night-side (city lights) texture URL/path. */
+  night?: string | null;
+  /**
+   * Base name for an orts server's multi-resolution upgrade (e.g. "earth" →
+   * earth_2k/4k/8k). Only used when a `textureBaseUrl` server is connected;
+   * standalone consumers can ignore this and just set `day`/`night`.
+   */
+  baseName?: string;
+  nightBaseName?: string;
 }
+
+/** How a body should be rendered. */
+export interface BodyDefinition {
+  id: string;
+  name?: string;
+  /** Physical radius in km (sets the scene scale and secondary-body sizing). */
+  radiusKm: number;
+  texture?: BodyTexture;
+  /** Solid colour shown when no texture is available/loaded (hex). */
+  fallbackColor?: number;
+  /** Emissive colour for lit materials (hex). */
+  emissiveColor?: number;
+  /** Whether the body emits its own light (e.g. the Sun). */
+  selfLuminous?: boolean;
+}
+
+/** A map of body id → definition. */
+export type BodyDefinitions = Record<string, BodyDefinition>;
 
 const base = import.meta.env.BASE_URL;
 
-const BODY_REGISTRY: Record<string, BodyRenderInfo> = {
+/** Built-in bodies. Consumers merge their own over these. */
+export const DEFAULT_BODIES: BodyDefinitions = {
   earth: {
     id: "earth",
     name: "Earth",
-    texturePath: `${base}textures/earth_2k.jpg`,
-    nightTexturePath: `${base}textures/earth_night_2k.jpg`,
-    textureBaseName: "earth",
-    nightTextureBaseName: "earth_night",
+    radiusKm: 6378.137,
+    texture: {
+      day: `${base}textures/earth_2k.jpg`,
+      night: `${base}textures/earth_night_2k.jpg`,
+      baseName: "earth",
+      nightBaseName: "earth_night",
+    },
     fallbackColor: 0x2255aa,
     emissiveColor: 0x112244,
-    isSelfLuminous: false,
+    selfLuminous: false,
   },
   moon: {
     id: "moon",
     name: "Moon",
-    texturePath: `${base}textures/moon.jpg`,
-    nightTexturePath: null,
-    textureBaseName: "moon",
+    radiusKm: 1737.4,
+    texture: { day: `${base}textures/moon.jpg`, baseName: "moon" },
     fallbackColor: 0x888888,
     emissiveColor: 0x222222,
-    isSelfLuminous: false,
+    selfLuminous: false,
   },
   sun: {
     id: "sun",
     name: "Sun",
-    texturePath: `${base}textures/sun.jpg`,
-    nightTexturePath: null,
-    textureBaseName: "sun",
+    radiusKm: 695700,
+    texture: { day: `${base}textures/sun.jpg`, baseName: "sun" },
     fallbackColor: 0xffcc00,
     emissiveColor: 0xffaa00,
-    isSelfLuminous: true,
+    selfLuminous: true,
   },
   mars: {
     id: "mars",
     name: "Mars",
-    texturePath: `${base}textures/mars.jpg`,
-    nightTexturePath: null,
-    textureBaseName: "mars",
+    radiusKm: 3389.5,
+    texture: { day: `${base}textures/mars.jpg`, baseName: "mars" },
     fallbackColor: 0xcc6633,
     emissiveColor: 0x331100,
-    isSelfLuminous: false,
+    selfLuminous: false,
   },
 };
 
-/** Known body radii in km, for rendering secondary bodies at correct scale. */
-const BODY_RADII: Record<string, number> = {
-  earth: 6378.137,
-  moon: 1737.4,
-  sun: 695700,
-  mars: 3389.5,
-};
-
-const UNKNOWN_BODY: BodyRenderInfo = {
+/** Render fallback for an id with no definition (flat grey sphere). */
+const UNKNOWN_BODY: BodyDefinition = {
   id: "unknown",
   name: "Unknown Body",
-  texturePath: null,
-  nightTexturePath: null,
+  radiusKm: 1,
   fallbackColor: 0x666666,
   emissiveColor: 0x222222,
-  isSelfLuminous: false,
+  selfLuminous: false,
 };
 
-/** Look up rendering info for a body by its identifier. */
-export function getBodyRenderInfo(bodyId: string): BodyRenderInfo {
-  return BODY_REGISTRY[bodyId] ?? UNKNOWN_BODY;
+/** Merge consumer-supplied bodies over the defaults (shallow, per id). */
+export function resolveBodyDefinitions(custom?: BodyDefinitions): BodyDefinitions {
+  return custom ? { ...DEFAULT_BODIES, ...custom } : DEFAULT_BODIES;
+}
+
+/** Look up a body definition, or undefined if absent. */
+export function getBodyDefinition(
+  bodyId: string,
+  bodies: BodyDefinitions,
+): BodyDefinition | undefined {
+  return bodies[bodyId];
+}
+
+/** Look up a body's render definition, falling back to a flat grey sphere. */
+export function getBodyRenderInfo(bodyId: string, bodies: BodyDefinitions): BodyDefinition {
+  return bodies[bodyId] ?? UNKNOWN_BODY;
+}
+
+/** Get a body's radius in km, or null if it's not one of the scene's bodies. */
+export function getBodyRadius(bodyId: string, bodies: BodyDefinitions): number | null {
+  return bodies[bodyId]?.radiusKm ?? null;
 }
 
 /**
- * Extract a known body ID from an entity path, or null if it's a satellite.
+ * Extract a body id from an orts server entity path, or null if it's a
+ * satellite / not one of the scene's bodies.
  *
- * Convention:
- * - `/world/sat/*` → satellite (returns null)
- * - `/world/<bodyId>` where bodyId is in BODY_REGISTRY → celestial body
+ * Convention (orts-server specific — kept internal, not part of the public API):
+ * - `/world/sat/*` → satellite (null)
+ * - `/world/<bodyId>` where `<bodyId>` is in `bodies` → that body
  */
-/** Get the radius of a known body in km, or null if unknown. */
-export function getBodyRadius(bodyId: string): number | null {
-  return BODY_RADII[bodyId] ?? null;
-}
-
-export function entityPathToBodyId(entityPath: string): string | null {
+export function entityPathToBodyId(entityPath: string, bodies: BodyDefinitions): string | null {
   if (entityPath.startsWith("/world/sat/")) return null;
   const segments = entityPath.split("/").filter(Boolean);
-  // Expected: ["world", "<bodyId>"]
   if (segments.length >= 2 && segments[0] === "world") {
     const candidate = segments[segments.length - 1];
-    if (candidate in BODY_REGISTRY) return candidate;
+    if (candidate in bodies) return candidate;
   }
   return null;
 }

--- a/viewer/src/bodies.ts
+++ b/viewer/src/bodies.ts
@@ -31,9 +31,11 @@ export interface BodyTexture {
   nightBaseName?: string;
 }
 
-/** How a body should be rendered. */
+/**
+ * How a body should be rendered. The body's id is the key in a
+ * {@link BodyDefinitions} map, so it isn't repeated here.
+ */
 export interface BodyDefinition {
-  id: string;
   name?: string;
   /** Physical radius in km (sets the scene scale and secondary-body sizing). */
   radiusKm: number;
@@ -54,7 +56,6 @@ const base = import.meta.env.BASE_URL;
 /** Built-in bodies. Consumers merge their own over these. */
 export const DEFAULT_BODIES: BodyDefinitions = {
   earth: {
-    id: "earth",
     name: "Earth",
     radiusKm: 6378.137,
     texture: {
@@ -68,7 +69,6 @@ export const DEFAULT_BODIES: BodyDefinitions = {
     selfLuminous: false,
   },
   moon: {
-    id: "moon",
     name: "Moon",
     radiusKm: 1737.4,
     texture: { day: `${base}textures/moon.jpg`, baseName: "moon" },
@@ -77,7 +77,6 @@ export const DEFAULT_BODIES: BodyDefinitions = {
     selfLuminous: false,
   },
   sun: {
-    id: "sun",
     name: "Sun",
     radiusKm: 695700,
     texture: { day: `${base}textures/sun.jpg`, baseName: "sun" },
@@ -86,7 +85,6 @@ export const DEFAULT_BODIES: BodyDefinitions = {
     selfLuminous: true,
   },
   mars: {
-    id: "mars",
     name: "Mars",
     radiusKm: 3389.5,
     texture: { day: `${base}textures/mars.jpg`, baseName: "mars" },
@@ -98,7 +96,6 @@ export const DEFAULT_BODIES: BodyDefinitions = {
 
 /** Render fallback for an id with no definition (flat grey sphere). */
 const UNKNOWN_BODY: BodyDefinition = {
-  id: "unknown",
   name: "Unknown Body",
   radiusKm: 1,
   fallbackColor: 0x666666,
@@ -109,14 +106,6 @@ const UNKNOWN_BODY: BodyDefinition = {
 /** Merge consumer-supplied bodies over the defaults (shallow, per id). */
 export function resolveBodyDefinitions(custom?: BodyDefinitions): BodyDefinitions {
   return custom ? { ...DEFAULT_BODIES, ...custom } : DEFAULT_BODIES;
-}
-
-/** Look up a body definition, or undefined if absent. */
-export function getBodyDefinition(
-  bodyId: string,
-  bodies: BodyDefinitions,
-): BodyDefinition | undefined {
-  return bodies[bodyId];
 }
 
 /** Look up a body's render definition, falling back to a flat grey sphere. */

--- a/viewer/src/components/CelestialBody.tsx
+++ b/viewer/src/components/CelestialBody.tsx
@@ -1,8 +1,36 @@
 import { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
-import { type BodyRenderInfo, getBodyRenderInfo } from "../bodies.js";
+import {
+  type BodyDefinition,
+  type BodyDefinitions,
+  DEFAULT_BODIES,
+  getBodyRenderInfo,
+} from "../bodies.js";
 import { type TextureResolution, useTextureResolution } from "../hooks/useTextureResolution.js";
 import { EarthBody } from "./EarthBody.js";
+
+/** Flat render fields the sphere sub-components consume (derived from a {@link BodyDefinition}). */
+interface RenderInfo {
+  texturePath: string | null;
+  nightTexturePath: string | null;
+  textureBaseName?: string;
+  nightTextureBaseName?: string;
+  fallbackColor: number;
+  emissiveColor: number;
+  isSelfLuminous: boolean;
+}
+
+function toRenderInfo(def: BodyDefinition): RenderInfo {
+  return {
+    texturePath: def.texture?.day ?? null,
+    nightTexturePath: def.texture?.night ?? null,
+    textureBaseName: def.texture?.baseName,
+    nightTextureBaseName: def.texture?.nightBaseName,
+    fallbackColor: def.fallbackColor ?? 0x666666,
+    emissiveColor: def.emissiveColor ?? 0x222222,
+    isSelfLuminous: def.selfLuminous ?? false,
+  };
+}
 
 interface CelestialBodyProps {
   /** Body identifier from the server (e.g., "earth"). */
@@ -27,6 +55,8 @@ interface CelestialBodyProps {
   textureRevision?: number;
   /** Base URL for fetching high-res textures. */
   textureBaseUrl?: string;
+  /** Body definitions to resolve `bodyId` against. Defaults to the built-in bodies. */
+  bodyDefinitions?: BodyDefinitions;
 }
 
 const FALLBACK_CHAIN: TextureResolution[] = ["16k", "8k", "4k"];
@@ -61,7 +91,7 @@ function TexturedBody({
   textureRevision,
   textureBaseUrl,
 }: {
-  renderInfo: BodyRenderInfo;
+  renderInfo: RenderInfo;
   radius: number;
   targetResolution?: TextureResolution;
   textureRevision?: number;
@@ -199,7 +229,7 @@ function TexturedBody({
   );
 }
 
-function FallbackBody({ renderInfo, radius }: { renderInfo: BodyRenderInfo; radius: number }) {
+function FallbackBody({ renderInfo, radius }: { renderInfo: RenderInfo; radius: number }) {
   return (
     <group>
       <mesh>
@@ -235,8 +265,9 @@ export function CelestialBody({
   physicalScale,
   textureRevision,
   textureBaseUrl,
+  bodyDefinitions = DEFAULT_BODIES,
 }: CelestialBodyProps) {
-  const renderInfo = getBodyRenderInfo(bodyId);
+  const renderInfo = toRenderInfo(getBodyRenderInfo(bodyId, bodyDefinitions));
   const isSatelliteCentered = lvlhPosition != null;
   const targetResolution = useTextureResolution(isSatelliteCentered);
 

--- a/viewer/src/components/CelestialBody.tsx
+++ b/viewer/src/components/CelestialBody.tsx
@@ -273,7 +273,11 @@ export function CelestialBody({
 
   let body: React.ReactNode;
 
-  if (renderInfo.nightTexturePath && renderInfo.texturePath && sunDirection) {
+  // The day/night terminator shader + atmosphere + ERA rotation in EarthBody are
+  // Earth-specific — gate them to the built-in Earth so a *custom* body with a
+  // night texture doesn't inherit Earth's atmosphere/rotation (it renders via the
+  // generic textured-sphere path below instead).
+  if (bodyId === "earth" && renderInfo.nightTexturePath && renderInfo.texturePath && sunDirection) {
     body = (
       <EarthBody
         radius={radius}

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -2,7 +2,12 @@ import { OrbitControls } from "@react-three/drei";
 import { useFrame, useThree } from "@react-three/fiber";
 import { useEffect, useMemo, useRef } from "react";
 import * as THREE from "three";
-import { entityPathToBodyId, getBodyRadius } from "../bodies.js";
+import {
+  type BodyDefinitions,
+  DEFAULT_BODIES,
+  entityPathToBodyId,
+  getBodyRadius,
+} from "../bodies.js";
 import { transformToLvlh } from "../coordTransform.js";
 import {
   computeSceneAmplification,
@@ -238,6 +243,7 @@ function SecondaryBody({
   lvlhAxes = null,
   textureRevision,
   textureBaseUrl,
+  bodyDefinitions,
 }: {
   bodyId: string;
   position: OrbitPoint;
@@ -249,8 +255,9 @@ function SecondaryBody({
   lvlhAxes?: LvlhAxes | null;
   textureRevision?: number;
   textureBaseUrl?: string;
+  bodyDefinitions: BodyDefinitions;
 }) {
-  const bodyRadiusKm = getBodyRadius(bodyId);
+  const bodyRadiusKm = getBodyRadius(bodyId, bodyDefinitions);
   const radius = bodyRadiusKm != null ? bodyRadiusKm / scaleRadius : 0.01;
 
   // Position transform: same pipeline as Satellite (ECI → ECEF → LVLH)
@@ -307,6 +314,7 @@ function SecondaryBody({
         sunDirection={sunDirection}
         textureRevision={textureRevision}
         textureBaseUrl={textureBaseUrl}
+        bodyDefinitions={bodyDefinitions}
       />
     </group>
   );
@@ -323,6 +331,8 @@ export interface OrbitSceneContentsProps {
   trailDrawStarts?: Map<string, number>;
   centralBody: string;
   centralBodyRadius: number;
+  /** Body definitions (render info + radii) for the central body and any secondary bodies. */
+  bodyDefinitions?: BodyDefinitions;
   /** Julian Date of the simulation epoch, or null if not set. */
   epochJd?: number | null;
   /** Reference frame for display (default: central-body inertial). */
@@ -358,6 +368,7 @@ export function OrbitSceneContents({
   trailDrawStarts,
   centralBody,
   centralBodyRadius,
+  bodyDefinitions = DEFAULT_BODIES,
   epochJd,
   referenceFrame = DEFAULT_FRAME,
   satelliteNames,
@@ -375,7 +386,8 @@ export function OrbitSceneContents({
     referenceFrame.center.type === "satellite" ? referenceFrame.center.id : null;
 
   // Detect if centered entity is a celestial body
-  const centeredBodyId = centeredSatId != null ? entityPathToBodyId(centeredSatId) : null;
+  const centeredBodyId =
+    centeredSatId != null ? entityPathToBodyId(centeredSatId, bodyDefinitions) : null;
 
   // Display scale profile for the current view center
   const displayProfile = useMemo(
@@ -386,11 +398,11 @@ export function OrbitSceneContents({
   // Override camera distance when centering on a known body
   const cameraDistanceOverride = useMemo(() => {
     if (centeredBodyId == null) return undefined;
-    const bodyRadiusKm = getBodyRadius(centeredBodyId);
+    const bodyRadiusKm = getBodyRadius(centeredBodyId, bodyDefinitions);
     if (bodyRadiusKm == null) return undefined;
     // Camera at ~3x body radius in scene units
     return (bodyRadiusKm / centralBodyRadius) * 3;
-  }, [centeredBodyId, centralBodyRadius]);
+  }, [centeredBodyId, centralBodyRadius, bodyDefinitions]);
 
   // Scene amplification: scale up environment to show correct proportions
   // relative to the satellite's exaggerated model at origin.
@@ -415,9 +427,9 @@ export function OrbitSceneContents({
           const p = satellitePositions?.get(id);
           return p ? { position: [p.x, p.y, p.z], velocity: [p.vx, p.vy, p.vz] } : null;
         },
-        (id) => entityPathToBodyId(id) != null,
+        (id) => entityPathToBodyId(id, bodyDefinitions) != null,
       ),
-    [referenceFrame, satellitePositions],
+    [referenceFrame, satellitePositions, bodyDefinitions],
   );
 
   // Dev/E2E-only: expose the resolved frame semantics so tests can assert
@@ -546,10 +558,10 @@ export function OrbitSceneContents({
           const color =
             satelliteColors?.get(centeredSatId) ??
             SATELLITE_COLORS[(idx < 0 ? 0 : idx) % SATELLITE_COLORS.length];
-          const centeredBodyId = entityPathToBodyId(centeredSatId);
+          const centeredBodyId = entityPathToBodyId(centeredSatId, bodyDefinitions);
           if (centeredBodyId != null) {
             // Render as CelestialBody at origin with physical radius + IAU orientation
-            const bodyRadiusKm = getBodyRadius(centeredBodyId);
+            const bodyRadiusKm = getBodyRadius(centeredBodyId, bodyDefinitions);
             const bodyRadius = bodyRadiusKm != null ? bodyRadiusKm / centralBodyRadius : 0.01;
             const q =
               epochJd != null ? body_orientation(centeredBodyId, epochJd, pos.t) : undefined;
@@ -566,6 +578,7 @@ export function OrbitSceneContents({
                   sunDirection={sunDirection}
                   textureRevision={textureRevision}
                   textureBaseUrl={textureBaseUrl}
+                  bodyDefinitions={bodyDefinitions}
                 />
               </group>
             );
@@ -607,6 +620,7 @@ export function OrbitSceneContents({
           physicalScale={physicalScale}
           textureRevision={textureRevision}
           textureBaseUrl={textureBaseUrl}
+          bodyDefinitions={bodyDefinitions}
         />
 
         {/* One entry per satellite that has a trail and/or a position. */}
@@ -615,7 +629,7 @@ export function OrbitSceneContents({
             satelliteColors?.get(satId) ?? SATELLITE_COLORS[index % SATELLITE_COLORS.length];
           const isCenteredSat = satId === centeredSatId;
           const trailScale = lvlhActive ? effectiveScaleRadius : centralBodyRadius;
-          const bodyId = entityPathToBodyId(satId);
+          const bodyId = entityPathToBodyId(satId, bodyDefinitions);
           return (
             <group key={satId}>
               {/* Mount on buffer *existence*, not current length: contents may be
@@ -647,6 +661,7 @@ export function OrbitSceneContents({
                   lvlhAxes={lvlhActive ? lvlhAxes : null}
                   textureRevision={textureRevision}
                   textureBaseUrl={textureBaseUrl}
+                  bodyDefinitions={bodyDefinitions}
                 />
               )}
               {pos && !isCenteredSat && bodyId == null && (

--- a/viewer/src/lib/OrbitViewer.tsx
+++ b/viewer/src/lib/OrbitViewer.tsx
@@ -72,8 +72,15 @@ export function OrbitViewer({
   // Body definitions: consumer-supplied bodies merged over the built-in defaults.
   const bodyDefinitions = useMemo(() => resolveBodyDefinitions(bodies), [bodies]);
   // Central-body radius: explicit prop wins; otherwise from the body definition.
-  const centralBodyRadius =
-    centralBody.radiusKm ?? getBodyRadius(centralBody.id, bodyDefinitions) ?? 1;
+  // Fail loudly rather than guess a scale — a wrong radius silently breaks the
+  // entire scene's sizing.
+  const centralBodyRadius = centralBody.radiusKm ?? getBodyRadius(centralBody.id, bodyDefinitions);
+  if (centralBodyRadius == null) {
+    throw new Error(
+      `OrbitViewer: central body "${centralBody.id}" has no radius. Pass ` +
+        "centralBody.radiusKm, or add the body to `bodies` with a radiusKm.",
+    );
+  }
 
   // Current position per satellite. `time` is stamped onto each point; the scene
   // reads it back as the simulation time that drives Sun direction and rotation.

--- a/viewer/src/lib/OrbitViewer.tsx
+++ b/viewer/src/lib/OrbitViewer.tsx
@@ -1,5 +1,6 @@
 import { Canvas } from "@react-three/fiber";
 import { useEffect, useMemo, useState } from "react";
+import { getBodyRadius, resolveBodyDefinitions } from "../bodies.js";
 import { OrbitSceneContents } from "../components/OrbitSceneContents.js";
 import type { OrbitPoint } from "../orbit.js";
 import { DEFAULT_CAMERA_POSITION, SCENE_UP } from "../sceneFrame.js";
@@ -56,6 +57,7 @@ function useArikaReady(enabled: boolean): boolean {
  */
 export function OrbitViewer({
   centralBody,
+  bodies,
   satellites,
   referenceFrame = DEFAULT_VIEWER_FRAME,
   epochJd,
@@ -66,6 +68,12 @@ export function OrbitViewer({
 }: OrbitViewerProps) {
   // Only load the arika WASM when an epoch is supplied (Sun/rotation features).
   const arikaReady = useArikaReady(epochJd != null);
+
+  // Body definitions: consumer-supplied bodies merged over the built-in defaults.
+  const bodyDefinitions = useMemo(() => resolveBodyDefinitions(bodies), [bodies]);
+  // Central-body radius: explicit prop wins; otherwise from the body definition.
+  const centralBodyRadius =
+    centralBody.radiusKm ?? getBodyRadius(centralBody.id, bodyDefinitions) ?? 1;
 
   // Current position per satellite. `time` is stamped onto each point; the scene
   // reads it back as the simulation time that drives Sun direction and rotation.
@@ -136,7 +144,8 @@ export function OrbitViewer({
           satelliteNames={satelliteNames}
           satelliteColors={satelliteColors}
           centralBody={centralBody.id}
-          centralBodyRadius={centralBody.radiusKm}
+          centralBodyRadius={centralBodyRadius}
+          bodyDefinitions={bodyDefinitions}
           epochJd={effectiveEpochJd}
           referenceFrame={internalFrame}
           textureBaseUrl={textureBaseUrl}

--- a/viewer/src/lib/index.ts
+++ b/viewer/src/lib/index.ts
@@ -13,6 +13,13 @@
  * See the package README (../../README.md).
  */
 
+// Central-body definitions: built-in bodies + the type for adding custom ones.
+export {
+  type BodyDefinition,
+  type BodyDefinitions,
+  type BodyTexture,
+  DEFAULT_BODIES,
+} from "../bodies.js";
 // Lower-level building blocks for assembling a custom scene.
 export { BodyAxes } from "../components/BodyAxes.js";
 export { CelestialBody } from "../components/CelestialBody.js";

--- a/viewer/src/lib/types.ts
+++ b/viewer/src/lib/types.ts
@@ -108,11 +108,15 @@ export interface OrbitViewerProps {
   /** The central body at the origin. */
   centralBody: CentralBody;
   /**
-   * Custom body definitions, merged over the built-in {@link DEFAULT_BODIES}
-   * (Earth / Moon / Sun / Mars). Add new bodies or override the defaults — e.g.
-   * `{ pluto: { id: "pluto", radiusKm: 1188.3, texture: { day: "/pluto.jpg" } } }`.
-   * Note: physical Sun lighting / rotation only apply to bodies the arika model
-   * knows; a custom body renders (radius / texture / colour) but does not spin.
+   * Custom body definitions, keyed by body id and merged over the built-in
+   * {@link DEFAULT_BODIES} (Earth / Moon / Sun / Mars) — e.g.
+   * `{ pluto: { radiusKm: 1188.3, texture: { day: "/pluto.jpg" } } }`.
+   *
+   * The merge is per-id and shallow: overriding a default replaces its *entire*
+   * definition, so a partial override drops the default's other fields (texture,
+   * colour, …). Note that physical Sun lighting / rotation only apply to bodies
+   * the arika model knows; a custom body renders (radius / texture / colour) but
+   * does not spin.
    */
   bodies?: BodyDefinitions;
   /** Satellites to display. */

--- a/viewer/src/lib/types.ts
+++ b/viewer/src/lib/types.ts
@@ -16,6 +16,7 @@
  */
 
 import type { CSSProperties } from "react";
+import type { BodyDefinitions } from "../bodies.js";
 
 /** A 3D vector `[x, y, z]`. Distances are in kilometres. */
 export type Vec3 = [number, number, number];
@@ -71,12 +72,16 @@ export interface SatelliteState {
 /** The central body rendered at the scene origin. */
 export interface CentralBody {
   /**
-   * Body identifier understood by the renderer, e.g. `"earth"`, `"moon"`,
-   * `"mars"`. Unknown ids fall back to a plain coloured sphere.
+   * Body id. One of the built-in bodies (`"earth"`, `"moon"`, `"sun"`,
+   * `"mars"`), or a custom body supplied via {@link OrbitViewerProps.bodies}.
+   * Unknown ids fall back to a plain coloured sphere.
    */
   id: string;
-  /** Physical radius in km. Used as the scene scale factor. */
-  radiusKm: number;
+  /**
+   * Physical radius in km (scene scale factor). Optional when the id resolves
+   * to a known/custom {@link BodyDefinition} — its `radiusKm` is used then.
+   */
+  radiusKm?: number;
 }
 
 /**
@@ -102,6 +107,14 @@ export type ViewerReferenceFrame =
 export interface OrbitViewerProps {
   /** The central body at the origin. */
   centralBody: CentralBody;
+  /**
+   * Custom body definitions, merged over the built-in {@link DEFAULT_BODIES}
+   * (Earth / Moon / Sun / Mars). Add new bodies or override the defaults — e.g.
+   * `{ pluto: { id: "pluto", radiusKm: 1188.3, texture: { day: "/pluto.jpg" } } }`.
+   * Note: physical Sun lighting / rotation only apply to bodies the arika model
+   * knows; a custom body renders (radius / texture / colour) but does not spin.
+   */
+  bodies?: BodyDefinitions;
   /** Satellites to display. */
   satellites: readonly SatelliteState[];
   /** Display frame. Defaults to central-body inertial (ECI-like). */

--- a/viewer/tests/orbit-viewer-lib.spec.ts
+++ b/viewer/tests/orbit-viewer-lib.spec.ts
@@ -132,6 +132,20 @@ test("satellite-centred inertial and LVLH are distinct frames (#90)", async ({ p
   expect(inertial?.cameraTracking).toBe(false);
 });
 
+test("renders a custom central body (bodies prop, radiusKm from the definition)", async ({
+  page,
+}) => {
+  const errors: string[] = [];
+  page.on("pageerror", (e) => errors.push(e.message));
+  // ?body=custom centres on a user-defined body with no built-in entry and an
+  // omitted centralBody.radiusKm (resolved from the definition).
+  await page.goto("/examples/orbit-viewer/?body=custom&animate=0");
+  await expect(page.locator("canvas").first()).toBeVisible();
+  await waitForTrail(page); // scene composes around the custom body without error
+  expect((await readTrail(page))?.length ?? 0).toBeGreaterThan(0);
+  expect(errors).toEqual([]);
+});
+
 test("a marker-only satellite (no trail prop) gets no trail buffer", async ({ page }) => {
   await page.goto("/examples/orbit-viewer/?animate=0");
   await waitForTrail(page); // scene is up: the demo satellite's trail is filled


### PR DESCRIPTION
First step of making the viewer a *framework* for building orbit-viewer-like
apps: the central body was hardcoded, which is the framework's core rigidity.

## Problem

`bodies.ts` had a module-global `BODY_REGISTRY` + `BODY_RADII` keyed on a fixed
set (earth/moon/sun/mars), and `entityPathToBodyId` only recognised those ids.
`<OrbitViewer>` took `centralBody.radiusKm` as a prop but pulled texture/colour
from the global by id string — so a consumer's custom body fell back to a grey
sphere, and there was no way to define one.

## Change — prop-injected body definitions

- Unify `BodyRenderInfo` + `BODY_RADII` into one **`BodyDefinition`**
  (`id` / `radiusKm` / `texture {day,night,baseName}` / `fallbackColor` /
  `emissiveColor` / `selfLuminous`) and export **`DEFAULT_BODIES`**.
- Body lookups become **pure functions of a definitions map** — no module
  global; a scene only sees the bodies it was handed.
- **`<OrbitViewer bodies={...}>`** merges consumer bodies over the defaults
  (`resolveBodyDefinitions`); **`centralBody.radiusKm` is now optional**
  (resolved from the definition). `OrbitSceneContents` / `CelestialBody` thread
  a `bodyDefinitions` prop, both defaulting to `DEFAULT_BODIES` — **existing
  behaviour, including the app, is unchanged**.
- `texture.day` / `texture.night` accept **direct URLs**, so a custom body isn't
  tied to the orts server's `baseName` multi-res convention.

Chosen prop-injection over a global `registerBody()`: it fits React/R3F data
flow, supports multiple viewers with different bodies, and is testable (a global
is painful under SSR / parallel tests). Designed with an external review pass.

## Honesty about limits

Physical Sun direction & body rotation come from the arika WASM model, which
only knows the built-in bodies — a **custom body renders (radius/texture/colour)
but doesn't get physical lighting or rotation**. `entityPathToBodyId` stays
internal (orts-server `/world` path convention; not public API).

## Tests

- `bodies` unit tests: defaults merge, custom-body recognition, render fallback.
- Example gains `?body=custom` (a user-defined planet, `radiusKm` omitted); a
  lib E2E renders a custom central body end-to-end with no page errors.
- vitest **424**, lib E2E **7/7**, app E2E (lvlh-orientation / history-trail) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
