### PR TITLE
chore(renovate): manage the pnpm example workspace packages (un-ignore examples/)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,17 @@
     "pnpm": "10"
   },
   "minimumReleaseAge": "7 days",
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/__tests__/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/__fixtures__/**",
+    "orts/examples/**",
+    "plugin-sdk/examples/**"
+  ],
   "customManagers": [
     {
       "description": "Match '# renovate: datasource=... depName=...' followed by a VARNAME=value assignment in shell/CI",


### PR DESCRIPTION
## Root cause (the real reason the three.js group never consolidated)

`renovate.json` → `github>sksat/renovate-config` → **`config:recommended`** → **`:ignoreModulesAndTests`** → `ignorePaths` includes **`**/examples/**`**.

So Renovate never proposed dependency updates for the two pnpm example packages that live under `examples/`:
- `tobari/examples/web` (three ^0.183)
- `viewer/examples/orbit-viewer` (@types/three ^0.183)

Only `viewer/package.json` (outside `examples/`) got bumped to three ^0.184 → the workspace split → two `@types/three` versions in the tree → viewer build `TS2322`. `ignorePaths` is applied at file-extraction time, so the `three` group rule (added earlier) can never reach those files — which is why rebasing, full runs, and close+recreate all kept producing a viewer-only PR.

## Fix

These two packages are real pnpm-workspace members that CI builds and tests (`tobari-example-web` is a required check; orbit-viewer has Playwright E2E), not throwaway snippets — they should be dependency-managed.

Override `ignorePaths` to the `:ignoreModulesAndTests` default **minus `**/examples/**`**, while explicitly keeping the non-pnpm example trees ignored so the un-ignore is scoped to exactly the two pnpm packages:
- keep ignored: `orts/examples/**` (Python: pyproject/uv.lock), `plugin-sdk/examples/**` (Rust Cargo + some Python)
- now managed: `tobari/examples/web`, `viewer/examples/orbit-viewer`

Combined with the `three` lockstep group, three.js now moves together across all workspaces and won't split again.

Validated with `renovate-config-validator`. Scope addressed per Codex review (the bare `**/examples/**` removal would also have pulled in the Python/Cargo example trees).

🤖 Generated with [Claude Code](https://claude.com/claude-code)