### PR TITLE
fix(tobari): gate build.rs IGRF helpers behind fetch-igrf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,12 @@ jobs:
       - name: Clippy
         run: cargo clippy --locked --workspace -- -D warnings
 
-      # Contract checks: `tobari` must compile at each feature tier.
-      # Uses `cargo check` instead of clippy because --no-default-features
-      # disables fetch-igrf, leaving build.rs IGRF helpers unused (dead_code).
-      - name: Check (tobari no_std)
-        run: cargo check --locked -p tobari --no-default-features
+      # Contract check: `tobari` must compile warning-free at its non-default
+      # tier. no-default-features disables both std and fetch-igrf, exercising
+      # the vendored-data copy path in build.rs (the IGRF download/generate
+      # helpers are `#[cfg(feature = "fetch-igrf")]`, so no dead_code here).
+      - name: Clippy (tobari no_std)
+        run: cargo clippy --locked -p tobari --no-default-features -- -D warnings
 
       # Contract checks: `arika` must compile at each feature tier.
       #   no_std, no alloc → pure math core only

--- a/tobari/build.rs
+++ b/tobari/build.rs
@@ -9,9 +9,11 @@
 
 use std::env;
 use std::fs;
+#[cfg(feature = "fetch-igrf")]
 use std::io::Write;
 use std::path::Path;
 
+#[cfg(feature = "fetch-igrf")]
 const MAX_DEGREE: usize = 13;
 
 fn main() {
@@ -65,11 +67,13 @@ fn download_and_generate(url: &str, dest: &Path) -> Result<(), String> {
 
 // Parsing
 
+#[cfg(feature = "fetch-igrf")]
 struct ParsedIgrf {
     columns: Vec<String>,
     rows: Vec<CoeffRow>,
 }
 
+#[cfg(feature = "fetch-igrf")]
 struct CoeffRow {
     gh: char,
     n: usize,
@@ -77,6 +81,7 @@ struct CoeffRow {
     values: Vec<f64>,
 }
 
+#[cfg(feature = "fetch-igrf")]
 fn parse_igrf(raw: &str) -> ParsedIgrf {
     let mut columns = Vec::new();
     let mut rows = Vec::new();
@@ -122,14 +127,17 @@ fn parse_igrf(raw: &str) -> ParsedIgrf {
 
 // Code generation
 
+#[cfg(feature = "fetch-igrf")]
 fn coeff_index(n: usize, m: usize) -> usize {
     (n - 1) * n / 2 + (n - 1) + m
 }
 
+#[cfg(feature = "fetch-igrf")]
 fn total_coeffs() -> usize {
     MAX_DEGREE * (MAX_DEGREE + 3) / 2
 }
 
+#[cfg(feature = "fetch-igrf")]
 fn extract_array(rows: &[CoeffRow], col_idx: usize, is_g: bool) -> Vec<f64> {
     let n = total_coeffs();
     let mut arr = vec![0.0_f64; n];
@@ -148,6 +156,7 @@ fn extract_array(rows: &[CoeffRow], col_idx: usize, is_g: bool) -> Vec<f64> {
     arr
 }
 
+#[cfg(feature = "fetch-igrf")]
 fn parse_year(label: &str) -> Option<f64> {
     if label.contains('-') {
         return None;
@@ -155,6 +164,7 @@ fn parse_year(label: &str) -> Option<f64> {
     label.parse::<f64>().ok()
 }
 
+#[cfg(feature = "fetch-igrf")]
 fn generate_rust(path: &Path, parsed: &ParsedIgrf) {
     let n = total_coeffs();
     let mut out = fs::File::create(path).unwrap();
@@ -236,6 +246,7 @@ fn generate_rust(path: &Path, parsed: &ParsedIgrf) {
     writeln!(out, "}}").unwrap();
 }
 
+#[cfg(feature = "fetch-igrf")]
 fn write_inner_array(out: &mut fs::File, arr: &[f64]) {
     write!(out, "    [").unwrap();
     for (i, val) in arr.iter().enumerate() {
@@ -247,6 +258,7 @@ fn write_inner_array(out: &mut fs::File, arr: &[f64]) {
     writeln!(out, "],").unwrap();
 }
 
+#[cfg(feature = "fetch-igrf")]
 fn write_flat_array(out: &mut fs::File, name: &str, arr: &[f64]) {
     let n = arr.len();
     writeln!(out, "#[rustfmt::skip]").unwrap();


### PR DESCRIPTION
## 背景

`tobari/build.rs` の IGRF 係数 parse/generate ヘルパ（`parse_igrf` / `coeff_index` / `total_coeffs` / `extract_array` / `parse_year` / `generate_rust` / `write_inner_array` / `write_flat_array` / `struct ParsedIgrf` / `struct CoeffRow` / `const MAX_DEGREE`）は `fetch-igrf` の download 経路からしか到達しない。feature off 時は `copy_vendored` のみが走るため、これらが `--no-default-features` で `dead_code` 警告を出していた。

CI はこの tier を clippy でなく `cargo check` で回避していたが、`cargo check` 自体は警告を出し続けており、ローカル等で目に入る状態だった（#161）。

## 変更

- 上記 fetch-igrf 専用アイテムに `#[cfg(feature = "fetch-igrf")]` を付与（issue が列挙した 11 項目 + それらでしか使われなくなる `use std::io::Write` import）。
- CI の tobari no-default-features tier を `cargo check` → `cargo clippy --no-default-features -- -D warnings` に変更し、コメントも更新。

挙動変更なし（vendored data コピー経路は不変）。

## 検証

- `cargo clippy -p tobari --no-default-features -- -D warnings` → ✅（修正前は dead_code 11件）
- `cargo clippy -p tobari --no-default-features --features fetch-igrf -- -D warnings` → ✅（generator 経路も維持）
- `cargo fmt --all -- --check` / `cargo clippy --workspace -- -D warnings` / `cargo test -p tobari`（10 tests, fetch-igrf ON）→ ✅
- codex review → 指摘なし

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)