### PR TITLE
docs(changelog): backfill the viewer into the 0.1.0 release notes

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -363,6 +363,30 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - `@duckdb/duckdb-wasm` 1.32.0 によるブラウザ内 OLAP + `uplot` 1.6
   rendering 層。React ≥ 18 を peer dependency として要求。
 
+### `viewer`
+
+- React + `@react-three/fiber` (Three.js) + Vite によるリアルタイム 3D
+  軌道ビューア。`orts-cli` バイナリに同梱し `http://localhost:9001` で配信。
+  standalone SPA としても deploy 済。
+- 3D シーン: 汎用 `CelestialBody` component によるテクスチャ付き中心天体
+  (Earth/Moon/Sun/Mars)。地球の day/night terminator と大気散乱の
+  カスタム GLSL shader、orbit-controls カメラ。
+- 衛星ごとの可視化: 3D 軌跡 trail、表示スケール設定可能な 3D 衛星モデル
+  (衛星中心ビューでは実スケール表示)、姿勢 quaternion による body-frame
+  の姿勢軸表示。
+- 参照フレーム選択: 中心天体中心の inertial (ECI) / body-fixed (ECEF) 表示、
+  または衛星を中心にしてその局所軌道 (LVLH) フレームで追尾。ECI ↔ ECEF
+  変換は `arika` WASM ビルドでブラウザ内実行。
+- データソース: CSV と `.rrd` 軌道ファイルの読込 (`.rrd` は `rrd-wasm` で
+  ブラウザ内 decode)、および `orts serve` から telemetry を streaming する
+  ライブ WebSocket モード (`useWebSocket`)。単一・多数の衛星に対応。
+- ブラウザ内シミュレーション制御: シミュレーション parameter を設定し、
+  実行中の `orts serve` シミュレーションを UI から pause / resume / terminate。
+- replay / playback: `useRealtimePlayback` hook が時刻ベースの軌道再生を駆動。
+  軌跡の漸進描画と `PlaybackBar` scrubber (再生 / 一時停止 / シーク)。
+- ブラウザ内解析: DuckDB-wasm + uPlot 時系列チャート (`uneri` ベース)。
+  ドラッグズーム、マルチ衛星 series。
+
 ### `starlight-rustdoc` (npm)
 
 - Astro / Starlight 統合。`cargo rustdoc --output-format json` 出力を

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -397,6 +397,32 @@ Release blog post: [orts: 人工衛星シミュレーションプラットフォ
 - Built on `@duckdb/duckdb-wasm` 1.32.0 for in-browser OLAP with `uplot`
   1.6 as the render layer. React ≥ 18 as peer dependency.
 
+### `viewer`
+
+- Web-based real-time 3D orbit viewer built on React + `@react-three/fiber`
+  (Three.js) + Vite. Bundled into the `orts-cli` binary and served at
+  `http://localhost:9001`, and also deployed as a standalone SPA.
+- 3D scene: textured central bodies via a generic `CelestialBody` component
+  (Earth / Moon / Sun / Mars), with custom GLSL shaders for Earth's day/night
+  terminator and atmospheric scattering, plus an orbit-controls camera.
+- Per-satellite visualization: 3D trajectory trails, 3D satellite models with
+  a configurable display scale (true-scale sizing in the satellite-centered
+  view), and body-frame attitude axes driven by the attitude quaternion.
+- Reference-frame selection: a central-body-centered inertial (ECI) or
+  body-fixed (ECEF) view, or recenter on a satellite to track it in its
+  local-orbital (LVLH) frame. ECI ↔ ECEF transforms run in-browser via the
+  `arika` WASM build.
+- Data sources: CSV and `.rrd` orbit-file loading (`.rrd` decoded in-browser
+  via `rrd-wasm`) and a live WebSocket mode (`useWebSocket`) streaming
+  telemetry from `orts serve` for one or many satellites.
+- In-browser simulation control: configure simulation parameters and
+  pause / resume / terminate the running `orts serve` simulation from the UI.
+- Replay / playback: a `useRealtimePlayback` hook drives time-based orbit replay
+  with progressive trail drawing and a `PlaybackBar` scrubber
+  (play / pause / seek).
+- In-browser analytics: DuckDB-wasm + uPlot time-series charts (built on
+  `uneri`) with drag-zoom and multi-satellite series.
+
 ### `starlight-rustdoc` (npm)
 
 - Astro / Starlight integration that turns `cargo rustdoc --output-format


### PR DESCRIPTION
## Why

While prepping the next release I found the **web viewer was never recorded
in the changelog**. It has existed since the very first commit and shipped in
0.1.0, yet `uneri` and every Rust crate were documented while `viewer` was
silently omitted — a gap, not a convention. This backfills it so the 0.1.0
release notes reflect what actually shipped.

This is a self-contained historical correction, kept separate from the
upcoming `[Unreleased]` reconstruction.

## What

Add a `viewer` section to the **0.1.0** notes (EN + JA), covering what shipped:

- React + @react-three/fiber + Vite, embedded in `orts-cli` and deployed as a standalone SPA
- Textured central bodies (Earth/Moon/Sun/Mars) with day/night + atmosphere GLSL shaders
- Per-satellite trails, 3D models (configurable display scale), and body-frame attitude axes
- Reference frames: central-body ECI/ECEF, satellite-centered LVLH (via `arika` WASM)
- CSV/`.rrd` file loading (`.rrd` via `rrd-wasm`) and the live WebSocket mode
- In-browser sim control (pause/resume/terminate) and `useRealtimePlayback`/`PlaybackBar` replay
- DuckDB-wasm + uPlot charts (built on `uneri`)

Additions only — `[Unreleased]`, 0.2.0, and 0.1.1 are untouched. EN/JA kept in parity (8 bullets each).

## Verification

- Every feature claim verified against the **v0.1.0 source tree** (not commit messages).
- 4 rounds of `codex review`: found and fixed 4 historical inaccuracies
  (`PlaybackController` → `useRealtimePlayback`/`PlaybackBar`; `@sksat/uneri` → `uneri`
  since the scope rename was 0.1.1; satellite-centered frame is LVLH not inertial;
  display-scaled models, not true-scale by default). Final review is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)