### PR TITLE
feat(viewer): dogfood the registry with a consumer example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1005,6 +1005,16 @@ jobs:
           ORTS_WS_URL: "ws://localhost:9001/ws"
           ORTS_BINARY: "${{ github.workspace }}/bin/orts"
 
+      # The registry-consumer example is a standalone package that imports the
+      # shadcn-distributed source (committed under components/orbit-viewer) and
+      # serves itself on its own Vite — this exercises the copied registry output
+      # end to end. Backend-free; reuses the wasm/Playwright setup above.
+      - name: Run registry-consumer example E2E
+        working-directory: viewer/examples/orbit-viewer
+        run: npx playwright test
+        env:
+          EXAMPLE_PORT: "5273"
+
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1020,7 +1020,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: viewer-playwright-report
-          path: viewer/test-results/
+          path: |
+            viewer/test-results/
+            viewer/examples/orbit-viewer/test-results/
           retention-days: 7
 
   # Verify that npm packages can be published. Runs after build jobs

--- a/biome.json
+++ b/biome.json
@@ -16,6 +16,7 @@
       "!arika/tests/fixtures",
       "!orts/tests/fixtures",
       "!viewer/src/protocol/generated",
+      "!viewer/examples/orbit-viewer/components/orbit-viewer",
       "!docs/.astro",
       "!docs/dist",
       "!docs/public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,50 @@ importers:
         specifier: ^8.19.0
         version: 8.21.0
 
+  viewer/examples/orbit-viewer:
+    dependencies:
+      '@react-three/drei':
+        specifier: ^10.0.0
+        version: 10.7.7(@react-three/fiber@9.5.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.183.2))(@types/react@19.2.17)(@types/three@0.183.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.183.2)
+      '@react-three/fiber':
+        specifier: ^9.0.0
+        version: 9.5.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.183.2)
+      arika-wasm:
+        specifier: workspace:*
+        version: link:../../../arika/wasm/pkg
+      react:
+        specifier: ^19.0.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.7(react@19.2.7)
+      three:
+        specifier: '>=0.176.0'
+        version: 0.183.2
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.61.0
+      '@types/react':
+        specifier: ^19.2.13
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@types/three':
+        specifier: ^0.183.0
+        version: 0.183.1
+      '@vitejs/plugin-react':
+        specifier: ^6.0.0
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.8
+        version: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+
+
 packages:
 
   '@antfu/install-pkg@1.1.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 packages:
   - "uneri"
   - "viewer"
+  # Standalone consumer of the viewer's shadcn registry (dogfoods the registry
+  # output): its own package so `shadcn add` can install the item's deps.
+  - "viewer/examples/orbit-viewer"
   - "docs"
   - "tobari/examples/web"
   - "starlight-rustdoc"

--- a/viewer/examples/orbit-viewer/README.md
+++ b/viewer/examples/orbit-viewer/README.md
@@ -1,0 +1,28 @@
+# orbit-viewer example — a shadcn registry consumer
+
+A standalone, backend-free app that renders [`<OrbitViewer>`](../../README.md)
+to **dogfood the viewer's shadcn registry**: instead of importing
+`viewer/src/lib`, it consumes the registry's `orbit-viewer` item via
+`shadcn add` and imports the copied source from
+[`components/orbit-viewer/`](./components/orbit-viewer). It serves itself on its
+own Vite and is exercised by [`tests/`](./tests) (also run in CI), so the
+registry output is verified end to end — a real consumer installs it and it
+compiles + runs.
+
+## The copied source is committed
+
+`components/orbit-viewer/` is the `shadcn add` output, committed like a real
+consumer owns its copied components (note `shadcn add` strips each file's
+leading banner comment — the registry source under `viewer/src` keeps them).
+`arika-wasm` stays a workspace dependency (it isn't copied — see the registry
+docs).
+
+Regenerate it after the registry's source changes:
+
+```sh
+pnpm --filter orts-viewer-orbit-example sync:registry   # registry:build + shadcn add --overwrite
+```
+
+`sync:registry` runs `shadcn add` locally; CI does not (it would hit the
+workspace's supply-chain release-age gate during dependency install), so the
+copied tree is committed and CI runs the E2E against it.

--- a/viewer/examples/orbit-viewer/components.json
+++ b/viewer/examples/orbit-viewer/components.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/index.css",
+    "baseColor": "neutral",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  }
+}

--- a/viewer/examples/orbit-viewer/components.json
+++ b/viewer/examples/orbit-viewer/components.json
@@ -5,9 +5,9 @@
   "tsx": true,
   "tailwind": {
     "config": "",
-    "css": "src/index.css",
+    "css": "",
     "baseColor": "neutral",
-    "cssVariables": true
+    "cssVariables": false
   },
   "aliases": {
     "components": "@/components",

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/bodies.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/bodies.ts
@@ -1,0 +1,125 @@
+import { BASE_URL } from "./env.js";
+
+/** Texture sources for a body. Provide direct URLs/paths via `day`/`night`. */
+export interface BodyTexture {
+  /** Day-side texture URL/path, or null/omitted for a flat fallback colour. */
+  day?: string | null;
+  /**
+   * Night-side (city lights) texture URL/path. Currently only the built-in
+   * Earth renders a day/night terminator; for other bodies this is ignored
+   * (they render with `day` as a flat-lit sphere).
+   */
+  night?: string | null;
+  /**
+   * Base name for an orts server's multi-resolution upgrade (e.g. "earth" →
+   * earth_2k/4k/8k). Only used when a `textureBaseUrl` server is connected;
+   * standalone consumers can ignore this and just set `day`/`night`.
+   */
+  baseName?: string;
+  nightBaseName?: string;
+}
+
+/**
+ * How a body should be rendered. The body's id is the key in a
+ * {@link BodyDefinitions} map, so it isn't repeated here.
+ */
+export interface BodyDefinition {
+  name?: string;
+  /** Physical radius in km (sets the scene scale and secondary-body sizing). */
+  radiusKm: number;
+  texture?: BodyTexture;
+  /** Solid colour shown when no texture is available/loaded (hex). */
+  fallbackColor?: number;
+  /** Emissive colour for lit materials (hex). */
+  emissiveColor?: number;
+  /** Whether the body emits its own light (e.g. the Sun). */
+  selfLuminous?: boolean;
+}
+
+/** A map of body id → definition. */
+export type BodyDefinitions = Record<string, BodyDefinition>;
+
+const base = BASE_URL;
+
+/** Built-in bodies. Consumers merge their own over these. */
+export const DEFAULT_BODIES: BodyDefinitions = {
+  earth: {
+    name: "Earth",
+    radiusKm: 6378.137,
+    texture: {
+      day: `${base}textures/earth_2k.jpg`,
+      night: `${base}textures/earth_night_2k.jpg`,
+      baseName: "earth",
+      nightBaseName: "earth_night",
+    },
+    fallbackColor: 0x2255aa,
+    emissiveColor: 0x112244,
+    selfLuminous: false,
+  },
+  moon: {
+    name: "Moon",
+    radiusKm: 1737.4,
+    texture: { day: `${base}textures/moon.jpg`, baseName: "moon" },
+    fallbackColor: 0x888888,
+    emissiveColor: 0x222222,
+    selfLuminous: false,
+  },
+  sun: {
+    name: "Sun",
+    radiusKm: 695700,
+    texture: { day: `${base}textures/sun.jpg`, baseName: "sun" },
+    fallbackColor: 0xffcc00,
+    emissiveColor: 0xffaa00,
+    selfLuminous: true,
+  },
+  mars: {
+    name: "Mars",
+    radiusKm: 3389.5,
+    texture: { day: `${base}textures/mars.jpg`, baseName: "mars" },
+    fallbackColor: 0xcc6633,
+    emissiveColor: 0x331100,
+    selfLuminous: false,
+  },
+};
+
+/** Render fallback for an id with no definition (flat grey sphere). */
+const UNKNOWN_BODY: BodyDefinition = {
+  name: "Unknown Body",
+  radiusKm: 1,
+  fallbackColor: 0x666666,
+  emissiveColor: 0x222222,
+  selfLuminous: false,
+};
+
+/** Merge consumer-supplied bodies over the defaults (shallow, per id). */
+export function resolveBodyDefinitions(custom?: BodyDefinitions): BodyDefinitions {
+  return custom ? { ...DEFAULT_BODIES, ...custom } : DEFAULT_BODIES;
+}
+
+/** Look up a body's render definition, falling back to a flat grey sphere. */
+export function getBodyRenderInfo(bodyId: string, bodies: BodyDefinitions): BodyDefinition {
+  return bodies[bodyId] ?? UNKNOWN_BODY;
+}
+
+/** Get a body's radius in km, or null if it's not one of the scene's bodies. */
+export function getBodyRadius(bodyId: string, bodies: BodyDefinitions): number | null {
+  return bodies[bodyId]?.radiusKm ?? null;
+}
+
+/**
+ * Extract a body id from an orts server entity path, or null if it's a
+ * satellite / not one of the scene's bodies.
+ *
+ * Convention (orts-server specific — kept internal, not part of the public API):
+ * - `/world/sat/*` → satellite (null)
+ * - `/world/<bodyId>` where `<bodyId>` is in `bodies` → that body
+ */
+export function entityPathToBodyId(entityPath: string, bodies: BodyDefinitions): string | null {
+  if (entityPath.startsWith("/world/sat/")) return null;
+  const segments = entityPath.split("/").filter(Boolean);
+  if (segments.length >= 2 && segments[0] === "world") {
+    const candidate = segments[segments.length - 1];
+    if (candidate in bodies) return candidate;
+  }
+  return null;
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/BodyAxes.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/BodyAxes.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from "react";
+import type * as THREE from "three";
+import { registerSatWorldQuat } from "../debug/satWorldQuat.js";
+
+interface BodyAxesProps {
+  /** Position in scene units (already divided by scaleRadius). */
+  position: [number, number, number];
+  /** Body-frame quaternion [w, x, y, z] (Hamilton scalar-first). */
+  quaternion: [number, number, number, number];
+  /** Length of each axis in scene units. */
+  axisLength?: number;
+  /**
+   * Optional satellite id. When set, the rendered world quaternion is published
+   * (dev/E2E only) via `window.__debug_get_sat_world_quat(id)`. BodyAxes shares the
+   * parent transform + quaternion with the satellite mesh, so its world quaternion
+   * equals the rendered body orientation in every display variant.
+   */
+  debugId?: string;
+}
+
+/**
+ * Renders RGB XYZ axes oriented by a body-frame quaternion.
+ *
+ * Uses the same quaternion-application pattern as SatelliteModel.tsx.
+ */
+export function BodyAxes({ position, quaternion, axisLength = 0.03, debugId }: BodyAxesProps) {
+  const groupRef = useRef<THREE.Group>(null);
+
+  useEffect(() => {
+    if (groupRef.current) {
+      const [w, x, y, z] = quaternion;
+      groupRef.current.quaternion.set(x, y, z, w); // Three.js: (x, y, z, w)
+    }
+  }, [quaternion]);
+
+  useEffect(() => {
+    if (!debugId) return;
+    return registerSatWorldQuat(debugId, () => groupRef.current);
+  }, [debugId]);
+
+  return (
+    <group position={position} ref={groupRef}>
+      <axesHelper args={[axisLength]} />
+    </group>
+  );
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/CelestialBody.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/CelestialBody.tsx
@@ -1,0 +1,330 @@
+import { useEffect, useRef, useState } from "react";
+import * as THREE from "three";
+import {
+  type BodyDefinition,
+  type BodyDefinitions,
+  DEFAULT_BODIES,
+  getBodyRenderInfo,
+} from "../bodies.js";
+import { type TextureResolution, useTextureResolution } from "../hooks/useTextureResolution.js";
+import { EarthBody } from "./EarthBody.js";
+
+/** Flat render fields the sphere sub-components consume (derived from a {@link BodyDefinition}). */
+interface RenderInfo {
+  texturePath: string | null;
+  nightTexturePath: string | null;
+  textureBaseName?: string;
+  nightTextureBaseName?: string;
+  fallbackColor: number;
+  emissiveColor: number;
+  isSelfLuminous: boolean;
+}
+
+function toRenderInfo(def: BodyDefinition): RenderInfo {
+  return {
+    texturePath: def.texture?.day ?? null,
+    nightTexturePath: def.texture?.night ?? null,
+    textureBaseName: def.texture?.baseName,
+    nightTextureBaseName: def.texture?.nightBaseName,
+    fallbackColor: def.fallbackColor ?? 0x666666,
+    emissiveColor: def.emissiveColor ?? 0x222222,
+    isSelfLuminous: def.selfLuminous ?? false,
+  };
+}
+
+interface CelestialBodyProps {
+  /** Body identifier from the server (e.g., "earth"). */
+  bodyId: string;
+  /** Radius in scene units (default 1). */
+  radius?: number;
+  /** Normalized sun direction in world space (ECI). */
+  sunDirection?: THREE.Vector3;
+  /** Earth Rotation Angle in radians (for Earth self-rotation in ECI). */
+  rotationAngle?: number;
+  /** Position in LVLH frame (scene units). When set, body is placed here instead of origin. */
+  lvlhPosition?: [number, number, number] | null;
+  /** Quaternion [x,y,z,w] for body orientation in LVLH frame. Replaces ERA-based euler. */
+  lvlhQuaternion?: [number, number, number, number] | null;
+  /** Ambient light intensity for shader-based bodies (matches scene ambient). */
+  ambientIntensity?: number;
+  /** Sun intensity scale factor: (1 AU / distance)². Default 1.0. */
+  sunIntensity?: number;
+  /** When true, atmosphere uses physical scale. Default false (amplified). */
+  physicalScale?: boolean;
+  /** Bumped when server notifies high-res textures are available. Triggers re-upgrade. */
+  textureRevision?: number;
+  /** Base URL for fetching high-res textures. */
+  textureBaseUrl?: string;
+  /** Body definitions to resolve `bodyId` against. Defaults to the built-in bodies. */
+  bodyDefinitions?: BodyDefinitions;
+}
+
+const FALLBACK_CHAIN: TextureResolution[] = ["16k", "8k", "4k"];
+
+// Decode off the main thread via createImageBitmap (see EarthBody). The bitmap
+// is pre-flipped to match TextureLoader; WebGL can't flip an ImageBitmap on
+// upload, so texture.flipY is off.
+const bitmapLoader = new THREE.ImageBitmapLoader();
+bitmapLoader.setOptions({ imageOrientation: "flipY" });
+
+function loadTexture(url: string): Promise<THREE.Texture | null> {
+  return new Promise((resolve) => {
+    bitmapLoader.load(
+      url,
+      (bitmap) => {
+        const tex = new THREE.Texture(bitmap);
+        tex.colorSpace = THREE.SRGBColorSpace;
+        tex.flipY = false;
+        tex.needsUpdate = true;
+        resolve(tex);
+      },
+      undefined,
+      () => resolve(null),
+    );
+  });
+}
+
+function TexturedBody({
+  renderInfo,
+  radius,
+  targetResolution,
+  textureRevision,
+  textureBaseUrl,
+}: {
+  renderInfo: RenderInfo;
+  radius: number;
+  targetResolution?: TextureResolution;
+  textureRevision?: number;
+  textureBaseUrl?: string;
+}) {
+  const [texture, setTexture] = useState<THREE.Texture | null>(null);
+  const [baseLoaded, setBaseLoaded] = useState(false);
+  const [upgraded, setUpgraded] = useState(false);
+  // Persisted across effect re-runs (e.g. textureRevision bumps) so upgrades
+  // never overlap, not just within a single effect execution.
+  const inFlightRef = useRef(false);
+
+  // Load base texture
+  useEffect(() => {
+    let cancelled = false;
+    setBaseLoaded(false);
+    setUpgraded(false);
+    new THREE.TextureLoader().load(
+      renderInfo.texturePath!,
+      (tex) => {
+        tex.colorSpace = THREE.SRGBColorSpace;
+        if (!cancelled) {
+          setTexture(tex);
+          setBaseLoaded(true);
+        }
+      },
+      undefined,
+      () => {},
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [renderInfo.texturePath]);
+
+  // Upgrade to higher resolution — re-runs on textureRevision bump (server notification)
+  // and retries periodically until successful.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: textureRevision is an intentional trigger to re-attempt texture upgrade when server notifies new textures are available.
+  useEffect(() => {
+    if (!baseLoaded || !renderInfo.textureBaseName) return;
+    if (!targetResolution || targetResolution === "2k") return;
+    if (upgraded) return;
+    // Only upgrade when a real texture source is provided (a connected orts
+    // server, or an explicit base URL). No source → keep the bundled 2K.
+    if (!textureBaseUrl) return;
+
+    let cancelled = false;
+    const basePath = textureBaseUrl;
+    const startIdx = FALLBACK_CHAIN.indexOf(targetResolution);
+    const candidates = startIdx >= 0 ? FALLBACK_CHAIN.slice(startIdx) : [];
+
+    async function tryUpgrade() {
+      // Don't stack a second load while one is in flight: decode is off-thread
+      // (ImageBitmapLoader) but the GPU upload is still synchronous on the main thread.
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
+      try {
+        for (const res of candidates) {
+          if (cancelled) return;
+          const url = `${basePath}${renderInfo.textureBaseName}_${res}.jpg`;
+          const newTex = await loadTexture(url);
+          if (cancelled) {
+            newTex?.dispose();
+            return;
+          }
+          if (newTex) {
+            setTexture((old) => {
+              old?.dispose();
+              return newTex;
+            });
+            setUpgraded(true);
+            return;
+          }
+        }
+      } finally {
+        inFlightRef.current = false;
+      }
+    }
+    tryUpgrade();
+
+    // Bounded fallback poll (textureRevision bump is the primary re-trigger).
+    // Stop after MAX_RETRIES so a permanently unavailable resolution doesn't
+    // loop forever, and never re-upload while a load is already running.
+    let attempts = 0;
+    const MAX_RETRIES = 3;
+    const timer = setInterval(() => {
+      if (cancelled) return;
+      // A load is still in flight — skip without spending a retry, so a slow load
+      // (>10s) doesn't exhaust the budget on ticks that tryUpgrade would bail on.
+      if (inFlightRef.current) return;
+      if (attempts >= MAX_RETRIES) {
+        clearInterval(timer);
+        return;
+      }
+      attempts += 1;
+      tryUpgrade();
+    }, 10_000);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [
+    baseLoaded,
+    targetResolution,
+    renderInfo.textureBaseName,
+    textureRevision,
+    upgraded,
+    textureBaseUrl,
+  ]);
+
+  return (
+    <group>
+      <mesh>
+        <sphereGeometry args={[radius, 64, 64]} />
+        {texture ? (
+          renderInfo.isSelfLuminous ? (
+            <meshBasicMaterial map={texture} />
+          ) : (
+            <meshStandardMaterial map={texture} />
+          )
+        ) : (
+          <meshPhongMaterial
+            color={renderInfo.fallbackColor}
+            emissive={renderInfo.emissiveColor}
+            emissiveIntensity={0.1}
+            shininess={25}
+          />
+        )}
+      </mesh>
+      <mesh>
+        <sphereGeometry args={[radius * 1.002, 24, 24]} />
+        <meshBasicMaterial color={0x4488cc} wireframe transparent opacity={0.15} />
+      </mesh>
+    </group>
+  );
+}
+
+function FallbackBody({ renderInfo, radius }: { renderInfo: RenderInfo; radius: number }) {
+  return (
+    <group>
+      <mesh>
+        <sphereGeometry args={[radius, 64, 64]} />
+        <meshPhongMaterial
+          color={renderInfo.fallbackColor}
+          emissive={renderInfo.emissiveColor}
+          emissiveIntensity={0.1}
+          shininess={25}
+        />
+      </mesh>
+      <mesh>
+        <sphereGeometry args={[radius * 1.002, 24, 24]} />
+        <meshBasicMaterial color={0x4488cc} wireframe transparent opacity={0.15} />
+      </mesh>
+    </group>
+  );
+}
+
+/**
+ * Renders a celestial body sphere with texture if available,
+ * falling back to a colored Phong sphere.
+ */
+export function CelestialBody({
+  bodyId,
+  radius = 1,
+  sunDirection,
+  rotationAngle,
+  lvlhPosition = null,
+  lvlhQuaternion = null,
+  ambientIntensity,
+  sunIntensity,
+  physicalScale,
+  textureRevision,
+  textureBaseUrl,
+  bodyDefinitions = DEFAULT_BODIES,
+}: CelestialBodyProps) {
+  const renderInfo = toRenderInfo(getBodyRenderInfo(bodyId, bodyDefinitions));
+  const isSatelliteCentered = lvlhPosition != null;
+  const targetResolution = useTextureResolution(isSatelliteCentered);
+
+  let body: React.ReactNode;
+
+  // The day/night terminator shader + atmosphere + ERA rotation in EarthBody are
+  // Earth-specific — gate them to the built-in Earth so a *custom* body with a
+  // night texture doesn't inherit Earth's atmosphere/rotation (it renders via the
+  // generic textured-sphere path below instead).
+  if (bodyId === "earth" && renderInfo.nightTexturePath && renderInfo.texturePath && sunDirection) {
+    body = (
+      <EarthBody
+        radius={radius}
+        sunDirection={sunDirection}
+        dayTexturePath={renderInfo.texturePath}
+        nightTexturePath={renderInfo.nightTexturePath}
+        rotationAngle={lvlhQuaternion != null ? undefined : rotationAngle}
+        targetResolution={targetResolution}
+        textureBaseName={renderInfo.textureBaseName}
+        nightTextureBaseName={renderInfo.nightTextureBaseName}
+        ambientIntensity={ambientIntensity}
+        sunIntensity={sunIntensity}
+        physicalScale={physicalScale}
+        textureRevision={textureRevision}
+        textureBaseUrl={textureBaseUrl}
+      />
+    );
+  } else if (renderInfo.texturePath) {
+    body = (
+      <TexturedBody
+        renderInfo={renderInfo}
+        radius={radius}
+        targetResolution={targetResolution}
+        textureRevision={textureRevision}
+        textureBaseUrl={textureBaseUrl}
+      />
+    );
+  } else {
+    body = <FallbackBody renderInfo={renderInfo} radius={radius} />;
+  }
+
+  // In LVLH mode: position and orient the body via an outer group
+  if (lvlhPosition != null || lvlhQuaternion != null) {
+    const quat = lvlhQuaternion
+      ? new THREE.Quaternion(
+          lvlhQuaternion[0],
+          lvlhQuaternion[1],
+          lvlhQuaternion[2],
+          lvlhQuaternion[3],
+        )
+      : undefined;
+    return (
+      <group position={lvlhPosition ?? undefined} quaternion={quat}>
+        {body}
+      </group>
+    );
+  }
+
+  return <>{body}</>;
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/EarthAtmosphere.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/EarthAtmosphere.tsx
@@ -1,0 +1,97 @@
+import { useFrame } from "@react-three/fiber";
+import { useEffect, useMemo, useRef } from "react";
+import * as THREE from "three";
+import {
+  ATMOSPHERE_SCALE_AMPLIFIED,
+  ATMOSPHERE_SCALE_PHYSICAL,
+  atmosphereFrag,
+  atmosphereVert,
+} from "../shaders/atmosphere.js";
+
+/** Number of sphere segments for the atmosphere shell. */
+export const ATMO_SEGMENTS = 48;
+
+/** Compute the atmosphere radius for the scattering shader. */
+export function getAtmosphereRadius(radius: number, physicalScale: boolean): number {
+  const scale = physicalScale ? ATMOSPHERE_SCALE_PHYSICAL : ATMOSPHERE_SCALE_AMPLIFIED;
+  return radius * scale;
+}
+
+/** Create the atmosphere ShaderMaterial with correct blending settings. */
+export function createAtmosphereMaterial(): THREE.ShaderMaterial {
+  return new THREE.ShaderMaterial({
+    uniforms: {
+      sunDirection: { value: new THREE.Vector3(1, 0, 0) },
+      sunIntensity: { value: 1.0 },
+      cameraWorldPos: { value: new THREE.Vector3(5, 0, 0) },
+      earthRadius: { value: 1.0 },
+      atmosphereRadius: { value: ATMOSPHERE_SCALE_AMPLIFIED },
+    },
+    vertexShader: atmosphereVert,
+    fragmentShader: atmosphereFrag,
+    transparent: true,
+    blending: THREE.AdditiveBlending,
+    side: THREE.BackSide,
+    depthWrite: false,
+    depthTest: true,
+  });
+}
+
+interface EarthAtmosphereProps {
+  radius: number;
+  sunDirection: THREE.Vector3;
+  sunIntensity?: number;
+  physicalScale?: boolean;
+}
+
+/**
+ * Renders an atmospheric scattering shell around the Earth.
+ * Uses a BackSide sphere with additive blending for limb glow.
+ */
+export function EarthAtmosphere({
+  radius,
+  sunDirection,
+  sunIntensity = 1.0,
+  physicalScale = false,
+}: EarthAtmosphereProps) {
+  // Create material once via useMemo (synchronous — available on first render).
+  const material = useMemo(() => createAtmosphereMaterial(), []);
+  const materialRef = useRef(material);
+  materialRef.current = material;
+
+  // Dispose on unmount.
+  useEffect(() => {
+    return () => {
+      materialRef.current.dispose();
+    };
+  }, []);
+
+  // Update uniforms reactively.
+  useEffect(() => {
+    material.uniforms.sunDirection.value.copy(sunDirection).normalize();
+  }, [material, sunDirection]);
+
+  useEffect(() => {
+    material.uniforms.sunIntensity.value = sunIntensity;
+  }, [material, sunIntensity]);
+
+  useEffect(() => {
+    material.uniforms.earthRadius.value = radius;
+    material.uniforms.atmosphereRadius.value = getAtmosphereRadius(radius, physicalScale);
+  }, [material, radius, physicalScale]);
+
+  // Update camera position every frame.
+  useFrame(({ camera }) => {
+    materialRef.current.uniforms.cameraWorldPos.value.copy(camera.position);
+  });
+
+  // Geometry radius: always use the amplified scale (larger) so the sphere
+  // is big enough for both physical and amplified modes.
+  const geometryRadius = radius * ATMOSPHERE_SCALE_AMPLIFIED;
+
+  return (
+    <mesh material={material}>
+      <sphereGeometry args={[geometryRadius, ATMO_SEGMENTS, ATMO_SEGMENTS]} />
+    </mesh>
+  );
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/EarthBody.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/EarthBody.tsx
@@ -1,0 +1,303 @@
+import { useEffect, useRef, useState } from "react";
+import * as THREE from "three";
+import { IS_DEV } from "../env.js";
+import type { TextureResolution } from "../hooks/useTextureResolution.js";
+import { earthDayNightFrag, earthDayNightVert } from "../shaders/earthDayNight.js";
+import { EarthAtmosphere } from "./EarthAtmosphere.js";
+
+/**
+ * Euler rotation [rx, ry, rz] that aligns the Three.js sphere (Y-pole)
+ * with the ECI coordinate system (Z = north pole).
+ *
+ * Rotation of +π/2 around X maps: local +Y → world +Z (north pole).
+ */
+export const POLE_ALIGNMENT_ROTATION: [number, number, number] = [Math.PI / 2, 0, 0];
+
+/** Resolution fallback chain: try highest first, then step down. */
+const FALLBACK_CHAIN: TextureResolution[] = ["16k", "8k", "4k"];
+
+interface EarthBodyProps {
+  radius: number;
+  sunDirection: THREE.Vector3;
+  dayTexturePath: string;
+  nightTexturePath: string;
+  /** Earth Rotation Angle in radians (for self-rotation around Z in ECI). */
+  rotationAngle?: number;
+  /** Target texture resolution determined by GPU capabilities. */
+  targetResolution?: TextureResolution;
+  /** Base name for multi-resolution day textures (e.g., "earth"). */
+  textureBaseName?: string;
+  /** Base name for multi-resolution night textures (e.g., "earth_night"). */
+  nightTextureBaseName?: string;
+  /** Ambient light intensity (matches scene ambient). Default 0.15. */
+  ambientIntensity?: number;
+  /** Sun intensity scale factor: (1 AU / distance)². Default 1.0. */
+  sunIntensity?: number;
+  /** When true, atmosphere uses physical scale (~100km). Default false (amplified). */
+  physicalScale?: boolean;
+  /** Bumped when server notifies high-res textures are available. Triggers re-upgrade. */
+  textureRevision?: number;
+  /** Base URL for fetching high-res textures. */
+  textureBaseUrl?: string;
+}
+
+// Decode textures off the main thread via createImageBitmap, so a large texture
+// doesn't decode synchronously while uploading (the dominant source of frame
+// hitches on big textures). The bitmap is pre-flipped to match TextureLoader's
+// default; WebGL can't flip an ImageBitmap at upload, so texture.flipY is off.
+const bitmapLoader = new THREE.ImageBitmapLoader();
+bitmapLoader.setOptions({ imageOrientation: "flipY" });
+
+/**
+ * Try loading a texture by URL. Returns the loaded texture or null on failure.
+ */
+function loadTexture(url: string): Promise<THREE.Texture | null> {
+  return new Promise((resolve) => {
+    bitmapLoader.load(
+      url,
+      (bitmap) => {
+        const tex = new THREE.Texture(bitmap);
+        tex.colorSpace = THREE.SRGBColorSpace;
+        tex.flipY = false;
+        tex.needsUpdate = true;
+        resolve(tex);
+      },
+      undefined,
+      () => resolve(null),
+    );
+  });
+}
+
+export function EarthBody({
+  radius,
+  sunDirection,
+  dayTexturePath,
+  nightTexturePath,
+  rotationAngle,
+  targetResolution,
+  textureBaseName,
+  nightTextureBaseName,
+  ambientIntensity = 0.15,
+  sunIntensity = 1.0,
+  physicalScale = false,
+  textureRevision,
+  textureBaseUrl,
+}: EarthBodyProps) {
+  const materialRef = useRef<THREE.ShaderMaterial | null>(null);
+  const poleGroupRef = useRef<THREE.Group>(null);
+  const [ready, setReady] = useState(false);
+  const [upgraded, setUpgraded] = useState(false);
+  // Guards against overlapping high-res loads. A ref (not an effect-local) so it
+  // persists across effect re-runs — e.g. a textureRevision bump that re-runs the
+  // upgrade effect while a previous load is still decoding — not just within one run.
+  const inFlightRef = useRef(false);
+
+  // 1. Load 2K textures manually (no Suspense — keeps Canvas interactive)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: uniform values are synced by separate effects below; recreating the material on every uniform change would reload textures unnecessarily.
+  useEffect(() => {
+    let cancelled = false;
+    setReady(false);
+    Promise.all([loadTexture(dayTexturePath), loadTexture(nightTexturePath)]).then(
+      ([dayMap, nightMap]) => {
+        if (cancelled || !dayMap || !nightMap) return;
+        materialRef.current = new THREE.ShaderMaterial({
+          uniforms: {
+            dayMap: { value: dayMap },
+            nightMap: { value: nightMap },
+            sunDirection: { value: sunDirection.clone().normalize() },
+            ambientIntensity: { value: ambientIntensity },
+            sunIntensity: { value: sunIntensity },
+          },
+          vertexShader: earthDayNightVert,
+          fragmentShader: earthDayNightFrag,
+        });
+        setReady(true);
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [dayTexturePath, nightTexturePath]);
+
+  // 2. Async upgrade to higher-resolution textures — re-runs on textureRevision bump
+  //    and retries periodically until successful.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: textureRevision is an intentional trigger to re-attempt texture upgrade when server notifies new textures are available.
+  useEffect(() => {
+    if (!ready) return;
+    if (!targetResolution || targetResolution === "2k" || !textureBaseName || !nightTextureBaseName)
+      return;
+    if (!materialRef.current) return;
+    if (upgraded) return;
+    // Only upgrade when a real texture source is provided (a connected orts
+    // server, or an explicit base URL). No source → keep the bundled 2K.
+    if (!textureBaseUrl) return;
+
+    let cancelled = false;
+    const basePath = textureBaseUrl;
+
+    // Build fallback chain starting from target resolution
+    const startIdx = FALLBACK_CHAIN.indexOf(targetResolution);
+    const candidates = startIdx >= 0 ? FALLBACK_CHAIN.slice(startIdx) : [];
+
+    async function tryUpgrade() {
+      // Don't stack a second load while one is in flight: decode is off-thread
+      // (ImageBitmapLoader) but the GPU upload of a large texture is still
+      // synchronous on the main thread, so overlapping loads pile up into hitches.
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
+      try {
+        for (const res of candidates) {
+          if (cancelled) return;
+
+          const dayUrl = `${basePath}${textureBaseName}_${res}.jpg`;
+          const nightUrl = `${basePath}${nightTextureBaseName}_${res}.jpg`;
+
+          const [newDay, newNight] = await Promise.all([
+            loadTexture(dayUrl),
+            loadTexture(nightUrl),
+          ]);
+
+          if (cancelled) {
+            newDay?.dispose();
+            newNight?.dispose();
+            return;
+          }
+
+          // Both textures must load successfully for this resolution
+          if (newDay && newNight) {
+            if (materialRef.current) {
+              const oldDay = materialRef.current.uniforms.dayMap.value as THREE.Texture;
+              const oldNight = materialRef.current.uniforms.nightMap.value as THREE.Texture;
+
+              materialRef.current.uniforms.dayMap.value = newDay;
+              materialRef.current.uniforms.nightMap.value = newNight;
+              materialRef.current.needsUpdate = true;
+
+              // Dispose old textures to free GPU memory
+              oldDay.dispose();
+              oldNight.dispose();
+            }
+            setUpgraded(true);
+            return; // success
+          }
+
+          // Partial load: clean up and try next resolution
+          newDay?.dispose();
+          newNight?.dispose();
+        }
+        // No resolution available right now — 2K stays. A textureRevision bump
+        // (server "textures_ready") re-runs this effect to try again.
+      } finally {
+        inFlightRef.current = false;
+      }
+    }
+
+    tryUpgrade();
+
+    // Bounded fallback poll. The textureRevision bump is the primary re-trigger;
+    // this just covers a missed signal. Stop after MAX_RETRIES so a permanently
+    // unavailable resolution doesn't loop forever (e.g. static hosting without
+    // the high-res files), and never re-upload while a load is already running.
+    let attempts = 0;
+    const MAX_RETRIES = 3;
+    const timer = setInterval(() => {
+      if (cancelled) return;
+      // A load is still in flight — skip without spending a retry, so a slow load
+      // (>10s) doesn't exhaust the budget on ticks that tryUpgrade would bail on.
+      if (inFlightRef.current) return;
+      if (attempts >= MAX_RETRIES) {
+        clearInterval(timer);
+        return;
+      }
+      attempts += 1;
+      tryUpgrade();
+    }, 10_000);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [
+    ready,
+    targetResolution,
+    textureBaseName,
+    nightTextureBaseName,
+    textureRevision,
+    upgraded,
+    textureBaseUrl,
+  ]);
+
+  // 3. Update uniforms reactively (no material recreation)
+  // `ready` dependency ensures uniforms are set after material creation
+  // (materialRef is populated asynchronously and not tracked by React).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: ready signals that materialRef.current is available.
+  useEffect(() => {
+    if (materialRef.current) {
+      materialRef.current.uniforms.sunDirection.value.copy(sunDirection).normalize();
+    }
+  }, [sunDirection, ready]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: ready signals that materialRef.current is available.
+  useEffect(() => {
+    if (materialRef.current) {
+      materialRef.current.uniforms.ambientIntensity.value = ambientIntensity;
+    }
+  }, [ambientIntensity, ready]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: ready signals that materialRef.current is available.
+  useEffect(() => {
+    if (materialRef.current) {
+      materialRef.current.uniforms.sunIntensity.value = sunIntensity;
+    }
+  }, [sunIntensity, ready]);
+
+  // Dev/E2E-only: expose the rendered Earth orientation (mesh world quaternion,
+  // which includes the internal POLE_ALIGNMENT_ROTATION) so E2E tests can assert
+  // the central-body orientation from the live scene graph without reading pixels.
+  // See viewer/tests/lvlh-orientation.spec.ts.
+  useEffect(() => {
+    if (!IS_DEV) return;
+    const w = window as unknown as Record<string, unknown>;
+    w.__debug_get_earth_world_quat = (): [number, number, number, number] | null => {
+      const g = poleGroupRef.current;
+      if (!g) return null;
+      const q = g.getWorldQuaternion(new THREE.Quaternion());
+      return [q.x, q.y, q.z, q.w];
+    };
+    return () => {
+      delete w.__debug_get_earth_world_quat;
+    };
+  }, []);
+
+  return (
+    <group>
+      <group rotation={[0, 0, rotationAngle ?? 0]}>
+        {/* Inner group: align Three.js Y-pole to ECI Z-pole (north pole → +Z) */}
+        <group ref={poleGroupRef} rotation={POLE_ALIGNMENT_ROTATION}>
+          <mesh material={materialRef.current ?? undefined}>
+            <sphereGeometry args={[radius, 64, 64]} />
+            {!ready && (
+              <meshPhongMaterial
+                color={0x2244aa}
+                emissive={0x112244}
+                emissiveIntensity={0.1}
+                shininess={25}
+              />
+            )}
+          </mesh>
+          <mesh>
+            <sphereGeometry args={[radius * 1.002, 24, 24]} />
+            <meshBasicMaterial color={0x4488cc} wireframe transparent opacity={0.15} />
+          </mesh>
+        </group>
+      </group>
+      {/* Atmosphere: uniform sphere, no rotation needed */}
+      <EarthAtmosphere
+        radius={radius}
+        sunDirection={sunDirection}
+        sunIntensity={sunIntensity}
+        physicalScale={physicalScale}
+      />
+    </group>
+  );
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
@@ -1,0 +1,696 @@
+import { OrbitControls } from "@react-three/drei";
+import { useFrame, useThree } from "@react-three/fiber";
+import { useEffect, useMemo, useRef } from "react";
+import * as THREE from "three";
+import {
+  type BodyDefinitions,
+  DEFAULT_BODIES,
+  entityPathToBodyId,
+  getBodyRadius,
+} from "../bodies.js";
+import { transformToLvlh } from "../coordTransform.js";
+import {
+  computeSceneAmplification,
+  type DisplayScaleProfile,
+  getDisplayScaleProfile,
+} from "../displayScale.js";
+import { IS_DEV } from "../env.js";
+import { resolveSceneFrame } from "../frameResolve.js";
+import type { OrbitPoint } from "../orbit.js";
+import { DEFAULT_FRAME, isLegacyEcef, type ReferenceFrame } from "../referenceFrame.js";
+import { getSatelliteModelConfig } from "../satelliteModels.js";
+import { type MarkerShape, resolveMarkerShape } from "../satelliteShapes.js";
+import { computeCameraUp, computeLvlhAxes, type LvlhAxes, SCENE_UP } from "../sceneFrame.js";
+import type { TrailBuffer } from "../utils/TrailBuffer.js";
+import { body_orientation, earth_rotation_angle, eci_to_ecef } from "../wasm/arikaInit.js";
+import { CelestialBody } from "./CelestialBody.js";
+import { OrbitTrail } from "./OrbitTrail.js";
+import { buildRenderEntries } from "./renderEntries.js";
+import { Satellite } from "./Satellite.js";
+import { AMBIENT_INTENSITY, SunLighting, useSunLighting } from "./SunLighting.js";
+
+/** Color palette for multiple satellites. */
+const SATELLITE_COLORS = [0x00ff88, 0xff4488, 0x44aaff, 0xffaa44, 0xaa44ff];
+
+/**
+ * Smoothing speed for exponential-decay tracking (both orientation and position).
+ * Higher = faster response (less smooth), lower = smoother (more lag).
+ * Uses frame-rate-independent exponential decay: alpha = 1 - e^(-speed * dt).
+ * At 60fps (dt≈0.017s) with speed=6: alpha≈0.10 per frame.
+ */
+const SMOOTHING_SPEED = 6;
+
+/**
+ * Tracks the LVLH frame and co-rotates the camera so that user-set
+ * orientation (e.g. "Earth below, velocity right") is maintained as
+ * the satellite orbits.
+ *
+ * The raw LVLH quaternion is smoothed via slerp to avoid jitter from
+ * discrete velocity updates and perturbation oscillations.
+ *
+ * Runs at useFrame priority -1 (before OrbitControls at priority 0).
+ * Each frame:
+ *   1. Compute target LVLH quaternion from position + velocity
+ *   2. Slerp smoothed quaternion toward target (exponential decay)
+ *   3. Compute delta from previous smoothed quaternion
+ *   4. Apply delta to camera.position (rotate around origin)
+ *   5. Set camera.up to smoothed radial direction
+ *
+ * OrbitControls re-derives its spherical state from camera.position
+ * each frame, so user drags are always relative to the current LVLH frame.
+ *
+ * Falls back to radial-only tracking when velocity is unavailable.
+ */
+function CameraLvlhTracker({
+  originPosition,
+  originVelocity,
+  lvlhActive,
+}: {
+  originPosition: [number, number, number] | null;
+  originVelocity: [number, number, number] | null;
+  /** When true, LVLH rotation is handled by the coordinate data, not the camera. */
+  lvlhActive: boolean;
+}) {
+  const { camera } = useThree();
+  const prevQuatRef = useRef<THREE.Quaternion | null>(null);
+
+  useFrame((_state, delta) => {
+    // Non-satellite-centered or LVLH body-frame mode: Z=radial is natural up
+    if (originPosition == null || lvlhActive) {
+      camera.up.set(...SCENE_UP);
+      prevQuatRef.current = null;
+      return;
+    }
+
+    const axes = computeLvlhAxes(originPosition, originVelocity);
+
+    if (!axes) {
+      // Fallback: radial-only tracking (no velocity available)
+      const up = computeCameraUp(originPosition);
+      camera.up.set(up[0], up[1], up[2]);
+      prevQuatRef.current = null;
+      return;
+    }
+
+    // LVLH basis: columns = [inTrack, crossTrack, radial] maps LVLH→ECI
+    const basisMat = new THREE.Matrix4().makeBasis(
+      new THREE.Vector3(...axes.inTrack),
+      new THREE.Vector3(...axes.crossTrack),
+      new THREE.Vector3(...axes.radial),
+    );
+    const targetQuat = new THREE.Quaternion().setFromRotationMatrix(basisMat);
+
+    // Frame-rate-independent smoothing: slerp toward target
+    const alpha = 1 - Math.exp(-SMOOTHING_SPEED * delta);
+    const prevQuat = prevQuatRef.current;
+    let smoothedQuat: THREE.Quaternion;
+
+    if (prevQuat) {
+      smoothedQuat = prevQuat.clone().slerp(targetQuat, alpha);
+      // Delta: rotation from previous smoothed to current smoothed
+      const deltaQuat = smoothedQuat.clone().multiply(prevQuat.clone().invert());
+      camera.position.applyQuaternion(deltaQuat);
+    } else {
+      smoothedQuat = targetQuat;
+    }
+
+    // Extract smoothed radial direction (3rd column of smoothed rotation matrix)
+    const m = new THREE.Matrix4().makeRotationFromQuaternion(smoothedQuat);
+    const e = m.elements;
+    camera.up.set(e[8], e[9], e[10]);
+
+    prevQuatRef.current = smoothedQuat;
+  }, -1); // Priority -1: run before OrbitControls (priority 0)
+
+  return null;
+}
+
+/**
+ * Wraps scene content in a group whose position smoothly tracks a target.
+ *
+ * Used for satellite-centered view: instead of subtracting the satellite's
+ * position from every trail point / satellite / central body each frame,
+ * the children render in central-body-relative coordinates and this group
+ * smoothly translates them by -originPosition/scaleRadius.
+ *
+ * Snaps instantly when the target jumps by more than 1 scene unit (e.g.,
+ * switching from central-body to satellite-centered mode).
+ */
+function SmoothOriginGroup({
+  children,
+  targetPosition,
+}: {
+  children: React.ReactNode;
+  targetPosition: [number, number, number];
+}) {
+  const groupRef = useRef<THREE.Group>(null);
+
+  useFrame((_state, delta) => {
+    const group = groupRef.current;
+    if (!group) return;
+
+    const [tx, ty, tz] = targetPosition;
+    const dx = tx - group.position.x;
+    const dy = ty - group.position.y;
+    const dz = tz - group.position.z;
+    const dist2 = dx * dx + dy * dy + dz * dz;
+
+    // Snap for large jumps (mode switch); smooth for small updates (server data)
+    if (dist2 > 1.0) {
+      group.position.set(tx, ty, tz);
+      return;
+    }
+
+    const alpha = 1 - Math.exp(-SMOOTHING_SPEED * delta);
+    group.position.x += dx * alpha;
+    group.position.y += dy * alpha;
+    group.position.z += dz * alpha;
+  });
+
+  return <group ref={groupRef}>{children}</group>;
+}
+
+/**
+ * Dynamically updates camera near/far planes based on the active display scale profile.
+ * Must be rendered inside the Canvas tree.
+ */
+function CameraConfigurator({ profile }: { profile: DisplayScaleProfile }) {
+  const { camera } = useThree();
+
+  useEffect(() => {
+    if (camera instanceof THREE.PerspectiveCamera) {
+      camera.near = profile.cameraNear;
+      camera.far = profile.cameraFar;
+      camera.updateProjectionMatrix();
+    }
+  }, [camera, profile.cameraNear, profile.cameraFar]);
+
+  return null;
+}
+
+/**
+ * Snaps camera position when transitioning between display scale profiles.
+ * Uses the profile's default direction if specified, otherwise keeps current direction.
+ * Runs at useFrame priority -2 (before CameraLvlhTracker at -1).
+ */
+function CameraDistanceTransition({
+  profile,
+  overrideDistance,
+}: {
+  profile: DisplayScaleProfile;
+  overrideDistance?: number;
+}) {
+  const { camera } = useThree();
+  // Empty sentinel so the first frame also snaps to the active profile's default
+  // placement — not only when switching profiles. This matters when the viewer
+  // *starts* in a non-default frame (e.g. an embedder mounting satellite-centred):
+  // otherwise the camera keeps the generic initial position instead of the
+  // profile's framing. (Body-centred uses defaultCameraDirection=null, so the
+  // initial snap only normalises distance and leaves the app's view unchanged.)
+  const prevKeyRef = useRef("");
+
+  useFrame(() => {
+    const key = `${profile.name}:${overrideDistance ?? ""}`;
+    if (key !== prevKeyRef.current) {
+      prevKeyRef.current = key;
+      const d = overrideDistance ?? profile.defaultCameraDistance;
+      if (profile.defaultCameraDirection) {
+        const [dx, dy, dz] = profile.defaultCameraDirection;
+        camera.position.set(dx * d, dy * d, dz * d);
+      } else {
+        const dir = camera.position.clone().normalize();
+        if (dir.length() > 0) {
+          camera.position.copy(dir.multiplyScalar(d));
+        }
+      }
+    }
+  }, -2);
+
+  return null;
+}
+
+/**
+ * Renders a secondary celestial body (e.g., Moon) at the correct position
+ * with a textured sphere scaled to its physical radius.
+ */
+function SecondaryBody({
+  bodyId,
+  position,
+  scaleRadius,
+  sunDirection,
+  referenceFrame = DEFAULT_FRAME,
+  epochJd,
+  originPosition = null,
+  lvlhAxes = null,
+  textureRevision,
+  textureBaseUrl,
+  bodyDefinitions,
+}: {
+  bodyId: string;
+  position: OrbitPoint;
+  scaleRadius: number;
+  sunDirection?: THREE.Vector3;
+  referenceFrame?: ReferenceFrame;
+  epochJd?: number | null;
+  originPosition?: [number, number, number] | null;
+  lvlhAxes?: LvlhAxes | null;
+  textureRevision?: number;
+  textureBaseUrl?: string;
+  bodyDefinitions: BodyDefinitions;
+}) {
+  const bodyRadiusKm = getBodyRadius(bodyId, bodyDefinitions);
+  const radius = bodyRadiusKm != null ? bodyRadiusKm / scaleRadius : 0.01;
+
+  // Position transform: same pipeline as Satellite (ECI → ECEF → LVLH)
+  let scenePos: [number, number, number];
+  if (isLegacyEcef(referenceFrame) && epochJd != null) {
+    const ecef = eci_to_ecef(position.x, position.y, position.z, epochJd, position.t);
+    scenePos = [ecef[0] / scaleRadius, ecef[1] / scaleRadius, ecef[2] / scaleRadius];
+  } else if (originPosition != null && lvlhAxes != null) {
+    scenePos = transformToLvlh(
+      position.x,
+      position.y,
+      position.z,
+      originPosition,
+      lvlhAxes,
+      scaleRadius,
+    );
+  } else if (originPosition != null) {
+    scenePos = [
+      (position.x - originPosition[0]) / scaleRadius,
+      (position.y - originPosition[1]) / scaleRadius,
+      (position.z - originPosition[2]) / scaleRadius,
+    ];
+  } else {
+    scenePos = [position.x / scaleRadius, position.y / scaleRadius, position.z / scaleRadius];
+  }
+
+  // Body orientation via IAU rotation model (arika WASM).
+  // IAU quaternion is body-fixed → ECI. For non-inertial display frames
+  // (ECEF, LVLH), we must apply the same frame rotation as positions get.
+  const orientation = useMemo(() => {
+    if (epochJd == null) return undefined;
+    const q = body_orientation(bodyId, epochJd, position.t);
+    if (!q) return undefined;
+    // IAU body-fixed → ECI: q = [w, x, y, z]
+    const iauQuat = new THREE.Quaternion(q[1], q[2], q[3], q[0]); // THREE uses (x,y,z,w)
+    // Pole alignment: rotate +Y (Three.js pole) → +Z (IAU pole)
+    const poleAlign = new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0));
+    // body-fixed → ECI → (optional frame rotation)
+    let combined = iauQuat.multiply(poleAlign);
+    // ECEF: apply inverse Earth rotation (same as position transform)
+    if (isLegacyEcef(referenceFrame) && epochJd != null) {
+      const era = earth_rotation_angle(epochJd, position.t);
+      const ecefRot = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, 0, -era));
+      combined = ecefRot.multiply(combined);
+    }
+    return combined;
+  }, [bodyId, epochJd, position.t, referenceFrame]);
+
+  return (
+    <group position={scenePos} quaternion={orientation ?? undefined}>
+      <CelestialBody
+        bodyId={bodyId}
+        radius={radius}
+        sunDirection={sunDirection}
+        textureRevision={textureRevision}
+        textureBaseUrl={textureBaseUrl}
+        bodyDefinitions={bodyDefinitions}
+      />
+    </group>
+  );
+}
+
+export interface OrbitSceneContentsProps {
+  /** Per-satellite TrailBuffers (all source types). */
+  trailBuffers?: Map<string, TrailBuffer>;
+  /** Per-satellite positions. */
+  satellitePositions?: Map<string, OrbitPoint | null>;
+  /** Per-satellite visible counts (when not live). */
+  trailVisibleCounts?: Map<string, number>;
+  /** Per-satellite draw start indices for time-range clipping. */
+  trailDrawStarts?: Map<string, number>;
+  centralBody: string;
+  centralBodyRadius: number;
+  /** Body definitions (render info + radii) for the central body and any secondary bodies. */
+  bodyDefinitions?: BodyDefinitions;
+  /** Julian Date of the simulation epoch, or null if not set. */
+  epochJd?: number | null;
+  /** Reference frame for display (default: central-body inertial). */
+  referenceFrame?: ReferenceFrame;
+  /** Per-satellite metadata for model lookup. */
+  satelliteNames?: Map<string, string | null>;
+  /** Per-satellite marker/trail colour override (0xRRGGBB); falls back to the palette. */
+  satelliteColors?: Map<string, number | undefined>;
+  /** Per-satellite marker shape override; falls back to {@link defaultMarkerShape} then auto. */
+  satelliteShapes?: Map<string, MarkerShape>;
+  /** Sim-declared per-satellite marker shapes (from SatelliteInfo); below override, above default. */
+  satelliteSimShapes?: Map<string, MarkerShape>;
+  /** Global default marker shape (null/undefined = automatic per attitude). */
+  defaultMarkerShape?: MarkerShape | null;
+  /** When true, atmosphere uses physical scale. Default: auto (true for satellite-centered). */
+  physicalScale?: boolean;
+  /** Bumped when server notifies high-res textures are available. */
+  textureRevision?: number;
+  /** Base URL for fetching high-res textures (e.g., "http://localhost:9001/textures/"). */
+  textureBaseUrl?: string;
+}
+
+/**
+ * The contents of the Three.js scene: camera rig, controls, lights, central
+ * body, orbit trail(s), and satellite(s). Rendered inside a @react-three/fiber
+ * Canvas — both the app's {@link Scene} and the embeddable OrbitViewer mount
+ * this same graph, so frame/lighting logic lives in exactly one place.
+ */
+export function OrbitSceneContents({
+  trailBuffers,
+  satellitePositions,
+  trailVisibleCounts,
+  trailDrawStarts,
+  centralBody,
+  centralBodyRadius,
+  bodyDefinitions = DEFAULT_BODIES,
+  epochJd,
+  referenceFrame = DEFAULT_FRAME,
+  satelliteNames,
+  satelliteColors,
+  satelliteShapes,
+  satelliteSimShapes,
+  defaultMarkerShape,
+  physicalScale,
+  textureRevision,
+  textureBaseUrl,
+}: OrbitSceneContentsProps) {
+  const isEcef = isLegacyEcef(referenceFrame);
+  const isSatCentered = referenceFrame.center.type === "satellite";
+  const centeredSatId =
+    referenceFrame.center.type === "satellite" ? referenceFrame.center.id : null;
+
+  // Detect if centered entity is a celestial body
+  const centeredBodyId =
+    centeredSatId != null ? entityPathToBodyId(centeredSatId, bodyDefinitions) : null;
+
+  // Display scale profile for the current view center
+  const displayProfile = useMemo(
+    () => getDisplayScaleProfile(referenceFrame.center),
+    [referenceFrame.center],
+  );
+
+  // Override camera distance when centering on a known body
+  const cameraDistanceOverride = useMemo(() => {
+    if (centeredBodyId == null) return undefined;
+    const bodyRadiusKm = getBodyRadius(centeredBodyId, bodyDefinitions);
+    if (bodyRadiusKm == null) return undefined;
+    // Camera at ~3x body radius in scene units
+    return (bodyRadiusKm / centralBodyRadius) * 3;
+  }, [centeredBodyId, centralBodyRadius, bodyDefinitions]);
+
+  // Scene amplification: scale up environment to show correct proportions
+  // relative to the satellite's exaggerated model at origin.
+  const sceneAmplification = useMemo(() => {
+    if (!isSatCentered || centeredSatId == null) return 1;
+    // Body entities (Moon, Sun, etc.) don't need satellite amplification
+    if (centeredBodyId != null) return 1;
+    const modelConfig = getSatelliteModelConfig(centeredSatId, satelliteNames?.get(centeredSatId));
+    return computeSceneAmplification(modelConfig, centralBodyRadius);
+  }, [isSatCentered, centeredSatId, centeredBodyId, satelliteNames, centralBodyRadius]);
+
+  // Effective scale radius: smaller when amplified, so positions appear larger
+  const effectiveScaleRadius = centralBodyRadius / sceneAmplification;
+
+  // Resolve the frame semantics (origin, LVLH axes, camera behaviour) through
+  // the shared kernel — the one place that honours `orientation` (#90).
+  const { originPosition, originVelocity, lvlhAxes, lvlhActive, cameraTracking } = useMemo(
+    () =>
+      resolveSceneFrame(
+        referenceFrame,
+        (id) => {
+          const p = satellitePositions?.get(id);
+          return p ? { position: [p.x, p.y, p.z], velocity: [p.vx, p.vy, p.vz] } : null;
+        },
+        (id) => entityPathToBodyId(id, bodyDefinitions) != null,
+      ),
+    [referenceFrame, satellitePositions, bodyDefinitions],
+  );
+
+  // Dev/E2E-only: expose the resolved frame semantics so tests can assert
+  // inertial vs local-orbital behaviour without reading pixels.
+  useEffect(() => {
+    if (!IS_DEV) return;
+    const w = window as unknown as Record<string, unknown>;
+    w.__debug_scene_frame = { lvlhActive, cameraTracking, originPosition };
+    return () => {
+      delete w.__debug_scene_frame;
+    };
+  }, [lvlhActive, cameraTracking, originPosition]);
+
+  // Determine sim time for sun direction from first available satellite position
+  const firstPosition = satellitePositions
+    ? (Array.from(satellitePositions.values()).find((p) => p != null) ?? null)
+    : null;
+  const simTime = firstPosition?.t ?? 0;
+  const quantizedSimTime = Math.floor(simTime / 60) * 60;
+
+  // Earth rotation angle (ERA) via WASM — updates every frame via simTime (not quantized)
+  const era = useMemo(() => {
+    if (epochJd == null) return undefined;
+    return earth_rotation_angle(epochJd, simTime);
+  }, [epochJd, simTime]);
+
+  // Sun direction + intensity (display frame). Shared by the lights and by the
+  // lit bodies below, so the scene holds them and passes them down explicitly.
+  const { sunDirection, sunIntensity, lightPosition } = useSunLighting({
+    centralBody,
+    epochJd,
+    quantizedSimTime,
+    isEcef,
+    era,
+    lvlhActive,
+    lvlhAxes,
+    sceneAmplification,
+  });
+
+  // Earth rotation angle for the mesh: ERA in ECI, 0 in ECEF (Earth is static)
+  const earthRotation = isEcef ? 0 : era;
+
+  // Central body position and orientation in LVLH frame
+  const bodyLvlhPosition = useMemo<[number, number, number] | null>(() => {
+    if (!lvlhActive || originPosition == null || lvlhAxes == null) return null;
+    return transformToLvlh(0, 0, 0, originPosition, lvlhAxes, effectiveScaleRadius);
+  }, [lvlhActive, originPosition, lvlhAxes, effectiveScaleRadius]);
+
+  const bodyLvlhQuaternion = useMemo<[number, number, number, number] | null>(() => {
+    if (!lvlhActive || lvlhAxes == null) return null;
+    // R_lvlh: basis matrix [inTrack, crossTrack, radial] maps LVLH→ECI
+    const lvlhMat = new THREE.Matrix4().makeBasis(
+      new THREE.Vector3(...lvlhAxes.inTrack),
+      new THREE.Vector3(...lvlhAxes.crossTrack),
+      new THREE.Vector3(...lvlhAxes.radial),
+    );
+    const lvlhQuat = new THREE.Quaternion().setFromRotationMatrix(lvlhMat);
+    let bodyToInertialQuat: THREE.Quaternion;
+    if (centralBody === "earth") {
+      // Keep Earth in the same simple ERA frame as position/geodetic transforms.
+      // EarthBody applies the Three.js mesh pole alignment internally.
+      bodyToInertialQuat = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, 0, era ?? 0));
+    } else {
+      const q = epochJd != null ? body_orientation(centralBody, epochJd, simTime) : undefined;
+      bodyToInertialQuat = q
+        ? new THREE.Quaternion(q[1], q[2], q[3], q[0])
+        : new THREE.Quaternion();
+
+      // Non-Earth bodies use TexturedBody/FallbackBody, which do not apply
+      // Three.js Y-pole → body-frame Z-pole alignment internally.
+      bodyToInertialQuat.multiply(
+        new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0)),
+      );
+    }
+
+    // Body orientation in LVLH: R_lvlh^T * R_body_to_inertial.
+    const bodyQuat = lvlhQuat.clone().conjugate().multiply(bodyToInertialQuat);
+    return [bodyQuat.x, bodyQuat.y, bodyQuat.z, bodyQuat.w];
+  }, [lvlhActive, lvlhAxes, epochJd, centralBody, simTime, era]);
+
+  // Target offset for SmoothOriginGroup (non-LVLH satellite-centered fallback)
+  const originOffset = useMemo<[number, number, number]>(() => {
+    if (originPosition == null || lvlhActive) return [0, 0, 0];
+    return [
+      -originPosition[0] / centralBodyRadius,
+      -originPosition[1] / centralBodyRadius,
+      -originPosition[2] / centralBodyRadius,
+    ];
+  }, [originPosition, centralBodyRadius, lvlhActive]);
+
+  // No useMemo: the Maps' references (from refs) never change, but the scene
+  // re-renders each frame, so reading inline picks up newly-added satellites.
+  // Satellites are rendered from the union of trails and positions, so one given
+  // only a position (no trail) still shows a marker.
+  const renderEntries = buildRenderEntries(trailBuffers, satellitePositions);
+
+  return (
+    <>
+      <CameraConfigurator profile={displayProfile} />
+      <CameraDistanceTransition
+        profile={displayProfile}
+        overrideDistance={cameraDistanceOverride}
+      />
+      <OrbitControls
+        enableDamping
+        dampingFactor={0.1}
+        minDistance={displayProfile.minDistance}
+        maxDistance={displayProfile.maxDistance}
+      />
+      {/* Camera co-rotation only when the kernel asked for it (local-orbital
+          approximated by the camera); an inertial centre keeps star-fixed axes. */}
+      <CameraLvlhTracker
+        originPosition={cameraTracking ? originPosition : null}
+        originVelocity={originVelocity}
+        lvlhActive={lvlhActive}
+      />
+
+      <SunLighting intensity={sunIntensity} position={lightPosition} />
+
+      {/* Centered satellite/body: always exactly at world origin (0,0,0). */}
+      {centeredSatId != null &&
+        (() => {
+          const pos = satellitePositions?.get(centeredSatId);
+          if (!pos) return null;
+          const idx = renderEntries.findIndex((e) => e.satId === centeredSatId);
+          const color =
+            satelliteColors?.get(centeredSatId) ??
+            SATELLITE_COLORS[(idx < 0 ? 0 : idx) % SATELLITE_COLORS.length];
+          const centeredBodyId = entityPathToBodyId(centeredSatId, bodyDefinitions);
+          if (centeredBodyId != null) {
+            // Render as CelestialBody at origin with physical radius + IAU orientation
+            const bodyRadiusKm = getBodyRadius(centeredBodyId, bodyDefinitions);
+            const bodyRadius = bodyRadiusKm != null ? bodyRadiusKm / centralBodyRadius : 0.01;
+            const q =
+              epochJd != null ? body_orientation(centeredBodyId, epochJd, pos.t) : undefined;
+            const iauQuat = q
+              ? new THREE.Quaternion(q[1], q[2], q[3], q[0]).multiply(
+                  new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0)),
+                )
+              : undefined;
+            return (
+              <group quaternion={iauQuat ?? undefined}>
+                <CelestialBody
+                  bodyId={centeredBodyId}
+                  radius={bodyRadius}
+                  sunDirection={sunDirection}
+                  textureRevision={textureRevision}
+                  textureBaseUrl={textureBaseUrl}
+                  bodyDefinitions={bodyDefinitions}
+                />
+              </group>
+            );
+          }
+          return (
+            <Satellite
+              position={pos}
+              scaleRadius={centralBodyRadius}
+              color={color}
+              referenceFrame={referenceFrame}
+              epochJd={epochJd ?? undefined}
+              satId={centeredSatId}
+              satName={satelliteNames?.get(centeredSatId)}
+              originPosition={originPosition}
+              lvlhAxes={lvlhAxes}
+              markerShape={resolveMarkerShape({
+                override: satelliteShapes?.get(centeredSatId),
+                simShape: satelliteSimShapes?.get(centeredSatId),
+                globalDefault: defaultMarkerShape,
+                hasAttitude: pos.qw != null,
+              })}
+            />
+          );
+        })()}
+
+      {/* All scene objects in a single stable tree — no ternary remounting.
+          SmoothOriginGroup handles non-LVLH satellite-centered offset;
+          in LVLH or body-centered mode originOffset is [0,0,0] (no-op). */}
+      <SmoothOriginGroup targetPosition={originOffset}>
+        <CelestialBody
+          bodyId={centralBody}
+          radius={lvlhActive ? sceneAmplification : 1}
+          sunDirection={sunDirection}
+          rotationAngle={earthRotation}
+          lvlhPosition={lvlhActive ? bodyLvlhPosition : null}
+          lvlhQuaternion={lvlhActive ? bodyLvlhQuaternion : null}
+          ambientIntensity={AMBIENT_INTENSITY}
+          sunIntensity={sunIntensity}
+          physicalScale={physicalScale}
+          textureRevision={textureRevision}
+          textureBaseUrl={textureBaseUrl}
+          bodyDefinitions={bodyDefinitions}
+        />
+
+        {/* One entry per satellite that has a trail and/or a position. */}
+        {renderEntries.map(({ satId, buf, pos }, index) => {
+          const color =
+            satelliteColors?.get(satId) ?? SATELLITE_COLORS[index % SATELLITE_COLORS.length];
+          const isCenteredSat = satId === centeredSatId;
+          const trailScale = lvlhActive ? effectiveScaleRadius : centralBodyRadius;
+          const bodyId = entityPathToBodyId(satId, bodyDefinitions);
+          return (
+            <group key={satId}>
+              {/* Mount on buffer *existence*, not current length: contents may be
+                  filled in a commit-phase effect after this render (#91), and an
+                  empty buffer draws nothing while OrbitTrail picks up points in
+                  useFrame — no re-render needed when they arrive. */}
+              {buf && (
+                <OrbitTrail
+                  trailBuffer={buf}
+                  visibleCount={trailVisibleCounts?.get(satId)}
+                  drawStart={trailDrawStarts?.get(satId)}
+                  scaleRadius={trailScale}
+                  color={color}
+                  referenceFrame={referenceFrame}
+                  epochJd={epochJd}
+                  originPosition={lvlhActive ? originPosition : null}
+                  lvlhAxes={lvlhActive ? lvlhAxes : null}
+                />
+              )}
+              {pos && !isCenteredSat && bodyId != null && (
+                <SecondaryBody
+                  bodyId={bodyId}
+                  position={pos}
+                  scaleRadius={trailScale}
+                  sunDirection={sunDirection}
+                  referenceFrame={referenceFrame}
+                  epochJd={epochJd}
+                  originPosition={lvlhActive ? originPosition : null}
+                  lvlhAxes={lvlhActive ? lvlhAxes : null}
+                  textureRevision={textureRevision}
+                  textureBaseUrl={textureBaseUrl}
+                  bodyDefinitions={bodyDefinitions}
+                />
+              )}
+              {pos && !isCenteredSat && bodyId == null && (
+                <Satellite
+                  position={pos}
+                  scaleRadius={trailScale}
+                  color={color}
+                  referenceFrame={referenceFrame}
+                  epochJd={epochJd ?? undefined}
+                  satId={satId}
+                  satName={satelliteNames?.get(satId)}
+                  originPosition={lvlhActive ? originPosition : null}
+                  lvlhAxes={lvlhActive ? lvlhAxes : null}
+                  markerShape={resolveMarkerShape({
+                    override: satelliteShapes?.get(satId),
+                    simShape: satelliteSimShapes?.get(satId),
+                    globalDefault: defaultMarkerShape,
+                    hasAttitude: pos.qw != null,
+                  })}
+                />
+              )}
+            </group>
+          );
+        })}
+      </SmoothOriginGroup>
+
+      {/* Reference axes: full ECI axes for body-centered, small LVLH reference for satellite-centered */}
+      <axesHelper args={[isSatCentered ? 0.015 : 2]} />
+    </>
+  );
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitTrail.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitTrail.tsx
@@ -1,0 +1,280 @@
+import { useFrame } from "@react-three/fiber";
+import { useEffect, useMemo, useRef } from "react";
+import * as THREE from "three";
+import {
+  batchEncodeEcefHighLow,
+  batchEncodeEciHighLow,
+  encodeFloat64ToHighLow,
+} from "../coordTransform.js";
+import type { OrbitPoint } from "../orbit.js";
+import { frameCenterEquals, isLegacyEcef, type ReferenceFrame } from "../referenceFrame.js";
+import type { LvlhAxes } from "../sceneFrame.js";
+import { orbitTrailFrag, orbitTrailVert } from "../shaders/orbitTrail.js";
+import type { TrailBuffer } from "../utils/TrailBuffer.js";
+
+/** Initial capacity for the streaming vertex buffer. Grows as needed. */
+const INITIAL_CAPACITY = 2048;
+
+interface OrbitTrailProps {
+  /** Number of vertices to render. */
+  visibleCount?: number;
+  /** TrailBuffer (bounded, generation-based invalidation). */
+  trailBuffer: TrailBuffer;
+  /** Central body radius in km, used as the scale factor. */
+  scaleRadius: number;
+  /** Trail color (default: 0x00ff88). */
+  color?: number;
+  /** Reference frame for display (default: central-body inertial). */
+  referenceFrame?: ReferenceFrame;
+  /** Julian Date of the simulation epoch (needed for ECEF transform). */
+  epochJd?: number | null;
+  /** Starting vertex index for the draw range (default 0). */
+  drawStart?: number;
+  /** Origin position in ECI [km] for the current frame center, or null for central body. */
+  originPosition?: [number, number, number] | null;
+  /** LVLH axes for satellite body-frame transform. When provided with originPosition,
+   *  trail points are transformed into the satellite's LVLH frame for better f32 precision. */
+  lvlhAxes?: LvlhAxes | null;
+}
+
+const DEFAULT_REF_FRAME: ReferenceFrame = {
+  center: { type: "central_body" },
+  orientation: "inertial",
+};
+
+const IDENTITY_MAT3 = new THREE.Matrix3();
+
+/**
+ * Orbit trajectory line component.
+ *
+ * Uses a custom ShaderMaterial with high/low split vertex attributes
+ * for f64-level precision on the GPU. Origin subtraction and frame
+ * rotation are applied in the vertex shader via uniforms, so mode
+ * switches (ECI, ECEF, LVLH) are O(1) per frame.
+ *
+ * Data flows through TrailBuffer (bounded, generation-based GPU invalidation).
+ */
+export function OrbitTrail({
+  visibleCount,
+  trailBuffer,
+  scaleRadius,
+  color = 0x00ff88,
+  referenceFrame = DEFAULT_REF_FRAME,
+  epochJd,
+  drawStart = 0,
+  originPosition = null,
+  lvlhAxes = null,
+}: OrbitTrailProps) {
+  const writtenCountRef = useRef(0);
+  const capacityRef = useRef(INITIAL_CAPACITY);
+  const positionHighRef = useRef(new Float32Array(INITIAL_CAPACITY * 3));
+  const positionLowRef = useRef(new Float32Array(INITIAL_CAPACITY * 3));
+  const generationRef = useRef(-1);
+  const prevFrameRef = useRef<ReferenceFrame>(referenceFrame);
+
+  // Geometry with dual high/low attributes
+  const geometry = useMemo(() => {
+    positionHighRef.current = new Float32Array(INITIAL_CAPACITY * 3);
+    positionLowRef.current = new Float32Array(INITIAL_CAPACITY * 3);
+    capacityRef.current = INITIAL_CAPACITY;
+    writtenCountRef.current = 0;
+    generationRef.current = trailBuffer.generation;
+
+    const geom = new THREE.BufferGeometry();
+    const highAttr = new THREE.BufferAttribute(positionHighRef.current, 3);
+    highAttr.setUsage(THREE.DynamicDrawUsage);
+    const lowAttr = new THREE.BufferAttribute(positionLowRef.current, 3);
+    lowAttr.setUsage(THREE.DynamicDrawUsage);
+    geom.setAttribute("positionHigh", highAttr);
+    geom.setAttribute("positionLow", lowAttr);
+    geom.setDrawRange(0, 0);
+    return geom;
+  }, [trailBuffer]);
+
+  // ShaderMaterial (stable, uniforms updated separately)
+  const material = useMemo(
+    () =>
+      new THREE.ShaderMaterial({
+        uniforms: {
+          uOriginHigh: { value: new THREE.Vector3(0, 0, 0) },
+          uOriginLow: { value: new THREE.Vector3(0, 0, 0) },
+          uFrameRotation: { value: new THREE.Matrix3() },
+          uInvScaleRadius: { value: 1 / scaleRadius },
+          uColor: { value: new THREE.Color(color) },
+          uOpacity: { value: 1.0 },
+        },
+        vertexShader: orbitTrailVert,
+        fragmentShader: orbitTrailFrag,
+      }),
+    [],
+  );
+
+  const lineObject = useMemo(() => {
+    const line = new THREE.Line(geometry, material);
+    line.frustumCulled = false;
+    return line;
+  }, [geometry, material]);
+
+  useEffect(() => {
+    return () => {
+      geometry.dispose();
+    };
+  }, [geometry]);
+
+  useEffect(() => {
+    return () => {
+      material.dispose();
+    };
+  }, [material]);
+
+  // Uniform updates
+  // scaleRadius and color change rarely → useEffect is fine.
+  useEffect(() => {
+    material.uniforms.uInvScaleRadius.value = 1 / scaleRadius;
+  }, [material, scaleRadius]);
+
+  useEffect(() => {
+    material.uniforms.uColor.value.set(color);
+  }, [material, color]);
+
+  // originPosition and lvlhAxes change every frame in satellite-centered/LVLH mode.
+  // They MUST be updated in useFrame (before render), not useEffect (after render),
+  // to avoid a one-frame lag where the trail is drawn with stale transform.
+  const originPositionRef = useRef(originPosition);
+  originPositionRef.current = originPosition;
+  const lvlhAxesRef = useRef(lvlhAxes);
+  lvlhAxesRef.current = lvlhAxes;
+
+  // Unified writePoints: encode source coordinates into high/low buffers
+  function writePoints(src: OrbitPoint[], from: number, to: number): void {
+    if (isLegacyEcef(referenceFrame) && epochJd != null) {
+      batchEncodeEcefHighLow(
+        src,
+        from,
+        to,
+        epochJd,
+        positionHighRef.current,
+        positionLowRef.current,
+        from,
+      );
+    } else {
+      batchEncodeEciHighLow(src, from, to, positionHighRef.current, positionLowRef.current, from);
+    }
+  }
+
+  useFrame(() => {
+    // Update per-frame uniforms (origin + rotation) before rendering.
+    // In ECEF mode, vertices are in body-fixed frame — origin/rotation uniforms
+    // must be identity to avoid mixing coordinate frames.
+    const isEcef = isLegacyEcef(referenceFrame);
+    const curOrigin = !isEcef ? originPositionRef.current : null;
+    if (curOrigin != null) {
+      const [xh, xl] = encodeFloat64ToHighLow(curOrigin[0]);
+      const [yh, yl] = encodeFloat64ToHighLow(curOrigin[1]);
+      const [zh, zl] = encodeFloat64ToHighLow(curOrigin[2]);
+      material.uniforms.uOriginHigh.value.set(xh, yh, zh);
+      material.uniforms.uOriginLow.value.set(xl, yl, zl);
+    } else {
+      material.uniforms.uOriginHigh.value.set(0, 0, 0);
+      material.uniforms.uOriginLow.value.set(0, 0, 0);
+    }
+
+    const curAxes = !isEcef ? lvlhAxesRef.current : null;
+    if (curAxes != null) {
+      const m = material.uniforms.uFrameRotation.value as THREE.Matrix3;
+      m.set(
+        curAxes.inTrack[0],
+        curAxes.inTrack[1],
+        curAxes.inTrack[2],
+        curAxes.crossTrack[0],
+        curAxes.crossTrack[1],
+        curAxes.crossTrack[2],
+        curAxes.radial[0],
+        curAxes.radial[1],
+        curAxes.radial[2],
+      );
+    } else {
+      (material.uniforms.uFrameRotation.value as THREE.Matrix3).copy(IDENTITY_MAT3);
+    }
+
+    // Detect reference frame change (ECI ↔ ECEF) → force full rewrite
+    const frameChanged =
+      referenceFrame.orientation !== prevFrameRef.current.orientation ||
+      !frameCenterEquals(referenceFrame.center, prevFrameRef.current.center);
+    if (frameChanged) {
+      prevFrameRef.current = referenceFrame;
+      writtenCountRef.current = 0;
+    }
+
+    const currentGen = trailBuffer.generation;
+    const allPoints = trailBuffer.getAll();
+    const totalPoints = allPoints.length;
+
+    // Empty trail fast-path: with no points, `writtenCountRef === 0` would
+    // otherwise count as "needs full rewrite" every frame — re-flagging the
+    // attributes (and, in ECEF mode, calling the WASM batch transform) for a
+    // zero-length range. Track the generation and draw nothing instead; the
+    // first non-empty frame still takes the full-write path below.
+    if (totalPoints === 0) {
+      generationRef.current = currentGen;
+      writtenCountRef.current = 0;
+      geometry.setDrawRange(0, 0);
+      return;
+    }
+
+    const needsFullRewrite = currentGen !== generationRef.current || writtenCountRef.current === 0;
+
+    if (needsFullRewrite) {
+      generationRef.current = currentGen;
+      ensureCapacity(totalPoints);
+      writePoints(allPoints, 0, totalPoints);
+      writtenCountRef.current = totalPoints;
+      markAttrsNeedUpdate();
+    } else if (totalPoints > writtenCountRef.current) {
+      appendPoints(allPoints, writtenCountRef.current, totalPoints);
+    }
+
+    const vc = visibleCount != null ? Math.min(visibleCount, totalPoints) : totalPoints;
+    const start = Math.min(drawStart, vc);
+    geometry.setDrawRange(start, vc - start);
+  });
+
+  /** Ensure GPU buffers can hold `needed` points; grows if necessary. */
+  function ensureCapacity(needed: number): void {
+    if (needed <= capacityRef.current) return;
+    const newCap = Math.max(needed * 2, capacityRef.current * 2);
+
+    const newHigh = new Float32Array(newCap * 3);
+    newHigh.set(positionHighRef.current);
+    positionHighRef.current = newHigh;
+
+    const newLow = new Float32Array(newCap * 3);
+    newLow.set(positionLowRef.current);
+    positionLowRef.current = newLow;
+
+    capacityRef.current = newCap;
+
+    const highAttr = new THREE.BufferAttribute(newHigh, 3);
+    highAttr.setUsage(THREE.DynamicDrawUsage);
+    geometry.setAttribute("positionHigh", highAttr);
+
+    const lowAttr = new THREE.BufferAttribute(newLow, 3);
+    lowAttr.setUsage(THREE.DynamicDrawUsage);
+    geometry.setAttribute("positionLow", lowAttr);
+  }
+
+  /** Append points[from..to) to the GPU buffers. */
+  function appendPoints(src: OrbitPoint[], from: number, to: number): void {
+    ensureCapacity(to);
+    writePoints(src, from, to);
+    writtenCountRef.current = to;
+    markAttrsNeedUpdate();
+  }
+
+  function markAttrsNeedUpdate(): void {
+    (geometry.getAttribute("positionHigh") as THREE.BufferAttribute).needsUpdate = true;
+    (geometry.getAttribute("positionLow") as THREE.BufferAttribute).needsUpdate = true;
+  }
+
+  return <primitive object={lineObject} />;
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/PrimitiveMarker.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/PrimitiveMarker.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from "react";
+import type * as THREE from "three";
+
+interface PrimitiveMarkerProps {
+  /** Position in scene units (already divided by scaleRadius). */
+  position: [number, number, number];
+  /**
+   * Body-to-display quaternion [w, x, y, z] (Hamilton scalar-first). When present,
+   * the cube is oriented by it so the attitude is visible. Same convention as
+   * SatelliteModel / BodyAxes.
+   */
+  quaternion?: [number, number, number, number];
+  /** Half-extent of the cube in scene units. */
+  size?: number;
+}
+
+/** Default half-extent, matching the legacy sphere marker's footprint. */
+const DEFAULT_SIZE = 0.008;
+
+/**
+ * Per-face colors of the XYZ orientation cube, in Three.js BoxGeometry face order
+ * [+X, -X, +Y, -Y, +Z, -Z]. Positive faces use the bright RGB axis colors (X=red,
+ * Y=green, Z=blue, matching {@link BodyAxes}); negative faces are dimmed so each of
+ * the six faces — hence the full orientation — is unambiguous at a glance.
+ */
+const AXES_CUBE_FACE_COLORS = [0xff4444, 0x802222, 0x44ff44, 0x228022, 0x4488ff, 0x224488] as const;
+
+/**
+ * Orientation-revealing fallback marker for satellites without a 3D model: an XYZ
+ * cube whose six faces are colored per body axis. A sphere is rotationally
+ * symmetric → attitude invisible; this cube reads orientation at a glance. Unlit
+ * materials so it is visible under the scene's faint ambient light. Pair with
+ * {@link BodyAxes} for explicit RGB axes.
+ */
+export function PrimitiveMarker({
+  position,
+  quaternion,
+  size = DEFAULT_SIZE,
+}: PrimitiveMarkerProps) {
+  const groupRef = useRef<THREE.Group>(null);
+
+  // Apply the body-to-display quaternion imperatively (Hamilton [w,x,y,z] →
+  // Three.js (x,y,z,w)), matching SatelliteModel.tsx / BodyAxes.tsx.
+  useEffect(() => {
+    if (groupRef.current && quaternion) {
+      const [w, x, y, z] = quaternion;
+      groupRef.current.quaternion.set(x, y, z, w);
+    }
+  }, [quaternion]);
+
+  return (
+    <group position={position} ref={groupRef}>
+      <mesh>
+        <boxGeometry args={[size * 2, size * 2, size * 2]} />
+        {AXES_CUBE_FACE_COLORS.map((c, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length face list, index is the face id.
+          <meshBasicMaterial key={i} attach={`material-${i}`} color={c} />
+        ))}
+      </mesh>
+    </group>
+  );
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/Satellite.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/Satellite.tsx
@@ -1,0 +1,182 @@
+import { Suspense } from "react";
+import { transformToLvlh } from "../coordTransform.js";
+import type { OrbitPoint } from "../orbit.js";
+import { isLegacyEcef, type ReferenceFrame } from "../referenceFrame.js";
+import { getSatelliteModelConfig } from "../satelliteModels.js";
+import { type MarkerShape, resolveMarkerShape } from "../satelliteShapes.js";
+import type { LvlhAxes } from "../sceneFrame.js";
+import { body_quat_to_rsw, eci_to_ecef } from "../wasm/arikaInit.js";
+import { BodyAxes } from "./BodyAxes.js";
+import { PrimitiveMarker } from "./PrimitiveMarker.js";
+import { SatelliteModel } from "./SatelliteModel.js";
+
+/** Default radius of the sphere fallback marker in scene units. */
+const DEFAULT_SPHERE_RADIUS = 0.005;
+
+interface SatelliteProps {
+  /** Current interpolated orbit state (position in km). */
+  position: OrbitPoint;
+  /** Central body radius in km, used as the scale factor. */
+  scaleRadius: number;
+  /** Marker color (default: 0xff4444). */
+  color?: number;
+  /** Reference frame for display (default: central-body inertial). */
+  referenceFrame?: ReferenceFrame;
+  /** Julian Date of the simulation epoch (needed for ECEF transform). */
+  epochJd?: number;
+  /** Satellite identifier for model lookup. */
+  satId?: string;
+  /** Satellite display name for model lookup fallback. */
+  satName?: string | null;
+  /** Origin position in ECI [km] for the current frame center, or null for central body. */
+  originPosition?: [number, number, number] | null;
+  /** LVLH axes for satellite body-frame transform. */
+  lvlhAxes?: LvlhAxes | null;
+  /** When true, suppress the marker fallback (used for centered satellite at origin). */
+  hideSphereFallback?: boolean;
+  /**
+   * Resolved marker shape for satellites without a 3D model. When omitted, falls
+   * back to automatic (orientation-revealing cube when attitude is present, else
+   * a sphere). A GLTF model, when available, always takes precedence.
+   */
+  markerShape?: MarkerShape;
+}
+
+const DEFAULT_REF_FRAME: ReferenceFrame = {
+  center: { type: "central_body" },
+  orientation: "inertial",
+};
+
+function SphereMarker({
+  position,
+  color,
+  radius = DEFAULT_SPHERE_RADIUS,
+}: {
+  position: [number, number, number];
+  color: number;
+  radius?: number;
+}) {
+  return (
+    <mesh position={position}>
+      <sphereGeometry args={[radius, 16, 16]} />
+      <meshBasicMaterial color={color} />
+    </mesh>
+  );
+}
+
+/**
+ * Satellite marker component: renders a 3D model for known satellites,
+ * or a small sphere for unknown ones.
+ */
+export function Satellite({
+  position,
+  scaleRadius,
+  color = 0xff4444,
+  referenceFrame = DEFAULT_REF_FRAME,
+  epochJd,
+  satId,
+  satName,
+  originPosition = null,
+  lvlhAxes = null,
+  hideSphereFallback = false,
+  markerShape,
+}: SatelliteProps) {
+  let scenePos: [number, number, number];
+
+  if (isLegacyEcef(referenceFrame) && epochJd != null) {
+    // WASM fast path for ECEF
+    const ecef = eci_to_ecef(position.x, position.y, position.z, epochJd, position.t);
+    scenePos = [ecef[0] / scaleRadius, ecef[1] / scaleRadius, ecef[2] / scaleRadius];
+  } else if (originPosition != null && lvlhAxes != null) {
+    // LVLH body-frame transform (f64 precision)
+    scenePos = transformToLvlh(
+      position.x,
+      position.y,
+      position.z,
+      originPosition,
+      lvlhAxes,
+      scaleRadius,
+    );
+  } else if (originPosition != null) {
+    // Simple offset subtraction fallback
+    scenePos = [
+      (position.x - originPosition[0]) / scaleRadius,
+      (position.y - originPosition[1]) / scaleRadius,
+      (position.z - originPosition[2]) / scaleRadius,
+    ];
+  } else {
+    scenePos = [position.x / scaleRadius, position.y / scaleRadius, position.z / scaleRadius];
+  }
+
+  // Extract attitude quaternion (body-to-ECI) and transform to display frame
+  const rawQuaternion: [number, number, number, number] | undefined =
+    position.qw != null
+      ? [position.qw, position.qx ?? 0, position.qy ?? 0, position.qz ?? 0]
+      : undefined;
+
+  let displayQuaternion: [number, number, number, number] | undefined;
+  if (rawQuaternion && lvlhAxes != null) {
+    // Local-orbital view: transform body-to-ECI → body-to-RSW via arika WASM.
+    // (The historical viewer label "lvlhAxes" refers to the local orbital
+    // frame; the arika API now uses standard RSW convention.)
+    displayQuaternion = body_quat_to_rsw(
+      position.x,
+      position.y,
+      position.z,
+      position.vx,
+      position.vy,
+      position.vz,
+      rawQuaternion[0],
+      rawQuaternion[1],
+      rawQuaternion[2],
+      rawQuaternion[3],
+    );
+  } else {
+    // ECI view: use body-to-ECI as-is
+    displayQuaternion = rawQuaternion;
+  }
+
+  const modelConfig = satId ? getSatelliteModelConfig(satId, satName) : null;
+
+  const bodyAxes = displayQuaternion ? (
+    <BodyAxes
+      position={scenePos}
+      quaternion={displayQuaternion}
+      axisLength={modelConfig ? modelConfig.scale * 5 : DEFAULT_SPHERE_RADIUS * 6}
+      debugId={satId}
+    />
+  ) : null;
+
+  if (modelConfig) {
+    return (
+      <>
+        <Suspense fallback={<SphereMarker position={scenePos} color={color} />}>
+          <SatelliteModel position={scenePos} config={modelConfig} quaternion={displayQuaternion} />
+        </Suspense>
+        {bodyAxes}
+      </>
+    );
+  }
+
+  if (hideSphereFallback) return bodyAxes;
+
+  // Pick the marker shape: caller-resolved override/default, else automatic
+  // (orientation-revealing cube when attitude is present — a sphere looks identical
+  // at every orientation — sphere otherwise).
+  const shape = resolveMarkerShape({
+    override: markerShape,
+    hasAttitude: displayQuaternion != null,
+  });
+  const fallbackMarker =
+    shape === "sphere" ? (
+      <SphereMarker position={scenePos} color={color} />
+    ) : (
+      <PrimitiveMarker position={scenePos} quaternion={displayQuaternion} />
+    );
+  return (
+    <>
+      {fallbackMarker}
+      {bodyAxes}
+    </>
+  );
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/SatelliteModel.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/SatelliteModel.tsx
@@ -1,0 +1,49 @@
+import { useGLTF } from "@react-three/drei";
+import { useEffect, useMemo, useRef } from "react";
+import * as THREE from "three";
+import { IS_DEV } from "../env.js";
+import type { SatelliteModelConfig } from "../satelliteModels.js";
+
+interface SatelliteModelProps {
+  /** Position in scene units (already divided by scaleRadius). */
+  position: [number, number, number];
+  /** Model configuration from the registry. */
+  config: SatelliteModelConfig;
+  /** Body-to-inertial quaternion [w, x, y, z] (Hamilton scalar-first). */
+  quaternion?: [number, number, number, number];
+}
+
+export function SatelliteModel({ position, config, quaternion }: SatelliteModelProps) {
+  const { scene } = useGLTF(config.modelUrl);
+  const cloned = useMemo(() => scene.clone(true), [scene]);
+  const groupRef = useRef<THREE.Group>(null);
+
+  // Dev-time measurement: log the model's native bounding box span
+  useEffect(() => {
+    if (IS_DEV && config.nativeSpanUnits == null) {
+      const box = new THREE.Box3().setFromObject(scene);
+      const size = box.getSize(new THREE.Vector3());
+      const span = Math.max(size.x, size.y, size.z);
+      console.log(
+        `[SatelliteModel] Native bounding box for "${config.modelUrl}":`,
+        `size=(${size.x.toFixed(2)}, ${size.y.toFixed(2)}, ${size.z.toFixed(2)})`,
+        `max span=${span.toFixed(2)}`,
+        `— set nativeSpanUnits to this value in satelliteModels.ts`,
+      );
+    }
+  }, [scene, config]);
+
+  // Apply body-to-inertial quaternion to the parent group
+  useEffect(() => {
+    if (groupRef.current && quaternion) {
+      const [w, x, y, z] = quaternion;
+      groupRef.current.quaternion.set(x, y, z, w); // Three.js: (x, y, z, w)
+    }
+  }, [quaternion]);
+
+  return (
+    <group position={position} ref={quaternion ? groupRef : undefined}>
+      <primitive object={cloned} scale={config.scale} rotation={config.rotation} />
+    </group>
+  );
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/SunLighting.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/SunLighting.tsx
@@ -1,0 +1,115 @@
+import { useMemo } from "react";
+import * as THREE from "three";
+import type { LvlhAxes } from "../sceneFrame.js";
+import { inverseSquareIntensity, sunDirectionInDisplayFrame } from "../sunLighting.js";
+import { sun_direction_from_body, sun_distance_from_body } from "../wasm/arikaInit.js";
+
+// Default sun direction when no epoch is provided: ECI +X (vernal equinox).
+const DEFAULT_SUN_DIRECTION_ECI: [number, number, number] = [1, 0, 0];
+
+/** Directional light distance from the origin, as a multiple of sceneAmplification. */
+const LIGHT_DISTANCE_FACTOR = 10;
+
+/** Ambient light intensity. Shared with the lit bodies' ambient term. */
+export const AMBIENT_INTENSITY = 0.15;
+
+/** Directional intensity at 1 AU, before the inverse-square distance scale. */
+const BASE_DIRECTIONAL_INTENSITY = 3.0;
+
+export interface SunLightingParams {
+  centralBody: string;
+  epochJd?: number | null;
+  /** Sim time, quantised (e.g. to 60s) to limit WASM recomputation. */
+  quantizedSimTime: number;
+  /** True when the display frame is Earth-fixed (ECEF). */
+  isEcef: boolean;
+  /** Earth rotation angle (radians); undefined when no epoch. */
+  era: number | undefined;
+  /** True when LVLH (local-orbital) rotation lives in the data. */
+  lvlhActive: boolean;
+  lvlhAxes: LvlhAxes | null;
+  /** Environment scale-up factor for satellite-centred views. */
+  sceneAmplification: number;
+}
+
+export interface SunLightingState {
+  /** Sun direction in the active display frame. */
+  sunDirection: THREE.Vector3;
+  /** Inverse-square intensity scale relative to 1 AU. */
+  sunIntensity: number;
+  /** Directional light position (sun direction scaled out by the light distance). */
+  lightPosition: [number, number, number];
+}
+
+/**
+ * Compute sun direction + intensity for the scene via the arika WASM model.
+ *
+ * `sunDirection`/`sunIntensity` are consumed both by {@link SunLighting} and by
+ * the lit bodies (CelestialBody/SecondaryBody), so the scene holds them and
+ * threads them down explicitly — there is no implicit lighting context (which
+ * would also leak into the embeddable OrbitViewer's prop-driven scene graph).
+ */
+export function useSunLighting({
+  centralBody,
+  epochJd,
+  quantizedSimTime,
+  isEcef,
+  era,
+  lvlhActive,
+  lvlhAxes,
+  sceneAmplification,
+}: SunLightingParams): SunLightingState {
+  // Sun direction in the body-centred inertial frame (ECI), via WASM.
+  const sunDirectionEci = useMemo<[number, number, number]>(() => {
+    if (epochJd == null) return DEFAULT_SUN_DIRECTION_ECI;
+    const dir = sun_direction_from_body(centralBody, epochJd, quantizedSimTime);
+    return [dir[0], dir[1], dir[2]];
+  }, [centralBody, epochJd, quantizedSimTime]);
+
+  // Sun intensity: inverse-square law based on the body-Sun distance.
+  const sunIntensity = useMemo(() => {
+    if (epochJd == null) return 1.0;
+    return inverseSquareIntensity(sun_distance_from_body(centralBody, epochJd, quantizedSimTime));
+  }, [centralBody, epochJd, quantizedSimTime]);
+
+  // Sun direction rotated into the active display frame.
+  const sunDirection = useMemo(
+    () =>
+      new THREE.Vector3(
+        ...sunDirectionInDisplayFrame(sunDirectionEci, { isEcef, era, lvlhActive, lvlhAxes }),
+      ),
+    [sunDirectionEci, isEcef, era, lvlhActive, lvlhAxes],
+  );
+
+  const lightDistance = sceneAmplification * LIGHT_DISTANCE_FACTOR;
+  const lightPosition = useMemo<[number, number, number]>(
+    () => [
+      sunDirection.x * lightDistance,
+      sunDirection.y * lightDistance,
+      sunDirection.z * lightDistance,
+    ],
+    [sunDirection, lightDistance],
+  );
+
+  return { sunDirection, sunIntensity, lightPosition };
+}
+
+/**
+ * Scene lighting: a fixed ambient term plus a sun-tracking directional light.
+ * Pair with {@link useSunLighting} for the position/intensity inputs.
+ */
+export function SunLighting({
+  intensity,
+  position,
+}: {
+  /** Inverse-square sun intensity scale (from {@link useSunLighting}). */
+  intensity: number;
+  position: [number, number, number];
+}) {
+  return (
+    <>
+      <ambientLight intensity={AMBIENT_INTENSITY} />
+      <directionalLight intensity={BASE_DIRECTIONAL_INTENSITY * intensity} position={position} />
+    </>
+  );
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/renderEntries.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/renderEntries.ts
@@ -1,0 +1,54 @@
+import type { OrbitPoint } from "../orbit.js";
+import type { TrailBuffer } from "../utils/TrailBuffer.js";
+
+/** A satellite to render: its trail buffer (if any) and current position (if any). */
+export interface RenderEntry {
+  satId: string;
+  buf: TrailBuffer | undefined;
+  pos: OrbitPoint | null | undefined;
+}
+
+/**
+ * The satellites to render: the union of those with a non-empty trail and those
+ * with a current position.
+ *
+ * Markers are driven by position and trails by the buffer, so a satellite given
+ * only a position (no trail history) still shows a marker — the streaming app
+ * always has both, but an embedder may just want to drop a point somewhere.
+ *
+ * Order: trail-having satellites first (in insertion order), then position-only
+ * ones. This is stable while each satellite's trail-status is stable; a satellite
+ * that gains or loses a trail moves between the two groups, which can shift the
+ * default palette-colour index of later satellites. Colours are cosmetic and such
+ * transitions are rare — pass an explicit `color` if you need guaranteed stability.
+ */
+export function buildRenderEntries(
+  trailBuffers: Map<string, TrailBuffer> | undefined,
+  satellitePositions: Map<string, OrbitPoint | null> | undefined,
+): RenderEntry[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+
+  if (trailBuffers) {
+    for (const [id, buf] of trailBuffers) {
+      if (buf.length > 0 && !seen.has(id)) {
+        seen.add(id);
+        ids.push(id);
+      }
+    }
+  }
+  if (satellitePositions) {
+    for (const [id, pos] of satellitePositions) {
+      if (pos && !seen.has(id)) {
+        seen.add(id);
+        ids.push(id);
+      }
+    }
+  }
+
+  return ids.map((satId) => ({
+    satId,
+    buf: trailBuffers?.get(satId),
+    pos: satellitePositions?.get(satId),
+  }));
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/coordTransform.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/coordTransform.ts
@@ -1,0 +1,227 @@
+import type { OrbitPoint } from "./orbit.js";
+import type { LvlhAxes } from "./sceneFrame.js";
+import { eci_to_ecef_batch as wasmBatch } from "./wasm/arikaInit.js";
+
+/**
+ * Batch-transform orbit points from ECI to ECEF via WASM, writing scaled
+ * results into `outBuf` starting at vertex index `outOffset`.
+ */
+export function batchEciToEcef(
+  points: OrbitPoint[],
+  from: number,
+  to: number,
+  epochJd: number,
+  outBuf: Float32Array,
+  outOffset: number,
+  scaleRadius: number,
+): void {
+  const count = to - from;
+
+  const positions = new Float32Array(count * 3);
+  const times = new Float32Array(count);
+  for (let i = 0; i < count; i++) {
+    const p = points[from + i];
+    positions[i * 3] = p.x;
+    positions[i * 3 + 1] = p.y;
+    positions[i * 3 + 2] = p.z;
+    times[i] = p.t;
+  }
+
+  const ecef = wasmBatch(positions, times, epochJd);
+
+  const invScale = 1 / scaleRadius;
+  for (let i = 0; i < count; i++) {
+    const outOff = (outOffset + i) * 3;
+    outBuf[outOff] = ecef[i * 3] * invScale;
+    outBuf[outOff + 1] = ecef[i * 3 + 1] * invScale;
+    outBuf[outOff + 2] = ecef[i * 3 + 2] * invScale;
+  }
+}
+
+/**
+ * Batch-transform orbit points by subtracting an origin offset and scaling.
+ *
+ * Used for satellite-centered (and future Moon/Sun-centered) views where
+ * the origin is shifted from the central body to another object.
+ *
+ * @param origin  Position of the new origin in ECI [km], or null for no offset.
+ */
+export function batchTransformWithOffset(
+  points: OrbitPoint[],
+  from: number,
+  to: number,
+  origin: [number, number, number] | null,
+  outBuf: Float32Array,
+  outOffset: number,
+  scaleRadius: number,
+): void {
+  const invScale = 1 / scaleRadius;
+  const ox = origin?.[0] ?? 0;
+  const oy = origin?.[1] ?? 0;
+  const oz = origin?.[2] ?? 0;
+
+  for (let i = from; i < to; i++) {
+    const p = points[i];
+    const outOff = (outOffset + i - from) * 3;
+    outBuf[outOff] = (p.x - ox) * invScale;
+    outBuf[outOff + 1] = (p.y - oy) * invScale;
+    outBuf[outOff + 2] = (p.z - oz) * invScale;
+  }
+}
+
+/**
+ * Transform a single ECI point into the satellite's LVLH body frame.
+ *
+ * LVLH scene axis mapping (Three.js Z-up):
+ *   X = inTrack (along orbit), Y = crossTrack (orbit normal), Z = radial (outward)
+ *
+ * The subtraction and dot products are computed in f64 before the result is
+ * returned, avoiding float32 precision loss from large ECI coordinates.
+ */
+export function transformToLvlh(
+  px: number,
+  py: number,
+  pz: number,
+  origin: [number, number, number],
+  axes: LvlhAxes,
+  scaleRadius: number,
+): [number, number, number] {
+  const dx = px - origin[0];
+  const dy = py - origin[1];
+  const dz = pz - origin[2];
+  const invScale = 1 / scaleRadius;
+
+  return [
+    (axes.inTrack[0] * dx + axes.inTrack[1] * dy + axes.inTrack[2] * dz) * invScale,
+    (axes.crossTrack[0] * dx + axes.crossTrack[1] * dy + axes.crossTrack[2] * dz) * invScale,
+    (axes.radial[0] * dx + axes.radial[1] * dy + axes.radial[2] * dz) * invScale,
+  ];
+}
+
+/**
+ * Batch-transform orbit points from ECI into the satellite's LVLH body frame,
+ * writing scaled results into `outBuf` starting at vertex index `outOffset`.
+ *
+ * All arithmetic (subtraction + dot product) is performed in f64 before
+ * writing to the Float32Array, preserving precision for satellite-relative
+ * coordinates.
+ */
+export function batchTransformToLvlh(
+  points: OrbitPoint[],
+  from: number,
+  to: number,
+  origin: [number, number, number],
+  axes: LvlhAxes,
+  outBuf: Float32Array,
+  outOffset: number,
+  scaleRadius: number,
+): void {
+  const invScale = 1 / scaleRadius;
+  const [ox, oy, oz] = origin;
+  const { radial, inTrack, crossTrack } = axes;
+
+  for (let i = from; i < to; i++) {
+    const p = points[i];
+    const dx = p.x - ox;
+    const dy = p.y - oy;
+    const dz = p.z - oz;
+
+    const outOff = (outOffset + i - from) * 3;
+    outBuf[outOff] = (inTrack[0] * dx + inTrack[1] * dy + inTrack[2] * dz) * invScale;
+    outBuf[outOff + 1] = (crossTrack[0] * dx + crossTrack[1] * dy + crossTrack[2] * dz) * invScale;
+    outBuf[outOff + 2] = (radial[0] * dx + radial[1] * dy + radial[2] * dz) * invScale;
+  }
+}
+
+// High/Low split encoding for GPU precision
+
+const HIGH_LOW_SPLIT = 65536.0; // 2^16
+
+/**
+ * Split a float64 value into high and low float32 parts using 2^16 chunking.
+ * Reconstruction: value ≈ high + low (in float64 arithmetic).
+ *
+ * In the GPU shader, `(posHigh - originHigh) + (posLow - originLow)`
+ * cancels the large common parts, preserving sub-meter precision even
+ * at interplanetary distances.
+ */
+export function encodeFloat64ToHighLow(value: number): [high: number, low: number] {
+  if (value >= 0.0) {
+    const high = Math.floor(value / HIGH_LOW_SPLIT) * HIGH_LOW_SPLIT;
+    return [high, value - high];
+  }
+  const doubleHigh = Math.floor(-value / HIGH_LOW_SPLIT) * HIGH_LOW_SPLIT;
+  return [-doubleHigh, value + doubleHigh];
+}
+
+/**
+ * Batch-encode ECI orbit points into high/low Float32Array pair.
+ * Positions are stored in km (not scaled by scaleRadius) so that
+ * scaleRadius changes don't invalidate the buffer.
+ */
+export function batchEncodeEciHighLow(
+  points: OrbitPoint[],
+  from: number,
+  to: number,
+  highBuf: Float32Array,
+  lowBuf: Float32Array,
+  outOffset: number,
+): void {
+  for (let i = from; i < to; i++) {
+    const p = points[i];
+    const outOff = (outOffset + i - from) * 3;
+
+    const [xh, xl] = encodeFloat64ToHighLow(p.x);
+    const [yh, yl] = encodeFloat64ToHighLow(p.y);
+    const [zh, zl] = encodeFloat64ToHighLow(p.z);
+
+    highBuf[outOff] = xh;
+    highBuf[outOff + 1] = yh;
+    highBuf[outOff + 2] = zh;
+    lowBuf[outOff] = xl;
+    lowBuf[outOff + 1] = yl;
+    lowBuf[outOff + 2] = zl;
+  }
+}
+
+/**
+ * Batch-encode orbit points after ECEF transform into high/low Float32Array pair.
+ * Calls WASM ECI→ECEF first, then splits the resulting km values.
+ */
+export function batchEncodeEcefHighLow(
+  points: OrbitPoint[],
+  from: number,
+  to: number,
+  epochJd: number,
+  highBuf: Float32Array,
+  lowBuf: Float32Array,
+  outOffset: number,
+): void {
+  const count = to - from;
+
+  const positions = new Float32Array(count * 3);
+  const times = new Float32Array(count);
+  for (let i = 0; i < count; i++) {
+    const p = points[from + i];
+    positions[i * 3] = p.x;
+    positions[i * 3 + 1] = p.y;
+    positions[i * 3 + 2] = p.z;
+    times[i] = p.t;
+  }
+
+  const ecef = wasmBatch(positions, times, epochJd);
+
+  for (let i = 0; i < count; i++) {
+    const outOff = (outOffset + i) * 3;
+    const [xh, xl] = encodeFloat64ToHighLow(ecef[i * 3]);
+    const [yh, yl] = encodeFloat64ToHighLow(ecef[i * 3 + 1]);
+    const [zh, zl] = encodeFloat64ToHighLow(ecef[i * 3 + 2]);
+
+    highBuf[outOff] = xh;
+    highBuf[outOff + 1] = yh;
+    highBuf[outOff + 2] = zh;
+    lowBuf[outOff] = xl;
+    lowBuf[outOff + 1] = yl;
+    lowBuf[outOff + 2] = zl;
+  }
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/debug/satWorldQuat.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/debug/satWorldQuat.ts
@@ -1,0 +1,40 @@
+import type * as THREE from "three";
+import { Quaternion } from "three";
+import { IS_DEV } from "../env.js";
+
+type GroupGetter = () => THREE.Object3D | null;
+
+interface DebugWindow extends Record<string, unknown> {
+  __debug_sat_quat_registry?: Map<string, GroupGetter>;
+  __debug_get_sat_world_quat?: (id: string) => [number, number, number, number] | null;
+}
+
+function ensureRegistry(): Map<string, GroupGetter> {
+  const w = window as unknown as DebugWindow;
+  let reg = w.__debug_sat_quat_registry;
+  if (!reg) {
+    reg = new Map();
+    w.__debug_sat_quat_registry = reg;
+    // Three.js (x, y, z, w) order, matching __debug_get_earth_world_quat.
+    w.__debug_get_sat_world_quat = (id) => {
+      const group = w.__debug_sat_quat_registry?.get(id)?.();
+      if (!group) return null;
+      const q = group.getWorldQuaternion(new Quaternion());
+      return [q.x, q.y, q.z, q.w];
+    };
+  }
+  return reg;
+}
+
+/**
+ * Register a satellite group so its world quaternion is queryable by `id`.
+ * Returns a cleanup function; a no-op (returning a no-op) outside dev builds.
+ */
+export function registerSatWorldQuat(id: string, getGroup: GroupGetter): () => void {
+  if (!IS_DEV) return () => {};
+  const reg = ensureRegistry();
+  reg.set(id, getGroup);
+  return () => {
+    reg.delete(id);
+  };
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/displayScale.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/displayScale.ts
@@ -1,0 +1,108 @@
+import type { FrameCenter } from "./referenceFrame.js";
+import { computeTrueModelScale, type SatelliteModelConfig } from "./satelliteModels.js";
+
+/** Parameters controlling object sizes and camera for a given view mode. */
+export interface DisplayScaleProfile {
+  /** Descriptive name (for debugging / profile identification). */
+  name: string;
+
+  /** Radius of the sphere fallback marker in scene units. */
+  sphereFallbackRadius: number;
+
+  /** Camera near plane in scene units. */
+  cameraNear: number;
+  /** Camera far plane in scene units. */
+  cameraFar: number;
+
+  /** OrbitControls minimum distance in scene units. */
+  minDistance: number;
+  /** OrbitControls maximum distance in scene units. */
+  maxDistance: number;
+
+  /** Default camera distance from origin when entering this profile. */
+  defaultCameraDistance: number;
+
+  /**
+   * Default camera direction when entering this profile.
+   * If null, keeps the current camera direction (only adjusts distance).
+   * In LVLH frame: X=inTrack, Y=crossTrack, Z=radial.
+   */
+  defaultCameraDirection: [number, number, number] | null;
+}
+
+/** Default physical size for unknown satellites (10 m). */
+const DEFAULT_SATELLITE_SIZE_KM = 0.01;
+
+/** Body-centered profile: exaggerated satellite sizes for visibility. */
+const BODY_CENTERED_PROFILE: DisplayScaleProfile = {
+  name: "body-centered",
+  sphereFallbackRadius: 0.005,
+  cameraNear: 0.01,
+  cameraFar: 1000,
+  minDistance: 1.5,
+  maxDistance: 200,
+  defaultCameraDistance: 5.4,
+  defaultCameraDirection: null,
+};
+
+/**
+ * Satellite-centered profile: camera close to satellite, scene amplified
+ * for physically accurate angular proportions.
+ */
+const SATELLITE_CENTERED_PROFILE: DisplayScaleProfile = {
+  name: "satellite-centered",
+  sphereFallbackRadius: 0.005,
+  cameraNear: 1e-4,
+  cameraFar: 1e6,
+  minDistance: 0.005,
+  maxDistance: 2000,
+  defaultCameraDistance: 0.15,
+  // Camera behind, slightly to the side, and slightly above satellite
+  // ~17° downward tilt toward Earth, ~17° cross-track offset
+  defaultCameraDirection: [-1, 0.3, 0.3],
+};
+
+/**
+ * Get the display scale profile for a given frame center.
+ *
+ * @param center - Which object is at the scene origin
+ */
+export function getDisplayScaleProfile(center: FrameCenter): DisplayScaleProfile {
+  switch (center.type) {
+    case "satellite":
+      return SATELLITE_CENTERED_PROFILE;
+    case "central_body":
+    case "moon":
+    case "sun":
+      return BODY_CENTERED_PROFILE;
+  }
+}
+
+/**
+ * Compute the scene amplification factor for satellite-centered mode.
+ *
+ * When a satellite is centered, its 3D model renders at exaggerated scale
+ * for visibility. To show the surrounding environment (Earth, orbit trails)
+ * at physically correct angular proportions relative to the satellite, all
+ * environment geometry is amplified by this factor.
+ *
+ * The factor is the ratio of the satellite's exaggerated display size to
+ * its true physical size in scene units (normalised by central body radius).
+ *
+ * @param satModelConfig - Model config of the centered satellite, or null for sphere fallback
+ * @param centralBodyRadius - Central body radius in km
+ */
+export function computeSceneAmplification(
+  satModelConfig: SatelliteModelConfig | null,
+  centralBodyRadius: number,
+): number {
+  if (satModelConfig) {
+    const trueScale = computeTrueModelScale(satModelConfig, centralBodyRadius);
+    if (trueScale != null) {
+      return satModelConfig.scale / trueScale;
+    }
+  }
+  // Sphere fallback: ratio of exaggerated sphere to true physical radius
+  const trueRadius = DEFAULT_SATELLITE_SIZE_KM / centralBodyRadius;
+  return BODY_CENTERED_PROFILE.sphereFallbackRadius / trueRadius;
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/env.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/env.ts
@@ -1,0 +1,7 @@
+const env = (import.meta as unknown as { env?: { BASE_URL?: string; DEV?: boolean } }).env;
+
+/** Base URL the app is served from (Vite `import.meta.env.BASE_URL`); "/" elsewhere. */
+export const BASE_URL: string = env?.BASE_URL ?? "/";
+
+/** Whether this is a development build (Vite `import.meta.env.DEV`); false elsewhere. */
+export const IS_DEV: boolean = env?.DEV ?? false;

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/frameResolve.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/frameResolve.ts
@@ -1,0 +1,74 @@
+import type { ReferenceFrame } from "./referenceFrame.js";
+import { computeLvlhAxes, type LvlhAxes } from "./sceneFrame.js";
+
+/** Current state of a centred entity, in the central-body inertial frame [km, km/s]. */
+export interface FrameEntityState {
+  position: [number, number, number];
+  velocity: [number, number, number] | null;
+}
+
+/** Look up an entity's current state by id; null when unknown/not yet known. */
+export type FrameEntityLookup = (id: string) => FrameEntityState | null;
+
+/** Everything the scene graph needs to render in the resolved frame. */
+export interface SceneFrameContext {
+  /** Centred satellite/entity id, or null for a central-body centre. */
+  centeredSatId: string | null;
+  /** ECI position [km] of the frame centre, or null for the central body. */
+  originPosition: [number, number, number] | null;
+  /** ECI velocity [km/s] of the frame centre, when known. */
+  originVelocity: [number, number, number] | null;
+  /** LVLH axes when `lvlhActive`; null otherwise. */
+  lvlhAxes: LvlhAxes | null;
+  /** True when positions/trails/attitudes get the LVLH (data) transform. */
+  lvlhActive: boolean;
+  /** True when the camera should co-rotate / radial-track the centre instead. */
+  cameraTracking: boolean;
+}
+
+export function resolveSceneFrame(
+  frame: ReferenceFrame,
+  getEntity: FrameEntityLookup,
+  isBodyEntity: (id: string) => boolean,
+): SceneFrameContext {
+  const inert: SceneFrameContext = {
+    centeredSatId: null,
+    originPosition: null,
+    originVelocity: null,
+    lvlhAxes: null,
+    lvlhActive: false,
+    cameraTracking: false,
+  };
+
+  if (frame.center.type !== "satellite") return inert;
+
+  const id = frame.center.id;
+  const state = getEntity(id);
+  if (state == null) return { ...inert, centeredSatId: id };
+
+  // Snapshot the caller-owned tuples: the context is returned from public API
+  // surfaces, and an embedder mutating its position array in place must not
+  // retroactively change an already-resolved frame.
+  const originPosition: [number, number, number] = [...state.position];
+  const originVelocity: [number, number, number] | null = state.velocity
+    ? [...state.velocity]
+    : null;
+  const localOrbital = frame.orientation === "local_orbital";
+
+  // Data-LVLH: only for a real satellite (bodies keep their IAU orientation in
+  // inertial axes) and only when the axes are computable from pos/vel.
+  const lvlhAxes =
+    localOrbital && !isBodyEntity(id) ? computeLvlhAxes(originPosition, originVelocity) : null;
+  const lvlhActive = lvlhAxes != null;
+
+  return {
+    centeredSatId: id,
+    originPosition,
+    originVelocity,
+    lvlhAxes,
+    lvlhActive,
+    // LVLH requested but not expressible in the data → approximate with the
+    // camera. An inertial centre never tracks: the axes stay star-fixed.
+    cameraTracking: localOrbital && !lvlhActive,
+  };
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/frameTransform.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/frameTransform.ts
@@ -1,0 +1,5 @@
+export function rotateZ(x: number, y: number, z: number, angle: number): [number, number, number] {
+  const c = Math.cos(angle);
+  const s = Math.sin(angle);
+  return [x * c - y * s, x * s + y * c, z];
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/hooks/useTextureResolution.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/hooks/useTextureResolution.ts
@@ -1,0 +1,36 @@
+import { useThree } from "@react-three/fiber";
+import { useMemo } from "react";
+
+export type TextureResolution = "2k" | "4k" | "8k" | "16k";
+
+/**
+ * Select the best texture resolution based on GPU capabilities and screen size.
+ * When `forceMax` is true, use the highest resolution the GPU supports
+ * (useful for satellite-centered view where the surface is close).
+ * Must be called inside the R3F Canvas tree.
+ */
+export function useTextureResolution(forceMax = false): TextureResolution {
+  const { gl } = useThree();
+
+  return useMemo(() => {
+    const maxTexSize = gl.capabilities.maxTextureSize;
+
+    if (forceMax) {
+      if (maxTexSize >= 16384) return "16k";
+      if (maxTexSize >= 8192) return "8k";
+      if (maxTexSize >= 4096) return "4k";
+      return "2k";
+    }
+
+    const dpr = window.devicePixelRatio ?? 1;
+    const screenWidth = window.innerWidth * dpr;
+
+    if (maxTexSize >= 8192 && screenWidth >= 1280) {
+      return "8k";
+    }
+    if (maxTexSize >= 4096 && screenWidth >= 960) {
+      return "4k";
+    }
+    return "2k";
+  }, [gl, forceMax]);
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/lib/OrbitViewer.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/lib/OrbitViewer.tsx
@@ -1,0 +1,164 @@
+import { Canvas } from "@react-three/fiber";
+import { useEffect, useMemo, useState } from "react";
+import { getBodyRadius, resolveBodyDefinitions } from "../bodies.js";
+import { OrbitSceneContents } from "../components/OrbitSceneContents.js";
+import { IS_DEV } from "../env.js";
+import type { OrbitPoint } from "../orbit.js";
+import { DEFAULT_CAMERA_POSITION, SCENE_UP } from "../sceneFrame.js";
+import { initArika, isArikaReady } from "../wasm/arikaInit.js";
+import { toOrbitPoint } from "./adapt.js";
+import { resolveFrameContext } from "./frameContext.js";
+import { DEFAULT_VIEWER_FRAME, type OrbitViewerProps } from "./types.js";
+import { useTrailBuffers } from "./useTrailBuffers.js";
+
+/**
+ * Drive the bundled arika WASM to readiness when `enabled`. Returns `true` once
+ * loaded so the scene can switch from default lighting to ephemeris-accurate
+ * Sun/rotation. When `enabled` is false (no epoch), the WASM is never loaded —
+ * epoch-less embedders pay no network/init cost and get the documented fixed Sun.
+ */
+function useArikaReady(enabled: boolean): boolean {
+  const [ready, setReady] = useState(() => isArikaReady());
+  useEffect(() => {
+    if (!enabled || ready) return;
+    let cancelled = false;
+    initArika()
+      .then(() => {
+        if (!cancelled) setReady(true);
+      })
+      .catch(() => {
+        // Leave `ready` false: the viewer keeps rendering with default lighting.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, ready]);
+  return ready;
+}
+
+/**
+ * Embeddable orbit viewer.
+ *
+ * Renders a central body at the origin and a set of satellites around it, with
+ * an orbit-controls camera. Choose the display frame via `referenceFrame`
+ * (central-body inertial/body-fixed, or satellite-centred). Supply `epochJd`
+ * (and advance `time`) for physically-correct Sun lighting and body rotation
+ * via the bundled arika WASM; otherwise a fixed Sun is used and the body is static.
+ *
+ * It composes the same {@link OrbitSceneContents} scene graph the app uses, so
+ * frame handling, lighting and the LVLH camera tracking are shared, not duplicated.
+ *
+ * @example
+ * ```tsx
+ * <OrbitViewer
+ *   centralBody={{ id: "earth", radiusKm: 6378.137 }}
+ *   satellites={[{ id: "sat-1", position: [7000, 0, 1500] }]}
+ * />
+ * ```
+ */
+export function OrbitViewer({
+  centralBody,
+  bodies,
+  satellites,
+  referenceFrame = DEFAULT_VIEWER_FRAME,
+  epochJd,
+  time = 0,
+  textureBaseUrl,
+  className,
+  style,
+}: OrbitViewerProps) {
+  // Only load the arika WASM when an epoch is supplied (Sun/rotation features).
+  const arikaReady = useArikaReady(epochJd != null);
+
+  // Body definitions: consumer-supplied bodies merged over the built-in defaults.
+  const bodyDefinitions = useMemo(() => resolveBodyDefinitions(bodies), [bodies]);
+  // Central-body radius: explicit prop wins; otherwise from the body definition.
+  // Fail loudly rather than guess a scale — a wrong radius silently breaks the
+  // entire scene's sizing.
+  const centralBodyRadius = centralBody.radiusKm ?? getBodyRadius(centralBody.id, bodyDefinitions);
+  if (centralBodyRadius == null) {
+    throw new Error(
+      `OrbitViewer: central body "${centralBody.id}" has no radius. Pass ` +
+        "centralBody.radiusKm, or add the body to `bodies` with a radiusKm.",
+    );
+  }
+
+  // Current position per satellite. `time` is stamped onto each point; the scene
+  // reads it back as the simulation time that drives Sun direction and rotation.
+  const satellitePositions = useMemo(() => {
+    const map = new Map<string, OrbitPoint>();
+    for (const sat of satellites) map.set(sat.id, toOrbitPoint(sat, time));
+    return map;
+  }, [satellites, time]);
+
+  const satelliteNames = useMemo(() => {
+    const map = new Map<string, string | null>();
+    for (const sat of satellites) map.set(sat.id, sat.name ?? null);
+    return map;
+  }, [satellites]);
+
+  // Per-satellite colour overrides from the public SatelliteState.color.
+  const satelliteColors = useMemo(() => {
+    const map = new Map<string, number | undefined>();
+    for (const sat of satellites) map.set(sat.id, sat.color);
+    return map;
+  }, [satellites]);
+
+  // Persistent per-satellite trail buffers (stable identity → incremental upload).
+  const trailBuffers = useTrailBuffers(satellites);
+
+  // Map the public frame onto the renderer's internal ReferenceFrame (incl.
+  // local_orbital); the scene resolves the geometry itself via the shared
+  // resolveSceneFrame kernel from the satellite positions it receives.
+  const internalFrame = useMemo(
+    () => resolveFrameContext(referenceFrame, () => undefined).referenceFrame,
+    [referenceFrame],
+  );
+
+  // Only hand the scene an epoch once arika is loaded; otherwise its Sun/rotation
+  // calls would run before the WASM is ready. Default lighting is used until then.
+  const effectiveEpochJd = arikaReady ? (epochJd ?? null) : null;
+
+  // Dev/E2E-only: expose per-satellite trail buffer state so E2E can prove that
+  // advancing `time` (or appending points) does not rebuild the trail — a stable
+  // `generation` means no full GPU re-upload. See tests/orbit-viewer-lib.spec.ts.
+  useEffect(() => {
+    if (!IS_DEV) return;
+    const w = window as unknown as Record<string, unknown>;
+    w.__debug_orbit_viewer = {
+      trail: (id: string) => {
+        const b = trailBuffers.get(id);
+        return b ? { length: b.length, generation: b.generation } : null;
+      },
+    };
+    return () => {
+      delete w.__debug_orbit_viewer;
+    };
+  }, [trailBuffers]);
+
+  return (
+    <div className={className} style={{ width: "100%", height: "100%", ...style }}>
+      {/* Set the camera up via the prop rather than mutating the global
+          THREE.Object3D.DEFAULT_UP (as the app's Scene does): a library shouldn't
+          change a global that affects the embedder's own Three.js objects.
+          CameraLvlhTracker keeps camera.up correct each frame. */}
+      <Canvas
+        camera={{ position: DEFAULT_CAMERA_POSITION, up: SCENE_UP, fov: 60, near: 0.01, far: 1000 }}
+        gl={{ logarithmicDepthBuffer: true }}
+      >
+        <OrbitSceneContents
+          trailBuffers={trailBuffers}
+          satellitePositions={satellitePositions}
+          satelliteNames={satelliteNames}
+          satelliteColors={satelliteColors}
+          centralBody={centralBody.id}
+          centralBodyRadius={centralBodyRadius}
+          bodyDefinitions={bodyDefinitions}
+          epochJd={effectiveEpochJd}
+          referenceFrame={internalFrame}
+          textureBaseUrl={textureBaseUrl}
+        />
+      </Canvas>
+    </div>
+  );
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/lib/adapt.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/lib/adapt.ts
@@ -1,0 +1,73 @@
+import type { OrbitPoint } from "../orbit.js";
+import { TrailBuffer } from "../utils/TrailBuffer.js";
+import type { SatelliteState, TrailPoint } from "./types.js";
+
+/**
+ * Convert a {@link SatelliteState} to an `OrbitPoint` at the given time.
+ *
+ * Orbital-element and chart fields the public type doesn't carry are filled
+ * with zeros — they're unused by the renderer for marker/trail display.
+ */
+export function toOrbitPoint(sat: SatelliteState, time: number): OrbitPoint {
+  const [x, y, z] = sat.position;
+  const [vx, vy, vz] = sat.velocity ?? [0, 0, 0];
+  const point: OrbitPoint = {
+    entityPath: sat.id,
+    t: time,
+    x,
+    y,
+    z,
+    vx,
+    vy,
+    vz,
+    a: 0,
+    e: 0,
+    inc: 0,
+    raan: 0,
+    omega: 0,
+    nu: 0,
+  };
+  if (sat.attitude) {
+    [point.qw, point.qx, point.qy, point.qz] = sat.attitude;
+  }
+  return point;
+}
+
+/**
+ * Convert a {@link TrailPoint} to an `OrbitPoint`.
+ *
+ * Uses the point's own `time` when present (required for body-fixed/ECEF trails,
+ * where each point is de-rotated by the Earth-rotation angle at its own time);
+ * otherwise falls back to the supplied index so the time axis stays monotonic.
+ */
+export function trailPointToOrbitPoint(point: TrailPoint, index: number): OrbitPoint {
+  const [x, y, z] = point.position;
+  return {
+    t: point.time ?? index,
+    x,
+    y,
+    z,
+    vx: 0,
+    vy: 0,
+    vz: 0,
+    a: 0,
+    e: 0,
+    inc: 0,
+    raan: 0,
+    omega: 0,
+    nu: 0,
+  };
+}
+
+/**
+ * Build a fresh {@link TrailBuffer} from a list of trail points (oldest first).
+ *
+ * Convenience for one-shot construction (tests, the advanced "bring your own
+ * buffer" path). The live viewer keeps a persistent buffer per satellite and
+ * appends incrementally instead — see the trail-sync hook.
+ */
+export function toTrailBuffer(points: readonly TrailPoint[]): TrailBuffer {
+  const buf = new TrailBuffer(Math.max(points.length, 1));
+  buf.pushMany(points.map(trailPointToOrbitPoint));
+  return buf;
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/lib/frameContext.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/lib/frameContext.ts
@@ -1,0 +1,72 @@
+import { resolveSceneFrame } from "../frameResolve.js";
+import type { ReferenceFrame } from "../referenceFrame.js";
+import type { LvlhAxes } from "../sceneFrame.js";
+import type { Vec3, ViewerReferenceFrame } from "./types.js";
+
+/** Minimal satellite state the frame resolver needs. */
+export interface FrameSatellite {
+  position: Vec3;
+  velocity?: Vec3;
+}
+
+/** Look up a satellite's current state by id (returns undefined if absent). */
+export type FrameSatelliteLookup = (satelliteId: string) => FrameSatellite | undefined;
+
+/** Everything the primitives need to render in the requested frame. */
+export interface FrameContext {
+  /** Internal reference frame handed to Satellite/OrbitTrail/CelestialBody. */
+  referenceFrame: ReferenceFrame;
+  /** ECI position [km] of the frame centre, or null when the central body is centred. */
+  originPosition: [number, number, number] | null;
+  /** LVLH axes when local-orbital framing is active, else null. */
+  lvlhAxes: LvlhAxes | null;
+  /** True when the central body is rendered body-fixed (ECEF-like). */
+  bodyFixed: boolean;
+  /** True when `localOrbital` was requested but velocity was unavailable. */
+  localOrbitalFallback: boolean;
+}
+
+export function resolveFrameContext(
+  frame: ViewerReferenceFrame,
+  getSatellite: FrameSatelliteLookup,
+): FrameContext {
+  if (frame.center === "centralBody") {
+    const bodyFixed = frame.orientation === "bodyFixed";
+    return {
+      referenceFrame: {
+        center: { type: "central_body" },
+        orientation: bodyFixed ? "body_fixed" : "inertial",
+      },
+      originPosition: null,
+      lvlhAxes: null,
+      bodyFixed,
+      localOrbitalFallback: false,
+    };
+  }
+
+  // Satellite-centred: map the public orientation onto the internal one and
+  // let the shared kernel resolve the geometry. The public API has no body
+  // entities, so the body predicate is constantly false.
+  const localOrbital = frame.orientation === "localOrbital";
+  const referenceFrame: ReferenceFrame = {
+    center: { type: "satellite", id: frame.center.satelliteId },
+    orientation: localOrbital ? "local_orbital" : "inertial",
+  };
+  const ctx = resolveSceneFrame(
+    referenceFrame,
+    (id) => {
+      const sat = getSatellite(id);
+      return sat ? { position: sat.position, velocity: sat.velocity ?? null } : null;
+    },
+    () => false,
+  );
+
+  return {
+    referenceFrame,
+    originPosition: ctx.originPosition,
+    lvlhAxes: ctx.lvlhAxes,
+    bodyFixed: false,
+    // LVLH was requested but the axes weren't computable (no velocity).
+    localOrbitalFallback: localOrbital && !ctx.lvlhActive && ctx.originPosition != null,
+  };
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/lib/index.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/lib/index.ts
@@ -1,0 +1,41 @@
+export {
+  type BodyDefinition,
+  type BodyDefinitions,
+  type BodyTexture,
+  DEFAULT_BODIES,
+} from "../bodies.js";
+// Lower-level building blocks for assembling a custom scene.
+export { BodyAxes } from "../components/BodyAxes.js";
+export { CelestialBody } from "../components/CelestialBody.js";
+export { EarthBody } from "../components/EarthBody.js";
+export { OrbitTrail } from "../components/OrbitTrail.js";
+export { Satellite } from "../components/Satellite.js";
+export { SatelliteModel } from "../components/SatelliteModel.js";
+// Domain types and helpers used across the building blocks.
+export type { OrbitPoint } from "../orbit.js";
+export { DEFAULT_FRAME, type ReferenceFrame } from "../referenceFrame.js";
+export { computeLvlhAxes, type LvlhAxes } from "../sceneFrame.js";
+export { TrailBuffer } from "../utils/TrailBuffer.js";
+// arika WASM control (Sun direction / body rotation). OrbitViewer auto-inits when
+// given an epoch; these let an embedder pre-load or point at an external .wasm.
+export { type InitArikaOptions, initArika, isArikaReady } from "../wasm/arikaInit.js";
+// Pure adapters and frame/trail logic (useful for custom scenes / advanced use).
+export { toOrbitPoint, toTrailBuffer, trailPointToOrbitPoint } from "./adapt.js";
+export {
+  type FrameContext,
+  type FrameSatellite,
+  type FrameSatelliteLookup,
+  resolveFrameContext,
+} from "./frameContext.js";
+// Headline component + its public types.
+export { OrbitViewer } from "./OrbitViewer.js";
+export {
+  type CentralBody,
+  DEFAULT_VIEWER_FRAME,
+  type OrbitViewerProps,
+  type Quat,
+  type SatelliteState,
+  type TrailPoint,
+  type Vec3,
+  type ViewerReferenceFrame,
+} from "./types.js";

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/lib/trailReconcile.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/lib/trailReconcile.ts
@@ -1,0 +1,28 @@
+import type { TrailBuffer } from "../utils/TrailBuffer.js";
+import { trailPointToOrbitPoint } from "./adapt.js";
+import { decideTrailUpdate, type TrailSyncState, trailSyncState } from "./trailSync.js";
+import type { TrailPoint } from "./types.js";
+
+/** A persistent per-satellite trail buffer plus the sync state of its contents. */
+export interface TrailEntry {
+  buffer: TrailBuffer;
+  sync: TrailSyncState | null;
+}
+
+/** Reconcile `entry.buffer` to hold exactly `points` (append when possible). */
+export function reconcileTrailEntry(
+  entry: TrailEntry,
+  points: readonly TrailPoint[],
+  version: string | number | undefined,
+): void {
+  const decision = decideTrailUpdate(entry.sync, points, version);
+  if (decision.kind === "rebuild") {
+    entry.buffer.clear();
+    entry.buffer.pushMany(points.map(trailPointToOrbitPoint));
+    entry.sync = trailSyncState(points, version);
+  } else if (decision.kind === "append") {
+    const from = decision.from;
+    entry.buffer.pushMany(points.slice(from).map((p, i) => trailPointToOrbitPoint(p, from + i)));
+    entry.sync = trailSyncState(points, version);
+  }
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/lib/trailSync.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/lib/trailSync.ts
@@ -1,0 +1,74 @@
+import type { TrailPoint, Vec3 } from "./types.js";
+
+/** Snapshot of what a trail buffer currently holds. */
+export interface TrailSyncState {
+  length: number;
+  version: string | number | undefined;
+  /**
+   * Position of the last point (index `length - 1`), or undefined when empty.
+   * Stored as a copy so an in-place Vec3 mutation by the caller can't silently
+   * mutate the captured state and defeat change detection.
+   */
+  lastPosition: Vec3 | undefined;
+  /**
+   * Time of the last point. Affects body-fixed/ECEF vertices (each point is
+   * de-rotated by the Earth-rotation angle at its own time), so a time change on
+   * an otherwise-identical point must still trigger a rebuild.
+   */
+  lastTime: number | undefined;
+}
+
+/** Reconciliation decision for a trail buffer. */
+export type TrailUpdate = { kind: "noop" } | { kind: "rebuild" } | { kind: "append"; from: number };
+
+function vec3Equal(a: Vec3 | undefined, b: Vec3 | undefined): boolean {
+  if (!a || !b) return a === b;
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
+}
+
+/** Capture the sync state for a trail array + version. */
+export function trailSyncState(
+  points: readonly TrailPoint[],
+  version: string | number | undefined,
+): TrailSyncState {
+  const last = points.length > 0 ? points[points.length - 1] : undefined;
+  return {
+    length: points.length,
+    version,
+    // Copy the Vec3 so a later in-place mutation by the caller can't change it.
+    lastPosition: last ? [last.position[0], last.position[1], last.position[2]] : undefined,
+    lastTime: last?.time,
+  };
+}
+
+/**
+ * Decide whether to leave the buffer alone, append the new tail, or rebuild.
+ *
+ * Order matters: an explicit version bump or a shrink always rebuilds; a grow is
+ * only treated as an append when the previously-last point still matches (i.e.
+ * the history wasn't rewritten).
+ */
+export function decideTrailUpdate(
+  prev: TrailSyncState | null,
+  points: readonly TrailPoint[],
+  version: string | number | undefined,
+): TrailUpdate {
+  if (prev === null) {
+    return points.length === 0 ? { kind: "noop" } : { kind: "rebuild" };
+  }
+  if (version !== prev.version) return { kind: "rebuild" };
+  if (points.length < prev.length) return { kind: "rebuild" };
+
+  // The point that used to be the tail must still be there unchanged, otherwise
+  // earlier history was rewritten and an append would corrupt the line. Compare
+  // both position and time (time affects body-fixed/ECEF vertices).
+  if (prev.length > 0) {
+    const tail = points[prev.length - 1];
+    if (!vec3Equal(tail?.position, prev.lastPosition) || tail?.time !== prev.lastTime) {
+      return { kind: "rebuild" };
+    }
+  }
+
+  if (points.length > prev.length) return { kind: "append", from: prev.length };
+  return { kind: "noop" };
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/lib/types.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/lib/types.ts
@@ -1,0 +1,129 @@
+import type { CSSProperties } from "react";
+import type { BodyDefinitions } from "../bodies.js";
+
+/** A 3D vector `[x, y, z]`. Distances are in kilometres. */
+export type Vec3 = [number, number, number];
+
+/** A quaternion in Hamilton scalar-first order `[w, x, y, z]`. */
+export type Quat = [number, number, number, number];
+
+/** A single past point on a satellite's trail. */
+export interface TrailPoint {
+  /** Position in km, central-body-centred inertial frame. */
+  position: Vec3;
+  /**
+   * Seconds since the epoch. Required only when displaying the trail in a
+   * body-fixed (ECEF) frame, where each point must be de-rotated by the
+   * Earth-rotation angle at its own time. Inertial/local-orbital frames ignore it.
+   */
+  time?: number;
+}
+
+/** One satellite (or arbitrary point object) to display in the scene. */
+export interface SatelliteState {
+  /** Stable identifier. Used for React keys, default colour, and trail buffers. */
+  id: string;
+  /** Position in km, central-body-centred inertial frame. */
+  position: Vec3;
+  /** Velocity in km/s. Optional; required for the `localOrbital` frame. */
+  velocity?: Vec3;
+  /** Body→inertial attitude quaternion `[w, x, y, z]`. Optional. */
+  attitude?: Quat;
+  /**
+   * Past trajectory, oldest first, rendered as a trailing line. Appending to
+   * this list re-uses the existing GPU buffer (only new points are uploaded);
+   * shrinking it, or bumping {@link SatelliteState.trailVersion}, forces a rebuild.
+   *
+   * Treat this immutably (new array reference on change), as with any React
+   * prop — in-place mutation is not detected.
+   */
+  trail?: readonly TrailPoint[];
+  /**
+   * Opaque token that, when changed, forces the trail's GPU buffer to be rebuilt
+   * from scratch. The append/rebuild diff only inspects the trail's length and
+   * its last point, so you MUST bump this whenever you rewrite *existing* points
+   * (seeking, a new run, editing earlier history) — otherwise a same-length edit
+   * to interior points is mistaken for "unchanged" and won't reach the GPU.
+   */
+  trailVersion?: string | number;
+  /** Marker/trail colour as a 0xRRGGBB integer. Defaults to a palette colour. */
+  color?: number;
+  /** Human-readable name. Used for 3D model lookup and labels. */
+  name?: string;
+}
+
+/** The central body rendered at the scene origin. */
+export interface CentralBody {
+  /**
+   * Body id. One of the built-in bodies (`"earth"`, `"moon"`, `"sun"`,
+   * `"mars"`), or a custom body supplied via {@link OrbitViewerProps.bodies}.
+   * Unknown ids fall back to a plain coloured sphere.
+   */
+  id: string;
+  /**
+   * Physical radius in km (scene scale factor). Optional when the id resolves
+   * to a known/custom {@link BodyDefinition} — its `radiusKm` is used then.
+   */
+  radiusKm?: number;
+}
+
+/**
+ * Which frame to render in. Deliberately narrower than the renderer's internal
+ * frame type: only the centres/orientations actually implemented are exposed.
+ *
+ * - `centralBody` + `inertial` — ECI-like, central body at the origin (default).
+ * - `centralBody` + `bodyFixed` — body-fixed (ECEF-like); the body is static and
+ *   positions rotate with it.
+ * - `{ satelliteId }` + `inertial` — that satellite at the origin with the axes
+ *   star-fixed: the central body appears to move around the satellite as it
+ *   orbits, and the camera does not co-rotate.
+ * - `{ satelliteId }` + `localOrbital` — that satellite at the origin, LVLH axes
+ *   (radial / along-track / cross-track): the central body stays "below" as the
+ *   satellite orbits. Requires the satellite's velocity; without it the view
+ *   falls back to a radial-up camera follow.
+ */
+export type ViewerReferenceFrame =
+  | { center: "centralBody"; orientation?: "inertial" | "bodyFixed" }
+  | { center: { satelliteId: string }; orientation?: "inertial" | "localOrbital" };
+
+/** Props for the {@link OrbitViewer} component. */
+export interface OrbitViewerProps {
+  /** The central body at the origin. */
+  centralBody: CentralBody;
+  /**
+   * Custom body definitions, keyed by body id and merged over the built-in
+   * {@link DEFAULT_BODIES} (Earth / Moon / Sun / Mars) — e.g.
+   * `{ pluto: { radiusKm: 1188.3, texture: { day: "/pluto.jpg" } } }`.
+   *
+   * The merge is per-id and shallow: overriding a default replaces its *entire*
+   * definition, so a partial override drops the default's other fields (texture,
+   * colour, …). Note that physical Sun lighting / rotation only apply to bodies
+   * the arika model knows; a custom body renders (radius / texture / colour) but
+   * does not spin.
+   */
+  bodies?: BodyDefinitions;
+  /** Satellites to display. */
+  satellites: readonly SatelliteState[];
+  /** Display frame. Defaults to central-body inertial (ECI-like). */
+  referenceFrame?: ViewerReferenceFrame;
+  /**
+   * Julian Date of the epoch. When provided, the Sun direction, lighting and
+   * body rotation are computed for real (via the bundled arika WASM). When
+   * omitted, a fixed default Sun direction is used and the body does not spin.
+   */
+  epochJd?: number;
+  /** Elapsed seconds since the epoch, for time-dependent Sun/rotation. Default 0. */
+  time?: number;
+  /** Base URL for high-resolution body textures (e.g. `"/textures/"`). */
+  textureBaseUrl?: string;
+  /** Class applied to the wrapping element. */
+  className?: string;
+  /** Inline style applied to the wrapping element. */
+  style?: CSSProperties;
+}
+
+/** Default frame when none is supplied: central-body inertial (ECI-like). */
+export const DEFAULT_VIEWER_FRAME: ViewerReferenceFrame = {
+  center: "centralBody",
+  orientation: "inertial",
+};

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/lib/useTrailBuffers.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/lib/useTrailBuffers.ts
@@ -1,0 +1,77 @@
+import { useLayoutEffect, useMemo, useRef } from "react";
+import { TrailBuffer } from "../utils/TrailBuffer.js";
+import { reconcileTrailEntry, type TrailEntry } from "./trailReconcile.js";
+import type { SatelliteState } from "./types.js";
+
+/**
+ * Floor for a trail buffer's capacity (in points). `TrailBuffer` is *bounded*:
+ * once a trail exceeds ~1.5× its capacity it trims the oldest points and bumps
+ * its generation (a one-off full re-upload). Capacity is fixed at creation
+ * (max of 2× the initial trail length and this floor), so raise it if you need
+ * very long histories without trimming.
+ */
+const INITIAL_CAPACITY = 4096;
+
+/**
+ * Keep one persistent {@link TrailBuffer} per satellite across renders, returning
+ * a map of stable buffer instances.
+ *
+ * Stable identity is the whole point: `OrbitTrail` rebuilds its GPU geometry only
+ * when the buffer object changes, so re-using the same instance lets it upload
+ * just the appended tail (or do a full rewrite only on a real reset).
+ *
+ * Phasing (#91): the render phase only guarantees *identities* — a stable empty
+ * buffer is created the first time an id is seen (idempotent and content-free,
+ * so a render that React later aborts at worst leaves an empty buffer to be
+ * pruned). All *content* mutations — fill, append, rebuild, and pruning of
+ * vanished ids — happen in `useLayoutEffect`, i.e. only for committed renders,
+ * so an aborted concurrent render can never leak points into the buffers.
+ * `OrbitTrail` reads contents in `useFrame` (after layout effects run, before
+ * the next animation frame), so the commit-phase fill adds no frame lag.
+ *
+ * `satellites` (and each `sat.trail`) must be treated immutably — supply new
+ * array references when points change, as with any React prop. The reconcile is
+ * keyed on the array's identity, so in-place mutation won't be picked up.
+ */
+export function useTrailBuffers(satellites: readonly SatelliteState[]): Map<string, TrailBuffer> {
+  const store = useRef(new Map<string, TrailEntry>());
+
+  // Render phase: ensure a stable buffer identity exists for each satellite
+  // that asked for a trail. Marker-only satellites (no `trail` prop) get no
+  // buffer, so no OrbitTrail is mounted for them.
+  const live = useMemo(() => {
+    const map = new Map<string, TrailBuffer>();
+    for (const sat of satellites) {
+      if (sat.trail === undefined) continue;
+      let entry = store.current.get(sat.id);
+      if (!entry) {
+        entry = {
+          buffer: new TrailBuffer(Math.max(sat.trail.length * 2, INITIAL_CAPACITY)),
+          sync: null,
+        };
+        store.current.set(sat.id, entry);
+      }
+      map.set(sat.id, entry.buffer);
+    }
+    return map;
+  }, [satellites]);
+
+  // Commit phase: apply content mutations only for renders that actually
+  // committed. reconcileTrailEntry is idempotent per input set, which also
+  // covers StrictMode's double-invoked effects.
+  useLayoutEffect(() => {
+    const seen = new Set<string>();
+    for (const sat of satellites) {
+      if (sat.trail === undefined) continue;
+      seen.add(sat.id);
+      const entry = store.current.get(sat.id);
+      if (entry) reconcileTrailEntry(entry, sat.trail, sat.trailVersion);
+    }
+    // Forget buffers for satellites that vanished or dropped their trail.
+    for (const id of store.current.keys()) {
+      if (!seen.has(id)) store.current.delete(id);
+    }
+  }, [satellites]);
+
+  return live;
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/orbit.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/orbit.ts
@@ -1,0 +1,184 @@
+import * as THREE from "three";
+
+/**
+ * Earth radius in km -- used as the scene scale factor.
+ * Positions in CSV are expected in km; divide by this to get scene units.
+ */
+const EARTH_RADIUS_KM = 6378.137;
+
+/** A single orbit state point from CSV or WebSocket. */
+export interface OrbitPoint {
+  /** Entity path identifier (from WebSocket protocol). */
+  entityPath?: string;
+  t: number;
+  x: number;
+  y: number;
+  z: number;
+  vx: number;
+  vy: number;
+  vz: number;
+  /** Semi-major axis [km] */
+  a: number;
+  /** Eccentricity [-] */
+  e: number;
+  /** Inclination [rad] */
+  inc: number;
+  /** Right ascension of ascending node [rad] */
+  raan: number;
+  /** Argument of periapsis [rad] */
+  omega: number;
+  /** True anomaly [rad] */
+  nu: number;
+  /** Pre-computed derived values from server (for chart display). */
+  altitude?: number;
+  specific_energy?: number;
+  angular_momentum?: number;
+  velocity_mag?: number;
+  /** Acceleration magnitudes [km/s²] — 0 when perturbation is inactive. */
+  accel_gravity?: number;
+  accel_drag?: number;
+  accel_srp?: number;
+  accel_third_body_sun?: number;
+  accel_third_body_moon?: number;
+  /** Body-to-inertial quaternion components (Hamilton scalar-first: w,x,y,z). */
+  qw?: number;
+  qx?: number;
+  qy?: number;
+  qz?: number;
+  /** Angular velocity in body frame [rad/s]. */
+  wx?: number;
+  wy?: number;
+  wz?: number;
+}
+
+/** Metadata parsed from CSV comment headers. */
+export interface CSVMetadata {
+  epochJd: number | null;
+  mu: number | null;
+  centralBody: string | null;
+  centralBodyRadius: number | null;
+  satelliteName: string | null;
+  /** Multi-satellite CSV: list of satellite IDs from `# satellites = ...` */
+  satellites: string[] | null;
+}
+
+/**
+ * Holds the Three.js objects for a rendered orbit so they can be
+ * removed from the scene when a new orbit is loaded.
+ */
+export interface OrbitVisualization {
+  orbitLine: THREE.Line;
+  satelliteMarker: THREE.Mesh;
+}
+
+/**
+ * Create Three.js objects for the orbit trajectory and satellite marker.
+ *
+ * @param points - Parsed orbit points (positions in km)
+ * @returns The line and marker meshes to be added to the scene
+ */
+export function createOrbitVisualization(points: OrbitPoint[]): OrbitVisualization {
+  // Convert positions from km to scene units (Earth radii)
+  const vertices: number[] = [];
+  for (const p of points) {
+    vertices.push(p.x / EARTH_RADIUS_KM, p.y / EARTH_RADIUS_KM, p.z / EARTH_RADIUS_KM);
+  }
+
+  // Orbit trajectory line
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.Float32BufferAttribute(vertices, 3));
+
+  const material = new THREE.LineBasicMaterial({
+    color: 0x00ff88,
+    linewidth: 1,
+  });
+
+  const orbitLine = new THREE.Line(geometry, material);
+
+  // Satellite marker at the last position
+  const lastPoint = points[points.length - 1];
+  const markerGeometry = new THREE.SphereGeometry(0.03, 16, 16);
+  const markerMaterial = new THREE.MeshBasicMaterial({ color: 0xff4444 });
+  const satelliteMarker = new THREE.Mesh(markerGeometry, markerMaterial);
+  satelliteMarker.position.set(
+    lastPoint.x / EARTH_RADIUS_KM,
+    lastPoint.y / EARTH_RADIUS_KM,
+    lastPoint.z / EARTH_RADIUS_KM,
+  );
+
+  return { orbitLine, satelliteMarker };
+}
+
+/**
+ * Update the satellite marker position to reflect a given orbit point.
+ *
+ * @param marker - The satellite mesh to reposition
+ * @param point  - The orbit state to move to (position in km)
+ */
+export function updateSatellitePosition(marker: THREE.Mesh, point: OrbitPoint): void {
+  marker.position.set(
+    point.x / EARTH_RADIUS_KM,
+    point.y / EARTH_RADIUS_KM,
+    point.z / EARTH_RADIUS_KM,
+  );
+}
+
+/**
+ * Update the orbit line's draw range so that only the trail up to (and
+ * including) `visibleCount` vertices is rendered.
+ *
+ * Call with `visibleCount = points.length` to show the full orbit, or a
+ * smaller value for a progressive trail effect during playback.
+ *
+ * @param line         - The THREE.Line whose geometry to update
+ * @param visibleCount - Number of vertices to render (clamped to valid range)
+ * @param totalCount   - Total number of vertices in the geometry
+ */
+export function updateOrbitTrail(line: THREE.Line, visibleCount: number, totalCount: number): void {
+  const clamped = Math.max(0, Math.min(visibleCount, totalCount));
+  line.geometry.setDrawRange(0, clamped);
+}
+
+/**
+ * Linearly interpolate between two OrbitPoints at the given fraction (0..1)
+ * between them. Quaternion attitude is interpolated via slerp.
+ */
+export function lerpPoint(a: OrbitPoint, b: OrbitPoint, frac: number): OrbitPoint {
+  const inv = 1 - frac;
+  const result: OrbitPoint = {
+    t: a.t * inv + b.t * frac,
+    x: a.x * inv + b.x * frac,
+    y: a.y * inv + b.y * frac,
+    z: a.z * inv + b.z * frac,
+    vx: a.vx * inv + b.vx * frac,
+    vy: a.vy * inv + b.vy * frac,
+    vz: a.vz * inv + b.vz * frac,
+    a: a.a * inv + b.a * frac,
+    e: a.e * inv + b.e * frac,
+    inc: a.inc * inv + b.inc * frac,
+    raan: a.raan * inv + b.raan * frac,
+    omega: a.omega * inv + b.omega * frac,
+    nu: a.nu * inv + b.nu * frac,
+  };
+
+  // Quaternion slerp for attitude interpolation
+  if (a.qw != null && b.qw != null) {
+    const qa = new THREE.Quaternion(a.qx, a.qy, a.qz, a.qw);
+    const qb = new THREE.Quaternion(b.qx, b.qy, b.qz, b.qw);
+    // Ensure shortest-path interpolation
+    if (qa.dot(qb) < 0) {
+      qb.set(-qb.x, -qb.y, -qb.z, -qb.w);
+    }
+    qa.slerp(qb, frac);
+    result.qw = qa.w;
+    result.qx = qa.x;
+    result.qy = qa.y;
+    result.qz = qa.z;
+    // Angular velocity: linear interpolation
+    result.wx = (a.wx ?? 0) * inv + (b.wx ?? 0) * frac;
+    result.wy = (a.wy ?? 0) * inv + (b.wy ?? 0) * frac;
+    result.wz = (a.wz ?? 0) * inv + (b.wz ?? 0) * frac;
+  }
+
+  return result;
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/referenceFrame.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/referenceFrame.ts
@@ -1,0 +1,39 @@
+export type FrameCenter =
+  | { type: "central_body" }
+  | { type: "moon" }
+  | { type: "sun" }
+  | { type: "satellite"; id: string };
+
+/** Orientation of the reference frame axes. */
+export type FrameOrientation = "inertial" | "body_fixed" | "local_orbital";
+
+/** Complete reference frame specification. */
+export interface ReferenceFrame {
+  center: FrameCenter;
+  orientation: FrameOrientation;
+}
+
+/** Default frame: central-body-centered inertial (equivalent to legacy "eci"). */
+export const DEFAULT_FRAME: ReferenceFrame = {
+  center: { type: "central_body" },
+  orientation: "inertial",
+};
+
+/** Whether the frame is equivalent to legacy ECI (central body + inertial). */
+export function isDefaultEci(frame: ReferenceFrame): boolean {
+  return frame.center.type === "central_body" && frame.orientation === "inertial";
+}
+
+/** Whether the frame is equivalent to legacy ECEF (central body + body-fixed). */
+export function isLegacyEcef(frame: ReferenceFrame): boolean {
+  return frame.center.type === "central_body" && frame.orientation === "body_fixed";
+}
+
+/** Structural equality check for FrameCenter values. */
+export function frameCenterEquals(a: FrameCenter, b: FrameCenter): boolean {
+  if (a.type !== b.type) return false;
+  if (a.type === "satellite" && b.type === "satellite") {
+    return a.id === b.id;
+  }
+  return true;
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/satelliteModels.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/satelliteModels.ts
@@ -1,0 +1,72 @@
+export interface SatelliteModelConfig {
+  /** URL to the GLB model file. */
+  modelUrl: string;
+  /** Scale factor applied to the loaded model for body-centered (exaggerated) display. */
+  scale: number;
+  /** Euler rotation [rx, ry, rz] to orient the model in ECI frame. */
+  rotation: [number, number, number];
+  /** Physical span of the real satellite in km (e.g. ISS = 0.109 km). */
+  physicalSpanKm?: number;
+  /**
+   * Native span of the 3D model in model-local units (before any scale).
+   * Used to compute true-scale: trueScale = (physicalSpanKm / bodyRadius) / nativeSpanUnits.
+   */
+  nativeSpanUnits?: number;
+}
+
+const MODEL_REGISTRY: Record<string, SatelliteModelConfig> = {
+  iss: {
+    modelUrl:
+      "https://assets.science.nasa.gov/content/dam/science/psd/solar/2023/09/i/ISS_stationary.glb",
+    scale: 0.0003,
+    rotation: [0, 0, 0],
+    physicalSpanKm: 0.109, // ~109 m
+    nativeSpanUnits: 111.99,
+  },
+};
+
+/** Name patterns that map to a registry key. */
+const NAME_PATTERNS: ReadonlyArray<{ pattern: RegExp; key: string }> = [
+  { pattern: /ISS/i, key: "iss" },
+];
+
+/**
+ * Look up model config for a satellite.
+ * Checks id first, then name patterns. Returns null for sphere fallback.
+ */
+export function getSatelliteModelConfig(
+  satId: string,
+  satName?: string | null,
+): SatelliteModelConfig | null {
+  if (MODEL_REGISTRY[satId]) return MODEL_REGISTRY[satId];
+  if (satName) {
+    for (const { pattern, key } of NAME_PATTERNS) {
+      if (pattern.test(satName)) return MODEL_REGISTRY[key] ?? null;
+    }
+  }
+  return null;
+}
+
+/** Default physical span for satellites without a known size (10 m). */
+const DEFAULT_PHYSICAL_SPAN_KM = 0.01;
+
+/**
+ * Compute the scene-unit scale for a satellite model at true 1:1 physical proportions.
+ *
+ * @param config - Model config (with optional physicalSpanKm / nativeSpanUnits)
+ * @param centralBodyRadius - Central body radius in km
+ * @returns Scale to apply to the model for true-size rendering, or null if
+ *          nativeSpanUnits is unknown (fall back to exaggerated scale).
+ */
+export function computeTrueModelScale(
+  config: SatelliteModelConfig,
+  centralBodyRadius: number,
+): number | null {
+  const nativeSpan = config.nativeSpanUnits;
+  if (nativeSpan == null || nativeSpan <= 0) return null;
+
+  const physicalKm = config.physicalSpanKm ?? DEFAULT_PHYSICAL_SPAN_KM;
+  // physicalKm / centralBodyRadius = desired span in scene units
+  // Divide by nativeSpan to get per-unit scale
+  return physicalKm / centralBodyRadius / nativeSpan;
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/satelliteShapes.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/satelliteShapes.ts
@@ -1,0 +1,54 @@
+export const MARKER_SHAPES = ["sphere", "axes-cube"] as const;
+export type MarkerShape = (typeof MARKER_SHAPES)[number];
+
+/** Shape used automatically for satellites that carry attitude. */
+export const DEFAULT_ATTITUDE_SHAPE: MarkerShape = "axes-cube";
+
+/** Human-readable labels for UI selectors. */
+export const MARKER_SHAPE_LABELS: Record<MarkerShape, string> = {
+  sphere: "Sphere",
+  "axes-cube": "XYZ Cube",
+};
+
+export function isMarkerShape(value: string): value is MarkerShape {
+  return (MARKER_SHAPES as readonly string[]).includes(value);
+}
+
+/**
+ * Resolve the marker shape for a satellite. Precedence (most specific first):
+ *   1. `override`     — per-satellite viewer choice
+ *   2. `simShape`     — shape declared by the simulation (via SatelliteInfo)
+ *   3. `globalDefault`— viewer-wide default
+ *   4. automatic      — orientation cube when attitude is present, else sphere
+ * A null/undefined value at any level falls through to the next.
+ */
+export function resolveMarkerShape(opts: {
+  override?: MarkerShape | null;
+  simShape?: MarkerShape | null;
+  globalDefault?: MarkerShape | null;
+  hasAttitude: boolean;
+}): MarkerShape {
+  if (opts.override) return opts.override;
+  if (opts.simShape) return opts.simShape;
+  if (opts.globalDefault) return opts.globalDefault;
+  return opts.hasAttitude ? DEFAULT_ATTITUDE_SHAPE : "sphere";
+}
+
+/** Read the global default marker shape from the `satShape` URL param (null = auto). */
+export function readSatShapeParam(): MarkerShape | null {
+  const raw = new URLSearchParams(window.location.search).get("satShape");
+  return raw && isMarkerShape(raw) ? raw : null;
+}
+
+/** Persist the global default marker shape into the `satShape` URL param. */
+export function writeSatShapeParam(shape: MarkerShape | null): void {
+  const params = new URLSearchParams(window.location.search);
+  if (shape == null) params.delete("satShape");
+  else params.set("satShape", shape);
+  const qs = params.toString();
+  history.replaceState(
+    null,
+    "",
+    qs ? `${window.location.pathname}?${qs}` : window.location.pathname,
+  );
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/sceneFrame.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/sceneFrame.ts
@@ -1,0 +1,86 @@
+export const SCENE_UP: [number, number, number] = [0, 0, 1];
+
+/**
+ * Euler rotation [rx, ry, rz] that aligns a Three.js sphere (Y-pole)
+ * with the display frame's polar axis.
+ *
+ * ECI: +π/2 around X maps local +Y → world +Z (north pole).
+ */
+export const POLE_ALIGNMENT_ROTATION: [number, number, number] = [Math.PI / 2, 0, 0];
+
+/**
+ * Default camera position for the display frame.
+ * Placed on the +X side (vernal equinox direction), slightly above the equator.
+ */
+export const DEFAULT_CAMERA_POSITION: [number, number, number] = [5, 0, 2];
+
+/**
+ * Compute the camera "up" direction for satellite-centered view.
+ *
+ * When centered on a satellite, the up vector is the radial outward direction
+ * (from central body through satellite), so the central body always appears
+ * "below" in the viewport. Returns SCENE_UP for non-satellite-centered views.
+ */
+export function computeCameraUp(
+  originPosition: [number, number, number] | null,
+): [number, number, number] {
+  if (originPosition == null) return SCENE_UP;
+  const [x, y, z] = originPosition;
+  const len = Math.sqrt(x * x + y * y + z * z);
+  if (len < 1e-10) return SCENE_UP;
+  return [x / len, y / len, z / len];
+}
+
+/** LVLH (Local Vertical Local Horizontal) axes as unit vectors. */
+export interface LvlhAxes {
+  /** Radial outward (from central body through satellite). */
+  radial: [number, number, number];
+  /** In-track (roughly along velocity, in the orbit plane). */
+  inTrack: [number, number, number];
+  /** Cross-track (orbit normal, completes right-handed triad: C × R = I). */
+  crossTrack: [number, number, number];
+}
+
+/**
+ * Compute the LVLH frame axes from satellite position and velocity.
+ *
+ * - Radial (R) = normalize(r)
+ * - Cross-track (C) = normalize(r × v)  (orbit normal)
+ * - In-track (I) = C × R  (in orbit plane, roughly along velocity)
+ *
+ * Returns null if position or velocity is null/zero.
+ */
+export function computeLvlhAxes(
+  position: [number, number, number] | null,
+  velocity: [number, number, number] | null,
+): LvlhAxes | null {
+  if (position == null || velocity == null) return null;
+
+  const [rx, ry, rz] = position;
+  const rLen = Math.sqrt(rx * rx + ry * ry + rz * rz);
+  if (rLen < 1e-10) return null;
+
+  const [vx, vy, vz] = velocity;
+  const vLen = Math.sqrt(vx * vx + vy * vy + vz * vz);
+  if (vLen < 1e-10) return null;
+
+  // Radial = normalize(r)
+  const radial: [number, number, number] = [rx / rLen, ry / rLen, rz / rLen];
+
+  // Cross-track = normalize(r × v)
+  const cx = ry * vz - rz * vy;
+  const cy = rz * vx - rx * vz;
+  const cz = rx * vy - ry * vx;
+  const cLen = Math.sqrt(cx * cx + cy * cy + cz * cz);
+  if (cLen < 1e-10) return null; // degenerate: r parallel to v
+  const crossTrack: [number, number, number] = [cx / cLen, cy / cLen, cz / cLen];
+
+  // In-track = crossTrack × radial
+  const inTrack: [number, number, number] = [
+    crossTrack[1] * radial[2] - crossTrack[2] * radial[1],
+    crossTrack[2] * radial[0] - crossTrack[0] * radial[2],
+    crossTrack[0] * radial[1] - crossTrack[1] * radial[0],
+  ];
+
+  return { radial, inTrack, crossTrack };
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/shaders/atmosphere.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/shaders/atmosphere.ts
@@ -1,0 +1,293 @@
+export const ATMOSPHERE_SCALE_AMPLIFIED = 1.06;
+
+/** Physical atmosphere scale (~100km Kármán line / 6371km Earth radius). */
+export const ATMOSPHERE_SCALE_PHYSICAL = 1.015;
+
+/**
+ * Rayleigh scattering coefficients [m⁻¹] for R, G, B channels.
+ * Blue scatters most (λ⁻⁴ law).
+ */
+export const RAYLEIGH_COEFFICIENTS: [number, number, number] = [5.5e-6, 13.0e-6, 22.4e-6];
+
+/** Mie scattering coefficient [m⁻¹] (wavelength-independent). */
+export const MIE_COEFFICIENT = 21e-6;
+
+/** Rayleigh scale height in Earth-radius units (8.0 km / 6371 km). */
+export const RAYLEIGH_SCALE_HEIGHT = 8.0 / 6371.0;
+
+/** Mie scale height in Earth-radius units (1.2 km / 6371 km). */
+export const MIE_SCALE_HEIGHT = 1.2 / 6371.0;
+
+/** Mie asymmetry parameter g (forward-scattering dominant). */
+export const MIE_ANISOTROPY = 0.76;
+
+/** Multi-scattering factor f_ms (Hillaire approximation). */
+export const MULTI_SCATTERING_FACTOR = 0.25;
+
+/** Airglow emission color (blue-dominant chemiluminescence at ~90-300 km). */
+export const AIRGLOW_COLOR: [number, number, number] = [0.1, 0.25, 0.5];
+
+/** Airglow emission strength factor. */
+export const AIRGLOW_STRENGTH = 2.0;
+
+// Math utility functions (also used in GLSL)
+
+/**
+ * Ray-sphere intersection for a sphere centered at the origin.
+ * Returns [near, far] distances along the ray, or null if no intersection.
+ * near < 0 means the ray origin is inside the sphere.
+ */
+export function raySphereIntersection(
+  origin: [number, number, number],
+  dir: [number, number, number],
+  radius: number,
+): [number, number] | null {
+  // Solve: |origin + t*dir|² = radius²
+  // → (dir·dir)t² + 2(origin·dir)t + (origin·origin - radius²) = 0
+  const a = dir[0] * dir[0] + dir[1] * dir[1] + dir[2] * dir[2];
+  const b = 2 * (origin[0] * dir[0] + origin[1] * dir[1] + origin[2] * dir[2]);
+  const c = origin[0] * origin[0] + origin[1] * origin[1] + origin[2] * origin[2] - radius * radius;
+
+  const discriminant = b * b - 4 * a * c;
+  if (discriminant < 0) return null;
+
+  const sqrtD = Math.sqrt(discriminant);
+  const near = (-b - sqrtD) / (2 * a);
+  const far = (-b + sqrtD) / (2 * a);
+  return [near, far];
+}
+
+/**
+ * Rayleigh phase function: (3/16π)(1 + cos²θ).
+ * Symmetric for forward and backward scattering.
+ */
+export function rayleighPhase(cosTheta: number): number {
+  return (3 / (16 * Math.PI)) * (1 + cosTheta * cosTheta);
+}
+
+/**
+ * Cornette-Shanks phase function (improved Henyey-Greenstein for Mie scattering).
+ * (3/8π) × (1 - g²)(1 + cos²θ) / ((2 + g²)(1 + g² - 2g·cosθ)^(3/2))
+ */
+export function miePhase(cosTheta: number, g: number): number {
+  const gg = g * g;
+  const num = (3 / (8 * Math.PI)) * (1 - gg) * (1 + cosTheta * cosTheta);
+  const denom = (2 + gg) * (1 + gg - 2 * g * cosTheta) ** 1.5;
+  return num / denom;
+}
+
+/**
+ * Atmospheric density at a given altitude: exp(-altitude / scaleHeight).
+ */
+export function atmosphericDensity(altitude: number, scaleHeight: number): number {
+  return Math.exp(-altitude / scaleHeight);
+}
+
+// GLSL Shaders
+
+/** Vertex shader for the atmosphere shell. */
+export const atmosphereVert = /* glsl */ `
+#include <common>
+#include <logdepthbuf_pars_vertex>
+
+varying vec3 vWorldPosition;
+varying vec3 vSphereCenter;
+
+void main() {
+  vec4 worldPos = modelMatrix * vec4(position, 1.0);
+  vWorldPosition = worldPos.xyz;
+  vSphereCenter = (modelMatrix * vec4(0.0, 0.0, 0.0, 1.0)).xyz;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+
+  #include <logdepthbuf_vertex>
+}
+`;
+
+/** Fragment shader for atmospheric scattering with ray-marching. */
+export const atmosphereFrag = /* glsl */ `
+#include <logdepthbuf_pars_fragment>
+
+uniform vec3 sunDirection;      // normalized, world space
+uniform float sunIntensity;     // inverse-square factor: (1 AU / distance)²
+uniform vec3 cameraWorldPos;    // camera position in world space
+uniform float earthRadius;      // scene units (1.0 for body-centered)
+uniform float atmosphereRadius; // scene units (earthRadius * scale)
+
+varying vec3 vWorldPosition;
+varying vec3 vSphereCenter;
+
+// Physical constants (all in Earth-radius units, earthRadius = 1)
+//
+// The shader normalizes all distances by earthRadius at the start of main(),
+// so these constants work correctly regardless of scene scale.
+
+// Rayleigh scattering coefficients per Earth-radius [R_E⁻¹].
+// Physical [m⁻¹] × 6.371e6 [m/R_E] → [R_E⁻¹].
+const vec3 RAY_BETA = vec3(5.5e-6, 13.0e-6, 22.4e-6) * 6.371e6;
+
+// Mie scattering coefficient per Earth-radius [R_E⁻¹].
+const vec3 MIE_BETA = vec3(21e-6) * 6.371e6;
+
+// Mie asymmetry (forward-scattering dominant).
+const float G_MIE = 0.76;
+
+// Multi-scattering approximation factor (Hillaire 2020).
+const float F_MS = 0.25;
+
+// Scale heights in Earth-radius units.
+const float HEIGHT_RAY = 0.001256;  // Rayleigh: 8.0 km / 6371 km
+const float HEIGHT_MIE = 0.000188;  // Mie: 1.2 km / 6371 km
+const float HEIGHT_GLOW = 0.01;     // Airglow: ~64 km (broad emission layer)
+
+// Number of ray-march steps.
+const int I_STEPS = 16;  // primary ray (view direction)
+const int J_STEPS = 8;   // secondary ray (toward sun)
+
+// Sun intensity multiplier for visual tuning.
+const float SUN_INTENSITY_SCALE = 20.0;
+
+// Airglow: faint atmospheric self-emission (chemiluminescence at ~90-300 km).
+// Visible from orbit as thin blue band on night-side limb.
+const vec3 AIRGLOW_COLOR = vec3(0.1, 0.25, 0.5);
+const float AIRGLOW_STRENGTH = 2.0;
+
+// Ray-sphere intersection
+
+// Returns (near, far) distances. near > far means no intersection.
+vec2 rsi(vec3 r0, vec3 rd, float sr) {
+  float a = dot(rd, rd);
+  float b = 2.0 * dot(rd, r0);
+  float c = dot(r0, r0) - sr * sr;
+  float d = b * b - 4.0 * a * c;
+  if (d < 0.0) return vec2(1e5, -1e5);
+  float sd = sqrt(d);
+  return vec2((-b - sd) / (2.0 * a), (-b + sd) / (2.0 * a));
+}
+
+// Phase functions
+
+// Rayleigh phase: (3/16π)(1 + cos²θ)
+float phaseRayleigh(float cosTheta) {
+  return 3.0 / (50.2654824574) * (1.0 + cosTheta * cosTheta);
+  // 50.2654824574 = 16π
+}
+
+// Cornette-Shanks (Mie) phase function.
+float phaseMie(float cosTheta, float g) {
+  float gg = g * g;
+  float num = 3.0 * (1.0 - gg) * (1.0 + cosTheta * cosTheta);
+  float denom = (8.0 * 3.14159265) * (2.0 + gg) * pow(1.0 + gg - 2.0 * g * cosTheta, 1.5);
+  return num / denom;
+}
+
+void main() {
+  // Normalize to Earth-radius units
+  // All constants (RAY_BETA, HEIGHT_RAY, etc.) assume earthRadius = 1.
+  // Dividing by earthRadius makes the shader scale-invariant.
+  vec3 center = vSphereCenter;
+  float R = earthRadius;   // scene-unit Earth radius (may be 1 or ~200)
+  float invR = 1.0 / R;
+
+  // Ray origin and direction in normalized units (planet center = origin, radius = 1).
+  vec3 r0 = (cameraWorldPos - center) * invR;
+  vec3 rd = normalize(vWorldPosition - cameraWorldPos);  // direction is scale-invariant
+
+  float nAtmoRadius = atmosphereRadius * invR;  // e.g. 1.06
+
+  // Intersect view ray with atmosphere and planet spheres (normalized).
+  vec2 atmoHit = rsi(r0, rd, nAtmoRadius);
+  vec2 planetHit = rsi(r0, rd, 1.0);
+
+  // No atmosphere intersection → fully transparent.
+  if (atmoHit.x > atmoHit.y) {
+    gl_FragColor = vec4(0.0);
+    #include <logdepthbuf_fragment>
+    return;
+  }
+
+  // Clamp ray start to atmosphere entry (max with 0 for camera inside atmo).
+  float tStart = max(atmoHit.x, 0.0);
+  float tEnd = atmoHit.y;
+
+  // If ray hits planet, end at planet surface.
+  if (planetHit.x < planetHit.y && planetHit.x > 0.0) {
+    tEnd = min(tEnd, planetHit.x);
+  }
+
+  // Step size along view ray (in normalized units).
+  float iStepSize = (tEnd - tStart) / float(I_STEPS);
+
+  // Accumulated scattering and optical depth.
+  vec3 totalRay = vec3(0.0);
+  vec3 totalMie = vec3(0.0);
+  float iOptRay = 0.0;
+  float iOptMie = 0.0;
+  float totalGlow = 0.0;
+
+  // Phase function values (constant along the ray).
+  float mu = dot(rd, sunDirection);
+  float pRay = phaseRayleigh(mu);
+  float pMie = phaseMie(mu, G_MIE);
+
+  // Primary ray-march (all in normalized Earth-radius units)
+  for (int i = 0; i < I_STEPS; i++) {
+    // Sample point at center of step.
+    vec3 iPos = r0 + rd * (tStart + iStepSize * (float(i) + 0.5));
+    float iHeight = length(iPos) - 1.0;  // altitude above surface in R_E
+
+    // Density at this sample point.
+    float dRay = exp(-iHeight / HEIGHT_RAY) * iStepSize;
+    float dMie = exp(-iHeight / HEIGHT_MIE) * iStepSize;
+
+    // Accumulate optical depth along view ray.
+    iOptRay += dRay;
+    iOptMie += dMie;
+    // Airglow: broad emission layer (~90-300 km altitude range).
+    totalGlow += exp(-iHeight / HEIGHT_GLOW) * iStepSize;
+
+    // Secondary ray-march toward sun
+    float jStepSize = rsi(iPos, sunDirection, nAtmoRadius).y / float(J_STEPS);
+    float jOptRay = 0.0;
+    float jOptMie = 0.0;
+
+    for (int j = 0; j < J_STEPS; j++) {
+      vec3 jPos = iPos + sunDirection * (jStepSize * (float(j) + 0.5));
+      float jHeight = length(jPos) - 1.0;
+      jOptRay += exp(-jHeight / HEIGHT_RAY) * jStepSize;
+      jOptMie += exp(-jHeight / HEIGHT_MIE) * jStepSize;
+    }
+
+    // Transmittance from sun through atmosphere to this point, then to camera.
+    vec3 attn = exp(-(RAY_BETA * (iOptRay + jOptRay) + MIE_BETA * (iOptMie + jOptMie)));
+
+    // Single-scattering contribution.
+    totalRay += dRay * attn;
+    totalMie += dMie * attn;
+  }
+
+  // Combine single-scattering with phase functions.
+  vec3 singleScatter = (pRay * RAY_BETA * totalRay + pMie * MIE_BETA * totalMie);
+
+  // Multi-scattering approximation (Hillaire 2020):
+  // Approximate higher-order scattering as isotropic, scaled by geometric series.
+  // L_ms ≈ L_isotropic / (1 - f_ms)
+  float isoPhase = 1.0 / (4.0 * 3.14159265);
+  vec3 multiScatter = (isoPhase * RAY_BETA * totalRay + isoPhase * MIE_BETA * totalMie)
+                      * F_MS / (1.0 - F_MS);
+
+  // Airglow: sun-independent emission visible on night-side limb.
+  vec3 airglow = AIRGLOW_COLOR * AIRGLOW_STRENGTH * totalGlow;
+  vec3 color = (singleScatter + multiScatter) * sunIntensity * SUN_INTENSITY_SCALE + airglow;
+
+  // With additive blending, color itself controls contribution intensity.
+  // Using alpha=1.0 avoids quadratic dimming (faint scatter × faint alpha)
+  // that would make thin physical-scale atmospheres invisible.
+  float alpha = 1.0;
+
+  gl_FragColor = vec4(color, alpha);
+
+  #include <tonemapping_fragment>
+  #include <colorspace_fragment>
+  #include <logdepthbuf_fragment>
+}
+`;

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/shaders/earthDayNight.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/shaders/earthDayNight.ts
@@ -1,0 +1,54 @@
+export const earthDayNightVert = /* glsl */ `
+#include <common>
+#include <logdepthbuf_pars_vertex>
+
+varying vec2 vUv;
+varying vec3 vWorldNormal;
+
+void main() {
+  vUv = uv;
+  vWorldNormal = normalize((modelMatrix * vec4(normal, 0.0)).xyz);
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+
+  #include <logdepthbuf_vertex>
+}
+`;
+
+/** Fragment shader for Earth day/night blending with smooth terminator. */
+export const earthDayNightFrag = /* glsl */ `
+#include <logdepthbuf_pars_fragment>
+
+uniform sampler2D dayMap;
+uniform sampler2D nightMap;
+uniform vec3 sunDirection;
+uniform float ambientIntensity;
+uniform float sunIntensity; // (1 AU / distance)^2
+
+varying vec2 vUv;
+varying vec3 vWorldNormal;
+
+void main() {
+  vec4 dayColor = texture2D(dayMap, vUv);
+  vec4 nightColor = texture2D(nightMap, vUv);
+
+  // Cosine of angle between surface normal and sun direction
+  float cosAngle = dot(vWorldNormal, sunDirection);
+
+  // Smooth terminator transition (~18 degree twilight zone)
+  float blend = smoothstep(-0.1, 0.2, cosAngle);
+
+  // Day side: Lambertian diffuse scaled by inverse-square sun intensity
+  float diffuse = max(cosAngle, 0.0);
+  vec3 litDay = dayColor.rgb * (ambientIntensity + (1.0 - ambientIntensity) * diffuse * sunIntensity);
+
+  // Night side: city lights (emissive)
+  vec3 litNight = nightColor.rgb;
+
+  vec3 finalColor = mix(litNight, litDay, blend);
+  gl_FragColor = vec4(finalColor, 1.0);
+
+  #include <tonemapping_fragment>
+  #include <colorspace_fragment>
+  #include <logdepthbuf_fragment>
+}
+`;

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/shaders/orbitTrail.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/shaders/orbitTrail.ts
@@ -1,0 +1,52 @@
+export const orbitTrailVert = /* glsl */ `
+#include <common>
+#include <logdepthbuf_pars_vertex>
+
+// High/low split position attributes (km, pre-split on CPU)
+attribute vec3 positionHigh;
+attribute vec3 positionLow;
+
+// Origin in high/low split (satellite ECI km, or [0,0,0] for central-body)
+uniform vec3 uOriginHigh;
+uniform vec3 uOriginLow;
+
+// Frame rotation matrix (identity for ECI/ECEF, LVLH rotation for body-frame)
+uniform mat3 uFrameRotation;
+
+// Inverse of scaleRadius: 1.0 / centralBodyRadius [1/km]
+uniform float uInvScaleRadius;
+
+void main() {
+  // Reconstruct relative position in km with high precision.
+  // The high-part subtraction cancels most magnitude, leaving a small
+  // value that the low-part subtraction refines.
+  vec3 relativeKm = (positionHigh - uOriginHigh) + (positionLow - uOriginLow);
+
+  // Apply frame rotation (identity for ECI/ECEF, LVLH for body-frame)
+  vec3 frameKm = uFrameRotation * relativeKm;
+
+  // Convert from km to scene units
+  vec3 scenePosition = frameKm * uInvScaleRadius;
+
+  vec4 mvPosition = modelViewMatrix * vec4(scenePosition, 1.0);
+  gl_Position = projectionMatrix * mvPosition;
+
+  #include <logdepthbuf_vertex>
+}
+`;
+
+/** Fragment shader for orbit trail. */
+export const orbitTrailFrag = /* glsl */ `
+#include <logdepthbuf_pars_fragment>
+
+uniform vec3 uColor;
+uniform float uOpacity;
+
+void main() {
+  gl_FragColor = vec4(uColor, uOpacity);
+
+  #include <tonemapping_fragment>
+  #include <colorspace_fragment>
+  #include <logdepthbuf_fragment>
+}
+`;

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/sunLighting.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/sunLighting.ts
@@ -1,0 +1,61 @@
+import { rotateZ } from "./frameTransform.js";
+import type { LvlhAxes } from "./sceneFrame.js";
+
+/** One astronomical unit in kilometres. */
+export const AU_KM = 149_597_870.7;
+
+/** Display-frame transform options for the sun direction. */
+export interface SunDisplayFrameOptions {
+  /** True when the display frame is Earth-fixed (ECEF). */
+  isEcef: boolean;
+  /** Earth rotation angle (radians); null/undefined when unavailable. */
+  era: number | null | undefined;
+  /** True when LVLH (local-orbital) rotation is applied to the data. */
+  lvlhActive: boolean;
+  /** LVLH basis when active; null falls back to the inertial/ECEF branch. */
+  lvlhAxes: LvlhAxes | null;
+}
+
+/**
+ * Transform a sun direction from the body-centred inertial frame (ECI) into the
+ * active display frame.
+ *
+ * - LVLH (`lvlhActive` with axes): project onto the LVLH basis
+ *   `[inTrack, crossTrack, radial]` so the sun tracks the satellite body frame.
+ * - ECEF (`isEcef`, `era` given): rotate by `-era` about Z to match Earth-fixed.
+ * - Otherwise: return the ECI direction unchanged.
+ *
+ * Works on and returns `[x, y, z]` tuples; the caller wraps the result in a
+ * `THREE.Vector3` at the React boundary.
+ */
+export function sunDirectionInDisplayFrame(
+  sunEci: [number, number, number],
+  { isEcef, era, lvlhActive, lvlhAxes }: SunDisplayFrameOptions,
+): [number, number, number] {
+  const [sx, sy, sz] = sunEci;
+
+  if (lvlhActive && lvlhAxes) {
+    const { inTrack, crossTrack, radial } = lvlhAxes;
+    return [
+      inTrack[0] * sx + inTrack[1] * sy + inTrack[2] * sz,
+      crossTrack[0] * sx + crossTrack[1] * sy + crossTrack[2] * sz,
+      radial[0] * sx + radial[1] * sy + radial[2] * sz,
+    ];
+  }
+
+  if (!isEcef || era == null) return [sx, sy, sz];
+
+  // ECEF: rotate the sun direction by -ERA to match the Earth-fixed frame.
+  return rotateZ(sx, sy, sz, -era);
+}
+
+/**
+ * Sun illumination scale from the inverse-square law, normalised to 1.0 at 1 AU.
+ *
+ * Guards against non-positive distances (which never occur for a real body-Sun
+ * distance) so a bad input can't produce Infinity/NaN intensity.
+ */
+export function inverseSquareIntensity(distKm: number): number {
+  if (!(distKm > 0)) return 1.0;
+  return (AU_KM / distKm) ** 2;
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/utils/TrailBuffer.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/utils/TrailBuffer.ts
@@ -1,0 +1,121 @@
+import { lerpPoint, type OrbitPoint } from "../orbit.js";
+
+/**
+ * Bounded buffer for orbit trail rendering.
+ *
+ * Keeps at most `capacity` points. When the buffer grows beyond
+ * `capacity * 1.5`, the oldest points are trimmed and `generation`
+ * is incremented so that consumers (e.g. OrbitTrail GPU buffer)
+ * know to do a full rewrite instead of an incremental append.
+ */
+export class TrailBuffer {
+  private points: OrbitPoint[] = [];
+  private _generation = 0;
+
+  constructor(public readonly capacity: number) {}
+
+  /** Push a single point. Trims if over capacity threshold. */
+  push(point: OrbitPoint): void {
+    this.points.push(point);
+    this.trimIfNeeded();
+  }
+
+  /** Push multiple points at once. Trims once at the end. */
+  pushMany(points: OrbitPoint[]): void {
+    for (const p of points) {
+      this.points.push(p);
+    }
+    this.trimIfNeeded();
+  }
+
+  get length(): number {
+    return this.points.length;
+  }
+
+  /**
+   * Generation counter. Incremented on trim or clear.
+   * OrbitTrail uses this to detect when a full GPU buffer rewrite is needed
+   * (as opposed to incremental append).
+   */
+  get generation(): number {
+    return this._generation;
+  }
+
+  /** The most recently pushed point, or null if empty. */
+  get latest(): OrbitPoint | null {
+    return this.points.length > 0 ? this.points[this.points.length - 1] : null;
+  }
+
+  /**
+   * Returns the internal array reference (no copy).
+   * Callers must not mutate the returned array.
+   */
+  getAll(): OrbitPoint[] {
+    return this.points;
+  }
+
+  /** Clear all points and increment generation. */
+  clear(): void {
+    this.points = [];
+    this._generation++;
+  }
+
+  /**
+   * Interpolate the orbit state at an arbitrary time value.
+   * Uses binary search + linear interpolation between bracketing points.
+   * Returns null if the buffer is empty.
+   * Clamps to first/last point if t is outside the data range.
+   */
+  interpolateAt(t: number): OrbitPoint | null {
+    const pts = this.points;
+    if (pts.length === 0) return null;
+    if (pts.length === 1 || t <= pts[0].t) return { ...pts[0] };
+    if (t >= pts[pts.length - 1].t) return { ...pts[pts.length - 1] };
+
+    // Binary search for the bracketing interval
+    let lo = 0;
+    let hi = pts.length - 1;
+    while (hi - lo > 1) {
+      const mid = (lo + hi) >>> 1;
+      if (pts[mid].t <= t) {
+        lo = mid;
+      } else {
+        hi = mid;
+      }
+    }
+
+    const dt = pts[hi].t - pts[lo].t;
+    const frac = dt > 0 ? (t - pts[lo].t) / dt : 0;
+    return lerpPoint(pts[lo], pts[hi], frac);
+  }
+
+  /**
+   * Return the index of the last point whose time is <= t.
+   * Returns -1 if the buffer is empty or all points are after t.
+   */
+  indexBefore(t: number): number {
+    const pts = this.points;
+    if (pts.length === 0) return -1;
+    if (t < pts[0].t) return -1;
+    if (t >= pts[pts.length - 1].t) return pts.length - 1;
+
+    let lo = 0;
+    let hi = pts.length - 1;
+    while (hi - lo > 1) {
+      const mid = (lo + hi) >>> 1;
+      if (pts[mid].t <= t) {
+        lo = mid;
+      } else {
+        hi = mid;
+      }
+    }
+    return lo;
+  }
+
+  private trimIfNeeded(): void {
+    if (this.points.length > this.capacity * 1.5) {
+      this.points = this.points.slice(-this.capacity);
+      this._generation++;
+    }
+  }
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/wasm/arikaInit.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/wasm/arikaInit.ts
@@ -1,0 +1,167 @@
+type EciToEcefBatch = (
+  positions: Float32Array,
+  times: Float32Array,
+  epoch_jd: number,
+) => Float32Array;
+
+type EciToEcef = (x: number, y: number, z: number, epoch_jd: number, t: number) => Float32Array;
+
+type EarthRotationAngle = (epoch_jd: number, t: number) => number;
+type SunDirectionEci = (epoch_jd: number, t: number) => Float32Array;
+type SunDirectionFromBody = (body: string, epoch_jd: number, t: number) => Float32Array;
+type SunDistanceFromBody = (body: string, epoch_jd: number, t: number) => number;
+type JdToUtcString = (epoch_jd: number, t: number) => string;
+type BodyOrientation = (body: string, epoch_jd: number, t: number) => Float64Array;
+type BodyQuatToRsw = (
+  pos_x: number,
+  pos_y: number,
+  pos_z: number,
+  vel_x: number,
+  vel_y: number,
+  vel_z: number,
+  qw: number,
+  qx: number,
+  qy: number,
+  qz: number,
+) => Float64Array;
+
+let initialized = false;
+let initPromise: Promise<void> | undefined;
+let wasmBatch: EciToEcefBatch | undefined;
+let wasmSingle: EciToEcef | undefined;
+let wasmEra: EarthRotationAngle | undefined;
+let wasmSunDir: SunDirectionEci | undefined;
+let wasmSunDirFromBody: SunDirectionFromBody | undefined;
+let wasmSunDistFromBody: SunDistanceFromBody | undefined;
+let wasmJdToUtc: JdToUtcString | undefined;
+let wasmBodyOrientation: BodyOrientation | undefined;
+let wasmBodyQuatToRsw: BodyQuatToRsw | undefined;
+
+/** Options for {@link initArika}. */
+export interface InitArikaOptions {
+  /**
+   * Where to load the arika `.wasm` from. Omit to let the bundler resolve it
+   * from the `arika-wasm` package (the usual case). Supply a URL to fetch it
+   * from elsewhere — e.g. a CDN, or when a bundler can't resolve the asset.
+   * Only the first init call's options take effect.
+   */
+  wasmUrl?: string | URL;
+}
+
+/**
+ * Initialize the arika WASM module. Safe to call multiple times (idempotent;
+ * the first call wins). Rejects on failure.
+ *
+ * `OrbitViewer` calls this for you when given an `epochJd`; call it explicitly
+ * only to pre-load, or to override where the wasm is fetched from via
+ * {@link InitArikaOptions.wasmUrl}.
+ */
+export function initArika(options?: InitArikaOptions): Promise<void> {
+  if (initialized) return Promise.resolve();
+  if (initPromise) return initPromise;
+
+  const p: Promise<void> = import("arika-wasm").then(async (mod) => {
+    await mod.default(options?.wasmUrl);
+    wasmBatch = mod.eci_to_ecef_batch;
+    wasmSingle = mod.eci_to_ecef;
+    wasmEra = mod.earth_rotation_angle;
+    wasmSunDir = mod.sun_direction_eci;
+    wasmSunDirFromBody = mod.sun_direction_from_body;
+    wasmSunDistFromBody = mod.sun_distance_from_body;
+    wasmJdToUtc = mod.jd_to_utc_string;
+    wasmBodyOrientation = mod.body_orientation;
+    wasmBodyQuatToRsw = mod.body_quat_to_rsw;
+    initialized = true;
+  });
+  initPromise = p;
+  return p;
+}
+
+/** Whether the WASM module is loaded and ready. */
+export function isArikaReady(): boolean {
+  return initialized;
+}
+
+/** Batch ECI→ECEF transform via WASM. */
+export function eci_to_ecef_batch(
+  positions: Float32Array,
+  times: Float32Array,
+  epoch_jd: number,
+): Float32Array {
+  return wasmBatch!(positions, times, epoch_jd);
+}
+
+/** Single-point ECI→ECEF transform via WASM. Returns [ex, ey, ez]. */
+export function eci_to_ecef(
+  x: number,
+  y: number,
+  z: number,
+  epoch_jd: number,
+  t: number,
+): Float32Array {
+  return wasmSingle!(x, y, z, epoch_jd, t);
+}
+
+/** Compute Earth Rotation Angle (GMST) in radians via WASM. */
+export function earth_rotation_angle(epoch_jd: number, t: number): number {
+  return wasmEra!(epoch_jd, t);
+}
+
+/** Approximate sun direction (unit vector) in ECI frame via WASM. Returns [x, y, z]. */
+export function sun_direction_eci(epoch_jd: number, t: number): Float32Array {
+  return wasmSunDir!(epoch_jd, t);
+}
+
+/** Sun direction (unit vector) as seen from a given body, in J2000 equatorial frame via WASM. Returns [x, y, z]. */
+export function sun_direction_from_body(body: string, epoch_jd: number, t: number): Float32Array {
+  return wasmSunDirFromBody!(body, epoch_jd, t);
+}
+
+/** Sun distance [km] from a given body via WASM. */
+export function sun_distance_from_body(body: string, epoch_jd: number, t: number): number {
+  return wasmSunDistFromBody!(body, epoch_jd, t);
+}
+
+/** Convert Julian Date + elapsed sim time to ISO 8601 UTC string via WASM. */
+export function jd_to_utc_string(epoch_jd: number, t: number): string {
+  return wasmJdToUtc!(epoch_jd, t);
+}
+
+/**
+ * Body-fixed → ECI orientation quaternion via IAU rotation model.
+ *
+ * Returns [w, x, y, z] (Hamilton scalar-first) or undefined for unknown bodies.
+ */
+export function body_orientation(
+  body: string,
+  epoch_jd: number,
+  t: number,
+): [number, number, number, number] | undefined {
+  const result = wasmBodyOrientation!(body, epoch_jd, t);
+  if (result.length === 0) return undefined;
+  return [result[0], result[1], result[2], result[3]];
+}
+
+/**
+ * Transform body-to-ECI quaternion to body-to-RSW frame via WASM.
+ *
+ * RSW axis order: [Radial, Along-track, Cross-track] (standard Vallado).
+ *
+ * Returns [w, x, y, z] (Hamilton scalar-first) or undefined if degenerate.
+ */
+export function body_quat_to_rsw(
+  pos_x: number,
+  pos_y: number,
+  pos_z: number,
+  vel_x: number,
+  vel_y: number,
+  vel_z: number,
+  qw: number,
+  qx: number,
+  qy: number,
+  qz: number,
+): [number, number, number, number] | undefined {
+  const result = wasmBodyQuatToRsw!(pos_x, pos_y, pos_z, vel_x, vel_y, vel_z, qw, qx, qy, qz);
+  if (result.length === 0) return undefined;
+  return [result[0], result[1], result[2], result[3]];
+}

--- a/viewer/examples/orbit-viewer/main.tsx
+++ b/viewer/examples/orbit-viewer/main.tsx
@@ -23,7 +23,7 @@ import {
   type TrailPoint,
   type Vec3,
   type ViewerReferenceFrame,
-} from "../../src/lib/index.js";
+} from "@/components/orbit-viewer/lib/index.js";
 
 const EARTH_RADIUS_KM = 6378.137;
 const MU = 398600.4418; // km^3/s^2

--- a/viewer/examples/orbit-viewer/package.json
+++ b/viewer/examples/orbit-viewer/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "orts-viewer-orbit-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Standalone consumer of the orts-viewer shadcn registry: installs the orbit-viewer item via `shadcn add` and renders it. Dogfoods the registry output.",
+  "scripts": {
+    "sync:registry": "pnpm --filter orts-viewer registry:build && pnpm dlx shadcn@4.11.0 add ../../public/r/orbit-viewer.json --yes --overwrite",
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "@react-three/drei": "^10.0.0",
+    "@react-three/fiber": "^9.0.0",
+    "arika-wasm": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "three": ">=0.176.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.2",
+    "@types/react": "^19.2.13",
+    "@types/react-dom": "^19.2.3",
+    "@types/three": "^0.183.0",
+    "@vitejs/plugin-react": "^6.0.0",
+    "typescript": "^5.7.0",
+    "vite": "^8.0.8"
+  }
+}

--- a/viewer/examples/orbit-viewer/playwright.config.ts
+++ b/viewer/examples/orbit-viewer/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     },
   },
   webServer: {
-    command: `vite --port ${PORT} --strictPort`,
+    command: `npx vite --port ${PORT} --strictPort`,
     port: PORT,
     reuseExistingServer: !!process.env.CI,
   },

--- a/viewer/examples/orbit-viewer/playwright.config.ts
+++ b/viewer/examples/orbit-viewer/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "@playwright/test";
+
+const PORT = Number(process.env.EXAMPLE_PORT ?? 15273);
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 60000,
+  // Live-server E2E is inherently subject to transient timing; retry on CI so a
+  // single flaky miss doesn't fail the whole job.
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    headless: true,
+    launchOptions: {
+      args: ["--use-gl=angle", "--use-angle=swiftshader"],
+    },
+  },
+  webServer: {
+    command: `vite --port ${PORT} --strictPort`,
+    port: PORT,
+    reuseExistingServer: !!process.env.CI,
+  },
+});

--- a/viewer/examples/orbit-viewer/tests/orbit-viewer-lib.spec.ts
+++ b/viewer/examples/orbit-viewer/tests/orbit-viewer-lib.spec.ts
@@ -1,6 +1,9 @@
 /**
- * E2E for the embeddable <OrbitViewer> (viewer/src/lib), driven by the standalone
- * example page (examples/orbit-viewer) — no backend.
+ * E2E for the embeddable <OrbitViewer> as a *registry consumer*: this example is
+ * a standalone workspace package that imports the shadcn-distributed source
+ * (`shadcn add`-copied into `components/orbit-viewer/`), not viewer/src/lib, and
+ * runs on its own Vite — so this also proves the registry output is consumable.
+ * No backend.
  *
  * The headline guarantee is performance: a satellite's trail is backed by a
  * *persistent* GPU buffer, so neither advancing `time` nor appending points
@@ -37,7 +40,7 @@ async function waitForTrail(page: import("@playwright/test").Page): Promise<void
 }
 
 test("renders a central body + satellite with a trail", async ({ page }) => {
-  await page.goto("/examples/orbit-viewer/");
+  await page.goto("/");
   await expect(page.locator("canvas").first()).toBeVisible();
   await waitForTrail(page);
 
@@ -47,7 +50,7 @@ test("renders a central body + satellite with a trail", async ({ page }) => {
 });
 
 test("advancing time does not rebuild the trail buffer (stable generation)", async ({ page }) => {
-  await page.goto("/examples/orbit-viewer/?animate=0"); // freeze so only the hook mutates state
+  await page.goto("/?animate=0"); // freeze so only the hook mutates state
   await waitForTrail(page);
 
   const before = await readTrail(page);
@@ -71,7 +74,7 @@ test("advancing time does not rebuild the trail buffer (stable generation)", asy
 test("appending trail points uploads incrementally (grows length, same generation)", async ({
   page,
 }) => {
-  await page.goto("/examples/orbit-viewer/?animate=0"); // freeze so only the hook mutates state
+  await page.goto("/?animate=0"); // freeze so only the hook mutates state
   await waitForTrail(page);
 
   const before = await readTrail(page);
@@ -90,7 +93,7 @@ test("appending trail points uploads incrementally (grows length, same generatio
 });
 
 test("local-orbital (LVLH) frame renders without error", async ({ page }) => {
-  await page.goto("/examples/orbit-viewer/?frame=lvlh");
+  await page.goto("/?frame=lvlh");
   await expect(page.locator("canvas").first()).toBeVisible();
   await waitForTrail(page);
   expect((await readTrail(page))?.length).toBeGreaterThan(0);
@@ -116,7 +119,7 @@ test("satellite-centred inertial and LVLH are distinct frames (#90)", async ({ p
   };
 
   // LVLH: data is transformed into the orbit frame; the camera stays put.
-  await page.goto("/examples/orbit-viewer/?frame=lvlh&animate=0");
+  await page.goto("/?frame=lvlh&animate=0");
   await waitForTrail(page);
   const lvlh = await readFrame();
   expect(lvlh?.lvlhActive).toBe(true);
@@ -124,7 +127,7 @@ test("satellite-centred inertial and LVLH are distinct frames (#90)", async ({ p
 
   // Inertial: satellite is still centred, but axes stay star-fixed —
   // no LVLH data transform and no camera co-rotation.
-  await page.goto("/examples/orbit-viewer/?frame=sat&animate=0");
+  await page.goto("/?frame=sat&animate=0");
   await waitForTrail(page);
   const inertial = await readFrame();
   expect(inertial?.originPosition).not.toBeNull();
@@ -139,7 +142,7 @@ test("renders a custom central body (bodies prop, radiusKm from the definition)"
   page.on("pageerror", (e) => errors.push(e.message));
   // ?body=custom centres on a user-defined body with no built-in entry and an
   // omitted centralBody.radiusKm (resolved from the definition).
-  await page.goto("/examples/orbit-viewer/?body=custom&animate=0");
+  await page.goto("/?body=custom&animate=0");
   await expect(page.locator("canvas").first()).toBeVisible();
   await waitForTrail(page); // scene composes around the custom body without error
   expect((await readTrail(page))?.length ?? 0).toBeGreaterThan(0);
@@ -147,7 +150,7 @@ test("renders a custom central body (bodies prop, radiusKm from the definition)"
 });
 
 test("a marker-only satellite (no trail prop) gets no trail buffer", async ({ page }) => {
-  await page.goto("/examples/orbit-viewer/?animate=0");
+  await page.goto("/?animate=0");
   await waitForTrail(page); // scene is up: the demo satellite's trail is filled
 
   const markerTrail = await page.evaluate(() => {

--- a/viewer/examples/orbit-viewer/tsconfig.json
+++ b/viewer/examples/orbit-viewer/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "types": ["vite/client"]
+  },
+  "include": ["main.tsx", "components", "tests", "vite.config.ts"]
+}

--- a/viewer/examples/orbit-viewer/vite.config.ts
+++ b/viewer/examples/orbit-viewer/vite.config.ts
@@ -1,0 +1,15 @@
+import { fileURLToPath } from "node:url";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// Standalone consumer app for the orbit-viewer registry item. `@` resolves to
+// this package root so `@/components/orbit-viewer/...` (where `shadcn add` writes
+// the copied source) imports the registry-distributed component tree.
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL(".", import.meta.url)),
+    },
+  },
+});

--- a/viewer/examples/orbit-viewer/vite.config.ts
+++ b/viewer/examples/orbit-viewer/vite.config.ts
@@ -7,6 +7,10 @@ import { defineConfig } from "vite";
 // the copied source) imports the registry-distributed component tree.
 export default defineConfig({
   plugins: [react()],
+  // Serve the viewer's static textures (/textures/earth_2k.jpg, …) that the
+  // copied default bodies request, so the example renders the textured output
+  // rather than flat fallback colours.
+  publicDir: fileURLToPath(new URL("../../public", import.meta.url)),
   resolve: {
     alias: {
       "@": fileURLToPath(new URL(".", import.meta.url)),


### PR DESCRIPTION
## What

Make `examples/orbit-viewer` a **standalone registry consumer** that imports the
shadcn-distributed source instead of `viewer/src/lib` — dogfooding the registry
from #168: a real consumer installs the `orbit-viewer` item and it compiles + runs.

Stacked on #167 (arika-wasm package) and #168 (the registry).

## How

- **Own package** `orts-viewer-orbit-example` (workspace member) with its own
  `components.json`, `tsconfig`, Vite, and Playwright config. It depends on
  `arika-wasm` via `workspace:*` (the registry omits the wasm engine; consumers
  provide it) and imports the copied tree via `@/components/orbit-viewer/*`.
- **`shadcn add` output is committed** (`components/orbit-viewer/`, 38 files) —
  that's the shadcn model ("you own the copied code"). `sync:registry`
  regenerates it (`registry:build` + `shadcn add --overwrite`).
- **E2E** moved here from `viewer/tests`, now navigating `/` against the
  example's own Vite, and wired into the `viewer-e2e` CI job (reuses its
  wasm/Playwright setup; backend-free).
- biome ignores the vendored copy.

## Verified

- example `tsc --noEmit` clean — the copied registry source compiles in a
  standalone consumer (own tsconfig, `@/` alias, the bundler-neutral env shim,
  arika-wasm types).
- Playwright **7/7** on the example's own Vite (arika-wasm loads; trails, frames,
  custom body, marker).
- Lockfile gains **only** the example importer (+44 lines, no incidental bumps).

## Notes for reviewers (decisions worth scrutiny)

- **Committed copy vs gitignore+regenerate.** smart-friend (codex) preferred
  gitignore+regenerate, but `shadcn add`'s dependency install trips this repo's
  release-age supply-chain gate, so it can't run in CI. Committing the copy (the
  faithful consumer model) keeps CI simple — it E2Es the committed output;
  `sync:registry` regenerates locally. Drift is bounded: the registry *manifest*
  is drift-checked in viewer, and the copy is a consumer snapshot.
- **`shadcn add` strips each file's leading banner comment** (20/38 files differ
  from source only by that). It's a shadcn add-time transform — the registry
  source under `viewer/src` and the built `public/r` retain the comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
