### PR TITLE
refactor(viewer): narrow the public barrel to the intended surface

### DIFF
--- a/viewer/README.md
+++ b/viewer/README.md
@@ -2,7 +2,9 @@
 
 A React component that renders a central body (Earth, a planet, …) and a set of
 satellites around it, with an orbit-controls camera. It's the reusable core of
-the orts viewer, exposed via the package's `./lib` entry.
+the orts viewer, exposed via the package's `./lib` entry — as `OrbitViewer`
+(batteries-included) or `OrbitScene` (for mounting inside your own
+`@react-three/fiber` Canvas).
 
 | Central-body view (ECI) | Satellite-centred view (LVLH) |
 | :---: | :---: |
@@ -41,6 +43,26 @@ physically-correct Sun lighting and body rotation; otherwise a fixed Sun is used
 and the body is static. See [`examples/orbit-viewer`](./examples/orbit-viewer)
 for an animated, backend-free example.
 
+### Bring your own Canvas
+
+`OrbitViewer` owns its `<Canvas>`. To compose the scene with your own lights,
+meshes, post-processing or camera, mount `OrbitScene` (the same data props, minus
+the wrapper/canvas) inside your Canvas — initialise the camera with `SCENE_UP`:
+
+```tsx
+import { Canvas } from "@react-three/fiber";
+import { OrbitScene, SCENE_UP } from "<pkg>/lib";
+
+<Canvas camera={{ up: SCENE_UP }}>
+  <ambientLight intensity={0.3} />
+  <OrbitScene
+    centralBody={{ id: "earth", radiusKm: 6378.137 }}
+    satellites={[{ id: "sat-1", position: [7000, 0, 1500] }]}
+    controls={false}
+  />
+</Canvas>;
+```
+
 ### Reference frames
 
 `referenceFrame` selects what's at the origin and how the axes are aligned:
@@ -58,6 +80,11 @@ Pass `trail` (an array of points) per satellite. Trails are uploaded
 incrementally: **append** to the array (new reference) to add points cheaply;
 treat `satellites`/`trail` as immutable (a new reference on change — in-place
 mutation isn't detected). Bump `trailVersion` to force a rebuild.
+
+For high-rate streaming, pass a `trailBuffer` (a `TrailBuffer` you own and mutate
+outside React) instead of `trail`: the scene reads it each frame, so appended
+points reach the GPU without a React re-render. `trail` and `trailBuffer` are
+mutually exclusive per satellite.
 
 ## Caveats
 
@@ -77,17 +104,21 @@ mutation isn't detected). Bump `trailVersion` to force a rebuild.
 
 ## Public API & stability
 
-The headline export is `OrbitViewer` plus its prop types
-(`OrbitViewerProps`, `SatelliteState`, `ViewerReferenceFrame`, `Vec3`, …).
+The entry points are **`OrbitViewer`** (batteries-included — its own `<div>` +
+`<Canvas>`) and **`OrbitScene`** (the scene graph to mount inside your own
+`@react-three/fiber` `<Canvas>`), plus their prop types (`OrbitViewerProps`,
+`OrbitSceneProps`, `SatelliteState`, `ViewerReferenceFrame`, `Vec3`, …), the body
+definitions (`DEFAULT_BODIES`, `BodyDefinition`), `MarkerShape`, `SCENE_UP`, and
+`initArika`.
 
-Lower-level building blocks are **also exported on purpose** so you can assemble
-a custom scene: the primitives (`CelestialBody`, `EarthBody`, `OrbitTrail`,
-`Satellite`, `SatelliteModel`, `BodyAxes`), the pure adapters/frame logic
-(`toOrbitPoint`, `resolveFrameContext`, `computeLvlhAxes`, `TrailBuffer`), and
-`initArika`. Note the trade-off: these primitives wrap internal Three.js /
-react-three-fiber components, so they carry a wider semver surface — refactors to
-their internals are breaking changes. If you only need the component, import just
-`OrbitViewer` and its types.
+The Three.js / react-three-fiber building blocks (`CelestialBody`, `Satellite`,
+`OrbitTrail`, …) and the internal frame wiring are **not** exported — they ride
+internal types and are an implementation detail. The one renderer primitive that
+_is_ public is the streaming **`TrailBuffer`** (with `TrailBufferLike`, the
+`OrbitPoint` it holds, and `toTrailBuffer` / `trailPointToOrbitPoint` to fill
+one), so a high-rate feed can hand the scene a buffer it mutates directly. To
+build a fully custom scene, drop `OrbitScene` into your own Canvas rather than
+wiring primitives by hand.
 
 ## Or copy the source (shadcn registry)
 
@@ -110,10 +141,11 @@ npx shadcn@4.11.0 add ./viewer/public/r/orbit-viewer.json
 > works without a checkout — isn't wired up yet (the deployed site currently
 > serves only the docs).
 
-The `orbit-viewer` item installs the full public closure (the `OrbitViewer`
-component, its primitives, frame/trail logic, shaders, and body definitions)
-under `<your components alias>/orbit-viewer/`, preserving the internal relative
-imports. It declares `react` / `react-dom` / `three` / `@react-three/fiber` /
+The `orbit-viewer` item installs the full import closure (the `OrbitViewer` /
+`OrbitScene` components plus the internal building blocks they use — frame/trail
+logic, shaders, body definitions) under `<your components alias>/orbit-viewer/`,
+preserving the internal relative imports. Copying the source gives you everything,
+including the internals that `./lib` doesn't re-export. It declares `react` / `react-dom` / `three` / `@react-three/fiber` /
 `@react-three/drei` as dependencies; you must **also** add `arika-wasm` yourself
 (it isn't on npm yet — install it from the orts workspace until it's published).
 

--- a/viewer/src/lib/index.ts
+++ b/viewer/src/lib/index.ts
@@ -1,16 +1,18 @@
 /**
- * Public, embeddable API of the orts viewer.
+ * Public API of the orts viewer.
  *
- * The headline export is {@link OrbitViewer}: give it a central body and a list
- * of satellites and you get an interactive 3D scene you can orbit the camera
- * around. The lower-level Three.js / react-three-fiber building blocks and the
- * pure frame/trail adapters are also exported for assembling custom scenes.
+ * Two entry components: {@link OrbitViewer} (batteries-included — its own sized
+ * `<div>` + `<Canvas>`) and {@link OrbitScene} (the scene graph to mount inside
+ * your own @react-three/fiber `<Canvas>`). Drive either with a central body and a
+ * list of {@link SatelliteState}.
  *
- * Surface note: the primitives below wrap internal Three.js/r3f components, so
- * they widen the semver surface (their internals changing is a breaking change).
- * That's an accepted trade-off for the "minimal component + primitives" goal —
- * consumers who only need the component should import just OrbitViewer + types.
- * See the package README (../../README.md).
+ * The Three.js / react-three-fiber building blocks (CelestialBody, Satellite,
+ * OrbitTrail, …) and the internal frame wiring are intentionally NOT exported:
+ * they ride internal types and are an implementation detail. The streaming
+ * {@link TrailBuffer} is the one renderer primitive that is public, since a
+ * high-rate feed needs to hand the scene a buffer it mutates directly
+ * (`SatelliteState.trailBuffer`); the {@link TrailPoint} adapters to fill one are
+ * exported alongside it. See the package README (../../README.md).
  */
 
 // Central-body definitions: built-in bodies + the type for adding custom ones.
@@ -20,36 +22,21 @@ export {
   type BodyTexture,
   DEFAULT_BODIES,
 } from "../bodies.js";
-// Lower-level building blocks for assembling a custom scene.
-export { BodyAxes } from "../components/BodyAxes.js";
-export { CelestialBody } from "../components/CelestialBody.js";
-export { EarthBody } from "../components/EarthBody.js";
-export { OrbitTrail } from "../components/OrbitTrail.js";
-export { Satellite } from "../components/Satellite.js";
-export { SatelliteModel } from "../components/SatelliteModel.js";
-// Domain types and helpers used across the building blocks.
+// Streaming trail buffer (SatelliteState.trailBuffer): the built-in buffer, its
+// read contract, the point type it holds, and adapters to fill one from TrailPoints.
 export type { OrbitPoint } from "../orbit.js";
-export { DEFAULT_FRAME, type ReferenceFrame } from "../referenceFrame.js";
 // Marker shape for a satellite (SatelliteState.markerShape / defaultMarkerShape).
 export type { MarkerShape } from "../satelliteShapes.js";
-// `SCENE_UP`: camera up convention — initialise a bring-your-own `<Canvas>`
-// camera with it (see OrbitScene); OrbitViewer applies it for you.
-export { computeLvlhAxes, type LvlhAxes, SCENE_UP } from "../sceneFrame.js";
-// Trail buffer: the built-in streaming buffer (SatelliteState.trailBuffer) plus
-// the read interface the scene accepts for a bring-your-own buffer.
+// Camera up convention: initialise a bring-your-own `<Canvas>` camera with it
+// (see OrbitScene); OrbitViewer applies it for you.
+export { SCENE_UP } from "../sceneFrame.js";
 export { TrailBuffer, type TrailBufferLike } from "../utils/TrailBuffer.js";
-// arika WASM control (Sun direction / body rotation). OrbitViewer auto-inits when
-// given an epoch; these let an embedder pre-load or point at an external .wasm.
+// arika WASM control (Sun direction / body rotation). OrbitViewer/OrbitScene
+// auto-init when given an epoch; these let an embedder pre-load or point at an
+// external .wasm.
 export { type InitArikaOptions, initArika, isArikaReady } from "../wasm/arikaInit.js";
-// Pure adapters and frame/trail logic (useful for custom scenes / advanced use).
-export { toOrbitPoint, toTrailBuffer, trailPointToOrbitPoint } from "./adapt.js";
-export {
-  type FrameContext,
-  type FrameSatellite,
-  type FrameSatelliteLookup,
-  resolveFrameContext,
-} from "./frameContext.js";
-// Headline component (own Canvas) + the mid-layer scene (bring your own Canvas).
+export { toTrailBuffer, trailPointToOrbitPoint } from "./adapt.js";
+// Entry components: headline (own Canvas) + mid-layer (bring your own Canvas).
 export { OrbitScene } from "./OrbitScene.js";
 export { OrbitViewer } from "./OrbitViewer.js";
 export {


### PR DESCRIPTION
## What

PR C (final) of the boundary refactor: narrow the public `./lib` surface to the intended API now that the app builds on `<OrbitScene>` (#175, #176).

## Removed from the public barrel (kept as internal source / registry-copied)

- Three.js / r3f primitives: `CelestialBody`, `EarthBody`, `OrbitTrail`, `Satellite`, `SatelliteModel`, `BodyAxes`
- internal frame wiring: `ReferenceFrame`, `DEFAULT_FRAME`, `resolveFrameContext`, `FrameContext`, `FrameSatellite`, `FrameSatelliteLookup`, `computeLvlhAxes`, `LvlhAxes`, and the internal marker adapter `toOrbitPoint`

## Kept public

`OrbitViewer` / `OrbitScene` + their prop types, `DEFAULT_BODIES` / `BodyDefinition(s)` / `BodyTexture`, `MarkerShape`, `SCENE_UP`, the `initArika` family, and the streaming **`TrailBuffer`** / `TrailBufferLike` with `OrbitPoint` and `toTrailBuffer` / `trailPointToOrbitPoint` (needed to feed a bring-your-own buffer).

No new package or subpath — the files stay in the source tree (still used internally) and in the shadcn registry closure; only the public re-exports go. A `./lib/unstable` can be added later if a concrete composition use case appears.

`viewer/README.md` is updated to match (documents `OrbitScene` and the streaming `trailBuffer`; drops the "primitives are exported" section).

## Validation

- `tsc --noEmit` + `tsc -p tsconfig.lib.json`: clean
- vitest: 38 files / 434 tests
- biome: no new errors; shadcn registry: no drift (file set unchanged — internals stay in the closure, only re-exports removed)
- codex review: 1 finding (README still documented the now-removed exports) → fixed; re-review converged

## Sequence

- PR A (#175, merged): extract `<OrbitScene>`.
- PR B (#176, merged): dogfood the app onto `<OrbitScene>`; `TrailBuffer` made a public streaming primitive.
- **PR C (this)**: narrow the public barrel to the intended surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)