### PR TITLE
docs(arika): sync frame docs with implemented IAU 2006 chain; trim verbosity

### DIFF
--- a/arika/src/earth/eop/mod.rs
+++ b/arika/src/earth/eop/mod.rs
@@ -14,7 +14,7 @@
 //! - [`FullEopProvider`] — 上記 4 つを全て実装した型に対する便宜 trait
 //!   (auto-blanket impl で自動付与される)
 //!
-//! 高精度 rotation API ([`Rotation<Gcrs, Cirs>::iau2006`](crate::frame::Rotation)
+//! 高精度 rotation API ([`Rotation<Gcrs, Cirs>::iau2006`](crate::frame::Rotation::iau2006)
 //! など) は必要な trait bound で gate される。`NullEop` を渡すと compile error に
 //! なるため、silent degradation は起こらない。
 //!
@@ -52,7 +52,7 @@ pub trait Ut1Offset {
 ///
 /// 極運動は Earth の瞬間的な rotation 軸が CIP (Celestial Intermediate Pole) から
 /// どれだけずれているかを表すパラメータで、通常は < 0.5 arcsec の範囲にある。
-/// [`Rotation<Tirs, Itrs>::polar_motion`](crate::frame::Rotation) で使用する。
+/// [`Rotation<Tirs, Itrs>::polar_motion`](crate::frame::Rotation::polar_motion) で使用する。
 pub trait PolarMotion {
     /// Return the x component of the polar motion [arcsec] at the given UTC MJD.
     fn x_pole(&self, utc_mjd: f64) -> f64;
@@ -104,7 +104,7 @@ impl<T> FullEopProvider for T where T: Ut1Offset + PolarMotion + NutationCorrect
 /// これを受け付けるのは provider-free な API (`Epoch<Utc>::to_ut1_naive` など) のみで、
 /// EOP trait bound を要求する全ての API では **compile error** になる。例えば
 /// `Epoch<Utc>::to_ut1<P: Ut1Offset>` や
-/// [`Rotation<Gcrs, Cirs>::iau2006`](crate::frame::Rotation) に `NullEop` を渡すと
+/// [`Rotation<Gcrs, Cirs>::iau2006`](crate::frame::Rotation::iau2006) に `NullEop` を渡すと
 /// 型エラーになる。
 ///
 /// # 存在意義

--- a/arika/src/earth/eop/mod.rs
+++ b/arika/src/earth/eop/mod.rs
@@ -14,25 +14,15 @@
 //! - [`FullEopProvider`] — 上記 4 つを全て実装した型に対する便宜 trait
 //!   (auto-blanket impl で自動付与される)
 //!
-//! 高精度 rotation API (Phase 3 で追加予定の `Rotation<Gcrs, Cirs>::iau2006` など)
-//! は必要な trait bound で gate される。`NullEop` を渡すと compile error になるため、
-//! silent degradation は起こらない。
+//! 高精度 rotation API ([`Rotation<Gcrs, Cirs>::iau2006`](crate::frame::Rotation)
+//! など) は必要な trait bound で gate される。`NullEop` を渡すと compile error に
+//! なるため、silent degradation は起こらない。
 //!
 //! # `NullEop`
 //!
 //! [`NullEop`] は **EOP 系 trait を一つも実装しない** placeholder 型。これを受け付ける
 //! のは provider-free な API (例: `Epoch<Utc>::to_ut1_naive`、`Epoch<Tai>::to_tt`) のみ
 //! で、EOP trait bound を要求する全ての API では compile error を誘発する。
-//!
-//! # Phase 2 の範囲
-//!
-//! 本 Phase では:
-//! - EOP trait 4 種 + `FullEopProvider` + `NullEop` を追加
-//! - [`Epoch::<Utc>::to_ut1<P: Ut1Offset>`](crate::epoch::Epoch::to_ut1) を追加
-//! - trybuild compile-fail test で `NullEop` が EOP trait を実装しないことを pin
-//!
-//! Phase 3 で rotation constructor (`iau2006`, `from_era`, `polar_motion`,
-//! `iau2006_full`) が追加された段階で、これらの trait bound を要求する。
 //!
 //! # Leap second は別体系
 //!
@@ -62,7 +52,7 @@ pub trait Ut1Offset {
 ///
 /// 極運動は Earth の瞬間的な rotation 軸が CIP (Celestial Intermediate Pole) から
 /// どれだけずれているかを表すパラメータで、通常は < 0.5 arcsec の範囲にある。
-/// `Rotation<Tirs, Itrs>::polar_motion(utc, eop)` (Phase 3) で使用する。
+/// [`Rotation<Tirs, Itrs>::polar_motion`](crate::frame::Rotation) で使用する。
 pub trait PolarMotion {
     /// Return the x component of the polar motion [arcsec] at the given UTC MJD.
     fn x_pole(&self, utc_mjd: f64) -> f64;
@@ -90,8 +80,8 @@ pub trait NutationCorrections {
 /// (通常 ~1 ms 程度)。Earth の自転速度変動を表し、速度変換 (velocity
 /// transformation between inertial and rotating frames) に使われる。
 ///
-/// Phase 3 の position-only rotation では LOD は不要だが、将来 velocity
-/// transformation を追加する際にこの trait が役に立つ。
+/// 現状の position-only な rotation chain では LOD は不要 (どの constructor も
+/// 要求しない)。velocity transformation を追加する際の bound として用意してある。
 pub trait LengthOfDay {
     /// Return the LOD [seconds] at the given UTC MJD.
     fn lod(&self, utc_mjd: f64) -> f64;
@@ -101,8 +91,8 @@ pub trait LengthOfDay {
 ///
 /// Implemented automatically via an auto-blanket impl for any type that
 /// implements [`Ut1Offset`] + [`PolarMotion`] + [`NutationCorrections`] +
-/// [`LengthOfDay`]. Phase 3 で `Rotation<Gcrs, Itrs>::iau2006_full<P: FullEopProvider>`
-/// のような完全 chain の bound として使う想定。
+/// [`LengthOfDay`]. position-only な chain は LOD を含まない個別 bound を使うため、
+/// この alias は LOD を要する velocity transform 用の便宜 bound。
 pub trait FullEopProvider: Ut1Offset + PolarMotion + NutationCorrections + LengthOfDay {}
 
 impl<T> FullEopProvider for T where T: Ut1Offset + PolarMotion + NutationCorrections + LengthOfDay {}
@@ -113,8 +103,9 @@ impl<T> FullEopProvider for T where T: Ut1Offset + PolarMotion + NutationCorrect
 ///
 /// これを受け付けるのは provider-free な API (`Epoch<Utc>::to_ut1_naive` など) のみで、
 /// EOP trait bound を要求する全ての API では **compile error** になる。例えば
-/// `Epoch<Utc>::to_ut1<P: Ut1Offset>` や Phase 3 で追加予定の
-/// `Rotation<Gcrs, Cirs>::iau2006` に `NullEop` を渡すと型エラーになる。
+/// `Epoch<Utc>::to_ut1<P: Ut1Offset>` や
+/// [`Rotation<Gcrs, Cirs>::iau2006`](crate::frame::Rotation) に `NullEop` を渡すと
+/// 型エラーになる。
 ///
 /// # 存在意義
 ///

--- a/arika/src/earth/geodetic.rs
+++ b/arika/src/earth/geodetic.rs
@@ -87,11 +87,11 @@ impl<F: frame::Ecef> Vec3<F> {
     /// Convert this Earth-fixed Cartesian vector to WGS-84 geodetic
     /// coordinates via Bowring iteration.
     ///
-    /// Available on any `Vec3<F>` where `F: `[`frame::Ecef`]
+    /// Available on any `Vec3<F>` where `F` implements [`frame::Ecef`]
     /// ([`SimpleEcef`](crate::frame::SimpleEcef), [`Tirs`](crate::frame::Tirs),
     /// [`Itrs`](crate::frame::Itrs)). The Tirs / Itrs variants assume the caller
     /// has already applied the IAU 2006 rotation chain (e.g.
-    /// [`Rotation::<Gcrs, Itrs>::iau2006_full_from_utc`](crate::frame::Rotation))
+    /// [`Rotation::<Gcrs, Itrs>::iau2006_full_from_utc`](crate::frame::Rotation::iau2006_full_from_utc))
     /// to produce the ECEF vector.
     pub fn to_geodetic(&self) -> Geodetic {
         let v = self.inner();

--- a/arika/src/earth/geodetic.rs
+++ b/arika/src/earth/geodetic.rs
@@ -75,30 +75,24 @@ impl From<SimpleEcef> for Geodetic {
     }
 }
 
-// Generic `to_geodetic()` method on any Earth-fixed `Vec3<F>`.
+// Generic `to_geodetic()` on any Earth-fixed `Vec3<F>`.
 //
-// Works for both [`crate::frame::SimpleEcef`] (the ERA-only simple path) and
-// [`crate::frame::Itrs`] (the full IAU 2006 CIO-based precise path). The
-// Bowring iteration is identical for both — the distinction only matters
-// up-stream, in the rotation that produced the ECEF vector in the first
-// place.
-//
-// The pre-existing `impl From<SimpleEcef> for Geodetic` is kept for
-// backwards source compatibility of `.into()` call sites that predate
-// Phase 4; new code should prefer `.to_geodetic()` because it works for
-// both the simple and precise Ecef markers without rewriting the
-// signature when the frame is upgraded from `SimpleEcef` to `Itrs`.
+// The Bowring iteration is identical for the approximate ([`crate::frame::SimpleEcef`])
+// and precise ([`crate::frame::Itrs`]) markers — the distinction only matters
+// upstream, in the rotation that produced the ECEF vector. The older
+// `impl From<SimpleEcef> for Geodetic` is kept for existing `.into()` call sites;
+// new code should prefer `.to_geodetic()` since it also works on `Itrs` without
+// changing signatures.
 impl<F: frame::Ecef> Vec3<F> {
     /// Convert this Earth-fixed Cartesian vector to WGS-84 geodetic
     /// coordinates via Bowring iteration.
     ///
-    /// Available on any `Vec3<F>` where `F` implements the
-    /// [`frame::Ecef`] category trait — currently
-    /// [`crate::frame::SimpleEcef`], [`crate::frame::Tirs`], and
-    /// [`crate::frame::Itrs`]. Tirs / Itrs variants require the caller
-    /// to have already applied the appropriate IAU 2006 rotation chain
-    /// (Phase 3B `Rotation<Gcrs, Itrs>::iau2006_full_from_utc` or
-    /// similar) to produce an Itrs vector.
+    /// Available on any `Vec3<F>` where `F: `[`frame::Ecef`]
+    /// ([`SimpleEcef`](crate::frame::SimpleEcef), [`Tirs`](crate::frame::Tirs),
+    /// [`Itrs`](crate::frame::Itrs)). The Tirs / Itrs variants assume the caller
+    /// has already applied the IAU 2006 rotation chain (e.g.
+    /// [`Rotation::<Gcrs, Itrs>::iau2006_full_from_utc`](crate::frame::Rotation))
+    /// to produce the ECEF vector.
     pub fn to_geodetic(&self) -> Geodetic {
         let v = self.inner();
         let p = (v.x * v.x + v.y * v.y).sqrt();

--- a/arika/src/earth/iau2006/cio_chain.rs
+++ b/arika/src/earth/iau2006/cio_chain.rs
@@ -1,7 +1,7 @@
 //! Public `Rotation` constructors for the IAU 2006 CIO-based
 //! GCRS ↔ ITRS chain.
 //!
-//! Phase 3B wires the pure-math evaluators from
+//! Wires the pure-math evaluators from
 //! [`super::cip`], [`super::precession`], [`super::fundamental_arguments`],
 //! and the EOP provider traits from [`crate::earth::eop`] into typed
 //! [`crate::frame::Rotation`] constructors.
@@ -79,9 +79,7 @@ use crate::frame::{Cirs, Gcrs, Itrs, Rotation, Tirs};
 /// s'(t) ≈ −47 µas × t
 /// ```
 ///
-/// Used by [`Rotation<Tirs, Itrs>::polar_motion`]. Exposed as a private
-/// helper; Phase 3A-1 / 3A-2 did not surface it because no consumer
-/// existed until the polar motion constructor below.
+/// Private helper used by [`Rotation<Tirs, Itrs>::polar_motion`].
 fn tio_locator_s_prime(tt_centuries: f64) -> Rad {
     Uas::new(-47.0 * tt_centuries).to_radians()
 }

--- a/arika/src/earth/iau2006/cip.rs
+++ b/arika/src/earth/iau2006/cip.rs
@@ -21,8 +21,7 @@
 //!   Matches ERFA `c2ixys`
 //!
 //! None of these are public [`crate::frame::Rotation`] constructors —
-//! those are Phase 3B. Phase 3A-3 ships the raw scalar evaluators, and
-//! Phase 3A-4 adds the 3×3 matrix composition that Phase 3B will wrap.
+//! those live in [`super::cio_chain`], which wraps the matrix composition here.
 //!
 //! # Independent variable
 //!

--- a/arika/src/earth/iau2006/mod.rs
+++ b/arika/src/earth/iau2006/mod.rs
@@ -2,34 +2,22 @@
 //!
 //! # Scope
 //!
-//! This module provides the pure-math building blocks for the IAU 2006 CIO-based
-//! Earth rotation chain. In Phase 3 it is populated incrementally:
+//! The pure-math building blocks for the IAU 2006 CIO-based Earth rotation
+//! chain, plus the public [`crate::frame::Rotation`] constructors that wrap
+//! them:
 //!
-//! - **Phase 3A-1**: typed angle primitives, fundamental arguments
-//!   `F1..F14`, and IAU 2006 precession polynomial expressions from
+//! - typed angle primitives, fundamental arguments `F1..F14`, and IAU 2006
+//!   precession polynomials ([`fundamental_arguments`], [`precession`]) from
 //!   [IERS Conventions 2010 TN36](https://www.iers.org/IERS/EN/Publications/TechnicalNotes/tn36.html)
 //!   Eq. (5.39), (5.40), (5.43), (5.44)
-//! - **Phase 3A-2**: CIP `X`, `Y` and CIO locator `s + XY/2` series
-//!   generated from the IERS electronic tables `tab5.2a.txt`,
-//!   `tab5.2b.txt`, `tab5.2d.txt` — stored as the crate-private
-//!   `tables_gen` submodule. The generator lives at
-//!   `arika/tools/generate_iau2006_tables.py`
-//! - **Phase 3A-3** (this commit): [`cip`] evaluators — `cip_xy`,
-//!   `cio_locator_s`, `cip_coordinates` — that consume the generated
-//!   series and return `Rad`-typed CIP coordinates + CIO locator
-//! - **Phase 3A-4**: GCRS→CIRS matrix composition in [`cip`] using
-//!   `(X, Y, s)` plus SOFA-style `R_z · R_y · R_z` assembly
-//! - **Phase 3B** (this commit): public [`crate::frame::Rotation`]
-//!   constructors in [`cio_chain`] —
-//!   `Rotation<Gcrs, Cirs>::iau2006(tt, utc, eop)`,
-//!   `Rotation<Cirs, Tirs>::from_era(ut1)`,
-//!   `Rotation<Tirs, Itrs>::polar_motion(tt, utc, eop)`,
-//!   `Rotation<Gcrs, Itrs>::iau2006_full(tt, ut1, utc, eop)`,
-//!   and the convenience `iau2006_full_from_utc(utc, eop)`. All EOP
-//!   trait bounds from Phase 2 are now enforced end-to-end
-//!
-//! No public [`crate::frame::Rotation`] constructors are exposed from this
-//! module yet — they appear in Phase 3B.
+//! - CIP `X`, `Y` and CIO locator `s + XY/2` series plus the GCRS→CIRS matrix
+//!   composition ([`cip`]). The series are generated from the IERS electronic
+//!   tables `tab5.2{a,b,d}.txt` into the crate-private `tables_gen` submodule
+//!   (generator: `arika/tools/generate_iau2006_tables.py`)
+//! - the GCRS → CIRS → TIRS → ITRS `Rotation` constructors ([`cio_chain`]):
+//!   `Rotation<Gcrs, Cirs>::iau2006`, `<Cirs, Tirs>::from_era`,
+//!   `<Tirs, Itrs>::polar_motion`, `<Gcrs, Itrs>::iau2006_full`, each gated by
+//!   the [`crate::earth::eop`] provider trait bounds
 //!
 //! # Independent variable
 //!

--- a/arika/src/earth/mod.rs
+++ b/arika/src/earth/mod.rs
@@ -11,12 +11,11 @@
 //!   ([`Ut1Offset`](eop::Ut1Offset), [`PolarMotion`](eop::PolarMotion),
 //!   [`NutationCorrections`](eop::NutationCorrections),
 //!   [`LengthOfDay`](eop::LengthOfDay)) and [`NullEop`](eop::NullEop) placeholder
-//! - [`iau2006`] — IAU 2006 / 2000A_R06 precession-nutation supporting math
-//!   (angular units, fundamental arguments, precession polynomials; Phase 3A-1)
-//!
-//! Phase 3 will add `Rotation<Gcrs, Cirs>::iau2006` / `Rotation<Cirs, Tirs>::from_era`
-//! / `Rotation<Tirs, Itrs>::polar_motion` constructors that consume these EOP
-//! traits for the full IAU 2006 CIO-based Earth rotation chain.
+//! - [`iau2006`] — full IAU 2006 / 2000A_R06 CIO-based Earth rotation chain:
+//!   the supporting math (angular units, fundamental arguments, precession /
+//!   nutation polynomials) plus the `Rotation<Gcrs, Cirs>::iau2006` /
+//!   `Rotation<Cirs, Tirs>::from_era` / `Rotation<Tirs, Itrs>::polar_motion`
+//!   constructors that consume the [`eop`] traits.
 
 pub mod ellipsoid;
 pub mod eop;

--- a/arika/src/earth/rotation.rs
+++ b/arika/src/earth/rotation.rs
@@ -3,10 +3,8 @@
 //! This is the base linear model (α₁, δ₁ ≠ 0, so the pole drifts from the
 //! ECI Z-axis over centuries). For short-term simulations where precession is
 //! negligible, the simpler ERA-only rotation
-//! (`Rotation::<SimpleEci, SimpleEcef>::from_ut1`) is preferred.
-//!
-//! For Phase 3 the strict IAU 2006 CIO-based precession / nutation chain
-//! will be added as a sibling module under `earth/`.
+//! (`Rotation::<SimpleEci, SimpleEcef>::from_ut1`) is preferred; for high
+//! precision use the IAU 2006 CIO chain in [`crate::earth::iau2006`].
 
 use crate::rotation::IauRotationModel;
 

--- a/arika/src/frame.rs
+++ b/arika/src/frame.rs
@@ -140,9 +140,10 @@ pub trait Frame: sealed::Sealed {
 
 /// Structural category for earth-centered inertial frames.
 ///
-/// 近似系 (`SimpleEci`) と厳密系 (`Gcrs`/`Cirs`/`Teme`) の両方を含む category。
-/// precision-aware な処理は concrete 型を関数シグネチャに書き、`<F: Eci>` generic
-/// bound は precision-agnostic な math (magnitude / dot / 等) のみに使う。
+/// 近似系 (`SimpleEci`)、厳密系 (`Gcrs`/`Cirs`)、SGP4 の quasi-inertial 系 (`Teme`)
+/// をまとめて含む category。precision-aware な処理は concrete 型を関数シグネチャに
+/// 書き、`<F: Eci>` generic bound は precision-agnostic な math (magnitude / dot /
+/// 等) のみに使う。
 pub trait Eci: Frame {}
 
 /// Structural category for earth-centered earth-fixed frames.
@@ -237,8 +238,8 @@ impl Frame for Tirs {
 impl Ecef for Tirs {}
 
 /// International Terrestrial Reference System. IAU 2006 CIO chain の Earth-fixed
-/// side (polar motion 適用済み)。WGS84 ellipsoid の geodetic 変換
-/// ([`Vec3::to_geodetic`]) はこの frame に紐づく。
+/// side (polar motion 適用済み)。geodetic 変換 ([`Vec3::to_geodetic`]) は任意の
+/// `Ecef` frame で使えるが、高精度 path では通常この ITRS から変換する。
 ///
 /// GCRS からの完全 chain は [`Rotation::<Gcrs, Itrs>::iau2006_full`]、polar motion
 /// 単体は [`Rotation::<Tirs, Itrs>::polar_motion`] を参照。

--- a/arika/src/frame.rs
+++ b/arika/src/frame.rs
@@ -12,20 +12,17 @@
 //! # Frame marker
 //!
 //! - [`SimpleEci`] — 歳差・章動・極運動を無視した近似的な Earth-centered inertial。
-//!   ERA-only Z 回転の親フレーム。Meeus ephemeris と可視化グレード計算の出発点
-//! - [`SimpleEcef`] — [`SimpleEci`] からの ERA Z 回転先。簡易地球固定系。
-//!   極運動や章動を一切適用しない近似的 Earth-fixed
-//! - [`Gcrs`] — Geocentric Celestial Reference System (IAU 2006 CIO chain の
-//!   celestial side)。Meeus ephemeris の返り型としても使う (strict な GCRS では
-//!   なく "geocentric inertial as returned by low-precision analytic models" の
-//!   意味。後続 Phase で precession/nutation 補正が加わると厳密な GCRS に近づく)
-//! - [`Cirs`] — Celestial Intermediate Reference System (IAU 2006 CIO chain 中間)。
-//!   Phase 2 では marker のみ、rotation chain impl は Phase 3 で追加
-//! - [`Tirs`] — Terrestrial Intermediate Reference System (polar motion 未適用)。
-//!   Phase 2 では marker のみ、rotation chain impl は Phase 3 で追加
-//! - [`Itrs`] — International Terrestrial Reference System。polar motion 適用済み
-//!   Earth-fixed frame で geodetic 変換はここに紐づく (本格的な bind は Phase 3+)。
-//!   Phase 2 では marker のみ、rotation chain impl は Phase 3 で追加
+//!   ERA-only Z 回転の親フレーム。可視化グレード計算の出発点
+//! - [`SimpleEcef`] — [`SimpleEci`] からの ERA-only Z 回転先。近似的 Earth-fixed
+//! - [`Gcrs`] — Geocentric Celestial Reference System。IAU 2006 CIO chain の
+//!   celestial side。Meeus ephemeris の返り型でもあり、その値は低精度 analytic
+//!   model 由来なので strict な GCRS とは限らない
+//! - [`Cirs`] — Celestial Intermediate Reference System (CIO chain の中間)
+//! - [`Tirs`] — Terrestrial Intermediate Reference System (polar motion 未適用)
+//! - [`Itrs`] — International Terrestrial Reference System (polar motion 適用済み)。
+//!   geodetic 変換はこの frame に紐づく
+//! - [`Teme`] — True Equator, Mean Equinox。SGP4 / TLE / OMM の平均要素フレーム
+//!   (marker のみ; ↔ Gcrs 回転は未実装)
 //! - [`Rsw`] — Radial / Along-track / Cross-track 軌道ローカル系。
 //!   軸順は標準 RSW 規約 [R̂, Ŝ, Ŵ] (R̂=normalize(r), Ŵ=normalize(r×v), Ŝ=Ŵ×R̂)
 //! - [`Body`] — 宇宙機機体座標系
@@ -33,7 +30,7 @@
 //! # Category trait
 //!
 //! - [`Eci`] — structural category for earth-centered inertial frames.
-//!   実装者: `SimpleEci`, `Gcrs`, `Cirs`
+//!   実装者: `SimpleEci`, `Gcrs`, `Cirs`, `Teme`
 //! - [`Ecef`] — structural category for earth-fixed frames.
 //!   実装者: `SimpleEcef`, `Tirs`, `Itrs`
 //! - [`LocalOrbital`] — structural category for local orbital frames.
@@ -143,20 +140,19 @@ pub trait Frame: sealed::Sealed {
 
 /// Structural category for earth-centered inertial frames.
 ///
-/// 実装者: [`SimpleEci`], [`Gcrs`]。近似系 (`SimpleEci`) と将来の厳密系
-/// (`Gcrs`/`Cirs` 等) の両方を含む category。precision-aware な処理は concrete
-/// 型を関数シグネチャに書き、`<F: Eci>` generic bound は precision-agnostic
-/// な math (magnitude / dot / 等) のみに使う。
+/// 近似系 (`SimpleEci`) と厳密系 (`Gcrs`/`Cirs`/`Teme`) の両方を含む category。
+/// precision-aware な処理は concrete 型を関数シグネチャに書き、`<F: Eci>` generic
+/// bound は precision-agnostic な math (magnitude / dot / 等) のみに使う。
 pub trait Eci: Frame {}
 
 /// Structural category for earth-centered earth-fixed frames.
 ///
-/// 実装者: [`SimpleEcef`]。将来 `Itrs`/`Tirs`/`Pef` が追加される。同上の注意。
+/// 実装者: [`SimpleEcef`] (近似), [`Tirs`], [`Itrs`] (厳密)。同上の注意。
 pub trait Ecef: Frame {}
 
 /// Structural category for local orbital frames.
 ///
-/// 実装者: [`Rsw`]。将来 `Ntw`/`Vvlh`/`Perifocal` 等が追加される。
+/// 実装者: [`Rsw`]。
 pub trait LocalOrbital: Frame {}
 
 // Concrete frame markers
@@ -193,9 +189,9 @@ impl Ecef for SimpleEcef {}
 
 /// Geocentric Celestial Reference System. IAU 2006 CIO chain の celestial side。
 ///
-/// 現 Phase では Meeus ephemeris (低精度 analytic model) の返り型として使用。
-/// 厳密な IAU 2006/2000A の precession-nutation 補正は後続 Phase で追加される。
-/// `Rotation<Gcrs, Itrs>::iau2006_full` など高精度 chain は Phase 3 で提供予定。
+/// Meeus ephemeris (低精度 analytic model) の返り型としても使うため、その値は
+/// 厳密な GCRS とは限らない。GCRS → ITRS の高精度変換は
+/// [`Rotation::<Gcrs, Itrs>::iau2006_full`] を参照。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Gcrs;
 impl sealed::Sealed for Gcrs {}
@@ -208,19 +204,12 @@ impl Eci for Gcrs {}
 /// Celestial Intermediate Reference System. IAU 2006 CIO chain の中間フレーム
 /// (precession/nutation 適用後、ERA による Z 回転の直前の celestial side)。
 ///
-/// # Phase 2 status
-///
-/// 本 Phase では **marker のみ** を提供する。`Rotation<Gcrs, Cirs>::iau2006(tt, eop)`
-/// などの rotation chain constructor は Phase 3 で実装予定。現状ではこのフレームを
-/// 使う API は存在しないため、runtime では `FrameDescriptor::Cirs` と
-/// `<Cirs as Frame>::DESCRIPTOR` 経由でのみ参照できる。
-///
 /// # Independent variable
 ///
-/// `Rotation<Gcrs, Cirs>` は TT (Terrestrial Time) の Julian centuries を独立変数と
-/// する — IAU 2006 precession と IAU 2000A/B nutation の series は TT centuries で
-/// 定義されているため。詳細は [`arika/DESIGN.md`](../../DESIGN.md) の「Frame rotation
-/// の time scale は definitional」を参照。
+/// [`Rotation::<Gcrs, Cirs>::iau2006`] は TT (Terrestrial Time) の Julian centuries
+/// を独立変数とする — IAU 2006 precession と IAU 2000A/B nutation の series は TT
+/// centuries で定義されているため。詳細は [`arika/DESIGN.md`](../../DESIGN.md) の
+/// 「Frame rotation の time scale は definitional」を参照。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Cirs;
 impl sealed::Sealed for Cirs {}
@@ -233,15 +222,11 @@ impl Eci for Cirs {}
 /// Terrestrial Intermediate Reference System. polar motion 未適用の Earth-fixed
 /// 中間フレーム ([`Cirs`] から ERA による Z 回転で得られる)。
 ///
-/// # Phase 2 status
-///
-/// 本 Phase では **marker のみ** を提供する。`Rotation<Cirs, Tirs>::from_era(ut1)` と
-/// `Rotation<Tirs, Itrs>::polar_motion(utc, eop)` は Phase 3 で実装予定。
-///
 /// # Independent variable
 ///
-/// [`Cirs`] → [`Tirs`] の変換は UT1 (Earth rotation angle) を独立変数とする — ERA は
-/// UT1 の definitional な関数であり、他の scale では物理的に意味をなさない。
+/// [`Cirs`] → [`Tirs`] の変換 ([`Rotation::<Cirs, Tirs>::from_era`]) は UT1 (Earth
+/// rotation angle) を独立変数とする — ERA は UT1 の definitional な関数であり、
+/// 他の scale では物理的に意味をなさない。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Tirs;
 impl sealed::Sealed for Tirs {}
@@ -252,16 +237,11 @@ impl Frame for Tirs {
 impl Ecef for Tirs {}
 
 /// International Terrestrial Reference System. IAU 2006 CIO chain の Earth-fixed
-/// side (polar motion 適用済み)。WGS84 / GRS80 ellipsoid の geodetic 変換はこの
-/// frame に紐づく — ただし本 Phase では変換 impl は [`SimpleEcef`] にしか生えて
-/// いない。
+/// side (polar motion 適用済み)。WGS84 ellipsoid の geodetic 変換
+/// ([`Vec3::to_geodetic`]) はこの frame に紐づく。
 ///
-/// # Phase 2 status
-///
-/// 本 Phase では **marker のみ** を提供する。Phase 3 以降:
-/// - `Rotation<Tirs, Itrs>::polar_motion(utc, eop)` の実装
-/// - `Rotation<Gcrs, Itrs>::iau2006_full(...)` の完全 chain
-/// - `Vec3<Itrs>::to_geodetic()` / `Vec3<Itrs>::to_geodetic_with::<E>()` の追加
+/// GCRS からの完全 chain は [`Rotation::<Gcrs, Itrs>::iau2006_full`]、polar motion
+/// 単体は [`Rotation::<Tirs, Itrs>::polar_motion`] を参照。
 ///
 /// # 独立性
 ///
@@ -281,14 +261,11 @@ impl Ecef for Itrs {}
 /// True Equator, Mean Equinox — the quasi-inertial frame in which SGP4 / TLE /
 /// OMM mean elements are expressed. Belongs to the [`Eci`] category.
 ///
-/// # Phase status
-///
-/// **marker only**. The TEME ↔ [`Gcrs`] / [`SimpleEci`] rotation (GMST +
-/// equation of the equinoxes + precession/nutation) is deferred to a later
-/// phase, as is tagging element-set-derived state vectors as `Vec3<Teme>` —
-/// today the parsers return mean elements ([`crate::omm::Omm`]), not
-/// frame-tagged vectors. The marker exists so those future APIs have an
-/// explicit frame to name.
+/// **marker only**: the TEME ↔ [`Gcrs`] / [`SimpleEci`] rotation (GMST +
+/// equation of the equinoxes + precession/nutation) is not implemented, and the
+/// element-set parsers return mean elements ([`crate::omm::Omm`]) rather than
+/// `Vec3<Teme>` state vectors. The marker exists so those APIs have an explicit
+/// frame to name.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Teme;
 impl sealed::Sealed for Teme {}
@@ -532,7 +509,7 @@ impl Rotation<SimpleEci, SimpleEcef> {
     ///
     /// `SimpleEcef = R_z(−ERA(UT1)) × SimpleEci`. Applies only the ERA Z
     /// rotation — no precession, nutation, or polar motion. For high-precision
-    /// work use the IAU 2006 CIO chain (not yet implemented: Phase 3).
+    /// work use the IAU 2006 CIO chain ([`Rotation::<Gcrs, Itrs>::iau2006_full`]).
     pub fn from_ut1(epoch: &Epoch<Ut1>) -> Self {
         Self::from_era(epoch.era())
     }

--- a/arika/src/rotation.rs
+++ b/arika/src/rotation.rs
@@ -14,8 +14,8 @@
 //! - [`crate::sun::rotation::SUN`] (via [`crate::sun::SUN`] re-export)
 //! - [`crate::planets::rotation::MARS`]
 //!
-//! Phase 3 will add strict IAU 2006 CIO-based precession / nutation / ERA /
-//! polar motion models under `earth/` as a sibling to this dispatcher.
+//! The strict IAU 2006 CIO-based precession / nutation / ERA / polar motion
+//! chain lives under [`crate::earth::iau2006`] as a sibling to this dispatcher.
 //!
 //! Reference: Archinal et al. (2011), "Report of the IAU Working Group on
 //! Cartographic Coordinates and Rotational Elements: 2009",


### PR DESCRIPTION
## 背景

`arika` の座標系まわりの改善点を調査したところ、ライブラリ自体（型安全 frame・IAU 2006 CIO chain・generic geodetic/topocentric）は成熟しているのに、**ドキュメントが Phase 2 時点のまま止まっていて、実装済みの API を「Phase 3 で実装予定 / marker only」と記述している**ことが分かった。読者が「未実装」と誤解する状態だったため、実態に同期する。ついでに「コードを読めば分かる」冗長な開発履歴記述も整理した。

調査で挙がった改善点のうち **P1（ドキュメント drift）** に対応する。P2〜P6（frame タグ配線 / 摂動の frame 混合 / TLE・TEME / velocity transform / 精密パスの CLI 入口）は別途。

## 変更内容

**stale な記述の修正（実装済みなのに未実装と書いていた）**
- `frame.rs` — `Cirs`/`Tirs`/`Itrs` の `# Phase 2 status`（"marker のみ / Phase 3 で実装予定"）を削除し、実在する `Rotation::<Gcrs, Itrs>::iau2006_full` / `polar_motion` / `Vec3::to_geodetic` を指すように。`Gcrs`/`Itrs` の "Phase 3 で提供予定" も修正
- `earth/mod.rs` / `earth/rotation.rs` / `rotation.rs` — "Phase 3 will add…" を `earth::iau2006` への現在形ポインタに
- `eop/mod.rs` — "# Phase 2 の範囲" 開発履歴ブロックと "Phase 3 で追加予定" 注記を削除（trait 分割の設計意図は残置）。`LengthOfDay`/`FullEopProvider` を「現状未使用 = velocity transform 用の bound」と正確に説明

**正確性の改善**
- `frame.rs` の frame marker 一覧に抜けていた `Teme` を追加、`Eci`/`Ecef` カテゴリの実装者リストを実態（`Teme`/`Tirs`/`Itrs`）に修正
- `iau2006/mod.rs` / `cip.rs` / `cio_chain.rs` の `(this commit)` や "Phase 3B will wrap" 等の矛盾した phase ナラティブを、簡潔な「何を提供するか」に置換

**意図的に残した（本当に未実装 / 設計の why）**
- TEME↔GCRS 回転・カスタム楕円体版 geodetic・velocity transform(`with_rates`/LOD) は「未実装」として正確に記述維持
- `SimpleEcef`↔`Itrs` を silent 変換させない設計理由、EOP trait 分割の理由などは残置

**スコープ外**: `precession.rs`/`tables_pin.rs`/`tables_gen.rs`/`fundamental_arguments.rs` の内部 pure-math テスト/pin コメントに残る "Phase 3A-x" 開発順ラベルは、公開 API を誤表現していないため今回触れていない

## 検証

doc 専用変更（正味 −56 行）。
- `cargo fmt -p arika --check` clean
- `cargo doc -p arika --no-deps` 新規 warning ゼロ（既存の `[km]` 等 baseline noise のみ）
- `cargo test -p arika` lib 303 + doctests 2 すべて pass
- codex review（gpt-5.5）: 指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)