### PR TITLE
fix(ci): correct kble Renovate datasource (crates → crate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,7 +465,7 @@ jobs:
           tool: cargo-binstall
       - name: Install kble
         run: |
-          # renovate: datasource=crates depName=kble
+          # renovate: datasource=crate depName=kble
           KBLE_VERSION=0.4.2
           cargo binstall --no-confirm "kble@${KBLE_VERSION}"
 


### PR DESCRIPTION
## What
ci.yml の kble custom-manager 注釈の datasource を **`crates` → `crate`**（1語）。

## Why
Renovate の crates.io datasource id は **`crate`（単数）**。`crates`（複数）は無効で、Renovate は kble を extract した後 **`skipReason: invalid-config`（"Missing datasource!"）でスキップ**していた。結果、kble は lookup されず **0.4.2 のまま**（0.5.0 が出ているのに更新されない）。

## どう特定・検証したか
1. **ローカル dry-run** `renovate --platform=local --dry-run=lookup`（LOG_LEVEL=debug）:
   - 修正前: `"datasource": "crates"`, `"skipReason": "invalid-config"`, `"updates": []`
   - 修正後: `"datasource": "crate"`, `"updates": [{ newVersion: "0.5.0" }]`
2. **公式ドキュメント**でも crates.io 用 datasource id は `crate` と確認。

他の custom-manager（wasm-pack / wasi-sdk）は有効な `github-releases` を使っているため無影響。code-review-gpt（codex）通過。

## References
- Renovate datasources 一覧: https://docs.renovatebot.com/modules/datasource/
- crate datasource: https://docs.renovatebot.com/modules/datasource/crate/

🤖 Generated with [Claude Code](https://claude.com/claude-code)