### PR TITLE
chore(renovate): group three.js + @react-three ecosystem across workspaces

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,12 @@
       "matchPackageNames": ["/^wasmtime/"]
     },
     {
+      "description": "three.js, @types/three and the @react-three/* ecosystem must move in lockstep across all workspaces (viewer, tobari/examples/web, orbit-viewer); a split bump leaves two @types/three versions in the tree and fails the viewer TypeScript build (TS2322)",
+      "matchManagers": ["npm"],
+      "groupName": "three",
+      "matchPackageNames": ["three", "@types/three", "/^@react-three//"]
+    },
+    {
       "description": "Auto-merge patch-level updates once required CI checks pass",
       "matchUpdateTypes": ["patch"],
       "automerge": true


### PR DESCRIPTION
## Why

`three`, `@types/three` and `@react-three/*` are declared in **three** workspace packages — `viewer`, `tobari/examples/web`, and `viewer/examples/orbit-viewer`. Renovate currently bumps them per-package, so #129 (`three ^0.184`) landed in `viewer` while the other two stayed on `^0.183` (a caret on a `0.x` version is minor-locked, so `^0.183.0` excludes `0.184`).

That split leaves **two `@types/three` versions** in the pnpm tree (0.183.1 + 0.184.1). TypeScript treats same-named types from the two package copies as distinct, so the viewer build fails:

```
src/components/CelestialBody.tsx(211,32): error TS2322:
Type 'Texture<unknown, TextureEventMap>' (@types+three@0.184.1)
  is not assignable to 'Texture<unknown> ...' (@types+three@0.183.1)
```

(The transitive `maath` / `stats-gl` resolve fine against 0.184 — they are not the blocker; the workspace version split is.)

## What

Renovate has **no built-in preset** for three.js / `@react-three` (confirmed against the group-presets and monorepo-presets lists; the only related preset, `group:definitelyTyped`, lumps *all* `@types/**` together and is too broad). So this adds a custom `packageRules` group — mirroring the repo's existing `wasmtime` / `rerun` lockstep groups — so `three`, `@types/three` and `@react-three/*` move together in a single PR across all workspaces and stay deduplicated.

## Effect
- Renovate will supersede the viewer-only #129 with a grouped "three" PR that bumps all three workspaces to 0.184 together → single `@types/three` → no TS2322.
- Prevents recurrence of the split on future three bumps.

Validated with `renovate-config-validator` (passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)