### PR TITLE
docs(changelog): reconstruct the [Unreleased] section for 0.3.0

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -8,6 +8,146 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 
 ## [Unreleased]
 
+### `orts` (Rust, crates.io)
+
+#### Added
+- 地上局コンタクトウィンドウ検出 (`visibility` module): `GroundStation`
+  (WGS-84 位置 + 仰角マスク)、`ContactWindow` (補間した AOS/LOS、最大仰角、
+  span クリップフラグ)、純粋な `PassTracker` ステートマシン、frame-aware な
+  `VisibilityMonitor<F: EarthFrameBridge>` (ECI サンプルを地上局ごとの
+  topocentric look angle に変換)。
+- `IndependentGroup::propagate_to_with(t_target, observer)` — 受理された全
+  積分ステップで `FnMut(&SatId, f64, &State)` observer を呼びながら伝播。
+  integrator 解像度で状態をサンプリングできる。`propagate_to` は no-op
+  observer で委譲し、軌道はビット単位で不変。
+- node messaging 層 (`plugin::message`、"msg-io"): FSW のコマンド & テレメトリ
+  用。`Message`、`NodeId` (`Ground` / `Satellite(u32)`)、`Payload`、
+  `NamedValue`、`Value` (`Boolean`/`Integer`/`Number`/`Text`/`Bytes`) を
+  `orts::plugin` から再エクスポート。
+- `PluginController` の transport hook (既定 no-op、WASM backend が実装):
+  msg-io の `deliver` / `take_outbound`、raw byte stream 用 stream-io の
+  `stream_deliver` / `stream_take` / `stream_close`。
+- WIT v0 plugin interface に msg-io / stream-io チャネルを追加。
+
+#### Changed
+- `StateEffector` を frame-generic 化 — `StateEffector<S, F: frame::Eci =
+  SimpleEci>` で `ExternalLoads<F>` を返す (`Model<S, F>` と同様)。effector は
+  host の慣性 frame で荷重を生成するようになった。既定の `F` により既存の
+  `StateEffector<S>` 実装はそのままコンパイル可能。
+
+#### Fixed
+- `SpacecraftDynamics` の不正な frame 再タグを除去。`ExternalLoads<SimpleEci>`
+  とタグ付けされた effector 荷重を変換なしで host frame `F` に貼り替えており、
+  `F != SimpleEci` (例: `Gcrs`) で座標を黙って誤ラベルしていた。出荷済み
+  effector が torque のみのため潜在的だったが、並進 effector では誤りとなる。(#103)
+
+#### Removed
+- **BREAKING**: `orts::tle` module を削除。TLE パースは `arika::tle`
+  (共有 `arika::omm::Omm` record へデコード) に移管。`orts::tle` を使う
+  下流コードは `arika` へ移行が必要。
+
+### `orts-cli` (Rust, crates.io, binary)
+
+#### Added
+- `orts run` の地上局コンタクトウィンドウ出力: `[[ground_station]]`
+  (`name`、`latitude_deg`、`longitude_deg`、`altitude_km`、`min_elevation_deg`)
+  で局を宣言。検出したウィンドウを AOS 順に stderr へ出力 (UTC 時刻、
+  sim-time オフセット、最大仰角。`*` は sim span でクリップされたウィンドウ)。
+  Earth 中心・エポック必須。
+- コンタクトウィンドウは `--output-interval` でなく integrator 解像度
+  (受理ステップごと / 制御 tick ごと) でサンプリング。検出が出力間引きに
+  依存しなくなった (1 サンプル間隔より短いパスは依然取りこぼし得る)。
+- `--omm <file>` で CCSDS OMM 入力 (JSON / KVN / XML、`-` で stdin) を
+  `arika::omm` でパース。TLE ペイロードは拒否し `--tle` を案内。
+- `orts serve` の `--stream-stdio SAT/STREAM` — 宣言済み stream-io stream の
+  1 本を kble-socket protocol で stdin/stdout に接続し、orts を kble の
+  `exec:` plug として実行可能にする。その stream の WebSocket endpoint は
+  HTTP 409 を返し、stdio peer が閉じるとサーバを停止。
+- `orts serve` の stream-io kble ブリッジ: 宣言済み各 stream を
+  `/stream/{sat}/{stream}` のバイナリ WebSocket endpoint として realtime
+  loop で駆動。未宣言ペアは HTTP 404。stream は config の `streams` で
+  衛星ごとに宣言。
+- config 駆動のコマンドタイムライン (FSW コマンド & テレメトリ):
+  `[[command]]` entry (`t` sim-time、`sat`、`kind`、任意の型付き `args`)。
+  host がスケジュール tick で決定論的に配送 (`orts run` のみ)。
+- WebSocket protocol の TypeScript 型を `ts-rs` で Rust 型から生成
+  (protocol enum、`SimConfig`、`SatelliteInfo` 等に `#[derive(TS)]`)。
+  `cargo test -p orts-cli` 実行時に viewer へ出力し、ドリフトすると CI が落ちる。
+
+#### Changed
+- `--tle` を再び TLE 専用 (2LE/3LE、`-` で stdin) とし、新規 `--omm` と
+  対にした。要素セットのパースは削除した `orts::tle` でなく
+  `arika::tle` / `arika::omm` を使用 (従来は `--tle` が OMM も自動受理)。
+- 軌道ソースの排他フラグは、片方を黙って優先するのでなくエラーにする:
+  `--sat` と `--tle` / `--omm` / `--tle-line1` / `--tle-line2` / `--norad-id`、
+  `--tle` と `--omm`、ファイルソースとインライン `--tle-line1` / `--tle-line2`
+  は併用不可。`--tle-line1` / `--tle-line2` は両方指定が必須。
+- TLE epoch の day-of-year を (閏考慮の) 年日数で検証。不正値はそのまま別の
+  年に繰り上がらず拒否される。
+
+#### Fixed
+- `--config` ファイルで起動した `orts serve` は `[[command]]` タイムラインを
+  含む config を明確なエラーで拒否する (コマンドタイムラインは `orts run`
+  のみ)。従来は黙って破棄していた。
+
+### `orts-plugin-sdk` (Rust, crates.io)
+
+#### Added
+- `msg-io` node messaging 層 (FSW コマンド & テレメトリ、将来の衛星間通信用):
+  WIT `interface msg-io` (`recv-batch` / `send-message`) が、論理 `node-id`
+  (`ground` / `satellite(u32)`) で宛先指定した型付き `payload` の datagram を
+  `tick-io` 制御プレーンとは別に運ぶ。SDK は `msg` module (`recv_batch`、
+  `recv_all`、`send`、`send_to`、`key_value`、`get`、`get_text`) を追加し
+  `Message` / `Outbound` / `NodeId` / `Payload` / `Value` / `NamedValue` を
+  再エクスポート。
+- `stream-io` raw byte-stream チャネル (kble 仮想ハーネス統合用): WIT
+  `interface stream-io` (名前付き stream の `read` / `write`)。orts は単なる
+  byte 導管で、framing は FSW + kble パイプライン側に委ねる。SDK は `stream`
+  module (`read`、`write`、`read_bytes`) を追加し `StreamRead` / `StreamError`
+  を再エクスポート。
+- example FSW に detumble→nadir モード遷移ガードを追加 (`commandable-mode-ff`、
+  `commandable-mode-rr`)。
+
+#### Changed
+- **BREAKING**: `world plugin` が `msg-io` と `stream-io` を追加で import する。
+  変更は純粋に追加的 (既存の interface / import / export / record の削除・改変
+  なし) のため、`orts_plugin!` の callback 型 guest は影響なし。手書きの
+  `impl Guest` guest は binding を再生成し新規 host import をリンクする必要がある。
+
+### `arika` (Rust, crates.io)
+
+#### Added
+- 要素セットのパース。共有 `omm::Omm` (CCSDS 平均要素 record: 識別子、UTC
+  epoch、6 個の SGP4 平均ケプラー要素、B\* drag。角度は rad、平均運動は rad/s)
+  に `semi_major_axis(mu)` / `to_keplerian_elements(mu)`。
+  - `tle` — NORAD TLE / 2LE / 3LE パーサ (`tle::parse`) が `Omm` を生成。
+    Alpha-5 英数字カタログ番号と `OBJECT_ID` 正規化に対応。
+  - `omm::json` / `omm::kvn` / `omm::xml` — JSON / KVN / XML 各シリアライズの
+    CCSDS OMM パーサ。JSON は単一オブジェクトまたは 1 要素配列 (CelesTrak の
+    単一衛星 GP) と Space-Track の文字列エンコード数値を受理。
+  - `omm::detect` + `omm::parse` — 形式判定 (`omm::Format`) と、TLE / OMM-JSON /
+    OMM-KVN / OMM-XML を自動判定して振り分ける BOM 許容の統一エントリ。
+- `kepler` module (`orts` から `arika` へ移管): `KeplerianElements`
+  (`from_state_vector` / `to_state_vector` / `period` / `energy`) と anomaly
+  変換群 (`solve_kepler_equation`、`mean_to_true_anomaly` 等)。公開
+  `arika::kepler` surface となり、`orts::orbital::kepler` が再エクスポート。
+- `frame::Teme` marker — True Equator, Mean Equinox (SGP4 / TLE 出力 frame)。
+  marker のみで、TEME ↔ GCRS 回転は未実装。
+- `earth::topocentric` — 地上局の look angle: `TopocentricSite<F: Ecef>`
+  (WGS-84 `Geodetic` から構築し局所 ENU 基底を事前計算) と `LookAngles`
+  (方位 / 仰角 / slant range)。`look_angles(target)` で算出。
+
+#### Changed
+- `Epoch::from_iso8601` が ordinal / day-of-year 形式
+  (`YYYY-DDDTHH:MM:SS`、CCSDS OMM で使用) も受理し、末尾の `Z` が任意になった。
+  厳密な緩和で、従来受理した入力は引き続きパース可能。
+
+### `utsuroi` (Rust, crates.io)
+
+#### Added
+- `IntegrationError` が `core::error::Error` を実装 (手書き、`thiserror` 不使用、
+  `no_std` でも動作)。`?` 連鎖や `Box<dyn Error>` に乗るようになった。
+
 ### `tobari` (Rust, crates.io)
 
 #### Changed
@@ -15,6 +155,113 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   `fetch-<source>` 規約(`fetch-igrf`、arika の `fetch-horizons`)に揃えた。
   `fetch` は全 `fetch-*` 源を束ねる傘 feature として存続するため、
   `features = ["fetch"]` は引き続きビルド可能(加えて `fetch-igrf` も有効化)。
+
+### `viewer`
+
+#### Added
+- 新しい `./lib` エントリ (`viewer/src/lib`) による組み込み可能な viewer
+  ライブラリ。同梱 SPA だけでなく任意の React + `@react-three/fiber` アプリに
+  orbit viewer を組み込める。レイヤ化 API:
+  - `OrbitViewer` — オールインワン: 自前のサイズ付き `<div>` + `<Canvas>` を
+    描画。`centralBody` と `SatelliteState[]` で駆動。
+  - `OrbitScene` — 自分の `<Canvas>` 内にマウントする scene graph
+    (bring-your-own Canvas)。エクスポートされた `SCENE_UP` で初期化。
+  - viewer 自身のアプリも公開 `OrbitScene` API 上に構築 (dogfooding)。
+    ライブラリとアプリが乖離しない。
+- shadcn registry としての配布 (`registry.json`、item `orbit-viewer`):
+  component とその primitive を `shadcn add` で consumer アプリに取り込める。
+  registry item を導入して描画するスタンドアロン consumer example
+  (`viewer/examples/orbit-viewer/`) を同梱。
+- 拡張可能な中心天体: `bodies` prop (`BodyDefinitions`) でカスタム定義を渡し、
+  組み込みの `DEFAULT_BODIES` (Earth / Moon / Sun / Mars) に重ねる。
+  `BodyDefinition` / `BodyDefinitions` / `BodyTexture` / `DEFAULT_BODIES` を
+  エクスポート。
+- 注入可能な arika WASM: `initArika({ wasmUrl? })` / `isArikaReady()` を
+  エクスポート。embedder が module を事前ロードしたり外部 `.wasm` URL を
+  指定できる。arika WASM は独自 workspace package (`arika-wasm`) に切り出し、
+  名前で import する (registry 配布に必要)。
+- 公開 `TrailBuffer` streaming primitive (`TrailBuffer` + `TrailBufferLike`):
+  呼び出し側が bounded な trail buffer を所有し React の外で mutate でき
+  (`SatelliteState.trailBuffer`)、scene が毎フレーム読むため streaming した
+  点が React 再レンダーなしで GPU に届く。`toTrailBuffer` /
+  `trailPointToOrbitPoint` と `OrbitPoint` / `TrailPoint` 型をエクスポート。
+- `SatelliteState` の衛星ごと表示プロパティ: `color`、`name`、`markerShape`、
+  `trailDisplay` (`visibleCount` / `drawStart`、playback スクラブ用)、
+  および衛星ごとの `time` (凍結 / スクラブした衛星のマーカーをその body-fixed
+  trail に整合させる)。
+- 衛星を trail だけでなく現在位置から描画 — 位置のみ (trail なし) の衛星も
+  マーカーを表示する。
+- 選択可能なマーカー形状 (`MarkerShape`: `"sphere"` | `"axes-cube"`)。
+  3D モデルなしで姿勢を示す非球の XYZ 姿勢キューブを含む。衛星ごと / scene
+  全体で解決でき、シミュレーションが wire 越しに宣言可能 (viewer 上書き可)。
+- 衛星中心 frame が要求された向きを尊重: star-fixed `inertial` (軸が共回転
+  しない) または `localOrbital` (LVLH)。従来は衛星中心ビューが常に LVLH に
+  収束していた。(#90)
+
+#### Changed
+- `./lib` の公開 barrel は意図的に絞っている: Three.js / r3f の構成要素と内部
+  frame 配線はエクスポートしない。公開 surface は `OrbitViewer`、`OrbitScene`、
+  `TrailBuffer` / `TrailBufferLike`、`toTrailBuffer` / `trailPointToOrbitPoint`、
+  `initArika` / `isArikaReady`、`SCENE_UP`、`DEFAULT_BODIES`、
+  `DEFAULT_VIEWER_FRAME` と対応する型。
+- DuckDB-wasm アセットを viewer 側で self-host (Vite `?url` import を uneri の
+  `initDuckDB({ bundles })` に渡す)。jsDelivr CDN への runtime 依存を排除。
+- Earth 固有の描画 (day/night terminator、大気、Earth の自転) を「night
+  texture を持つか」でなく `earth` body id に限定。カスタム天体は汎用の
+  textured-sphere 経路で描画。
+- 中心天体に解決可能な半径がない場合、`OrbitScene` / `OrbitViewer` は半径 1 で
+  黙ってフォールバックして scene scale を狂わせるのでなく、明確なエラーを出す。
+- arika WASM は `epochJd` が与えられた時のみロード。epoch なしの embedder は
+  init コストを払わない (固定の Sun 方向、天体回転なし)。
+- WS protocol 型は `ts-rs` 生成 binding になった (`orts-cli` 参照)。手書きの
+  wire 型を置き換え、`satellite_added` variant を追加。
+
+#### Fixed
+- static deploy での既定 WebSocket URL を、`window.location` から到達不能な
+  host を導出するのでなく `ws://localhost:9001/ws` にフォールバック。
+- static deployment で高解像度天体テクスチャを復元 (サーバからのみ取得、
+  off-thread デコード、bounded な upgrade retry、in-flight guard)。(#105)
+- LVLH (衛星中心) の中心天体の向きを修正。Earth (ERA) と非 Earth
+  (`body_orientation` + pole) で経路を分離。
+- quaternion slerp が `qw` だけでなく完全な quaternion (qw/qx/qy/qz 全て) を
+  guard し、NaN はそのまま通す。scene の per-render アロケーションを削除。
+- trail buffer の mutation を commit phase で適用、trail buffer reset 時に
+  `satellites[]` を再構築、body-fixed マーカーで衛星ごとの位置時刻を保持、
+  `SatelliteState.color` を尊重、file / RRD adapter は restart 時にクリーンに
+  リセットし fatal な worker error で破棄。
+
+#### Performance
+- trail なしの衛星は trail buffer 確保と毎フレームの trail 処理を丸ごとスキップ。
+
+### `uneri` (npm: `@sksat/uneri`)
+
+#### Added
+- `initDuckDB` が DuckDB-wasm の worker / wasm を、jsDelivr CDN でなく
+  呼び出し側が注入する self-host bundle URL からロード可能に。新しい
+  `DuckDBInitOptions` (`bundles?`、`fallbackToJsDelivr?`) と `DuckDBBundleUrls`
+  型、純粋関数 `resolveBundleSource(options?)` を追加。uneri は bundler 中立の
+  まま、アプリ側が URL を解決して渡す。
+- 堅牢な init: `initDuckDB` は linear backoff でリトライし、死んだ worker は
+  `error` listener で即 fail (ハングしない)、terminal failure 後はキャッシュ
+  された reject promise を破棄して次回呼び出しでリトライする。(#70)
+
+#### Changed
+- 引数なしの `initDuckDB()` の既定動作は不変 — 引き続き jsDelivr CDN から
+  bundle を取得するため既存 consumer はそのまま動く。self-host は
+  `options.bundles` で opt-in。
+
+#### Fixed
+- init 時の worker 404 / "invalid URL": bundle URL を `initDuckDB` 内で worker
+  origin に対して絶対化する。DuckDB が worker を `blob:` URL から生成するため、
+  root-relative パスでは解決できないことへの対処。
+
+### Dependencies
+
+- Rust toolchain → 1.96.0。
+- Rust: `wasmtime` / `wasmtime-wasi` 44 (security)、`rerun` 0.33、
+  `tokio-tungstenite` 0.29、`nalgebra` 0.35、`tokio` 1.52、`axum` 0.8.9。
+- npm: `vite` 8、`@vitejs/plugin-react` 6、React monorepo、`ws` 8.21
+  (security)、`mermaid` 11.15 (security)。
 
 ## [0.2.0](https://github.com/sksat/orts/releases/tag/v0.2.0) - 2026-04-20
 

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -15,36 +15,36 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   (WGS-84 位置 + 仰角マスク)、`ContactWindow` (補間した AOS/LOS、最大仰角、
   span クリップフラグ)、純粋な `PassTracker` ステートマシン、frame-aware な
   `VisibilityMonitor<F: EarthFrameBridge>` (ECI サンプルを地上局ごとの
-  topocentric look angle に変換)。
+  topocentric look angle に変換)。([#112](https://github.com/sksat/orts/pull/112))
 - `IndependentGroup::propagate_to_with(t_target, observer)` — 受理された全
   積分ステップで `FnMut(&SatId, f64, &State)` observer を呼びながら伝播。
   integrator 解像度で状態をサンプリングできる。`propagate_to` は no-op
-  observer で委譲し、軌道はビット単位で不変。
+  observer で委譲し、軌道はビット単位で不変。([#112](https://github.com/sksat/orts/pull/112))
 - node messaging 層 (`plugin::message`、"msg-io"): FSW のコマンド & テレメトリ
   用。`Message`、`NodeId` (`Ground` / `Satellite(u32)`)、`Payload`、
   `NamedValue`、`Value` (`Boolean`/`Integer`/`Number`/`Text`/`Bytes`) を
-  `orts::plugin` から再エクスポート。
+  `orts::plugin` から再エクスポート。([#58](https://github.com/sksat/orts/pull/58))
 - `PluginController` の transport hook (既定 no-op、WASM backend が実装):
   msg-io の `deliver` / `take_outbound`、raw byte stream 用 stream-io の
-  `stream_deliver` / `stream_take` / `stream_close`。
-- WIT v0 plugin interface に msg-io / stream-io チャネルを追加。
+  `stream_deliver` / `stream_take` / `stream_close`。([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
+- WIT v0 plugin interface に msg-io / stream-io チャネルを追加。([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
 - `StateEffector` を frame-generic 化 — `StateEffector<S, F: frame::Eci =
   SimpleEci>` で `ExternalLoads<F>` を返す (`Model<S, F>` と同様)。effector は
   host の慣性 frame で荷重を生成するようになった。既定の `F` により既存の
-  `StateEffector<S>` 実装はそのままコンパイル可能。
+  `StateEffector<S>` 実装はそのままコンパイル可能。([#148](https://github.com/sksat/orts/pull/148))
 
 #### Fixed
 - `SpacecraftDynamics` の不正な frame 再タグを除去。`ExternalLoads<SimpleEci>`
   とタグ付けされた effector 荷重を変換なしで host frame `F` に貼り替えており、
   `F != SimpleEci` (例: `Gcrs`) で座標を黙って誤ラベルしていた。出荷済み
-  effector が torque のみのため潜在的だったが、並進 effector では誤りとなる。(#103)
+  effector が torque のみのため潜在的だったが、並進 effector では誤りとなる。([#148](https://github.com/sksat/orts/pull/148), [#103](https://github.com/sksat/orts/issues/103))
 
 #### Removed
 - **BREAKING**: `orts::tle` module を削除。TLE パースは `arika::tle`
   (共有 `arika::omm::Omm` record へデコード) に移管。`orts::tle` を使う
-  下流コードは `arika` へ移行が必要。
+  下流コードは `arika` へ移行が必要。([#87](https://github.com/sksat/orts/pull/87))
 
 ### `orts-cli` (Rust, crates.io, binary)
 
@@ -53,42 +53,42 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   (`name`、`latitude_deg`、`longitude_deg`、`altitude_km`、`min_elevation_deg`)
   で局を宣言。検出したウィンドウを AOS 順に stderr へ出力 (UTC 時刻、
   sim-time オフセット、最大仰角。`*` は sim span でクリップされたウィンドウ)。
-  Earth 中心・エポック必須。
+  Earth 中心・エポック必須。([#112](https://github.com/sksat/orts/pull/112))
 - コンタクトウィンドウは `--output-interval` でなく integrator 解像度
   (受理ステップごと / 制御 tick ごと) でサンプリング。検出が出力間引きに
-  依存しなくなった (1 サンプル間隔より短いパスは依然取りこぼし得る)。
+  依存しなくなった (1 サンプル間隔より短いパスは依然取りこぼし得る)。([#112](https://github.com/sksat/orts/pull/112))
 - `--omm <file>` で CCSDS OMM 入力 (JSON / KVN / XML、`-` で stdin) を
-  `arika::omm` でパース。TLE ペイロードは拒否し `--tle` を案内。
+  `arika::omm` でパース。TLE ペイロードは拒否し `--tle` を案内。([#87](https://github.com/sksat/orts/pull/87))
 - `orts serve` の `--stream-stdio SAT/STREAM` — 宣言済み stream-io stream の
   1 本を kble-socket protocol で stdin/stdout に接続し、orts を kble の
   `exec:` plug として実行可能にする。その stream の WebSocket endpoint は
-  HTTP 409 を返し、stdio peer が閉じるとサーバを停止。
+  HTTP 409 を返し、stdio peer が閉じるとサーバを停止。([#114](https://github.com/sksat/orts/pull/114))
 - `orts serve` の stream-io kble ブリッジ: 宣言済み各 stream を
   `/stream/{sat}/{stream}` のバイナリ WebSocket endpoint として realtime
   loop で駆動。未宣言ペアは HTTP 404。stream は config の `streams` で
-  衛星ごとに宣言。
+  衛星ごとに宣言。([#106](https://github.com/sksat/orts/pull/106))
 - config 駆動のコマンドタイムライン (FSW コマンド & テレメトリ):
   `[[command]]` entry (`t` sim-time、`sat`、`kind`、任意の型付き `args`)。
-  host がスケジュール tick で決定論的に配送 (`orts run` のみ)。
+  host がスケジュール tick で決定論的に配送 (`orts run` のみ)。([#58](https://github.com/sksat/orts/pull/58))
 - WebSocket protocol の TypeScript 型を `ts-rs` で Rust 型から生成
   (protocol enum、`SimConfig`、`SatelliteInfo` 等に `#[derive(TS)]`)。
-  `cargo test -p orts-cli` 実行時に viewer へ出力し、ドリフトすると CI が落ちる。
+  `cargo test -p orts-cli` 実行時に viewer へ出力し、ドリフトすると CI が落ちる。([#95](https://github.com/sksat/orts/pull/95))
 
 #### Changed
 - `--tle` を再び TLE 専用 (2LE/3LE、`-` で stdin) とし、新規 `--omm` と
   対にした。要素セットのパースは削除した `orts::tle` でなく
-  `arika::tle` / `arika::omm` を使用 (従来は `--tle` が OMM も自動受理)。
+  `arika::tle` / `arika::omm` を使用 (従来は `--tle` が OMM も自動受理)。([#87](https://github.com/sksat/orts/pull/87))
 - 軌道ソースの排他フラグは、片方を黙って優先するのでなくエラーにする:
   `--sat` と `--tle` / `--omm` / `--tle-line1` / `--tle-line2` / `--norad-id`、
   `--tle` と `--omm`、ファイルソースとインライン `--tle-line1` / `--tle-line2`
-  は併用不可。`--tle-line1` / `--tle-line2` は両方指定が必須。
+  は併用不可。`--tle-line1` / `--tle-line2` は両方指定が必須。([#87](https://github.com/sksat/orts/pull/87))
 - TLE epoch の day-of-year を (閏考慮の) 年日数で検証。不正値はそのまま別の
-  年に繰り上がらず拒否される。
+  年に繰り上がらず拒否される。([#87](https://github.com/sksat/orts/pull/87))
 
 #### Fixed
 - `--config` ファイルで起動した `orts serve` は `[[command]]` タイムラインを
   含む config を明確なエラーで拒否する (コマンドタイムラインは `orts run`
-  のみ)。従来は黙って破棄していた。
+  のみ)。従来は黙って破棄していた。([#58](https://github.com/sksat/orts/pull/58))
 
 ### `orts-plugin-sdk` (Rust, crates.io)
 
@@ -99,27 +99,28 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   `tick-io` 制御プレーンとは別に運ぶ。SDK は `msg` module (`recv_batch`、
   `recv_all`、`send`、`send_to`、`key_value`、`get`、`get_text`) を追加し
   `Message` / `Outbound` / `NodeId` / `Payload` / `Value` / `NamedValue` を
-  再エクスポート。
+  再エクスポート。([#58](https://github.com/sksat/orts/pull/58))
 - `stream-io` raw byte-stream チャネル (kble 仮想ハーネス統合用): WIT
   `interface stream-io` (名前付き stream の `read` / `write`)。orts は単なる
   byte 導管で、framing は FSW + kble パイプライン側に委ねる。SDK は `stream`
   module (`read`、`write`、`read_bytes`) を追加し `StreamRead` / `StreamError`
-  を再エクスポート。
+  を再エクスポート。([#84](https://github.com/sksat/orts/pull/84))
 - example FSW に detumble→nadir モード遷移ガードを追加 (`commandable-mode-ff`、
-  `commandable-mode-rr`)。
+  `commandable-mode-rr`)。([#58](https://github.com/sksat/orts/pull/58))
 
 #### Changed
 - **BREAKING**: `world plugin` が `msg-io` と `stream-io` を追加で import する。
   変更は純粋に追加的 (既存の interface / import / export / record の削除・改変
   なし) のため、`orts_plugin!` の callback 型 guest は影響なし。手書きの
-  `impl Guest` guest は binding を再生成し新規 host import をリンクする必要がある。
+  `impl Guest` guest は binding を再生成し新規 host import をリンクする必要がある。([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 ### `arika` (Rust, crates.io)
 
 #### Added
-- 要素セットのパース。共有 `omm::Omm` (CCSDS 平均要素 record: 識別子、UTC
-  epoch、6 個の SGP4 平均ケプラー要素、B\* drag。角度は rad、平均運動は rad/s)
-  に `semi_major_axis(mu)` / `to_keplerian_elements(mu)`。
+- 要素セットのパース ([#87](https://github.com/sksat/orts/pull/87))。共有
+  `omm::Omm` (CCSDS 平均要素 record: 識別子、UTC epoch、6 個の SGP4 平均
+  ケプラー要素、B\* drag。角度は rad、平均運動は rad/s) に
+  `semi_major_axis(mu)` / `to_keplerian_elements(mu)`。
   - `tle` — NORAD TLE / 2LE / 3LE パーサ (`tle::parse`) が `Omm` を生成。
     Alpha-5 英数字カタログ番号と `OBJECT_ID` 正規化に対応。
   - `omm::json` / `omm::kvn` / `omm::xml` — JSON / KVN / XML 各シリアライズの
@@ -130,23 +131,23 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - `kepler` module (`orts` から `arika` へ移管): `KeplerianElements`
   (`from_state_vector` / `to_state_vector` / `period` / `energy`) と anomaly
   変換群 (`solve_kepler_equation`、`mean_to_true_anomaly` 等)。公開
-  `arika::kepler` surface となり、`orts::orbital::kepler` が再エクスポート。
+  `arika::kepler` surface となり、`orts::orbital::kepler` が再エクスポート。([#87](https://github.com/sksat/orts/pull/87))
 - `frame::Teme` marker — True Equator, Mean Equinox (SGP4 / TLE 出力 frame)。
-  marker のみで、TEME ↔ GCRS 回転は未実装。
+  marker のみで、TEME ↔ GCRS 回転は未実装。([#87](https://github.com/sksat/orts/pull/87))
 - `earth::topocentric` — 地上局の look angle: `TopocentricSite<F: Ecef>`
   (WGS-84 `Geodetic` から構築し局所 ENU 基底を事前計算) と `LookAngles`
-  (方位 / 仰角 / slant range)。`look_angles(target)` で算出。
+  (方位 / 仰角 / slant range)。`look_angles(target)` で算出。([#112](https://github.com/sksat/orts/pull/112))
 
 #### Changed
 - `Epoch::from_iso8601` が ordinal / day-of-year 形式
   (`YYYY-DDDTHH:MM:SS`、CCSDS OMM で使用) も受理し、末尾の `Z` が任意になった。
-  厳密な緩和で、従来受理した入力は引き続きパース可能。
+  厳密な緩和で、従来受理した入力は引き続きパース可能。([#87](https://github.com/sksat/orts/pull/87))
 
 ### `utsuroi` (Rust, crates.io)
 
 #### Added
 - `IntegrationError` が `core::error::Error` を実装 (手書き、`thiserror` 不使用、
-  `no_std` でも動作)。`?` 連鎖や `Box<dyn Error>` に乗るようになった。
+  `no_std` でも動作)。`?` 連鎖や `Box<dyn Error>` に乗るようになった。([#147](https://github.com/sksat/orts/pull/147))
 
 ### `tobari` (Rust, crates.io)
 
@@ -154,7 +155,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - CSSI 宇宙天気ダウンロードの feature `fetch` を `fetch-cssi` にリネーム。
   `fetch-<source>` 規約(`fetch-igrf`、arika の `fetch-horizons`)に揃えた。
   `fetch` は全 `fetch-*` 源を束ねる傘 feature として存続するため、
-  `features = ["fetch"]` は引き続きビルド可能(加えて `fetch-igrf` も有効化)。
+  `features = ["fetch"]` は引き続きビルド可能(加えて `fetch-igrf` も有効化)。([#150](https://github.com/sksat/orts/pull/150))
 
 ### `viewer`
 
@@ -168,70 +169,71 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
     (bring-your-own Canvas)。エクスポートされた `SCENE_UP` で初期化。
   - viewer 自身のアプリも公開 `OrbitScene` API 上に構築 (dogfooding)。
     ライブラリとアプリが乖離しない。
+  ([#89](https://github.com/sksat/orts/pull/89), [#175](https://github.com/sksat/orts/pull/175), [#176](https://github.com/sksat/orts/pull/176))
 - shadcn registry としての配布 (`registry.json`、item `orbit-viewer`):
   component とその primitive を `shadcn add` で consumer アプリに取り込める。
   registry item を導入して描画するスタンドアロン consumer example
-  (`viewer/examples/orbit-viewer/`) を同梱。
+  (`viewer/examples/orbit-viewer/`) を同梱。([#168](https://github.com/sksat/orts/pull/168), [#169](https://github.com/sksat/orts/pull/169))
 - 拡張可能な中心天体: `bodies` prop (`BodyDefinitions`) でカスタム定義を渡し、
   組み込みの `DEFAULT_BODIES` (Earth / Moon / Sun / Mars) に重ねる。
   `BodyDefinition` / `BodyDefinitions` / `BodyTexture` / `DEFAULT_BODIES` を
-  エクスポート。
+  エクスポート。([#164](https://github.com/sksat/orts/pull/164))
 - 注入可能な arika WASM: `initArika({ wasmUrl? })` / `isArikaReady()` を
   エクスポート。embedder が module を事前ロードしたり外部 `.wasm` URL を
   指定できる。arika WASM は独自 workspace package (`arika-wasm`) に切り出し、
-  名前で import する (registry 配布に必要)。
+  名前で import する (registry 配布に必要)。([#159](https://github.com/sksat/orts/pull/159), [#167](https://github.com/sksat/orts/pull/167))
 - 公開 `TrailBuffer` streaming primitive (`TrailBuffer` + `TrailBufferLike`):
   呼び出し側が bounded な trail buffer を所有し React の外で mutate でき
   (`SatelliteState.trailBuffer`)、scene が毎フレーム読むため streaming した
   点が React 再レンダーなしで GPU に届く。`toTrailBuffer` /
-  `trailPointToOrbitPoint` と `OrbitPoint` / `TrailPoint` 型をエクスポート。
+  `trailPointToOrbitPoint` と `OrbitPoint` / `TrailPoint` 型をエクスポート。([#176](https://github.com/sksat/orts/pull/176))
 - `SatelliteState` の衛星ごと表示プロパティ: `color`、`name`、`markerShape`、
   `trailDisplay` (`visibleCount` / `drawStart`、playback スクラブ用)、
   および衛星ごとの `time` (凍結 / スクラブした衛星のマーカーをその body-fixed
-  trail に整合させる)。
+  trail に整合させる)。([#89](https://github.com/sksat/orts/pull/89), [#176](https://github.com/sksat/orts/pull/176))
 - 衛星を trail だけでなく現在位置から描画 — 位置のみ (trail なし) の衛星も
-  マーカーを表示する。
+  マーカーを表示する。([#89](https://github.com/sksat/orts/pull/89))
 - 選択可能なマーカー形状 (`MarkerShape`: `"sphere"` | `"axes-cube"`)。
   3D モデルなしで姿勢を示す非球の XYZ 姿勢キューブを含む。衛星ごと / scene
-  全体で解決でき、シミュレーションが wire 越しに宣言可能 (viewer 上書き可)。
+  全体で解決でき、シミュレーションが wire 越しに宣言可能 (viewer 上書き可)。([#158](https://github.com/sksat/orts/pull/158))
 - 衛星中心 frame が要求された向きを尊重: star-fixed `inertial` (軸が共回転
   しない) または `localOrbital` (LVLH)。従来は衛星中心ビューが常に LVLH に
-  収束していた。(#90)
+  収束していた。([#111](https://github.com/sksat/orts/pull/111), [#90](https://github.com/sksat/orts/issues/90))
 
 #### Changed
 - `./lib` の公開 barrel は意図的に絞っている: Three.js / r3f の構成要素と内部
   frame 配線はエクスポートしない。公開 surface は `OrbitViewer`、`OrbitScene`、
   `TrailBuffer` / `TrailBufferLike`、`toTrailBuffer` / `trailPointToOrbitPoint`、
   `initArika` / `isArikaReady`、`SCENE_UP`、`DEFAULT_BODIES`、
-  `DEFAULT_VIEWER_FRAME` と対応する型。
+  `DEFAULT_VIEWER_FRAME` と対応する型。([#177](https://github.com/sksat/orts/pull/177))
 - DuckDB-wasm アセットを viewer 側で self-host (Vite `?url` import を uneri の
-  `initDuckDB({ bundles })` に渡す)。jsDelivr CDN への runtime 依存を排除。
+  `initDuckDB({ bundles })` に渡す)。jsDelivr CDN への runtime 依存を排除。([#171](https://github.com/sksat/orts/pull/171))
 - Earth 固有の描画 (day/night terminator、大気、Earth の自転) を「night
   texture を持つか」でなく `earth` body id に限定。カスタム天体は汎用の
-  textured-sphere 経路で描画。
+  textured-sphere 経路で描画。([#164](https://github.com/sksat/orts/pull/164))
 - 中心天体に解決可能な半径がない場合、`OrbitScene` / `OrbitViewer` は半径 1 で
-  黙ってフォールバックして scene scale を狂わせるのでなく、明確なエラーを出す。
+  黙ってフォールバックして scene scale を狂わせるのでなく、明確なエラーを出す。([#164](https://github.com/sksat/orts/pull/164))
 - arika WASM は `epochJd` が与えられた時のみロード。epoch なしの embedder は
-  init コストを払わない (固定の Sun 方向、天体回転なし)。
+  init コストを払わない (固定の Sun 方向、天体回転なし)。([#89](https://github.com/sksat/orts/pull/89))
 - WS protocol 型は `ts-rs` 生成 binding になった (`orts-cli` 参照)。手書きの
-  wire 型を置き換え、`satellite_added` variant を追加。
+  wire 型を置き換え、`satellite_added` variant を追加。([#95](https://github.com/sksat/orts/pull/95))
 
 #### Fixed
 - static deploy での既定 WebSocket URL を、`window.location` から到達不能な
-  host を導出するのでなく `ws://localhost:9001/ws` にフォールバック。
+  host を導出するのでなく `ws://localhost:9001/ws` にフォールバック。([#143](https://github.com/sksat/orts/pull/143))
 - static deployment で高解像度天体テクスチャを復元 (サーバからのみ取得、
-  off-thread デコード、bounded な upgrade retry、in-flight guard)。(#105)
+  off-thread デコード、bounded な upgrade retry、in-flight guard)。([#88](https://github.com/sksat/orts/pull/88), [#113](https://github.com/sksat/orts/pull/113), [#105](https://github.com/sksat/orts/issues/105))
 - LVLH (衛星中心) の中心天体の向きを修正。Earth (ERA) と非 Earth
-  (`body_orientation` + pole) で経路を分離。
+  (`body_orientation` + pole) で経路を分離。([#51](https://github.com/sksat/orts/pull/51))
 - quaternion slerp が `qw` だけでなく完全な quaternion (qw/qx/qy/qz 全て) を
-  guard し、NaN はそのまま通す。scene の per-render アロケーションを削除。
+  guard し、NaN はそのまま通す。scene の per-render アロケーションを削除。([#172](https://github.com/sksat/orts/pull/172))
 - trail buffer の mutation を commit phase で適用、trail buffer reset 時に
   `satellites[]` を再構築、body-fixed マーカーで衛星ごとの位置時刻を保持、
   `SatelliteState.color` を尊重、file / RRD adapter は restart 時にクリーンに
-  リセットし fatal な worker error で破棄。
+  リセットし fatal な worker error で破棄。([#89](https://github.com/sksat/orts/pull/89), [#107](https://github.com/sksat/orts/pull/107), [#108](https://github.com/sksat/orts/pull/108), [#176](https://github.com/sksat/orts/pull/176))
 
 #### Performance
-- trail なしの衛星は trail buffer 確保と毎フレームの trail 処理を丸ごとスキップ。
+- trail なしの衛星は trail buffer 確保と毎フレームの trail 処理を丸ごとスキップ。([#107](https://github.com/sksat/orts/pull/107))
 
 ### `uneri` (npm: `@sksat/uneri`)
 
@@ -240,20 +242,20 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   呼び出し側が注入する self-host bundle URL からロード可能に。新しい
   `DuckDBInitOptions` (`bundles?`、`fallbackToJsDelivr?`) と `DuckDBBundleUrls`
   型、純粋関数 `resolveBundleSource(options?)` を追加。uneri は bundler 中立の
-  まま、アプリ側が URL を解決して渡す。
+  まま、アプリ側が URL を解決して渡す。([#171](https://github.com/sksat/orts/pull/171))
 - 堅牢な init: `initDuckDB` は linear backoff でリトライし、死んだ worker は
   `error` listener で即 fail (ハングしない)、terminal failure 後はキャッシュ
-  された reject promise を破棄して次回呼び出しでリトライする。(#70)
+  された reject promise を破棄して次回呼び出しでリトライする。([#76](https://github.com/sksat/orts/pull/76), [#70](https://github.com/sksat/orts/issues/70))
 
 #### Changed
 - 引数なしの `initDuckDB()` の既定動作は不変 — 引き続き jsDelivr CDN から
   bundle を取得するため既存 consumer はそのまま動く。self-host は
-  `options.bundles` で opt-in。
+  `options.bundles` で opt-in。([#171](https://github.com/sksat/orts/pull/171))
 
 #### Fixed
 - init 時の worker 404 / "invalid URL": bundle URL を `initDuckDB` 内で worker
   origin に対して絶対化する。DuckDB が worker を `blob:` URL から生成するため、
-  root-relative パスでは解決できないことへの対処。
+  root-relative パスでは解決できないことへの対処。([#171](https://github.com/sksat/orts/pull/171))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,37 +18,37 @@ section is subdivided by package.
   (WGS-84 location + elevation mask), `ContactWindow` (interpolated AOS/LOS, max
   elevation, span-clip flags), the pure `PassTracker` state machine, and a
   frame-aware `VisibilityMonitor<F: EarthFrameBridge>` that turns ECI samples
-  into per-station topocentric look angles.
+  into per-station topocentric look angles. ([#112](https://github.com/sksat/orts/pull/112))
 - `IndependentGroup::propagate_to_with(t_target, observer)` — propagate while a
   `FnMut(&SatId, f64, &State)` observer runs on every accepted integration step,
   so callers can sample state at integrator resolution. `propagate_to` delegates
-  to it with a no-op observer; trajectories stay bit-identical.
+  to it with a no-op observer; trajectories stay bit-identical. ([#112](https://github.com/sksat/orts/pull/112))
 - Node-messaging layer (`plugin::message`, "msg-io") for flight-software command
   & telemetry: `Message`, `NodeId` (`Ground` / `Satellite(u32)`), `Payload`,
   `NamedValue`, and `Value` (`Boolean`/`Integer`/`Number`/`Text`/`Bytes`),
-  re-exported from `orts::plugin`.
+  re-exported from `orts::plugin`. ([#58](https://github.com/sksat/orts/pull/58))
 - `PluginController` transport hooks (default no-op, implemented by the WASM
   backends): msg-io `deliver` / `take_outbound`, and stream-io `stream_deliver`
-  / `stream_take` / `stream_close` for raw byte streams.
-- WIT v0 plugin interface extended with the msg-io and stream-io channels.
+  / `stream_take` / `stream_close` for raw byte streams. ([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
+- WIT v0 plugin interface extended with the msg-io and stream-io channels. ([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
 - `StateEffector` is now frame-generic — `StateEffector<S, F: frame::Eci =
   SimpleEci>` returning `ExternalLoads<F>`, like `Model<S, F>` — so effectors
   produce loads already in the host inertial frame. The defaulted `F` keeps
-  existing `StateEffector<S>` impls compiling unchanged.
+  existing `StateEffector<S>` impls compiling unchanged. ([#148](https://github.com/sksat/orts/pull/148))
 
 #### Fixed
 - Removed an unsound frame re-tag in `SpacecraftDynamics`: effector loads tagged
   `ExternalLoads<SimpleEci>` were relabeled as the host frame `F` without
   conversion, silently mislabeling coordinates for any `F != SimpleEci`. Latent
   (the only shipped effector is torque-only) but wrong for a translational
-  effector. (#103)
+  effector. ([#148](https://github.com/sksat/orts/pull/148), [#103](https://github.com/sksat/orts/issues/103))
 
 #### Removed
 - **BREAKING**: the `orts::tle` module is removed; TLE parsing moved to
   `arika::tle` (decoding into the shared `arika::omm::Omm` record). Downstream
-  code using `orts::tle` must migrate to `arika`.
+  code using `orts::tle` must migrate to `arika`. ([#87](https://github.com/sksat/orts/pull/87))
 
 ### `orts-cli` (Rust, crates.io, binary)
 
@@ -57,45 +57,45 @@ section is subdivided by package.
   `[[ground_station]]` (`name`, `latitude_deg`, `longitude_deg`, `altitude_km`,
   `min_elevation_deg`); detected windows print to stderr ordered by AOS, with
   UTC timestamps, sim-time offsets, and max elevation (`*` marks windows clipped
-  by the sim span). Earth-centered, epoch-required.
+  by the sim span). Earth-centered, epoch-required. ([#112](https://github.com/sksat/orts/pull/112))
 - Contact windows are sampled at integrator resolution (every accepted step /
   control tick) rather than at `--output-interval`, so detection no longer
   depends on the output decimation. (A pass shorter than one integrator /
-  control sample gap can still be missed.)
+  control sample gap can still be missed.) ([#112](https://github.com/sksat/orts/pull/112))
 - `--omm <file>` for CCSDS OMM input (JSON / KVN / XML; `-` for stdin), parsed
-  with `arika::omm`; rejects a TLE payload and points to `--tle`.
+  with `arika::omm`; rejects a TLE payload and points to `--tle`. ([#87](https://github.com/sksat/orts/pull/87))
 - `--stream-stdio SAT/STREAM` on `orts serve` — wire one declared stream-io
   stream to stdin/stdout over the kble-socket protocol so orts can run as a kble
   `exec:` plug. That stream's WebSocket endpoint then answers HTTP 409; the
-  server shuts down when the stdio peer closes.
+  server shuts down when the stdio peer closes. ([#114](https://github.com/sksat/orts/pull/114))
 - stream-io kble bridge in `orts serve`: each declared stream is a binary
   WebSocket endpoint at `/stream/{sat}/{stream}` driven by a realtime loop;
   undeclared pairs return HTTP 404. Streams are declared per satellite via the
-  config `streams` field.
+  config `streams` field. ([#106](https://github.com/sksat/orts/pull/106))
 - Config-driven command timeline for flight-software command & telemetry:
   `[[command]]` entries with `t` (sim-time), `sat`, `kind`, and an optional typed
   `args` table, delivered deterministically by the host at the scheduled tick
-  (`orts run`).
+  (`orts run`). ([#58](https://github.com/sksat/orts/pull/58))
 - WebSocket protocol TypeScript types are generated from the Rust types via
   `ts-rs` (`#[derive(TS)]` on the protocol enums, `SimConfig`, `SatelliteInfo`,
   …). Bindings are emitted into the viewer when `cargo test -p orts-cli` runs,
-  and CI fails if they drift.
+  and CI fails if they drift. ([#95](https://github.com/sksat/orts/pull/95))
 
 #### Changed
 - `--tle` is TLE-only again (2LE/3LE; `-` for stdin) and pairs with the new
   `--omm`; element-set parsing is now backed by `arika::tle` / `arika::omm`
-  instead of the removed `orts::tle`. (Previously `--tle` also auto-accepted OMM.)
+  instead of the removed `orts::tle`. (Previously `--tle` also auto-accepted OMM.) ([#87](https://github.com/sksat/orts/pull/87))
 - Mutually-exclusive orbit-source flags now error instead of silently letting one
   win: `--sat` vs `--tle` / `--omm` / `--tle-line1` / `--tle-line2` /
   `--norad-id`; `--tle` vs `--omm`; file sources vs inline `--tle-line1` /
-  `--tle-line2`; and `--tle-line1` / `--tle-line2` must be given together.
+  `--tle-line2`; and `--tle-line1` / `--tle-line2` must be given together. ([#87](https://github.com/sksat/orts/pull/87))
 - TLE epoch day-of-year is validated against the (leap-aware) year length, so a
-  malformed field is rejected rather than rolling into another year.
+  malformed field is rejected rather than rolling into another year. ([#87](https://github.com/sksat/orts/pull/87))
 
 #### Fixed
 - `orts serve` started with a `--config` file now rejects a `[[command]]`
   timeline with a clear error (command timelines run only under `orts run`)
-  instead of silently dropping it.
+  instead of silently dropping it. ([#58](https://github.com/sksat/orts/pull/58))
 
 ### `orts-plugin-sdk` (Rust, crates.io)
 
@@ -106,27 +106,28 @@ section is subdivided by package.
   (`ground` / `satellite(u32)`) with a typed `payload`, separate from the
   `tick-io` control plane. The SDK adds a `msg` module (`recv_batch`, `recv_all`,
   `send`, `send_to`, `key_value`, `get`, `get_text`) re-exporting `Message` /
-  `Outbound` / `NodeId` / `Payload` / `Value` / `NamedValue`.
+  `Outbound` / `NodeId` / `Payload` / `Value` / `NamedValue`. ([#58](https://github.com/sksat/orts/pull/58))
 - `stream-io` raw byte-stream channel for kble virtual-harness integration: a WIT
   `interface stream-io` (`read` / `write` over named streams). orts is a dumb
   byte conduit; framing is left to the FSW + kble pipeline. The SDK adds a
   `stream` module (`read`, `write`, `read_bytes`) re-exporting `StreamRead` /
-  `StreamError`.
+  `StreamError`. ([#84](https://github.com/sksat/orts/pull/84))
 - Example FSWs gain a detumble→nadir mode-transition guard (`commandable-mode-ff`,
-  `commandable-mode-rr`).
+  `commandable-mode-rr`). ([#58](https://github.com/sksat/orts/pull/58))
 
 #### Changed
 - **BREAKING**: `world plugin` now also imports `msg-io` and `stream-io`. The
   change is purely additive (nothing removed or altered), so callback-style
   guests using `orts_plugin!` are unaffected; hand-written `impl Guest` guests
-  must regenerate bindings and link the two new host imports.
+  must regenerate bindings and link the two new host imports. ([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 ### `arika` (Rust, crates.io)
 
 #### Added
-- Element-set parsing. A shared `omm::Omm` CCSDS mean-element record (identity,
-  UTC epoch, six SGP4 mean Keplerian elements, B\* drag; angles in radians, mean
-  motion in rad/s) with `semi_major_axis(mu)` / `to_keplerian_elements(mu)`.
+- Element-set parsing ([#87](https://github.com/sksat/orts/pull/87)). A shared
+  `omm::Omm` CCSDS mean-element record (identity, UTC epoch, six SGP4 mean
+  Keplerian elements, B\* drag; angles in radians, mean motion in rad/s) with
+  `semi_major_axis(mu)` / `to_keplerian_elements(mu)`.
   - `tle` — NORAD TLE / 2LE / 3LE parser (`tle::parse`) → `Omm`, with Alpha-5
     alphanumeric catalog numbers and `OBJECT_ID` normalization.
   - `omm::json` / `omm::kvn` / `omm::xml` — CCSDS OMM parsers for the JSON, KVN,
@@ -138,24 +139,24 @@ section is subdivided by package.
 - `kepler` module (moved into `arika` from `orts`): `KeplerianElements`
   (`from_state_vector` / `to_state_vector` / `period` / `energy`) and the anomaly
   conversions (`solve_kepler_equation`, `mean_to_true_anomaly`, …). Now a public
-  `arika::kepler` surface; `orts::orbital::kepler` re-exports it.
+  `arika::kepler` surface; `orts::orbital::kepler` re-exports it. ([#87](https://github.com/sksat/orts/pull/87))
 - `frame::Teme` marker — True Equator, Mean Equinox (the SGP4 / TLE output
-  frame). Marker only; the TEME ↔ GCRS rotation is not yet implemented.
+  frame). Marker only; the TEME ↔ GCRS rotation is not yet implemented. ([#87](https://github.com/sksat/orts/pull/87))
 - `earth::topocentric` — ground-site look angles: `TopocentricSite<F: Ecef>`
   (from a WGS-84 `Geodetic`, precomputing the local ENU basis) and `LookAngles`
-  (azimuth / elevation / slant range), via `look_angles(target)`.
+  (azimuth / elevation / slant range), via `look_angles(target)`. ([#112](https://github.com/sksat/orts/pull/112))
 
 #### Changed
 - `Epoch::from_iso8601` also accepts the ordinal / day-of-year form
   (`YYYY-DDDTHH:MM:SS`, used by CCSDS OMM), and the trailing `Z` is now optional.
-  A strict relaxation — previously-accepted inputs still parse.
+  A strict relaxation — previously-accepted inputs still parse. ([#87](https://github.com/sksat/orts/pull/87))
 
 ### `utsuroi` (Rust, crates.io)
 
 #### Added
 - `IntegrationError` now implements `core::error::Error` (by hand, no
   `thiserror`, works under `no_std`), so it participates in `?` chains and
-  `Box<dyn Error>`.
+  `Box<dyn Error>`. ([#147](https://github.com/sksat/orts/pull/147))
 
 ### `tobari` (Rust, crates.io)
 
@@ -164,7 +165,7 @@ section is subdivided by package.
   matching the `fetch-<source>` convention (`fetch-igrf`, and `arika`'s
   `fetch-horizons`). `fetch` is retained as an umbrella feature that enables
   every `fetch-*` source, so `features = ["fetch"]` keeps building (and now
-  also pulls in `fetch-igrf`).
+  also pulls in `fetch-igrf`). ([#150](https://github.com/sksat/orts/pull/150))
 
 ### `viewer`
 
@@ -178,73 +179,74 @@ section is subdivided by package.
     (bring-your-own Canvas), initialised with the exported `SCENE_UP`.
   - The viewer's own app is now built on the public `OrbitScene` API
     (dogfooded), so the library and the app cannot drift apart.
+  ([#89](https://github.com/sksat/orts/pull/89), [#175](https://github.com/sksat/orts/pull/175), [#176](https://github.com/sksat/orts/pull/176))
 - Distribution as a shadcn registry (`registry.json`, item `orbit-viewer`): the
   component and its primitives can be vendored into a consumer app via
   `shadcn add`. Ships a standalone consumer example (`viewer/examples/orbit-viewer/`)
-  that installs and renders the registry item.
+  that installs and renders the registry item. ([#168](https://github.com/sksat/orts/pull/168), [#169](https://github.com/sksat/orts/pull/169))
 - Extensible central bodies: custom definitions via the `bodies` prop
   (`BodyDefinitions`) merged over the built-in `DEFAULT_BODIES`
   (Earth / Moon / Sun / Mars). Exports `BodyDefinition` / `BodyDefinitions` /
-  `BodyTexture` / `DEFAULT_BODIES`.
+  `BodyTexture` / `DEFAULT_BODIES`. ([#164](https://github.com/sksat/orts/pull/164))
 - Injectable arika WASM: `initArika({ wasmUrl? })` / `isArikaReady()` are
   exported so an embedder can preload the module or point at an external `.wasm`
   URL. The arika WASM was extracted into its own workspace package (`arika-wasm`),
-  imported by name (required for registry distribution).
+  imported by name (required for registry distribution). ([#159](https://github.com/sksat/orts/pull/159), [#167](https://github.com/sksat/orts/pull/167))
 - Public `TrailBuffer` streaming primitive (`TrailBuffer` + `TrailBufferLike`): a
   caller can own a bounded trail buffer and mutate it outside React
   (`SatelliteState.trailBuffer`); the scene reads it each frame so streamed points
   reach the GPU without a React re-render. Exports `toTrailBuffer` /
-  `trailPointToOrbitPoint` and the `OrbitPoint` / `TrailPoint` types.
+  `trailPointToOrbitPoint` and the `OrbitPoint` / `TrailPoint` types. ([#176](https://github.com/sksat/orts/pull/176))
 - Per-satellite display props on `SatelliteState`: `color`, `name`,
   `markerShape`, `trailDisplay` (`visibleCount` / `drawStart`, for playback
   scrubbing), and a per-satellite `time` so a frozen/scrubbed satellite keeps its
-  marker aligned with its own body-fixed trail.
+  marker aligned with its own body-fixed trail. ([#89](https://github.com/sksat/orts/pull/89), [#176](https://github.com/sksat/orts/pull/176))
 - Satellites render from their current position, not only from trails — a
-  position-only satellite still shows a marker.
+  position-only satellite still shows a marker. ([#89](https://github.com/sksat/orts/pull/89))
 - Selectable marker shapes (`MarkerShape`: `"sphere"` | `"axes-cube"`), including
   a non-sphere XYZ orientation cube that shows attitude without a hosted 3D
   model; resolvable per-satellite or scene-wide, and declarable by the simulation
-  over the wire (viewer-overridable).
+  over the wire (viewer-overridable). ([#158](https://github.com/sksat/orts/pull/158))
 - Satellite-centred frames now honour the requested orientation: star-fixed
   `inertial` (axes don't co-rotate) or `localOrbital` (LVLH). Previously a
-  satellite-centred view always collapsed to LVLH. (#90)
+  satellite-centred view always collapsed to LVLH. ([#111](https://github.com/sksat/orts/pull/111), [#90](https://github.com/sksat/orts/issues/90))
 
 #### Changed
 - The `./lib` public barrel is intentionally narrow: the Three.js / r3f building
   blocks and the internal frame wiring are not exported. Supported surface:
   `OrbitViewer`, `OrbitScene`, `TrailBuffer` / `TrailBufferLike`, `toTrailBuffer`
   / `trailPointToOrbitPoint`, `initArika` / `isArikaReady`, `SCENE_UP`,
-  `DEFAULT_BODIES`, `DEFAULT_VIEWER_FRAME`, and the supporting types.
+  `DEFAULT_BODIES`, `DEFAULT_VIEWER_FRAME`, and the supporting types. ([#177](https://github.com/sksat/orts/pull/177))
 - DuckDB-wasm assets are self-hosted by the viewer (Vite `?url` imports passed to
   uneri's `initDuckDB({ bundles })`) instead of the jsDelivr CDN, removing a
-  third-party-CDN runtime dependency.
+  third-party-CDN runtime dependency. ([#171](https://github.com/sksat/orts/pull/171))
 - Earth-specific rendering (day/night terminator, atmosphere, Earth spin) is
   gated to the `earth` body id, not "has a night texture"; custom bodies render
-  via the generic textured-sphere path.
+  via the generic textured-sphere path. ([#164](https://github.com/sksat/orts/pull/164))
 - `OrbitScene` / `OrbitViewer` throw a clear error when the central body has no
-  resolvable radius, instead of silently using radius 1 and a wrong scene scale.
+  resolvable radius, instead of silently using radius 1 and a wrong scene scale. ([#164](https://github.com/sksat/orts/pull/164))
 - The arika WASM loads only when an `epochJd` is supplied; epoch-less embedders
-  pay no init cost (fixed Sun direction, no body rotation).
+  pay no init cost (fixed Sun direction, no body rotation). ([#89](https://github.com/sksat/orts/pull/89))
 - WS protocol types are now the `ts-rs`-generated bindings (see `orts-cli`),
-  replacing the hand-written wire types and adding the `satellite_added` variant.
+  replacing the hand-written wire types and adding the `satellite_added` variant. ([#95](https://github.com/sksat/orts/pull/95))
 
 #### Fixed
 - Default WebSocket URL on static deploys falls back to `ws://localhost:9001/ws`
-  instead of deriving an unreachable host from `window.location`.
+  instead of deriving an unreachable host from `window.location`. ([#143](https://github.com/sksat/orts/pull/143))
 - High-resolution body textures restored in static deployment (server-only fetch,
-  off-thread decode, bounded upgrade retries, in-flight guard). (#105)
+  off-thread decode, bounded upgrade retries, in-flight guard). ([#88](https://github.com/sksat/orts/pull/88), [#113](https://github.com/sksat/orts/pull/113), [#105](https://github.com/sksat/orts/issues/105))
 - LVLH (satellite-centred) central-body orientation corrected, with separate
-  Earth (ERA) vs non-Earth (`body_orientation` + pole) paths.
+  Earth (ERA) vs non-Earth (`body_orientation` + pole) paths. ([#51](https://github.com/sksat/orts/pull/51))
 - Quaternion slerp guards on a complete quaternion (all of qw/qx/qy/qz) rather
   than `qw` alone; NaN passes through. Dropped a per-render allocation in the
-  scene.
+  scene. ([#172](https://github.com/sksat/orts/pull/172))
 - Trail-buffer mutations are applied in the commit phase; `satellites[]` is
   rebuilt on a trail-buffer reset; per-satellite position time is preserved for
   body-fixed markers; `SatelliteState.color` is honoured; file / RRD adapters
-  reset cleanly on restart and tear down on fatal worker errors.
+  reset cleanly on restart and tear down on fatal worker errors. ([#89](https://github.com/sksat/orts/pull/89), [#107](https://github.com/sksat/orts/pull/107), [#108](https://github.com/sksat/orts/pull/108), [#176](https://github.com/sksat/orts/pull/176))
 
 #### Performance
-- Trail-less satellites skip trail-buffer allocation and per-frame trail work.
+- Trail-less satellites skip trail-buffer allocation and per-frame trail work. ([#107](https://github.com/sksat/orts/pull/107))
 
 ### `uneri` (npm: `@sksat/uneri`)
 
@@ -253,20 +255,20 @@ section is subdivided by package.
   self-hosted bundle URLs instead of the jsDelivr CDN. New `DuckDBInitOptions`
   (`bundles?`, `fallbackToJsDelivr?`) and `DuckDBBundleUrls` types, plus a pure
   `resolveBundleSource(options?)`. uneri stays bundler-neutral; the app resolves
-  and passes the URLs.
+  and passes the URLs. ([#171](https://github.com/sksat/orts/pull/171))
 - Resilient init: `initDuckDB` retries with linear backoff, fast-fails on a dead
   worker via an `error` listener instead of hanging, and drops the cached
-  rejected promise after terminal failure so a later call retries. (#70)
+  rejected promise after terminal failure so a later call retries. ([#76](https://github.com/sksat/orts/pull/76), [#70](https://github.com/sksat/orts/issues/70))
 
 #### Changed
 - Calling `initDuckDB()` with no options is unchanged — it still sources bundles
   from the jsDelivr CDN — so existing consumers keep working; self-hosting is
-  opt-in via `options.bundles`.
+  opt-in via `options.bundles`. ([#171](https://github.com/sksat/orts/pull/171))
 
 #### Fixed
 - Worker 404 / "invalid URL" on init: bundle URLs are absolutized against the
   worker origin inside `initDuckDB`, because DuckDB instantiates its worker from a
-  `blob:` URL against which a root-relative path cannot resolve.
+  `blob:` URL against which a root-relative path cannot resolve. ([#171](https://github.com/sksat/orts/pull/171))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,152 @@ section is subdivided by package.
 
 ## [Unreleased]
 
+### `orts` (Rust, crates.io)
+
+#### Added
+- Ground-station contact-window detection (`visibility` module): `GroundStation`
+  (WGS-84 location + elevation mask), `ContactWindow` (interpolated AOS/LOS, max
+  elevation, span-clip flags), the pure `PassTracker` state machine, and a
+  frame-aware `VisibilityMonitor<F: EarthFrameBridge>` that turns ECI samples
+  into per-station topocentric look angles.
+- `IndependentGroup::propagate_to_with(t_target, observer)` — propagate while a
+  `FnMut(&SatId, f64, &State)` observer runs on every accepted integration step,
+  so callers can sample state at integrator resolution. `propagate_to` delegates
+  to it with a no-op observer; trajectories stay bit-identical.
+- Node-messaging layer (`plugin::message`, "msg-io") for flight-software command
+  & telemetry: `Message`, `NodeId` (`Ground` / `Satellite(u32)`), `Payload`,
+  `NamedValue`, and `Value` (`Boolean`/`Integer`/`Number`/`Text`/`Bytes`),
+  re-exported from `orts::plugin`.
+- `PluginController` transport hooks (default no-op, implemented by the WASM
+  backends): msg-io `deliver` / `take_outbound`, and stream-io `stream_deliver`
+  / `stream_take` / `stream_close` for raw byte streams.
+- WIT v0 plugin interface extended with the msg-io and stream-io channels.
+
+#### Changed
+- `StateEffector` is now frame-generic — `StateEffector<S, F: frame::Eci =
+  SimpleEci>` returning `ExternalLoads<F>`, like `Model<S, F>` — so effectors
+  produce loads already in the host inertial frame. The defaulted `F` keeps
+  existing `StateEffector<S>` impls compiling unchanged.
+
+#### Fixed
+- Removed an unsound frame re-tag in `SpacecraftDynamics`: effector loads tagged
+  `ExternalLoads<SimpleEci>` were relabeled as the host frame `F` without
+  conversion, silently mislabeling coordinates for any `F != SimpleEci`. Latent
+  (the only shipped effector is torque-only) but wrong for a translational
+  effector. (#103)
+
+#### Removed
+- **BREAKING**: the `orts::tle` module is removed; TLE parsing moved to
+  `arika::tle` (decoding into the shared `arika::omm::Omm` record). Downstream
+  code using `orts::tle` must migrate to `arika`.
+
+### `orts-cli` (Rust, crates.io, binary)
+
+#### Added
+- Ground-station contact-window reporting in `orts run`: declare stations with
+  `[[ground_station]]` (`name`, `latitude_deg`, `longitude_deg`, `altitude_km`,
+  `min_elevation_deg`); detected windows print to stderr ordered by AOS, with
+  UTC timestamps, sim-time offsets, and max elevation (`*` marks windows clipped
+  by the sim span). Earth-centered, epoch-required.
+- Contact windows are sampled at integrator resolution (every accepted step /
+  control tick) rather than at `--output-interval`, so detection no longer
+  depends on the output decimation. (A pass shorter than one integrator /
+  control sample gap can still be missed.)
+- `--omm <file>` for CCSDS OMM input (JSON / KVN / XML; `-` for stdin), parsed
+  with `arika::omm`; rejects a TLE payload and points to `--tle`.
+- `--stream-stdio SAT/STREAM` on `orts serve` — wire one declared stream-io
+  stream to stdin/stdout over the kble-socket protocol so orts can run as a kble
+  `exec:` plug. That stream's WebSocket endpoint then answers HTTP 409; the
+  server shuts down when the stdio peer closes.
+- stream-io kble bridge in `orts serve`: each declared stream is a binary
+  WebSocket endpoint at `/stream/{sat}/{stream}` driven by a realtime loop;
+  undeclared pairs return HTTP 404. Streams are declared per satellite via the
+  config `streams` field.
+- Config-driven command timeline for flight-software command & telemetry:
+  `[[command]]` entries with `t` (sim-time), `sat`, `kind`, and an optional typed
+  `args` table, delivered deterministically by the host at the scheduled tick
+  (`orts run`).
+- WebSocket protocol TypeScript types are generated from the Rust types via
+  `ts-rs` (`#[derive(TS)]` on the protocol enums, `SimConfig`, `SatelliteInfo`,
+  …). Bindings are emitted into the viewer when `cargo test -p orts-cli` runs,
+  and CI fails if they drift.
+
+#### Changed
+- `--tle` is TLE-only again (2LE/3LE; `-` for stdin) and pairs with the new
+  `--omm`; element-set parsing is now backed by `arika::tle` / `arika::omm`
+  instead of the removed `orts::tle`. (Previously `--tle` also auto-accepted OMM.)
+- Mutually-exclusive orbit-source flags now error instead of silently letting one
+  win: `--sat` vs `--tle` / `--omm` / `--tle-line1` / `--tle-line2` /
+  `--norad-id`; `--tle` vs `--omm`; file sources vs inline `--tle-line1` /
+  `--tle-line2`; and `--tle-line1` / `--tle-line2` must be given together.
+- TLE epoch day-of-year is validated against the (leap-aware) year length, so a
+  malformed field is rejected rather than rolling into another year.
+
+#### Fixed
+- `orts serve` started with a `--config` file now rejects a `[[command]]`
+  timeline with a clear error (command timelines run only under `orts run`)
+  instead of silently dropping it.
+
+### `orts-plugin-sdk` (Rust, crates.io)
+
+#### Added
+- `msg-io` node-messaging layer for flight-software command & telemetry (and
+  future inter-satellite links): a WIT `interface msg-io` (`recv-batch` /
+  `send-message`) carrying datagrams addressed by logical `node-id`
+  (`ground` / `satellite(u32)`) with a typed `payload`, separate from the
+  `tick-io` control plane. The SDK adds a `msg` module (`recv_batch`, `recv_all`,
+  `send`, `send_to`, `key_value`, `get`, `get_text`) re-exporting `Message` /
+  `Outbound` / `NodeId` / `Payload` / `Value` / `NamedValue`.
+- `stream-io` raw byte-stream channel for kble virtual-harness integration: a WIT
+  `interface stream-io` (`read` / `write` over named streams). orts is a dumb
+  byte conduit; framing is left to the FSW + kble pipeline. The SDK adds a
+  `stream` module (`read`, `write`, `read_bytes`) re-exporting `StreamRead` /
+  `StreamError`.
+- Example FSWs gain a detumble→nadir mode-transition guard (`commandable-mode-ff`,
+  `commandable-mode-rr`).
+
+#### Changed
+- **BREAKING**: `world plugin` now also imports `msg-io` and `stream-io`. The
+  change is purely additive (nothing removed or altered), so callback-style
+  guests using `orts_plugin!` are unaffected; hand-written `impl Guest` guests
+  must regenerate bindings and link the two new host imports.
+
+### `arika` (Rust, crates.io)
+
+#### Added
+- Element-set parsing. A shared `omm::Omm` CCSDS mean-element record (identity,
+  UTC epoch, six SGP4 mean Keplerian elements, B\* drag; angles in radians, mean
+  motion in rad/s) with `semi_major_axis(mu)` / `to_keplerian_elements(mu)`.
+  - `tle` — NORAD TLE / 2LE / 3LE parser (`tle::parse`) → `Omm`, with Alpha-5
+    alphanumeric catalog numbers and `OBJECT_ID` normalization.
+  - `omm::json` / `omm::kvn` / `omm::xml` — CCSDS OMM parsers for the JSON, KVN,
+    and XML serializations. JSON accepts a single object or a 1-element array
+    (CelesTrak single-satellite GP) and Space-Track string-encoded numbers.
+  - `omm::detect` + `omm::parse` — format sniffing (`omm::Format`) plus a
+    unified, BOM-tolerant entry point that auto-detects and dispatches
+    TLE / OMM-JSON / OMM-KVN / OMM-XML.
+- `kepler` module (moved into `arika` from `orts`): `KeplerianElements`
+  (`from_state_vector` / `to_state_vector` / `period` / `energy`) and the anomaly
+  conversions (`solve_kepler_equation`, `mean_to_true_anomaly`, …). Now a public
+  `arika::kepler` surface; `orts::orbital::kepler` re-exports it.
+- `frame::Teme` marker — True Equator, Mean Equinox (the SGP4 / TLE output
+  frame). Marker only; the TEME ↔ GCRS rotation is not yet implemented.
+- `earth::topocentric` — ground-site look angles: `TopocentricSite<F: Ecef>`
+  (from a WGS-84 `Geodetic`, precomputing the local ENU basis) and `LookAngles`
+  (azimuth / elevation / slant range), via `look_angles(target)`.
+
+#### Changed
+- `Epoch::from_iso8601` also accepts the ordinal / day-of-year form
+  (`YYYY-DDDTHH:MM:SS`, used by CCSDS OMM), and the trailing `Z` is now optional.
+  A strict relaxation — previously-accepted inputs still parse.
+
+### `utsuroi` (Rust, crates.io)
+
+#### Added
+- `IntegrationError` now implements `core::error::Error` (by hand, no
+  `thiserror`, works under `no_std`), so it participates in `?` chains and
+  `Box<dyn Error>`.
+
 ### `tobari` (Rust, crates.io)
 
 #### Changed
@@ -19,6 +165,116 @@ section is subdivided by package.
   `fetch-horizons`). `fetch` is retained as an umbrella feature that enables
   every `fetch-*` source, so `features = ["fetch"]` keeps building (and now
   also pulls in `fetch-igrf`).
+
+### `viewer`
+
+#### Added
+- Embeddable viewer library at a new `./lib` entry (`viewer/src/lib`), so the
+  orbit viewer can be dropped into any React + `@react-three/fiber` app, not only
+  the bundled SPA. Layered API:
+  - `OrbitViewer` — batteries-included: renders its own sized `<div>` +
+    `<Canvas>`; drive it with a `centralBody` and a `SatelliteState[]`.
+  - `OrbitScene` — the scene graph to mount inside your own `<Canvas>`
+    (bring-your-own Canvas), initialised with the exported `SCENE_UP`.
+  - The viewer's own app is now built on the public `OrbitScene` API
+    (dogfooded), so the library and the app cannot drift apart.
+- Distribution as a shadcn registry (`registry.json`, item `orbit-viewer`): the
+  component and its primitives can be vendored into a consumer app via
+  `shadcn add`. Ships a standalone consumer example (`viewer/examples/orbit-viewer/`)
+  that installs and renders the registry item.
+- Extensible central bodies: custom definitions via the `bodies` prop
+  (`BodyDefinitions`) merged over the built-in `DEFAULT_BODIES`
+  (Earth / Moon / Sun / Mars). Exports `BodyDefinition` / `BodyDefinitions` /
+  `BodyTexture` / `DEFAULT_BODIES`.
+- Injectable arika WASM: `initArika({ wasmUrl? })` / `isArikaReady()` are
+  exported so an embedder can preload the module or point at an external `.wasm`
+  URL. The arika WASM was extracted into its own workspace package (`arika-wasm`),
+  imported by name (required for registry distribution).
+- Public `TrailBuffer` streaming primitive (`TrailBuffer` + `TrailBufferLike`): a
+  caller can own a bounded trail buffer and mutate it outside React
+  (`SatelliteState.trailBuffer`); the scene reads it each frame so streamed points
+  reach the GPU without a React re-render. Exports `toTrailBuffer` /
+  `trailPointToOrbitPoint` and the `OrbitPoint` / `TrailPoint` types.
+- Per-satellite display props on `SatelliteState`: `color`, `name`,
+  `markerShape`, `trailDisplay` (`visibleCount` / `drawStart`, for playback
+  scrubbing), and a per-satellite `time` so a frozen/scrubbed satellite keeps its
+  marker aligned with its own body-fixed trail.
+- Satellites render from their current position, not only from trails — a
+  position-only satellite still shows a marker.
+- Selectable marker shapes (`MarkerShape`: `"sphere"` | `"axes-cube"`), including
+  a non-sphere XYZ orientation cube that shows attitude without a hosted 3D
+  model; resolvable per-satellite or scene-wide, and declarable by the simulation
+  over the wire (viewer-overridable).
+- Satellite-centred frames now honour the requested orientation: star-fixed
+  `inertial` (axes don't co-rotate) or `localOrbital` (LVLH). Previously a
+  satellite-centred view always collapsed to LVLH. (#90)
+
+#### Changed
+- The `./lib` public barrel is intentionally narrow: the Three.js / r3f building
+  blocks and the internal frame wiring are not exported. Supported surface:
+  `OrbitViewer`, `OrbitScene`, `TrailBuffer` / `TrailBufferLike`, `toTrailBuffer`
+  / `trailPointToOrbitPoint`, `initArika` / `isArikaReady`, `SCENE_UP`,
+  `DEFAULT_BODIES`, `DEFAULT_VIEWER_FRAME`, and the supporting types.
+- DuckDB-wasm assets are self-hosted by the viewer (Vite `?url` imports passed to
+  uneri's `initDuckDB({ bundles })`) instead of the jsDelivr CDN, removing a
+  third-party-CDN runtime dependency.
+- Earth-specific rendering (day/night terminator, atmosphere, Earth spin) is
+  gated to the `earth` body id, not "has a night texture"; custom bodies render
+  via the generic textured-sphere path.
+- `OrbitScene` / `OrbitViewer` throw a clear error when the central body has no
+  resolvable radius, instead of silently using radius 1 and a wrong scene scale.
+- The arika WASM loads only when an `epochJd` is supplied; epoch-less embedders
+  pay no init cost (fixed Sun direction, no body rotation).
+- WS protocol types are now the `ts-rs`-generated bindings (see `orts-cli`),
+  replacing the hand-written wire types and adding the `satellite_added` variant.
+
+#### Fixed
+- Default WebSocket URL on static deploys falls back to `ws://localhost:9001/ws`
+  instead of deriving an unreachable host from `window.location`.
+- High-resolution body textures restored in static deployment (server-only fetch,
+  off-thread decode, bounded upgrade retries, in-flight guard). (#105)
+- LVLH (satellite-centred) central-body orientation corrected, with separate
+  Earth (ERA) vs non-Earth (`body_orientation` + pole) paths.
+- Quaternion slerp guards on a complete quaternion (all of qw/qx/qy/qz) rather
+  than `qw` alone; NaN passes through. Dropped a per-render allocation in the
+  scene.
+- Trail-buffer mutations are applied in the commit phase; `satellites[]` is
+  rebuilt on a trail-buffer reset; per-satellite position time is preserved for
+  body-fixed markers; `SatelliteState.color` is honoured; file / RRD adapters
+  reset cleanly on restart and tear down on fatal worker errors.
+
+#### Performance
+- Trail-less satellites skip trail-buffer allocation and per-frame trail work.
+
+### `uneri` (npm: `@sksat/uneri`)
+
+#### Added
+- `initDuckDB` can load the DuckDB-wasm worker / wasm from caller-injected,
+  self-hosted bundle URLs instead of the jsDelivr CDN. New `DuckDBInitOptions`
+  (`bundles?`, `fallbackToJsDelivr?`) and `DuckDBBundleUrls` types, plus a pure
+  `resolveBundleSource(options?)`. uneri stays bundler-neutral; the app resolves
+  and passes the URLs.
+- Resilient init: `initDuckDB` retries with linear backoff, fast-fails on a dead
+  worker via an `error` listener instead of hanging, and drops the cached
+  rejected promise after terminal failure so a later call retries. (#70)
+
+#### Changed
+- Calling `initDuckDB()` with no options is unchanged — it still sources bundles
+  from the jsDelivr CDN — so existing consumers keep working; self-hosting is
+  opt-in via `options.bundles`.
+
+#### Fixed
+- Worker 404 / "invalid URL" on init: bundle URLs are absolutized against the
+  worker origin inside `initDuckDB`, because DuckDB instantiates its worker from a
+  `blob:` URL against which a root-relative path cannot resolve.
+
+### Dependencies
+
+- Rust toolchain → 1.96.0.
+- Rust: `wasmtime` / `wasmtime-wasi` 44 (security), `rerun` 0.33,
+  `tokio-tungstenite` 0.29, `nalgebra` 0.35, `tokio` 1.52, `axum` 0.8.9.
+- npm: `vite` 8, `@vitejs/plugin-react` 6, the React monorepo, `ws` 8.21
+  (security), `mermaid` 11.15 (security).
 
 ## [0.2.0](https://github.com/sksat/orts/releases/tag/v0.2.0) - 2026-04-20
 


### PR DESCRIPTION
## Why

Preparing the 0.3.0 release. The `[Unreleased]` changelog held only the
`tobari` `fetch`→`fetch-cssi` rename, while `v0.2.0..main` spans **97 PRs**
across every package. This reconstructs `[Unreleased]` so it reflects what
actually shipped since 0.2.0.

The `[Unreleased]` heading is kept as-is (not renamed to `0.3.0`) — the version
bump is a separate step.

## What

Per-package `Added` / `Changed` / `Fixed` entries (EN + JA, 58 bullets each):

- **`orts`** — ground-station visibility, `propagate_to_with` observer, msg-io node
  messaging + stream-io controller hooks, frame-generic `StateEffector`, #103
  frame-retag fix. **BREAKING:** `orts::tle` removed (moved to `arika`).
- **`orts-cli`** — contact-window reporting, `--omm`, stream-io kble/stdio bridges,
  config command timeline, `ts-rs` WS protocol codegen; `--tle` is TLE-only again
  and orbit-source flags are now mutually exclusive.
- **`orts-plugin-sdk`** — msg-io + stream-io WIT interfaces and SDK modules.
  **BREAKING:** `world plugin` imports them (hand-written guests must regenerate).
- **`arika`** — TLE + OMM (JSON/KVN/XML) parsers, `kepler` (moved from `orts`),
  `Teme` frame marker, topocentric look angles, `from_iso8601` relaxation.
- **`utsuroi`** — `IntegrationError` implements `core::error::Error`.
- **`tobari`** — `fetch`→`fetch-cssi` rename (pre-existing entry, kept).
- **`viewer`** — embeddable `./lib` (`OrbitViewer`/`OrbitScene`), shadcn registry,
  extensible bodies, `TrailBuffer` streaming, marker shapes, frame fixes.
- **`uneri`** — injectable self-hosted DuckDB bundles + resilient init.
- **Dependencies** — toolchain 1.96, wasmtime 44, rerun 0.33, nalgebra 0.35, …

Additions only — `[0.2.0]` / `[0.1.1]` / `[0.1.0]` untouched. (Builds on the
0.1.0 viewer backfill from #178.)

## Verification

- Drafts produced by **four package-scoped investigation passes**, each verifying
  every symbol / flag / behavior against the `v0.2.0..origin/main` source tree
  (not commit messages).
- **2 rounds of `codex review`**: found and fixed two overstated claims
  (contact-window detection limits; the `[[command]]`-on-serve rejection applies
  to `--config` startup only). Final review is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)