### PR TITLE
refactor(viewer): extract <OrbitScene> mid-layer from OrbitViewer

### DIFF
--- a/viewer/registry.json
+++ b/viewer/registry.json
@@ -113,6 +113,11 @@
           "target": "@components/orbit-viewer/hooks/useTextureResolution.ts"
         },
         {
+          "path": "src/lib/OrbitScene.tsx",
+          "type": "registry:component",
+          "target": "@components/orbit-viewer/lib/OrbitScene.tsx"
+        },
+        {
           "path": "src/lib/OrbitViewer.tsx",
           "type": "registry:component",
           "target": "@components/orbit-viewer/lib/OrbitViewer.tsx"

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -1,4 +1,4 @@
-import { OrbitControls } from "@react-three/drei";
+import { OrbitControls, type OrbitControlsProps } from "@react-three/drei";
 import { useFrame, useThree } from "@react-three/fiber";
 import { useEffect, useMemo, useRef } from "react";
 import * as THREE from "three";
@@ -354,6 +354,16 @@ export interface OrbitSceneContentsProps {
   textureRevision?: number;
   /** Base URL for fetching high-res textures (e.g., "http://localhost:9001/textures/"). */
   textureBaseUrl?: string;
+  /**
+   * Default orbit camera package: OrbitControls plus the frame-aware camera rig
+   * (near/far configurator, distance transitions, LVLH tracking). `true`
+   * (default) renders it; `false` hands the camera entirely to the caller; an
+   * object enables it and is spread onto OrbitControls. Disabling it means the
+   * caller is responsible for camera placement, near/far, and `camera.up`.
+   */
+  controls?: boolean | Partial<OrbitControlsProps>;
+  /** Render the reference axes helper. Default `true`. */
+  axes?: boolean;
 }
 
 /**
@@ -380,7 +390,14 @@ export function OrbitSceneContents({
   physicalScale,
   textureRevision,
   textureBaseUrl,
+  controls = true,
+  axes = true,
 }: OrbitSceneContentsProps) {
+  // Default camera package (controls + frame-aware rig). `false` opts out
+  // entirely; an object enables it and is spread onto OrbitControls.
+  const controlsEnabled = controls !== false;
+  const controlsProps = typeof controls === "object" ? controls : undefined;
+
   const isEcef = isLegacyEcef(referenceFrame);
   const isSatCentered = referenceFrame.center.type === "satellite";
   const centeredSatId =
@@ -537,24 +554,31 @@ export function OrbitSceneContents({
 
   return (
     <>
-      <CameraConfigurator profile={displayProfile} />
-      <CameraDistanceTransition
-        profile={displayProfile}
-        overrideDistance={cameraDistanceOverride}
-      />
-      <OrbitControls
-        enableDamping
-        dampingFactor={0.1}
-        minDistance={displayProfile.minDistance}
-        maxDistance={displayProfile.maxDistance}
-      />
-      {/* Camera co-rotation only when the kernel asked for it (local-orbital
-          approximated by the camera); an inertial centre keeps star-fixed axes. */}
-      <CameraLvlhTracker
-        originPosition={cameraTracking ? originPosition : null}
-        originVelocity={originVelocity}
-        lvlhActive={lvlhActive}
-      />
+      {/* Default camera package: render only when `controls` is not false, so a
+          bring-your-own-Canvas caller can take over the camera entirely. */}
+      {controlsEnabled && (
+        <>
+          <CameraConfigurator profile={displayProfile} />
+          <CameraDistanceTransition
+            profile={displayProfile}
+            overrideDistance={cameraDistanceOverride}
+          />
+          <OrbitControls
+            enableDamping
+            dampingFactor={0.1}
+            minDistance={displayProfile.minDistance}
+            maxDistance={displayProfile.maxDistance}
+            {...controlsProps}
+          />
+          {/* Camera co-rotation only when the kernel asked for it (local-orbital
+              approximated by the camera); an inertial centre keeps star-fixed axes. */}
+          <CameraLvlhTracker
+            originPosition={cameraTracking ? originPosition : null}
+            originVelocity={originVelocity}
+            lvlhActive={lvlhActive}
+          />
+        </>
+      )}
 
       <SunLighting intensity={sunIntensity} position={lightPosition} />
 
@@ -698,7 +722,7 @@ export function OrbitSceneContents({
       </SmoothOriginGroup>
 
       {/* Reference axes: full ECI axes for body-centered, small LVLH reference for satellite-centered */}
-      <axesHelper args={[isSatCentered ? 0.015 : 2]} />
+      {axes && <axesHelper args={[isSatCentered ? 0.015 : 2]} />}
     </>
   );
 }

--- a/viewer/src/lib/OrbitScene.tsx
+++ b/viewer/src/lib/OrbitScene.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useMemo, useState } from "react";
+import { getBodyRadius, resolveBodyDefinitions } from "../bodies.js";
+import { OrbitSceneContents } from "../components/OrbitSceneContents.js";
+import { IS_DEV } from "../env.js";
+import type { OrbitPoint } from "../orbit.js";
+import { initArika, isArikaReady } from "../wasm/arikaInit.js";
+import { toOrbitPoint } from "./adapt.js";
+import { resolveFrameContext } from "./frameContext.js";
+import { DEFAULT_VIEWER_FRAME, type OrbitSceneProps } from "./types.js";
+import { useTrailBuffers } from "./useTrailBuffers.js";
+
+/**
+ * Drive the bundled arika WASM to readiness when `enabled`. Returns `true` once
+ * loaded so the scene can switch from default lighting to ephemeris-accurate
+ * Sun/rotation. When `enabled` is false (no epoch), the WASM is never loaded —
+ * epoch-less embedders pay no network/init cost and get the documented fixed Sun.
+ */
+function useArikaReady(enabled: boolean): boolean {
+  const [ready, setReady] = useState(() => isArikaReady());
+  useEffect(() => {
+    if (!enabled || ready) return;
+    let cancelled = false;
+    initArika()
+      .then(() => {
+        if (!cancelled) setReady(true);
+      })
+      .catch(() => {
+        // Leave `ready` false: the viewer keeps rendering with default lighting.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, ready]);
+  return ready;
+}
+
+/**
+ * The orbit scene graph, for mounting inside your own @react-three/fiber `<Canvas>`.
+ *
+ * This is the framework boundary: it adapts the public {@link OrbitSceneProps}
+ * (a central body + a list of satellites) onto the internal renderer, handling
+ * frame resolution, trail buffers and arika WASM init, and renders the central
+ * body, satellites and trails plus (by default) the orbit camera rig + controls.
+ *
+ * Unlike {@link OrbitViewer}, it does NOT create a Canvas or a wrapping element,
+ * so you can compose it with your own lights, meshes, post-processing or camera.
+ * Initialise your Canvas camera with `up = SCENE_UP`; with the default camera
+ * package (`controls` not `false`) the rig keeps `camera.up` correct each frame.
+ *
+ * @example
+ * ```tsx
+ * <Canvas camera={{ up: SCENE_UP }}>
+ *   <OrbitScene
+ *     centralBody={{ id: "earth", radiusKm: 6378.137 }}
+ *     satellites={[{ id: "sat-1", position: [7000, 0, 1500] }]}
+ *   />
+ * </Canvas>
+ * ```
+ */
+export function OrbitScene({
+  centralBody,
+  bodies,
+  satellites,
+  referenceFrame = DEFAULT_VIEWER_FRAME,
+  epochJd,
+  time = 0,
+  textureBaseUrl,
+  controls = true,
+  axes = true,
+}: OrbitSceneProps) {
+  // Only load the arika WASM when an epoch is supplied (Sun/rotation features).
+  const arikaReady = useArikaReady(epochJd != null);
+
+  // Body definitions: consumer-supplied bodies merged over the built-in defaults.
+  const bodyDefinitions = useMemo(() => resolveBodyDefinitions(bodies), [bodies]);
+  // Central-body radius: explicit prop wins; otherwise from the body definition.
+  // Fail loudly rather than guess a scale — a wrong radius silently breaks the
+  // entire scene's sizing.
+  const centralBodyRadius = centralBody.radiusKm ?? getBodyRadius(centralBody.id, bodyDefinitions);
+  if (centralBodyRadius == null) {
+    throw new Error(
+      `OrbitScene: central body "${centralBody.id}" has no radius. Pass ` +
+        "centralBody.radiusKm, or add the body to `bodies` with a radiusKm.",
+    );
+  }
+
+  // Current position per satellite. `time` is stamped onto each point; the scene
+  // reads it back as the simulation time that drives Sun direction and rotation.
+  const satellitePositions = useMemo(() => {
+    const map = new Map<string, OrbitPoint>();
+    for (const sat of satellites) map.set(sat.id, toOrbitPoint(sat, time));
+    return map;
+  }, [satellites, time]);
+
+  const satelliteNames = useMemo(() => {
+    const map = new Map<string, string | null>();
+    for (const sat of satellites) map.set(sat.id, sat.name ?? null);
+    return map;
+  }, [satellites]);
+
+  // Per-satellite colour overrides from the public SatelliteState.color.
+  const satelliteColors = useMemo(() => {
+    const map = new Map<string, number | undefined>();
+    for (const sat of satellites) map.set(sat.id, sat.color);
+    return map;
+  }, [satellites]);
+
+  // Persistent per-satellite trail buffers (stable identity → incremental upload).
+  const trailBuffers = useTrailBuffers(satellites);
+
+  // Map the public frame onto the renderer's internal ReferenceFrame (incl.
+  // local_orbital); the scene resolves the geometry itself via the shared
+  // resolveSceneFrame kernel from the satellite positions it receives.
+  const internalFrame = useMemo(
+    () => resolveFrameContext(referenceFrame, () => undefined).referenceFrame,
+    [referenceFrame],
+  );
+
+  // Only hand the scene an epoch once arika is loaded; otherwise its Sun/rotation
+  // calls would run before the WASM is ready. Default lighting is used until then.
+  const effectiveEpochJd = arikaReady ? (epochJd ?? null) : null;
+
+  // Dev/E2E-only: expose per-satellite trail buffer state so E2E can prove that
+  // advancing `time` (or appending points) does not rebuild the trail — a stable
+  // `generation` means no full GPU re-upload. See tests/orbit-viewer-lib.spec.ts.
+  useEffect(() => {
+    if (!IS_DEV) return;
+    const w = window as unknown as Record<string, unknown>;
+    w.__debug_orbit_viewer = {
+      trail: (id: string) => {
+        const b = trailBuffers.get(id);
+        return b ? { length: b.length, generation: b.generation } : null;
+      },
+    };
+    return () => {
+      delete w.__debug_orbit_viewer;
+    };
+  }, [trailBuffers]);
+
+  return (
+    <OrbitSceneContents
+      trailBuffers={trailBuffers}
+      satellitePositions={satellitePositions}
+      satelliteNames={satelliteNames}
+      satelliteColors={satelliteColors}
+      centralBody={centralBody.id}
+      centralBodyRadius={centralBodyRadius}
+      bodyDefinitions={bodyDefinitions}
+      epochJd={effectiveEpochJd}
+      referenceFrame={internalFrame}
+      textureBaseUrl={textureBaseUrl}
+      controls={controls}
+      axes={axes}
+    />
+  );
+}

--- a/viewer/src/lib/OrbitViewer.tsx
+++ b/viewer/src/lib/OrbitViewer.tsx
@@ -1,40 +1,7 @@
 import { Canvas } from "@react-three/fiber";
-import { useEffect, useMemo, useState } from "react";
-import { getBodyRadius, resolveBodyDefinitions } from "../bodies.js";
-import { OrbitSceneContents } from "../components/OrbitSceneContents.js";
-import { IS_DEV } from "../env.js";
-import type { OrbitPoint } from "../orbit.js";
 import { DEFAULT_CAMERA_POSITION, SCENE_UP } from "../sceneFrame.js";
-import { initArika, isArikaReady } from "../wasm/arikaInit.js";
-import { toOrbitPoint } from "./adapt.js";
-import { resolveFrameContext } from "./frameContext.js";
-import { DEFAULT_VIEWER_FRAME, type OrbitViewerProps } from "./types.js";
-import { useTrailBuffers } from "./useTrailBuffers.js";
-
-/**
- * Drive the bundled arika WASM to readiness when `enabled`. Returns `true` once
- * loaded so the scene can switch from default lighting to ephemeris-accurate
- * Sun/rotation. When `enabled` is false (no epoch), the WASM is never loaded —
- * epoch-less embedders pay no network/init cost and get the documented fixed Sun.
- */
-function useArikaReady(enabled: boolean): boolean {
-  const [ready, setReady] = useState(() => isArikaReady());
-  useEffect(() => {
-    if (!enabled || ready) return;
-    let cancelled = false;
-    initArika()
-      .then(() => {
-        if (!cancelled) setReady(true);
-      })
-      .catch(() => {
-        // Leave `ready` false: the viewer keeps rendering with default lighting.
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [enabled, ready]);
-  return ready;
-}
+import { OrbitScene } from "./OrbitScene.js";
+import type { OrbitViewerProps } from "./types.js";
 
 /**
  * Embeddable orbit viewer.
@@ -45,8 +12,10 @@ function useArikaReady(enabled: boolean): boolean {
  * (and advance `time`) for physically-correct Sun lighting and body rotation
  * via the bundled arika WASM; otherwise a fixed Sun is used and the body is static.
  *
- * It composes the same {@link OrbitSceneContents} scene graph the app uses, so
- * frame handling, lighting and the LVLH camera tracking are shared, not duplicated.
+ * This is the batteries-included wrapper: a sized `<div>` and a configured
+ * `<Canvas>` around the shared {@link OrbitScene} graph. Drop {@link OrbitScene}
+ * into your own Canvas instead when you need to compose it with your own lights,
+ * meshes, post-processing or camera.
  *
  * @example
  * ```tsx
@@ -56,108 +25,25 @@ function useArikaReady(enabled: boolean): boolean {
  * />
  * ```
  */
-export function OrbitViewer({
-  centralBody,
-  bodies,
-  satellites,
-  referenceFrame = DEFAULT_VIEWER_FRAME,
-  epochJd,
-  time = 0,
-  textureBaseUrl,
-  className,
-  style,
-}: OrbitViewerProps) {
-  // Only load the arika WASM when an epoch is supplied (Sun/rotation features).
-  const arikaReady = useArikaReady(epochJd != null);
-
-  // Body definitions: consumer-supplied bodies merged over the built-in defaults.
-  const bodyDefinitions = useMemo(() => resolveBodyDefinitions(bodies), [bodies]);
-  // Central-body radius: explicit prop wins; otherwise from the body definition.
-  // Fail loudly rather than guess a scale — a wrong radius silently breaks the
-  // entire scene's sizing.
-  const centralBodyRadius = centralBody.radiusKm ?? getBodyRadius(centralBody.id, bodyDefinitions);
-  if (centralBodyRadius == null) {
-    throw new Error(
-      `OrbitViewer: central body "${centralBody.id}" has no radius. Pass ` +
-        "centralBody.radiusKm, or add the body to `bodies` with a radiusKm.",
-    );
-  }
-
-  // Current position per satellite. `time` is stamped onto each point; the scene
-  // reads it back as the simulation time that drives Sun direction and rotation.
-  const satellitePositions = useMemo(() => {
-    const map = new Map<string, OrbitPoint>();
-    for (const sat of satellites) map.set(sat.id, toOrbitPoint(sat, time));
-    return map;
-  }, [satellites, time]);
-
-  const satelliteNames = useMemo(() => {
-    const map = new Map<string, string | null>();
-    for (const sat of satellites) map.set(sat.id, sat.name ?? null);
-    return map;
-  }, [satellites]);
-
-  // Per-satellite colour overrides from the public SatelliteState.color.
-  const satelliteColors = useMemo(() => {
-    const map = new Map<string, number | undefined>();
-    for (const sat of satellites) map.set(sat.id, sat.color);
-    return map;
-  }, [satellites]);
-
-  // Persistent per-satellite trail buffers (stable identity → incremental upload).
-  const trailBuffers = useTrailBuffers(satellites);
-
-  // Map the public frame onto the renderer's internal ReferenceFrame (incl.
-  // local_orbital); the scene resolves the geometry itself via the shared
-  // resolveSceneFrame kernel from the satellite positions it receives.
-  const internalFrame = useMemo(
-    () => resolveFrameContext(referenceFrame, () => undefined).referenceFrame,
-    [referenceFrame],
-  );
-
-  // Only hand the scene an epoch once arika is loaded; otherwise its Sun/rotation
-  // calls would run before the WASM is ready. Default lighting is used until then.
-  const effectiveEpochJd = arikaReady ? (epochJd ?? null) : null;
-
-  // Dev/E2E-only: expose per-satellite trail buffer state so E2E can prove that
-  // advancing `time` (or appending points) does not rebuild the trail — a stable
-  // `generation` means no full GPU re-upload. See tests/orbit-viewer-lib.spec.ts.
-  useEffect(() => {
-    if (!IS_DEV) return;
-    const w = window as unknown as Record<string, unknown>;
-    w.__debug_orbit_viewer = {
-      trail: (id: string) => {
-        const b = trailBuffers.get(id);
-        return b ? { length: b.length, generation: b.generation } : null;
-      },
-    };
-    return () => {
-      delete w.__debug_orbit_viewer;
-    };
-  }, [trailBuffers]);
-
+export function OrbitViewer({ className, style, canvas, ...sceneProps }: OrbitViewerProps) {
   return (
     <div className={className} style={{ width: "100%", height: "100%", ...style }}>
       {/* Set the camera up via the prop rather than mutating the global
-          THREE.Object3D.DEFAULT_UP (as the app's Scene does): a library shouldn't
-          change a global that affects the embedder's own Three.js objects.
-          CameraLvlhTracker keeps camera.up correct each frame. */}
+          THREE.Object3D.DEFAULT_UP: a library shouldn't change a global that
+          affects the embedder's own Three.js objects. The camera rig keeps
+          camera.up correct each frame. The `canvas` prop merges over these. */}
       <Canvas
-        camera={{ position: DEFAULT_CAMERA_POSITION, up: SCENE_UP, fov: 60, near: 0.01, far: 1000 }}
-        gl={{ logarithmicDepthBuffer: true }}
+        camera={{
+          position: DEFAULT_CAMERA_POSITION,
+          up: SCENE_UP,
+          fov: 60,
+          near: 0.01,
+          far: 1000,
+          ...canvas?.camera,
+        }}
+        gl={{ logarithmicDepthBuffer: true, ...canvas?.gl }}
       >
-        <OrbitSceneContents
-          trailBuffers={trailBuffers}
-          satellitePositions={satellitePositions}
-          satelliteNames={satelliteNames}
-          satelliteColors={satelliteColors}
-          centralBody={centralBody.id}
-          centralBodyRadius={centralBodyRadius}
-          bodyDefinitions={bodyDefinitions}
-          epochJd={effectiveEpochJd}
-          referenceFrame={internalFrame}
-          textureBaseUrl={textureBaseUrl}
-        />
+        <OrbitScene {...sceneProps} />
       </Canvas>
     </div>
   );

--- a/viewer/src/lib/index.ts
+++ b/viewer/src/lib/index.ts
@@ -30,7 +30,9 @@ export { SatelliteModel } from "../components/SatelliteModel.js";
 // Domain types and helpers used across the building blocks.
 export type { OrbitPoint } from "../orbit.js";
 export { DEFAULT_FRAME, type ReferenceFrame } from "../referenceFrame.js";
-export { computeLvlhAxes, type LvlhAxes } from "../sceneFrame.js";
+// `SCENE_UP`: camera up convention — initialise a bring-your-own `<Canvas>`
+// camera with it (see OrbitScene); OrbitViewer applies it for you.
+export { computeLvlhAxes, type LvlhAxes, SCENE_UP } from "../sceneFrame.js";
 export { TrailBuffer } from "../utils/TrailBuffer.js";
 // arika WASM control (Sun direction / body rotation). OrbitViewer auto-inits when
 // given an epoch; these let an embedder pre-load or point at an external .wasm.
@@ -43,11 +45,15 @@ export {
   type FrameSatelliteLookup,
   resolveFrameContext,
 } from "./frameContext.js";
-// Headline component + its public types.
+// Headline component (own Canvas) + the mid-layer scene (bring your own Canvas).
+export { OrbitScene } from "./OrbitScene.js";
 export { OrbitViewer } from "./OrbitViewer.js";
 export {
   type CentralBody,
+  type ControlsProp,
   DEFAULT_VIEWER_FRAME,
+  type OrbitSceneDataProps,
+  type OrbitSceneProps,
   type OrbitViewerProps,
   type Quat,
   type SatelliteState,

--- a/viewer/src/lib/types.ts
+++ b/viewer/src/lib/types.ts
@@ -15,7 +15,9 @@
  *   scalar-first order `[w, x, y, z]`.
  */
 
+import type { OrbitControlsProps } from "@react-three/drei";
 import type { CSSProperties } from "react";
+import type { WebGLRendererParameters } from "three";
 import type { BodyDefinitions } from "../bodies.js";
 
 /** A 3D vector `[x, y, z]`. Distances are in kilometres. */
@@ -103,8 +105,11 @@ export type ViewerReferenceFrame =
   | { center: "centralBody"; orientation?: "inertial" | "bodyFixed" }
   | { center: { satelliteId: string }; orientation?: "inertial" | "localOrbital" };
 
-/** Props for the {@link OrbitViewer} component. */
-export interface OrbitViewerProps {
+/**
+ * Scene data + display props shared by {@link OrbitViewer} (which owns its own
+ * `<Canvas>`) and {@link OrbitScene} (which you mount inside your own `<Canvas>`).
+ */
+export interface OrbitSceneDataProps {
   /** The central body at the origin. */
   centralBody: CentralBody;
   /**
@@ -133,10 +138,59 @@ export interface OrbitViewerProps {
   time?: number;
   /** Base URL for high-resolution body textures (e.g. `"/textures/"`). */
   textureBaseUrl?: string;
+}
+
+/**
+ * Enable/disable the default orbit camera controls, or pass an
+ * {@link OrbitControlsProps} object to configure them. Default: enabled.
+ */
+export type ControlsProp = boolean | Partial<OrbitControlsProps>;
+
+/**
+ * Props for {@link OrbitScene}: the orbit scene graph rendered inside a
+ * caller-supplied @react-three/fiber `<Canvas>`. Bring your own Canvas to
+ * compose the scene with your own lights, meshes or post-processing.
+ *
+ * The caller's Canvas camera should be initialised with `up = SCENE_UP`
+ * (exported); the default camera rig keeps `camera.up` correct each frame, but
+ * OrbitControls reads the initial camera state at mount.
+ */
+export interface OrbitSceneProps extends OrbitSceneDataProps {
+  /** Default orbit camera/controls. `true` (default) | `false` | an OrbitControls config. */
+  controls?: ControlsProp;
+  /** Render the reference axes helper. Default `true`. */
+  axes?: boolean;
+}
+
+/** Props for the {@link OrbitViewer} component. */
+export interface OrbitViewerProps extends OrbitSceneDataProps {
   /** Class applied to the wrapping element. */
   className?: string;
   /** Inline style applied to the wrapping element. */
   style?: CSSProperties;
+  /**
+   * Overrides merged onto the internal `<Canvas>` setup: perspective-camera
+   * framing and WebGL renderer flags. For full control (a custom WebGLRenderer
+   * or camera instance, your own controls, extra meshes/lights), drop
+   * {@link OrbitScene} into your own `<Canvas>` instead.
+   */
+  canvas?: {
+    /** Perspective camera overrides merged onto the defaults. */
+    camera?: {
+      position?: Vec3;
+      up?: Vec3;
+      fov?: number;
+      near?: number;
+      far?: number;
+      zoom?: number;
+    };
+    /** WebGL renderer flags merged onto the defaults. */
+    gl?: Partial<WebGLRendererParameters>;
+  };
+  /** See {@link OrbitSceneProps.controls}. */
+  controls?: ControlsProp;
+  /** See {@link OrbitSceneProps.axes}. */
+  axes?: boolean;
 }
 
 /** Default frame when none is supplied: central-body inertial (ECI-like). */

--- a/viewer/src/lib/types.ts
+++ b/viewer/src/lib/types.ts
@@ -175,10 +175,14 @@ export interface OrbitViewerProps extends OrbitSceneDataProps {
    * {@link OrbitScene} into your own `<Canvas>` instead.
    */
   canvas?: {
-    /** Perspective camera overrides merged onto the defaults. */
+    /**
+     * Perspective camera overrides merged onto the defaults. `position`/`up` are
+     * in Three.js scene units/directions (NOT the km-valued {@link Vec3}); the
+     * central body is one scene unit in radius.
+     */
     camera?: {
-      position?: Vec3;
-      up?: Vec3;
+      position?: [number, number, number];
+      up?: [number, number, number];
       fov?: number;
       near?: number;
       far?: number;


### PR DESCRIPTION
## What

First of a 3-PR boundary refactor turning the viewer lib into a framework you can build viewer-like apps on. Introduces a public `<OrbitScene>` — the orbit scene graph for mounting inside your **own** `@react-three/fiber` `<Canvas>` — between the batteries-included `<OrbitViewer>` and the internal `OrbitSceneContents` renderer.

This PR is **behaviour-preserving**: `<OrbitViewer>` and the app render identically. No app migration and no public-surface removal yet (those are PRs B and C).

## Changes

- **types**: new `OrbitSceneDataProps` base; `OrbitViewerProps` and `OrbitSceneProps` both extend it (not `Omit<…>`). `OrbitViewer` gains a `canvas` escape hatch (perspective-camera framing + WebGL renderer flags, merged onto the defaults); both gain `controls` (`boolean | OrbitControls config`) and `axes`.
- **`OrbitScene`** (new): owns the public-props → renderer adaptation (frame resolution, trail buffers, arika WASM init, satellite maps) that used to live in `OrbitViewer`, then renders `OrbitSceneContents`. No Canvas, no wrapper element — bring your own Canvas to compose with your own lights / meshes / post-processing / camera.
- **`OrbitViewer`**: now a thin `<div><Canvas><OrbitScene/></Canvas>` wrapper.
- **`OrbitSceneContents`**: `controls` / `axes` gate the default camera package (OrbitControls + camera rig) and the axes helper; both default `true`, so the app's `Scene` path is unchanged.
- **barrel**: export `OrbitScene`, the new prop types, and `SCENE_UP` (to initialise a bring-your-own-Canvas camera).
- **shadcn registry**: regenerated (`orbit-viewer` item 38 → 39 files).

## Validation

- `tsc --noEmit` (full viewer) + `tsc -p tsconfig.lib.json` (lib dts): clean
- `biome check`: clean
- vitest: 37 files / 429 tests pass
- registry drift check: clean
- codex review: 1 finding (P2 — `canvas.gl`/`camera` overrides would silently drop renderer/camera factories or instances) → addressed by narrowing the `canvas` type to mergeable plain-object params; full renderer/camera control is via `<OrbitScene>` + your own Canvas.

## Sequence

- **PR A (this)**: extract `<OrbitScene>`, behaviour-preserving.
- **PR B**: migrate the app onto `<OrbitScene>`, remove the global `THREE.Object3D.DEFAULT_UP` mutation, reshape app-coupled Map/server props into clean per-satellite / scene props.
- **PR C**: remove now-internal primitives / low-level adapters from the public barrel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)