### PR TITLE
fix(docs): restore docs deploy under Starlight 0.40 + gate the docs site build on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -702,6 +702,113 @@ jobs:
       - name: Test
         run: pnpm --filter starlight-rustdoc test
 
+  # Build the full docs site (astro/starlight) on PRs. The Deploy Site
+  # workflow only builds on push to main, so a docs-build regression — e.g.
+  # a Starlight sidebar schema change — would otherwise not surface until
+  # after merge (the required `starlight-rustdoc` check builds the
+  # starlight-rustdoc *package*, not the orts docs site). Path-gated: the
+  # heavy build runs only when docs-affecting files change; on unrelated PRs
+  # the job exits early as a success so the required check still passes. The
+  # job always runs (only inner steps are conditional) to avoid the
+  # skipped-required-check ambiguity. Textures and the Pages deploy are
+  # omitted — this validates the build, it does not publish.
+  build-site:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    env:
+      VITE_BASE_PATH: /orts/viewer/
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Detect docs-affecting changes
+        id: changes
+        run: |
+          set -euo pipefail
+          case "${{ github.event_name }}" in
+            pull_request) base="${{ github.event.pull_request.base.sha }}" ;;
+            merge_group)  base="${{ github.event.merge_group.base_sha }}" ;;
+            *)            base="" ;;
+          esac
+          if [ -z "$base" ] || ! git rev-parse --verify "$base^{commit}" >/dev/null 2>&1; then
+            echo "Base ref unavailable; building to be safe."
+            echo "docs=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(git diff --name-only "$base" HEAD)
+          echo "Changed files:"; echo "$changed"
+          # Inputs the docs site build consumes: docs config/content, the
+          # local starlight-rustdoc plugin (imported by astro.config.mjs), the
+          # embedded viewer/tobari demos, the typedoc source (uneri), JS deps
+          # (manifest + lockfile), and this workflow itself. NOTE: this does
+          # not gate on Rust crate sources, so a rustdoc-content regression
+          # driven purely by a doc-comment change is not caught here.
+          if echo "$changed" | grep -qE '^(docs/|starlight-rustdoc/|viewer/|uneri/|tobari/|package\.json|pnpm-lock\.yaml|\.github/workflows/ci\.yml)'; then
+            echo "docs=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: No docs-affecting changes — skip site build
+        if: steps.changes.outputs.docs != 'true'
+        run: echo "No docs-affecting files changed; skipping site build (required check passes)."
+
+      - name: Setup pnpm
+        if: steps.changes.outputs.docs == 'true'
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        if: steps.changes.outputs.docs == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.changes.outputs.docs == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Install mold linker
+        if: steps.changes.outputs.docs == 'true'
+        run: sudo apt-get update && sudo apt-get install -y mold
+
+      - name: Parse rust-toolchain.toml
+        if: steps.changes.outputs.docs == 'true'
+        id: rust-toolchain
+        uses: ./.github/actions/parse-rust-toolchain
+
+      - name: Install Rust
+        if: steps.changes.outputs.docs == 'true'
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+          targets: wasm32-unknown-unknown
+
+      - name: Install Rust nightly (for rustdoc JSON)
+        if: steps.changes.outputs.docs == 'true'
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: nightly
+
+      - name: Cache Cargo artifacts
+        if: steps.changes.outputs.docs == 'true'
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: build-site
+
+      - name: Install wasm-pack
+        if: steps.changes.outputs.docs == 'true'
+        uses: ./.github/actions/install-wasm-pack
+
+      - name: Build site
+        if: steps.changes.outputs.docs == 'true'
+        run: pnpm build:site
+        env:
+          VITE_TEXTURE_BASE_URL: ${{ env.VITE_BASE_PATH }}textures/
+
   uneri:
     runs-on: ubuntu-latest
     steps:

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -160,7 +160,7 @@ export default defineConfig({
       sidebar: [
         { label: "Getting Started", slug: "getting-started" },
         { label: "Architecture", slug: "architecture" },
-        { label: "Examples", autogenerate: { directory: "examples" } },
+        { label: "Examples", items: [{ autogenerate: { directory: "examples" } }] },
         {
           label: "orts",
           items: [
@@ -168,7 +168,7 @@ export default defineConfig({
             {
               label: "API",
               collapsed: true,
-              autogenerate: { directory: "orts/api" },
+              items: [{ autogenerate: { directory: "orts/api", collapsed: true } }],
             },
           ],
         },
@@ -179,7 +179,7 @@ export default defineConfig({
             {
               label: "API",
               collapsed: true,
-              autogenerate: { directory: "arika/api" },
+              items: [{ autogenerate: { directory: "arika/api", collapsed: true } }],
             },
           ],
         },
@@ -190,7 +190,7 @@ export default defineConfig({
             {
               label: "API",
               collapsed: true,
-              autogenerate: { directory: "utsuroi/api" },
+              items: [{ autogenerate: { directory: "utsuroi/api", collapsed: true } }],
             },
           ],
         },
@@ -198,11 +198,11 @@ export default defineConfig({
           label: "tobari",
           items: [
             { label: "Overview", slug: "tobari/overview" },
-            { label: "Examples", autogenerate: { directory: "tobari/examples" } },
+            { label: "Examples", items: [{ autogenerate: { directory: "tobari/examples" } }] },
             {
               label: "API",
               collapsed: true,
-              autogenerate: { directory: "tobari/api" },
+              items: [{ autogenerate: { directory: "tobari/api", collapsed: true } }],
             },
           ],
         },
@@ -210,16 +210,16 @@ export default defineConfig({
           label: "uneri",
           items: [
             { label: "Overview", slug: "uneri/api/readme" },
-            { label: "Examples", autogenerate: { directory: "uneri/examples" } },
+            { label: "Examples", items: [{ autogenerate: { directory: "uneri/examples" } }] },
             {
               label: "API Reference",
               collapsed: true,
               items: [
-                { label: "Classes", autogenerate: { directory: "uneri/api/classes" } },
-                { label: "Interfaces", autogenerate: { directory: "uneri/api/interfaces" } },
-                { label: "Functions", autogenerate: { directory: "uneri/api/functions" } },
-                { label: "Type Aliases", autogenerate: { directory: "uneri/api/type-aliases" } },
-                { label: "Variables", autogenerate: { directory: "uneri/api/variables" } },
+                { label: "Classes", items: [{ autogenerate: { directory: "uneri/api/classes" } }] },
+                { label: "Interfaces", items: [{ autogenerate: { directory: "uneri/api/interfaces" } }] },
+                { label: "Functions", items: [{ autogenerate: { directory: "uneri/api/functions" } }] },
+                { label: "Type Aliases", items: [{ autogenerate: { directory: "uneri/api/type-aliases" } }] },
+                { label: "Variables", items: [{ autogenerate: { directory: "uneri/api/variables" } }] },
               ],
             },
           ],

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -216,10 +216,22 @@ export default defineConfig({
               collapsed: true,
               items: [
                 { label: "Classes", items: [{ autogenerate: { directory: "uneri/api/classes" } }] },
-                { label: "Interfaces", items: [{ autogenerate: { directory: "uneri/api/interfaces" } }] },
-                { label: "Functions", items: [{ autogenerate: { directory: "uneri/api/functions" } }] },
-                { label: "Type Aliases", items: [{ autogenerate: { directory: "uneri/api/type-aliases" } }] },
-                { label: "Variables", items: [{ autogenerate: { directory: "uneri/api/variables" } }] },
+                {
+                  label: "Interfaces",
+                  items: [{ autogenerate: { directory: "uneri/api/interfaces" } }],
+                },
+                {
+                  label: "Functions",
+                  items: [{ autogenerate: { directory: "uneri/api/functions" } }],
+                },
+                {
+                  label: "Type Aliases",
+                  items: [{ autogenerate: { directory: "uneri/api/type-aliases" } }],
+                },
+                {
+                  label: "Variables",
+                  items: [{ autogenerate: { directory: "uneri/api/variables" } }],
+                },
               ],
             },
           ],


### PR DESCRIPTION
## What & why

Merging #126 (`@astrojs/starlight` → 0.40) turned the `main` **docs `deploy`** job red. Starlight 0.40 changed the sidebar schema: an autogenerated group must now wrap `autogenerate` inside an `items` array.

- **Before:** `{ label, autogenerate: { directory } }`
- **After:** `{ label, items: [{ autogenerate: { directory } }] }`

The old shape fails `astro:config:setup` with `Invalid config passed to starlight integration` (`Expected type { link } | { items } | { slug } | string`), which is exactly what broke `deploy` on every `main` push after #126.

### Why PR CI didn't catch it
The full docs site build (`pnpm build:site` → `astro build`, the only place the sidebar config is validated) lives **only** in `Deploy Site` (`deploy.yml`), which triggers on **push to main only** — never on PRs. The required `starlight-rustdoc` check is misleadingly named: it builds/tests the standalone `starlight-rustdoc` *package*, not the orts docs site, so it never touches `docs/astro.config.mjs`. No required check exercised the docs build, so #126 went green and only failed post-merge.

## Changes

1. **`docs/astro.config.mjs`** — migrate all 8 autogenerate sidebar groups to the 0.40 schema. For the crate-`API` groups that were `collapsed: true`, pin `autogenerate.collapsed: true` so the prior collapsed-subgroup behavior is preserved (0.40 dropped the parent→subgroup `collapsed` inheritance).
2. **`.github/workflows/ci.yml`** — add a path-gated `build-site` job that runs the full `pnpm build:site` on `pull_request`/`merge_group`. The heavy build runs only when docs-affecting files change (`docs/`, `starlight-rustdoc/`, `viewer/`, `uneri/`, `tobari/`, `package.json`, `pnpm-lock.yaml`, this workflow); unrelated PRs exit early as success. The job **always runs** (only inner steps are conditional) so it is safe to mark required without skipped-check ambiguity. Textures and the Pages deploy are omitted — it validates the build, it does not publish.

## Verification
- Local A/B with Starlight 0.40 installed: the **pre-fix** config reproduces `Invalid config passed to starlight integration` on `astro sync`; the **fixed** config passes `astro:config:setup` cleanly (typedoc generated, content synced).
- The new `build-site` job runs on this PR (docs paths changed) → it builds the real site, so **this PR's own CI validates the fix end-to-end**.

## Notes
- Known gap: `build-site` does **not** gate on Rust crate sources, so a rustdoc-*content* regression driven purely by a doc-comment change is not caught here (accepted cost trade-off; `viewer-build` already covers the wasm path).
- Making `build-site` a **required** status check needs a `protect main` ruleset update — left out of this PR pending confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)