### PR TITLE
docs(claude): refine CLAUDE.md — add dev-process guidance, trim low-value lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,9 @@ Rust libraries are split by responsibility (e.g., coordinate transforms, numeric
 - **Test cases**: SSO orbits, satellite constellations, multi-year solar system trajectories, Lagrange points, gravity assists (swing-by).
 - **Playwright** for viewer E2E tests.
 - **CLI execution** enables simple E2E testing of the simulator independently from the viewer.
+- **Validate the design before implementing**: an issue or spec is a starting point, not a fixed prescription. For non-trivial designs or refactors, sanity-check the approach with an independent design review (the `smart-friend` skill / Codex) before writing code — the stated plan is not always the cleanest one (a proposed "shared utility" may already exist in `std`; a literal file split may be the wrong granularity).
+- **External review before merge**: get a code review (Codex / Copilot) on non-trivial PRs. Independent reviewers catch complementary issues — design/whole-program vs. line-level edge cases.
+- **Behavior-preserving refactors**: pin the existing behavior with a characterization test, and include boundary *and* non-finite inputs (`NaN`, `±∞`) — float predicate rewrites can match for finite values yet diverge at `NaN`.
 
 ## Pre-commit Checklist
 
@@ -54,6 +57,7 @@ Before committing, always run the relevant checks and confirm they pass.
 - `cargo fmt --all` — format all crates (CI enforces `--check`)
 - `cargo clippy --workspace -- -D warnings` — lint with warnings as errors
 - `cargo test --workspace` — run all tests
+- Some crates are `no_std` and/or built for `wasm` beyond the default std build, and CI checks each applicable tier per crate. When changing a crate, run the tiers that apply to it — not just the std `--workspace` checks above.
 
 ### TypeScript (viewer + uneri)
 - `pnpm lint` — lint & format check (Biome, CI enforces)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,6 @@ Rust libraries are split by responsibility (e.g., coordinate transforms, numeric
 ## Build Commands
 
 ### Rust (Cargo workspace)
-- `cargo build --workspace` — build all crates
-- `cargo test --workspace` — run all tests
-- `cargo clippy --workspace` — lint all crates
 - `cargo run --bin orts -- run` — run a simulation (auto-detects orts.toml in CWD)
 - `cargo run --bin orts -- serve` — start WebSocket server (port 9001)
 - `cargo run --bin orts -- serve --sat "altitude=800" --dt 5` — custom parameters
@@ -29,20 +26,10 @@ Rust libraries are split by responsibility (e.g., coordinate transforms, numeric
 - `cargo test -p orts` — test the simulation library (orts crate)
 - `cargo test -p orts-cli` — run CLI E2E tests
 
-### Viewer (React + TypeScript)
-- `cd viewer && pnpm install` — install dependencies
-- `cd viewer && pnpm dev` — start dev server (hot reload)
-- `cd viewer && pnpm build` — production build
-
-### Docs (Starlight + Astro)
-- `cd docs && pnpm dev` — start docs dev server (hot reload)
-- `cd docs && pnpm build` — production build
-
 ## Development Methodology
 
 - **TDD-first**: Write unit tests before integration. Every module (numerical integration, coordinate transforms, etc.) must have unit tests verifying behavior before being integrated.
 - **Reference validation**: Use GMAT and Orekit as reference implementations for E2E black-box testing.
-- **Test cases**: SSO orbits, satellite constellations, multi-year solar system trajectories, Lagrange points, gravity assists (swing-by).
 - **Playwright** for viewer E2E tests.
 - **CLI execution** enables simple E2E testing of the simulator independently from the viewer.
 - **Validate the design before implementing**: an issue or spec is a starting point, not a fixed prescription. For non-trivial designs or refactors, sanity-check the approach with an independent design review (the `smart-friend` skill / Codex) before writing code — the stated plan is not always the cleanest one (a proposed "shared utility" may already exist in `std`; a literal file split may be the wrong granularity).
@@ -79,5 +66,4 @@ WebSocket 通信、データフロー、UI 統合など mock しにくい部分�
 ## Architecture Notes
 
 - Systems and precision are configurable — e.g., Earth-Moon-Sun for SSO vs. full N-body for solar system simulations; detailed atmospheric drag vs. simple drag coefficients.
-- Start simple (2-body/3-body at low precision), build test infrastructure, then progressively increase accuracy and problem complexity.
 - Strict separation of concerns across modules to enable parallel development.


### PR DESCRIPTION
## 概要

#104 のクリーンアップ作業を踏まえ、CLAUDE.md を改訂。

**追加**
- Development Methodology: ①設計検証（issue は出発点であって仕様でない／非自明な設計・リファクタは実装前に smart-friend・Codex で設計レビュー）②マージ前外部レビュー（Codex/Copilot）③挙動保存リファクタは characterization test に**非有限(NaN, ±∞)入力**も含める
- Pre-commit: foundation crate は no_std/wasm 等の feature tier も検証（std `--workspace` だけで済ませない）

**削除**（lean 化）
- Claude が既知の標準コマンド（`cargo build/test/clippy --workspace`、viewer/docs の標準 pnpm）
- ロードマップ的記述（Test cases リスト、"start simple→徐々に高精度" 哲学）→ DESIGN.md 領域

判断基準は Anthropic 公式ルーブリック（各行に「消したら Claude がミスするか? No なら削る」／「肥大は指示を埋もれさせる」）。

## 評価（知見）

変更を勘でなく軽い ablation で裏付けた（model=sonnet, **N=6=方向性レベルの小規模実験**）。

**手法上の発見**: Agent サブエージェントは worktree の CLAUDE.md を context に自動ロードしない（メモリは読む）。よって行動評価は「ルールを prompt に注入する WITH vs BASELINE」、あるいは CLAUDE.md を実ロードする独立セッション（`claude -p`）で行う必要がある。

**① 追加した behavior-preserving ルールの価値**（非誘導タスク=「リファクタを実装しテストも追加せよ」、NaN とは明示しない）:

| arm | NaN を含むテストを書いた |
|---|:--:|
| ルール無し | **0/6** |
| ルール有り | **6/6** |

実装に集中するとルール無しでは NaN が完全に抜ける（本番 #154 で実際に漏らし外部レビューが拾った事象を再現）。ルール有りでは全数が NaN/±∞ を検証し、数体は naive な binary search が NaN で原実装と乖離するバグまで検出 → このルールは現実的価値がある。

**② lean に保つ理由（希釈効果）**: 同一ルール・同一タスクで周辺コンテキスト量だけ変えて adherence を測定:

| ルールの置かれ方 | NaN テスト率 |
|---|:--:|
| 単独 | 6/6 (100%) |
| 実 CLAUDE.md 全文に埋込 | 3/6 (50%) |
| 肥大版に埋込 | 2/6 (33%) |

総量が増えるほど per-rule adherence が単調低下。→ 低価値行の trim は残す規約の効きを上げる。CLAUDE.md ルールは ~advisory（現実条件で半減）ゆえ、必ず守らせたい不変条件は hook、品質ゲートは外部レビューで補完する前提。

caveats: N=6 は方向性レベル、model=sonnet、タスク1種（transfer 未検証）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)