### PR TITLE
fix(viewer): guard complete quaternions + drop per-render alloc (#170)

### DIFF
--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
@@ -444,10 +444,18 @@ export function OrbitSceneContents({
     };
   }, [lvlhActive, cameraTracking, originPosition]);
 
-  // Determine sim time for sun direction from first available satellite position
-  const firstPosition = satellitePositions
-    ? (Array.from(satellitePositions.values()).find((p) => p != null) ?? null)
-    : null;
+  // Determine sim time for sun direction from the first available satellite
+  // position. Iterate the Map's values directly rather than materializing an
+  // array every render just to find the first non-null entry.
+  let firstPosition: OrbitPoint | null = null;
+  if (satellitePositions) {
+    for (const p of satellitePositions.values()) {
+      if (p != null) {
+        firstPosition = p;
+        break;
+      }
+    }
+  }
   const simTime = firstPosition?.t ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/orbit.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/orbit.ts
@@ -139,6 +139,11 @@ export function updateOrbitTrail(line: THREE.Line, visibleCount: number, totalCo
   line.geometry.setDrawRange(0, clamped);
 }
 
+/** Whether a point carries a complete quaternion (all of qw/qx/qy/qz). */
+function hasQuaternion(p: OrbitPoint): boolean {
+  return p.qw != null && p.qx != null && p.qy != null && p.qz != null;
+}
+
 /**
  * Linearly interpolate between two OrbitPoints at the given fraction (0..1)
  * between them. Quaternion attitude is interpolated via slerp.
@@ -161,8 +166,10 @@ export function lerpPoint(a: OrbitPoint, b: OrbitPoint, frac: number): OrbitPoin
     nu: a.nu * inv + b.nu * frac,
   };
 
-  // Quaternion slerp for attitude interpolation
-  if (a.qw != null && b.qw != null) {
+  // Quaternion slerp for attitude interpolation. Require a *complete* quaternion
+  // on both points — guarding on qw alone would let a partial one (missing
+  // qx/qy/qz, which Three defaults to 0) build an un-normalized rotation.
+  if (hasQuaternion(a) && hasQuaternion(b)) {
     const qa = new THREE.Quaternion(a.qx, a.qy, a.qz, a.qw);
     const qb = new THREE.Quaternion(b.qx, b.qy, b.qz, b.qw);
     // Ensure shortest-path interpolation

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -444,10 +444,18 @@ export function OrbitSceneContents({
     };
   }, [lvlhActive, cameraTracking, originPosition]);
 
-  // Determine sim time for sun direction from first available satellite position
-  const firstPosition = satellitePositions
-    ? (Array.from(satellitePositions.values()).find((p) => p != null) ?? null)
-    : null;
+  // Determine sim time for sun direction from the first available satellite
+  // position. Iterate the Map's values directly rather than materializing an
+  // array every render just to find the first non-null entry.
+  let firstPosition: OrbitPoint | null = null;
+  if (satellitePositions) {
+    for (const p of satellitePositions.values()) {
+      if (p != null) {
+        firstPosition = p;
+        break;
+      }
+    }
+  }
   const simTime = firstPosition?.t ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 

--- a/viewer/src/orbit.test.ts
+++ b/viewer/src/orbit.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { lerpPoint, type OrbitPoint } from "./orbit.js";
+
+/** A minimal OrbitPoint with all required fields zeroed; override as needed. */
+function pt(overrides: Partial<OrbitPoint> = {}): OrbitPoint {
+  return {
+    t: 0,
+    x: 0,
+    y: 0,
+    z: 0,
+    vx: 0,
+    vy: 0,
+    vz: 0,
+    a: 7000,
+    e: 0,
+    inc: 0,
+    raan: 0,
+    omega: 0,
+    nu: 0,
+    ...overrides,
+  };
+}
+
+const S = Math.SQRT1_2; // sin/cos(45°)
+
+describe("lerpPoint quaternion handling", () => {
+  it("slerps when both points carry a complete quaternion", () => {
+    // identity → 90° about Z, halfway = 45° about Z (normalized)
+    const a = pt({ qw: 1, qx: 0, qy: 0, qz: 0 });
+    const b = pt({ qw: S, qx: 0, qy: 0, qz: S });
+    const r = lerpPoint(a, b, 0.5);
+    for (const c of [r.qw, r.qx, r.qy, r.qz]) expect(c).toBeTypeOf("number");
+    const mag = Math.hypot(r.qw as number, r.qx as number, r.qy as number, r.qz as number);
+    expect(mag).toBeCloseTo(1, 6);
+    expect(r.qz as number).toBeGreaterThan(0); // rotated partway toward b
+  });
+
+  it("skips attitude interpolation when a quaternion is incomplete (qw only)", () => {
+    // Guarding on qw alone would build an un-normalized (0,0,0,qw) rotation.
+    const a = pt({ qw: 0.5 }); // qx/qy/qz missing
+    const b = pt({ qw: S, qx: 0, qy: 0, qz: S });
+    const r = lerpPoint(a, b, 0.5);
+    expect(r.qw).toBeUndefined();
+    expect(r.qx).toBeUndefined();
+    expect(r.qy).toBeUndefined();
+    expect(r.qz).toBeUndefined();
+  });
+
+  it("leaves the result quaternion-free when neither point has one", () => {
+    const r = lerpPoint(pt(), pt(), 0.5);
+    expect(r.qw).toBeUndefined();
+    expect(r.qz).toBeUndefined();
+  });
+
+  it("interpolates the non-quaternion fields regardless", () => {
+    const r = lerpPoint(pt({ t: 0, x: 0 }), pt({ t: 10, x: 100 }), 0.3);
+    expect(r.t).toBeCloseTo(3);
+    expect(r.x).toBeCloseTo(30);
+  });
+
+  it("does not reject a present-but-NaN component (only missing ones are guarded)", () => {
+    // Characterization: the guard checks presence, not finiteness; a NaN that is
+    // *present* still enters the slerp path (out of scope for the missing-field fix).
+    const a = pt({ qw: Number.NaN, qx: 0, qy: 0, qz: 0 });
+    const b = pt({ qw: 1, qx: 0, qy: 0, qz: 0 });
+    const r = lerpPoint(a, b, 0.5);
+    expect(r.qw).toBeDefined();
+  });
+});

--- a/viewer/src/orbit.ts
+++ b/viewer/src/orbit.ts
@@ -139,6 +139,11 @@ export function updateOrbitTrail(line: THREE.Line, visibleCount: number, totalCo
   line.geometry.setDrawRange(0, clamped);
 }
 
+/** Whether a point carries a complete quaternion (all of qw/qx/qy/qz). */
+function hasQuaternion(p: OrbitPoint): boolean {
+  return p.qw != null && p.qx != null && p.qy != null && p.qz != null;
+}
+
 /**
  * Linearly interpolate between two OrbitPoints at the given fraction (0..1)
  * between them. Quaternion attitude is interpolated via slerp.
@@ -161,8 +166,10 @@ export function lerpPoint(a: OrbitPoint, b: OrbitPoint, frac: number): OrbitPoin
     nu: a.nu * inv + b.nu * frac,
   };
 
-  // Quaternion slerp for attitude interpolation
-  if (a.qw != null && b.qw != null) {
+  // Quaternion slerp for attitude interpolation. Require a *complete* quaternion
+  // on both points — guarding on qw alone would let a partial one (missing
+  // qx/qy/qz, which Three defaults to 0) build an un-normalized rotation.
+  if (hasQuaternion(a) && hasQuaternion(b)) {
     const qa = new THREE.Quaternion(a.qx, a.qy, a.qz, a.qw);
     const qb = new THREE.Quaternion(b.qx, b.qy, b.qz, b.qw);
     // Ensure shortest-path interpolation


### PR DESCRIPTION
Fixes the two `viewer/src` nits surfaced by the registry copy in #169. Closes #170.

## Changes
- **`orbit.ts` `lerpPoint`** — guard on a *complete* quaternion (all of qw/qx/qy/qz, via `hasQuaternion`) before slerping. Guarding on `qw` alone let a partial point (missing qx/qy/qz, which Three defaults to 0) build an un-normalized rotation. New `orbit.test.ts` covers complete / partial / absent / NaN-passthrough.
- **`OrbitSceneContents`** — find the first non-null satellite position by iterating the Map's values directly instead of `Array.from(...).find(...)` (which allocated an array every render).
- Re-synced the example's committed registry copy of these two files (verbatim — neither has a leading banner for `shadcn add` to strip, so `registry.json` and the import graph are unchanged).

## Verified
- `tsc` clean, **429** vitest (incl. 5 new `orbit.test`), example Playwright **7/7**, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)