### PR TITLE
fix(viewer): de-flake viewer-e2e — pre-bundle + self-host DuckDB-wasm (#70)

### DIFF
--- a/uneri/src/db/duckdb.test.ts
+++ b/uneri/src/db/duckdb.test.ts
@@ -1,6 +1,6 @@
 import * as duckdb from "@duckdb/duckdb-wasm";
 import { describe, expect, it } from "vitest";
-import { type DuckDBBundleUrls, resolveBundleSource } from "./duckdb.js";
+import { type DuckDBBundleUrls, resolveBundleSource, toAbsoluteBundleUrl } from "./duckdb.js";
 
 // Self-hosted bundle URLs as an app bundler (e.g. Vite `?url`) would resolve
 // them: root-relative asset paths, never a CDN.
@@ -44,5 +44,38 @@ describe("resolveBundleSource", () => {
 
   it("uses no secondary fallback when jsDelivr is already the primary source", () => {
     expect(resolveBundleSource().allowJsDelivrFallback).toBe(false);
+  });
+});
+
+describe("toAbsoluteBundleUrl", () => {
+  // DuckDB instantiates its worker from a Blob whose base is the opaque
+  // `blob:` URL, so root-relative paths (what a Vite `?url` import yields)
+  // must be absolutized against the document origin before `importScripts`.
+  const WORKER_BASE = "http://localhost:15173/@fs/repo/uneri/src/worker/multiChartDataWorker.ts";
+
+  it("absolutizes a Vite build root-relative asset path against the origin", () => {
+    expect(toAbsoluteBundleUrl("/assets/duckdb-eh.wasm", WORKER_BASE)).toBe(
+      "http://localhost:15173/assets/duckdb-eh.wasm",
+    );
+  });
+
+  it("absolutizes a Vite dev `/@fs/` path against the origin", () => {
+    expect(toAbsoluteBundleUrl("/@fs/repo/node_modules/duckdb-eh.wasm?url", WORKER_BASE)).toBe(
+      "http://localhost:15173/@fs/repo/node_modules/duckdb-eh.wasm?url",
+    );
+  });
+
+  it("honors a configured base path in the root-relative URL", () => {
+    expect(
+      toAbsoluteBundleUrl(
+        "/orts/viewer/assets/duckdb-eh.wasm",
+        "https://sksat.github.io/orts/viewer/",
+      ),
+    ).toBe("https://sksat.github.io/orts/viewer/assets/duckdb-eh.wasm");
+  });
+
+  it("passes an already-absolute URL (e.g. jsDelivr) through unchanged", () => {
+    const cdn = "https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm/dist/duckdb-eh.wasm";
+    expect(toAbsoluteBundleUrl(cdn, WORKER_BASE)).toBe(cdn);
   });
 });

--- a/uneri/src/db/duckdb.test.ts
+++ b/uneri/src/db/duckdb.test.ts
@@ -1,0 +1,48 @@
+import * as duckdb from "@duckdb/duckdb-wasm";
+import { describe, expect, it } from "vitest";
+import { type DuckDBBundleUrls, resolveBundleSource } from "./duckdb.js";
+
+// Self-hosted bundle URLs as an app bundler (e.g. Vite `?url`) would resolve
+// them: root-relative asset paths, never a CDN.
+const LOCAL_BUNDLES: DuckDBBundleUrls = {
+  mvp: {
+    mainModule: "/assets/duckdb-mvp.wasm",
+    mainWorker: "/assets/duckdb-browser-mvp.worker.js",
+  },
+  eh: {
+    mainModule: "/assets/duckdb-eh.wasm",
+    mainWorker: "/assets/duckdb-browser-eh.worker.js",
+  },
+};
+
+describe("resolveBundleSource", () => {
+  it("returns injected bundles verbatim (never the CDN) when bundles are given", () => {
+    const { bundles } = resolveBundleSource({ bundles: LOCAL_BUNDLES });
+    // Referential identity proves jsDelivr was never consulted.
+    expect(bundles).toBe(LOCAL_BUNDLES);
+    expect(bundles.mvp.mainModule).not.toContain("jsdelivr");
+  });
+
+  it("falls back to the jsDelivr CDN bundles when no options are given", () => {
+    const { bundles } = resolveBundleSource();
+    const cdn = duckdb.getJsDelivrBundles();
+    expect(bundles.mvp.mainModule).toBe(cdn.mvp.mainModule);
+    expect(bundles.mvp.mainModule).toContain("jsdelivr");
+  });
+
+  it("forbids a jsDelivr fallback for explicit local bundles by default (hermetic)", () => {
+    expect(resolveBundleSource({ bundles: LOCAL_BUNDLES }).allowJsDelivrFallback).toBe(false);
+  });
+
+  it("permits a jsDelivr fallback for local bundles only when explicitly opted in", () => {
+    const { allowJsDelivrFallback } = resolveBundleSource({
+      bundles: LOCAL_BUNDLES,
+      fallbackToJsDelivr: true,
+    });
+    expect(allowJsDelivrFallback).toBe(true);
+  });
+
+  it("uses no secondary fallback when jsDelivr is already the primary source", () => {
+    expect(resolveBundleSource().allowJsDelivrFallback).toBe(false);
+  });
+});

--- a/uneri/src/db/duckdb.ts
+++ b/uneri/src/db/duckdb.ts
@@ -6,19 +6,74 @@ const MAX_ATTEMPTS = 3;
 // Generous backstop for a silently-dead/hung worker — kept long so it does NOT
 // abort a slow-but-healthy first load (large wasm fetch + compile on a slow
 // network/device). The worker `error` listener below fast-fails the common
-// CDN-unreachable case well before this fires.
+// load-failure case well before this fires.
 const INIT_TIMEOUT_MS = 45000;
 
 /**
- * One DuckDB-wasm instantiation attempt using the jsDelivr CDN bundles.
- *
- * Rejects (rather than hanging) when the CDN worker/wasm can't be fetched: a
- * failed `importScripts` kills the worker, after which `instantiate()` would
- * otherwise wait forever for a dead worker to reply. A worker `error` event or
- * an overall timeout both abort the attempt so the caller can retry.
+ * URLs for one DuckDB-wasm platform bundle variant. Matches the shape
+ * `duckdb.selectBundle` expects, but every field is a plain string so the
+ * whole object is structured-clonable across a `postMessage` boundary
+ * (Worker `init`) and free of any bundler-specific import syntax.
  */
-async function instantiateOnce(): Promise<duckdb.AsyncDuckDB> {
-  const bundle = await duckdb.selectBundle(duckdb.getJsDelivrBundles());
+export interface DuckDBBundleUrls {
+  mvp: { mainModule: string; mainWorker: string };
+  eh?: { mainModule: string; mainWorker: string };
+  coi?: { mainModule: string; mainWorker: string; pthreadWorker: string };
+}
+
+/**
+ * How `initDuckDB` should source the DuckDB-wasm worker/wasm assets.
+ *
+ * The app (which owns a bundler) resolves the self-hosted asset URLs and
+ * passes them in via `bundles`; uneri itself stays bundler-neutral and never
+ * references `?url`/`new URL(..., import.meta.url)`. When `bundles` is omitted
+ * the legacy jsDelivr CDN path is used so existing consumers keep working.
+ */
+export interface DuckDBInitOptions {
+  /** Pre-resolved self-hosted bundle URLs. Omit to use the jsDelivr CDN. */
+  bundles?: DuckDBBundleUrls;
+  /**
+   * When `bundles` is set, permit a last-ditch jsDelivr CDN attempt if every
+   * local attempt fails. Defaults to `false`: an explicitly self-hosted setup
+   * should fail loudly rather than silently reaching the network, which is the
+   * whole point of going hermetic. Ignored when `bundles` is omitted.
+   */
+  fallbackToJsDelivr?: boolean;
+}
+
+/**
+ * Decide which bundle set to load and whether a jsDelivr fallback is allowed.
+ * Pure (no I/O) so the policy is unit-testable without instantiating DuckDB.
+ *
+ * - Injected `bundles` are returned verbatim — jsDelivr is never consulted,
+ *   and a fallback is only allowed when explicitly opted into.
+ * - With no options, the jsDelivr CDN bundles are the primary source; there is
+ *   no secondary fallback because we are already on the CDN (the retry loop in
+ *   `initDuckDB` handles transient CDN hiccups).
+ */
+export function resolveBundleSource(options?: DuckDBInitOptions): {
+  bundles: duckdb.DuckDBBundles;
+  allowJsDelivrFallback: boolean;
+} {
+  if (options?.bundles) {
+    return {
+      bundles: options.bundles as duckdb.DuckDBBundles,
+      allowJsDelivrFallback: options.fallbackToJsDelivr ?? false,
+    };
+  }
+  return { bundles: duckdb.getJsDelivrBundles(), allowJsDelivrFallback: false };
+}
+
+/**
+ * One DuckDB-wasm instantiation attempt against an already-selected bundle set.
+ *
+ * Rejects (rather than hanging) when the worker/wasm can't be fetched: a failed
+ * `importScripts` kills the worker, after which `instantiate()` would otherwise
+ * wait forever for a dead worker to reply. A worker `error` event or an overall
+ * timeout both abort the attempt so the caller can retry.
+ */
+async function instantiateOnce(bundles: duckdb.DuckDBBundles): Promise<duckdb.AsyncDuckDB> {
+  const bundle = await duckdb.selectBundle(bundles);
 
   const workerUrl = URL.createObjectURL(
     new Blob([`importScripts("${bundle.mainWorker!}");`], { type: "text/javascript" }),
@@ -40,11 +95,7 @@ async function instantiateOnce(): Promise<duckdb.AsyncDuckDB> {
         "error",
         (ev: ErrorEvent) =>
           settle(() =>
-            reject(
-              new Error(
-                `DuckDB worker failed to load (CDN unreachable?): ${ev.message || "unknown error"}`,
-              ),
-            ),
+            reject(new Error(`DuckDB worker failed to load: ${ev.message || "unknown error"}`)),
           ),
         { once: true },
       );
@@ -62,33 +113,51 @@ async function instantiateOnce(): Promise<duckdb.AsyncDuckDB> {
   }
 }
 
-/**
- * Initialize DuckDB-wasm (singleton), loading the worker/wasm from the jsDelivr
- * CDN. Retries a few times so a transient CDN hiccup doesn't fail the whole
- * session — a recurring source of viewer E2E flakiness (see #70).
- * Safe to call multiple times — returns the same promise.
- */
-export function initDuckDB(): Promise<duckdb.AsyncDuckDB> {
-  if (dbPromise) return dbPromise;
-
-  dbPromise = (async () => {
-    let lastError: unknown;
-    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-      try {
-        return await instantiateOnce();
-      } catch (e) {
-        lastError = e;
-        if (attempt < MAX_ATTEMPTS) {
-          await new Promise((r) => setTimeout(r, attempt * 500));
-        }
+/** Run `instantiateOnce` up to `MAX_ATTEMPTS` times with linear backoff. */
+async function instantiateWithRetry(bundles: duckdb.DuckDBBundles): Promise<duckdb.AsyncDuckDB> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      return await instantiateOnce(bundles);
+    } catch (e) {
+      lastError = e;
+      if (attempt < MAX_ATTEMPTS) {
+        await new Promise((r) => setTimeout(r, attempt * 500));
       }
     }
-    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+/**
+ * Initialize DuckDB-wasm (singleton). By default the worker/wasm are loaded
+ * from self-hosted URLs supplied via `options.bundles`; with no options the
+ * jsDelivr CDN is used (legacy behavior). Retries a few times so a transient
+ * hiccup doesn't fail the whole session — historically a source of viewer E2E
+ * flakiness (see #70/#65). Safe to call multiple times — returns the same
+ * promise, so the first caller's `options` win.
+ */
+export function initDuckDB(options?: DuckDBInitOptions): Promise<duckdb.AsyncDuckDB> {
+  if (dbPromise) return dbPromise;
+
+  const { bundles, allowJsDelivrFallback } = resolveBundleSource(options);
+
+  dbPromise = (async () => {
+    try {
+      return await instantiateWithRetry(bundles);
+    } catch (e) {
+      // Only reachable when the caller injected local bundles AND opted into a
+      // CDN fallback; the default hermetic path rethrows here.
+      if (allowJsDelivrFallback) {
+        return await instantiateWithRetry(duckdb.getJsDelivrBundles());
+      }
+      throw e;
+    }
   })();
 
-  // If every attempt failed, drop the cached rejected promise so a later
-  // call (e.g. after the user reconnects) retries from scratch instead of
-  // replaying the same rejection for the rest of the session.
+  // If every attempt failed, drop the cached rejected promise so a later call
+  // (e.g. after the user reconnects) retries from scratch instead of replaying
+  // the same rejection for the rest of the session.
   dbPromise.catch(() => {
     dbPromise = null;
   });

--- a/uneri/src/db/duckdb.ts
+++ b/uneri/src/db/duckdb.ts
@@ -65,6 +65,19 @@ export function resolveBundleSource(options?: DuckDBInitOptions): {
 }
 
 /**
+ * Resolve a (possibly root-relative) bundle URL to an absolute URL against
+ * `base`. DuckDB instantiates its worker from a Blob whose base is the opaque
+ * `blob:` URL, against which a root-relative path like `/assets/duckdb-eh.wasm`
+ * (what a Vite `?url` import yields) cannot be resolved — `importScripts` throws
+ * "invalid URL". Absolutizing here lets callers pass the URLs their bundler
+ * produces verbatim. Already-absolute URLs (e.g. jsDelivr) pass through
+ * unchanged. Pure.
+ */
+export function toAbsoluteBundleUrl(url: string, base: string): string {
+  return new URL(url, base).href;
+}
+
+/**
  * One DuckDB-wasm instantiation attempt against an already-selected bundle set.
  *
  * Rejects (rather than hanging) when the worker/wasm can't be fetched: a failed
@@ -73,10 +86,21 @@ export function resolveBundleSource(options?: DuckDBInitOptions): {
  * timeout both abort the attempt so the caller can retry.
  */
 async function instantiateOnce(bundles: duckdb.DuckDBBundles): Promise<duckdb.AsyncDuckDB> {
-  const bundle = await duckdb.selectBundle(bundles);
+  const selected = await duckdb.selectBundle(bundles);
+
+  if (!selected.mainWorker) {
+    throw new Error("Selected DuckDB bundle has no mainWorker URL");
+  }
+  // Absolutize against the worker's own origin so root-relative bundler URLs
+  // work inside the blob worker below (see `toAbsoluteBundleUrl`).
+  const base = self.location.href;
+  const mainWorker = toAbsoluteBundleUrl(selected.mainWorker, base);
+  const mainModule = toAbsoluteBundleUrl(selected.mainModule, base);
+  const pthreadWorker =
+    selected.pthreadWorker != null ? toAbsoluteBundleUrl(selected.pthreadWorker, base) : undefined;
 
   const workerUrl = URL.createObjectURL(
-    new Blob([`importScripts("${bundle.mainWorker!}");`], { type: "text/javascript" }),
+    new Blob([`importScripts("${mainWorker}");`], { type: "text/javascript" }),
   );
   const worker = new Worker(workerUrl);
   const db = new duckdb.AsyncDuckDB(new duckdb.VoidLogger(), worker);
@@ -99,7 +123,7 @@ async function instantiateOnce(bundles: duckdb.DuckDBBundles): Promise<duckdb.As
           ),
         { once: true },
       );
-      db.instantiate(bundle.mainModule, bundle.pthreadWorker).then(
+      db.instantiate(mainModule, pthreadWorker).then(
         () => settle(resolve),
         (err) => settle(() => reject(err)),
       );

--- a/uneri/src/db/duckdb.ts
+++ b/uneri/src/db/duckdb.ts
@@ -154,12 +154,12 @@ async function instantiateWithRetry(bundles: duckdb.DuckDBBundles): Promise<duck
 }
 
 /**
- * Initialize DuckDB-wasm (singleton). By default the worker/wasm are loaded
- * from self-hosted URLs supplied via `options.bundles`; with no options the
- * jsDelivr CDN is used (legacy behavior). Retries a few times so a transient
- * hiccup doesn't fail the whole session — historically a source of viewer E2E
- * flakiness (see #70/#65). Safe to call multiple times — returns the same
- * promise, so the first caller's `options` win.
+ * Initialize DuckDB-wasm (singleton). When `options.bundles` is provided, the
+ * worker/wasm are loaded from those (self-hosted) URLs; with no options it
+ * falls back to the jsDelivr CDN (legacy behavior). Retries a few times so a
+ * transient hiccup doesn't fail the whole session — historically a source of
+ * viewer E2E flakiness (see #70/#65). Safe to call multiple times — returns the
+ * same promise, so the first caller's `options` win.
  */
 export function initDuckDB(options?: DuckDBInitOptions): Promise<duckdb.AsyncDuckDB> {
   if (dbPromise) return dbPromise;

--- a/uneri/src/hooks/useTimeSeriesStoreWorker.ts
+++ b/uneri/src/hooks/useTimeSeriesStoreWorker.ts
@@ -8,6 +8,7 @@
  */
 
 import { useEffect, useRef, useState } from "react";
+import type { DuckDBInitOptions } from "../db/duckdb.js";
 import type { IngestBuffer } from "../db/IngestBuffer.js";
 import type { ChartDataMap, TableSchema, TimePoint } from "../types.js";
 import { ChartDataWorkerClient } from "../worker/chartDataWorkerClient.js";
@@ -37,6 +38,11 @@ export interface UseTimeSeriesStoreWorkerOptions<T extends TimePoint> {
   clientRef?: React.MutableRefObject<ChartDataWorkerClient | null>;
   /** Set to false to disable the Worker (no Worker is spawned). Default: true. */
   enabled?: boolean;
+  /**
+   * How the Worker should source DuckDB-wasm assets. Pass self-hosted bundle
+   * URLs here to avoid the jsDelivr CDN. Defaults to the CDN when omitted.
+   */
+  duckDB?: DuckDBInitOptions;
 }
 
 /** Extract the serializable portion of a TableSchema (excluding toRow). */
@@ -62,7 +68,10 @@ export function useTimeSeriesStoreWorker<T extends TimePoint>(
     hotRowBudget,
     clientRef: externalClientRef,
     enabled = true,
+    duckDB,
   } = options;
+  const duckDBRef = useRef(duckDB);
+  duckDBRef.current = duckDB;
 
   const [data, setData] = useState<ChartDataMap | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -107,6 +116,7 @@ export function useTimeSeriesStoreWorker<T extends TimePoint>(
       tickInterval,
       coldRefreshEveryN,
       hotRowBudget,
+      duckDB: duckDBRef.current,
     });
 
     // Send initial configuration

--- a/uneri/src/index.ts
+++ b/uneri/src/index.ts
@@ -11,7 +11,8 @@ export {
   TimeSeriesChart,
 } from "./components/TimeSeriesChart.js";
 // DB
-export { initDuckDB } from "./db/duckdb.js";
+export type { DuckDBBundleUrls, DuckDBInitOptions } from "./db/duckdb.js";
+export { initDuckDB, resolveBundleSource } from "./db/duckdb.js";
 export { IngestBuffer } from "./db/IngestBuffer.js";
 export type { CompactOptions } from "./db/store.js";
 export {

--- a/uneri/src/worker/chartDataWorker.ts
+++ b/uneri/src/worker/chartDataWorker.ts
@@ -277,7 +277,7 @@ self.onmessage = async (e: MessageEvent<MainToWorkerMessage>) => {
           useAdaptiveAllMode = false;
         }
         if (msg.hotRowBudget != null) HOT_ROW_BUDGET = msg.hotRowBudget;
-        const db = await initDuckDB();
+        const db = await initDuckDB(msg.duckDB);
         conn = await db.connect();
         await createTable(conn, toTableSchema(schema));
 

--- a/uneri/src/worker/chartDataWorkerClient.ts
+++ b/uneri/src/worker/chartDataWorkerClient.ts
@@ -5,6 +5,7 @@
  * and typed callbacks for chart data and errors.
  */
 
+import type { DuckDBInitOptions } from "../db/duckdb.js";
 import type { TimeRange } from "../hooks/useTimeSeriesStore.js";
 import type { ChartDataMap } from "../types.js";
 import type {
@@ -42,7 +43,12 @@ export class ChartDataWorkerClient {
   /** Initialize the Worker with a table schema and optional tick parameters. */
   init(
     schema: WorkerTableSchema,
-    opts?: { tickInterval?: number; coldRefreshEveryN?: number; hotRowBudget?: number },
+    opts?: {
+      tickInterval?: number;
+      coldRefreshEveryN?: number;
+      hotRowBudget?: number;
+      duckDB?: DuckDBInitOptions;
+    },
   ): void {
     this.send({ type: "init", schema, ...opts });
   }

--- a/uneri/src/worker/multiChartDataWorker.ts
+++ b/uneri/src/worker/multiChartDataWorker.ts
@@ -320,7 +320,7 @@ self.onmessage = async (e: MessageEvent<MultiMainToWorkerMessage>) => {
         if (msg.queryEveryN != null) QUERY_EVERY_N = msg.queryEveryN;
         if (msg.compactEveryN != null) COMPACT_EVERY_N = msg.compactEveryN;
 
-        const db = await initDuckDB();
+        const db = await initDuckDB(msg.duckDB);
         conn = await db.connect();
 
         // Create tables for initial satellite configs

--- a/uneri/src/worker/multiChartDataWorkerClient.ts
+++ b/uneri/src/worker/multiChartDataWorkerClient.ts
@@ -2,6 +2,7 @@
  * Main-thread typed wrapper for the multi-satellite chart data Web Worker.
  */
 
+import type { DuckDBInitOptions } from "../db/duckdb.js";
 import type { TimeRange } from "../hooks/useTimeSeriesStore.js";
 import type {
   MultiMainToWorkerMessage,
@@ -53,7 +54,12 @@ export class MultiChartDataWorkerClient {
     baseSchema: WorkerTableSchema,
     satelliteConfigs: WorkerSatelliteConfig[],
     metricNames: string[],
-    opts?: { tickInterval?: number; queryEveryN?: number; compactEveryN?: number },
+    opts?: {
+      tickInterval?: number;
+      queryEveryN?: number;
+      compactEveryN?: number;
+      duckDB?: DuckDBInitOptions;
+    },
   ): void {
     this.send({
       type: "multi-init",

--- a/uneri/src/worker/protocol.ts
+++ b/uneri/src/worker/protocol.ts
@@ -6,6 +6,7 @@
  * ready-to-render ChartDataMap via zero-copy ArrayBuffer transfer.
  */
 
+import type { DuckDBInitOptions } from "../db/duckdb.js";
 import type { TimeRange } from "../hooks/useTimeSeriesStore.js";
 import type { ColumnDef, DerivedColumn } from "../types.js";
 
@@ -33,6 +34,8 @@ export type MainToWorkerMessage =
       tickInterval?: number;
       coldRefreshEveryN?: number;
       hotRowBudget?: number;
+      /** How the Worker should source DuckDB-wasm assets (self-host vs CDN). */
+      duckDB?: DuckDBInitOptions;
     }
   | { type: "ingest"; rows: RowTuple[]; latestT: number }
   | { type: "rebuild"; rows: RowTuple[]; latestT: number }
@@ -63,6 +66,8 @@ export type MultiMainToWorkerMessage =
       tickInterval?: number;
       queryEveryN?: number;
       compactEveryN?: number;
+      /** How the Worker should source DuckDB-wasm assets (self-host vs CDN). */
+      duckDB?: DuckDBInitOptions;
     }
   | { type: "multi-ingest"; satelliteId: string; rows: RowTuple[]; latestT: number }
   | { type: "multi-rebuild"; satelliteId: string; rows: RowTuple[]; latestT: number }

--- a/viewer/src/duckdbBundles.ts
+++ b/viewer/src/duckdbBundles.ts
@@ -21,7 +21,16 @@ import type { DuckDBBundleUrls } from "@sksat/uneri";
  * `crossOriginIsolated` is true. The mvp + eh variants cover every browser we
  * target.
  */
+// Vite resolves `?url` to a *root-relative* path (`/assets/…` in a build,
+// `/@fs/…` in dev). DuckDB instantiates its worker via a Blob that calls
+// `importScripts(mainWorker)`; inside that Blob worker the base URL is the
+// opaque `blob:` URL, against which a root-relative path cannot be resolved
+// ("invalid URL"). Resolving to an absolute URL against the document origin
+// up front makes both the `importScripts` and the worker's own wasm fetch
+// work regardless of the worker's base.
+const abs = (url: string): string => new URL(url, window.location.origin).href;
+
 export const duckdbBundles: DuckDBBundleUrls = {
-  mvp: { mainModule: mvpWasm, mainWorker: mvpWorker },
-  eh: { mainModule: ehWasm, mainWorker: ehWorker },
+  mvp: { mainModule: abs(mvpWasm), mainWorker: abs(mvpWorker) },
+  eh: { mainModule: abs(ehWasm), mainWorker: abs(ehWorker) },
 };

--- a/viewer/src/duckdbBundles.ts
+++ b/viewer/src/duckdbBundles.ts
@@ -1,0 +1,27 @@
+import ehWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url";
+import mvpWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url";
+import ehWasm from "@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url";
+import mvpWasm from "@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url";
+import type { DuckDBBundleUrls } from "@sksat/uneri";
+
+/**
+ * Self-hosted DuckDB-wasm bundle URLs, resolved by Vite from the installed
+ * `@duckdb/duckdb-wasm` package — no jsDelivr CDN.
+ *
+ * Vite emits these assets into the build and rewrites the imports to hashed,
+ * root-relative URLs, so they resolve against the document origin even from
+ * the nested DuckDB worker. Keeping the CDN out of the runtime path makes the
+ * viewer hermetic (offline-capable, no third-party dependency) and removes the
+ * intermittent CDN/worker-asset load failures behind the viewer-e2e flakiness
+ * (issue #70). This is bundler-specific glue, so it lives in the app rather
+ * than in uneri (which only consumes the resolved string URLs).
+ *
+ * `coi` (cross-origin-isolated / pthreads) is intentionally omitted: it needs
+ * COOP/COEP headers we don't serve, and `selectBundle` only picks it when
+ * `crossOriginIsolated` is true. The mvp + eh variants cover every browser we
+ * target.
+ */
+export const duckdbBundles: DuckDBBundleUrls = {
+  mvp: { mainModule: mvpWasm, mainWorker: mvpWorker },
+  eh: { mainModule: ehWasm, mainWorker: ehWorker },
+};

--- a/viewer/src/duckdbBundles.ts
+++ b/viewer/src/duckdbBundles.ts
@@ -8,29 +8,22 @@ import type { DuckDBBundleUrls } from "@sksat/uneri";
  * Self-hosted DuckDB-wasm bundle URLs, resolved by Vite from the installed
  * `@duckdb/duckdb-wasm` package — no jsDelivr CDN.
  *
- * Vite emits these assets into the build and rewrites the imports to hashed,
- * root-relative URLs, so they resolve against the document origin even from
- * the nested DuckDB worker. Keeping the CDN out of the runtime path makes the
- * viewer hermetic (offline-capable, no third-party dependency) and removes the
+ * Vite emits these assets into the build and rewrites the imports to hashed
+ * asset URLs. Keeping the CDN out of the runtime path makes the viewer
+ * hermetic (offline-capable, no third-party dependency) and removes the
  * intermittent CDN/worker-asset load failures behind the viewer-e2e flakiness
  * (issue #70). This is bundler-specific glue, so it lives in the app rather
- * than in uneri (which only consumes the resolved string URLs).
+ * than in uneri (which only consumes the resolved string URLs). The URLs Vite
+ * produces are root-relative; `initDuckDB` absolutizes them against the worker
+ * origin so they work inside DuckDB's blob worker (see `toAbsoluteBundleUrl`),
+ * matching the duckdb-wasm Vite usage example.
  *
  * `coi` (cross-origin-isolated / pthreads) is intentionally omitted: it needs
  * COOP/COEP headers we don't serve, and `selectBundle` only picks it when
  * `crossOriginIsolated` is true. The mvp + eh variants cover every browser we
  * target.
  */
-// Vite resolves `?url` to a *root-relative* path (`/assets/…` in a build,
-// `/@fs/…` in dev). DuckDB instantiates its worker via a Blob that calls
-// `importScripts(mainWorker)`; inside that Blob worker the base URL is the
-// opaque `blob:` URL, against which a root-relative path cannot be resolved
-// ("invalid URL"). Resolving to an absolute URL against the document origin
-// up front makes both the `importScripts` and the worker's own wasm fetch
-// work regardless of the worker's base.
-const abs = (url: string): string => new URL(url, window.location.origin).href;
-
 export const duckdbBundles: DuckDBBundleUrls = {
-  mvp: { mainModule: abs(mvpWasm), mainWorker: abs(mvpWorker) },
-  eh: { mainModule: abs(ehWasm), mainWorker: abs(ehWorker) },
+  mvp: { mainModule: mvpWasm, mainWorker: mvpWorker },
+  eh: { mainModule: ehWasm, mainWorker: ehWorker },
 };

--- a/viewer/src/hooks/useMultiSatelliteStoreWorker.ts
+++ b/viewer/src/hooks/useMultiSatelliteStoreWorker.ts
@@ -5,13 +5,19 @@
  * buildMultiChartData entirely to a Web Worker.
  */
 
-import { useEffect, useRef, useState } from "react";
-import type { IngestBuffer, TableSchema, TimePoint, TimeRange } from "@sksat/uneri";
+import type {
+  DuckDBInitOptions,
+  IngestBuffer,
+  TableSchema,
+  TimePoint,
+  TimeRange,
+} from "@sksat/uneri";
 import type {
   MultiChartDataResult,
   MultiChartDataWorkerClient,
 } from "@sksat/uneri/multiWorkerClient";
 import type { WorkerSatelliteConfig, WorkerTableSchema } from "@sksat/uneri/workerProtocol";
+import { useEffect, useRef, useState } from "react";
 import type { MultiChartDataMap, SatelliteConfig } from "./buildMultiChartData.js";
 
 export interface UseMultiSatelliteStoreWorkerOptions<T extends TimePoint> {
@@ -31,6 +37,11 @@ export interface UseMultiSatelliteStoreWorkerOptions<T extends TimePoint> {
    * (e.g. `handleChartZoom`) and fire ad-hoc `zoomQuery` requests.
    */
   clientRef?: React.RefObject<MultiChartDataWorkerClient | null>;
+  /**
+   * How the Worker should source DuckDB-wasm assets. Pass self-hosted bundle
+   * URLs here to avoid the jsDelivr CDN. Defaults to the CDN when omitted.
+   */
+  duckDB?: DuckDBInitOptions;
 }
 
 export interface UseMultiSatelliteStoreWorkerReturn {
@@ -80,7 +91,10 @@ export function useMultiSatelliteStoreWorker<T extends TimePoint>(
     drainInterval = 500,
     enabled = true,
     clientRef: externalClientRef,
+    duckDB,
   } = options;
+  const duckDBRef = useRef(duckDB);
+  duckDBRef.current = duckDB;
 
   const [data, setData] = useState<MultiChartDataMap | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -152,6 +166,7 @@ export function useMultiSatelliteStoreWorker<T extends TimePoint>(
         toWorkerSchema(baseSchemaRef.current),
         toWorkerConfigs(configsRef.current),
         metricNamesRef.current,
+        { duckDB: duckDBRef.current },
       );
 
       client.configure(timeRangeRef.current, maxPointsRef.current);

--- a/viewer/src/hooks/useSimulationData.ts
+++ b/viewer/src/hooks/useSimulationData.ts
@@ -1,4 +1,3 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ChartDataWorkerClient, IngestBuffer as IngestBufferType } from "@sksat/uneri";
 import {
   type ChartBuffer,
@@ -13,8 +12,10 @@ import type {
   MultiChartDataResult,
   MultiChartDataWorkerClient,
 } from "@sksat/uneri/multiWorkerClient";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { METRIC_NAMES } from "../chartMetrics.js";
 import { createOrbitSchema } from "../db/orbitSchema.js";
+import { duckdbBundles } from "../duckdbBundles.js";
 import type { OrbitPoint } from "../orbit.js";
 import type { MultiChartDataMap } from "./buildMultiChartData.js";
 import type { SatelliteConfig } from "./useMultiSatelliteStore.js";
@@ -248,6 +249,7 @@ export function useSimulationData(options: UseSimulationDataOptions): Simulation
     timeRange,
     enabled: !isMultiSatellite,
     clientRef: workerClientRef,
+    duckDB: { bundles: duckdbBundles },
   });
 
   // Charts: multi-satellite mode (Worker-based)
@@ -259,6 +261,7 @@ export function useSimulationData(options: UseSimulationDataOptions): Simulation
     timeRange,
     enabled: isMultiSatellite,
     clientRef: multiWorkerClientRef,
+    duckDB: { bundles: duckdbBundles },
   });
 
   // When the user zooms, the one-shot multi-zoom-query result takes

--- a/viewer/vite.config.ts
+++ b/viewer/vite.config.ts
@@ -41,6 +41,13 @@ export default defineConfig({
     outDir: "dist",
   },
   optimizeDeps: {
-    exclude: ["@duckdb/duckdb-wasm"],
+    // Force pre-bundling of duckdb-wasm. Without it, the chart Web Worker pulls
+    // duckdb's transitive graph (apache-arrow et al., ~140 modules) as raw ESM
+    // requests; on a cold CI dev server one of them intermittently 404s and
+    // kills the worker — the dominant cause of viewer-e2e flakiness (#70).
+    // Pre-bundling collapses that to a handful of requests. (Previously
+    // `exclude` — a cargo-culted duckdb-wasm default; pre-bundling works here.
+    // `include` also forces it even when Vite's dep scan skips pre-bundling.)
+    include: ["@duckdb/duckdb-wasm"],
   },
 });


### PR DESCRIPTION
## Why

`viewer-e2e` is flaky on `main` (~5%), always the same test: `multi-satellite-nan.spec.ts › aligned multi-sat chart data…` (issue **#70**). The symptom: the chart Web Worker can't initialize DuckDB → the chart never populates → 30s timeout.

The worker must load two things over the dev server: (1) DuckDB's wasm/worker **binary assets**, and (2) the **`@duckdb/duckdb-wasm` JS library** (+ its transitive deps: apache-arrow, flatbuffers, …). A failure of either kills the worker with the same symptom.

### Root cause (dominant): un-prebundled library module graph

`viewer/vite.config.ts` had `optimizeDeps.exclude: ["@duckdb/duckdb-wasm"]`, so Vite never pre-bundled duckdb and the worker loaded its transitive graph as raw individual ESM requests. Measured locally:

| | `exclude` (before) | `include` (after) |
|---|---:|---:|
| worker module-graph requests | **138** | **3** |
| └ apache-arrow | 129 | 0 |
| └ flatbuffers | 6 | 0 |
| wasm/worker assets | 6 | 6 |

On a cold CI dev server, one of those ~138 requests intermittently 404s → worker dies (`Worker error: undefined`, a *module-load* failure, not an asset failure). Switching to `optimizeDeps.include` collapses the graph to ~3 requests; the worker still inits and `vite build` is unaffected (optimizeDeps is dev-only). `include` also forces pre-bundling even when Vite's dep scan skips it (a separate pre-existing issue: the `@/components/orbit-viewer/lib/index.js` example import from #168 fails to resolve and disables pre-bundling for the run).

### Complementary: self-host the binary assets (no jsDelivr)

DuckDB's wasm/worker were fetched from the jsDelivr CDN at runtime (`getJsDelivrBundles()`) — a real but secondary trigger (only ~6 of the requests; CDN latency could still stall init). This PR makes them injectable so the app self-hosts them from its own bundler output (hermetic, offline-capable, no third-party runtime dependency).

- **uneri (bundler-neutral core):** `initDuckDB(options?)` accepts pre-resolved `DuckDBBundleUrls`; pure, unit-tested `resolveBundleSource` returns injected bundles verbatim and never consults jsDelivr (no CDN fallback unless `fallbackToJsDelivr`). `toAbsoluteBundleUrl` (pure, unit-tested) absolutizes the selected bundle URLs against the worker origin so root-relative bundler URLs work inside DuckDB's blob worker. `duckDB` option threaded through the worker protocol/clients/init handlers and chart hooks (URLs travel via the worker init message). No options ⇒ legacy CDN path (back-compat).
- **viewer (app):** `duckdbBundles.ts` resolves mvp+eh wasm/worker via Vite `?url` (bundler glue stays in the app), wired into both chart hooks.

Together the worker loads only a handful of reliable, local resources.

## Verification

- uneri unit **154** (9 new: `resolveBundleSource` + `toAbsoluteBundleUrl`, TDD-first), viewer unit **424**, typecheck/build green
- Worker module-graph race surface: **138 → 3** requests (measured)
- Hermetic E2E (jsDelivr blocked): multi-sat chart populates from localhost, **0 jsDelivr requests**
- `multi-satellite-nan` green locally; the intermittent CI flake is validated by repeated CI runs (can't be proven locally)
- Reviewed by codex (clean after fixes) + Copilot (1 doc nit, fixed)

## Trade-off

Self-hosting adds the DuckDB wasm to the build output (eh ~34MB + mvp ~39MB raw; one fetched at runtime, ~8MB gzip). Consistent with the viewer already shipping large textures.

Closes #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)