### PR TITLE
test(orts): pin J2+third-body frame-agnosticism; document the raw-vector approximation

### DIFF
--- a/orts/src/perturbations/srp.rs
+++ b/orts/src/perturbations/srp.rs
@@ -87,8 +87,8 @@ impl SolarRadiationPressure {
     /// Sun position comes from Meeus ephemeris (`Vec3<Gcrs>`); the geometry is
     /// pure raw vector arithmetic, used directly whatever frame the satellite
     /// state is tagged with. Same intentional raw-vector approximation as
-    /// [`ThirdBodyGravity::acceleration`](crate::perturbations::ThirdBodyGravity)
-    /// — suited to Meeus / visualization precision, not high-accuracy GCRS work.
+    /// `ThirdBodyGravity::acceleration` — suited to Meeus / visualization
+    /// precision, not high-accuracy GCRS work.
     pub(crate) fn acceleration(
         &self,
         sat_position: &Vector3<f64>,

--- a/orts/src/perturbations/srp.rs
+++ b/orts/src/perturbations/srp.rs
@@ -84,9 +84,11 @@ impl SolarRadiationPressure {
 impl SolarRadiationPressure {
     /// Compute SRP acceleration [km/s²].
     ///
-    /// Sun position comes from Meeus ephemeris (`Vec3<Gcrs>`).
-    /// The tidal geometry is pure raw vector arithmetic — frame-independent
-    /// at Meeus precision.
+    /// Sun position comes from Meeus ephemeris (`Vec3<Gcrs>`); the geometry is
+    /// pure raw vector arithmetic, used directly whatever frame the satellite
+    /// state is tagged with. Same intentional raw-vector approximation as
+    /// [`ThirdBodyGravity::acceleration`](crate::perturbations::ThirdBodyGravity)
+    /// — suited to Meeus / visualization precision, not high-accuracy GCRS work.
     pub(crate) fn acceleration(
         &self,
         sat_position: &Vector3<f64>,

--- a/orts/src/perturbations/third_body.rs
+++ b/orts/src/perturbations/third_body.rs
@@ -108,12 +108,12 @@ impl ThirdBodyGravity {
     ///
     /// Pure vector arithmetic on raw `Vector3<f64>`: the `Vec3<Gcrs>` body
     /// position (Meeus) is used directly, whatever frame the satellite state is
-    /// tagged with. This is an intentional raw-vector approximation — the
-    /// default `SimpleEci` frame is only loosely related to GCRS (`arika::frame`:
-    /// it omits precession, nutation, and frame bias), so the raw mix is
-    /// appropriate at the Meeus / visualization precision this path targets, not
-    /// for high-accuracy GCRS work. The orbital effect is bounded against Orekit
-    /// by the GCRF oracle tests.
+    /// tagged with — the integration-frame orientation is never consulted. This
+    /// is an intentional raw-vector approximation for Meeus / visualization
+    /// precision: `SimpleEci` is only loosely related to GCRS (omits precession,
+    /// nutation, frame bias), and `Gcrs` gains no accuracy over `SimpleEci` here.
+    /// A frame whose axes differ from GCRS (e.g. `Teme`) would be silently wrong;
+    /// the frame-aware force-model redesign is tracked in issue #191.
     pub(crate) fn acceleration(
         &self,
         sat_position: &Vector3<f64>,

--- a/orts/src/perturbations/third_body.rs
+++ b/orts/src/perturbations/third_body.rs
@@ -106,10 +106,14 @@ impl ThirdBodyGravity {
 impl ThirdBodyGravity {
     /// Compute third-body gravitational acceleration [km/s²].
     ///
-    /// The tidal formula is pure vector arithmetic on raw `Vector3<f64>`.
-    /// The body position closure returns `Vec3<Gcrs>` whose raw inner
-    /// value is numerically equal to any other ECI frame at Meeus
-    /// precision, so this function is frame-independent.
+    /// Pure vector arithmetic on raw `Vector3<f64>`: the `Vec3<Gcrs>` body
+    /// position (Meeus) is used directly, whatever frame the satellite state is
+    /// tagged with. This is an intentional raw-vector approximation — the
+    /// default `SimpleEci` frame is only loosely related to GCRS (`arika::frame`:
+    /// it omits precession, nutation, and frame bias), so the raw mix is
+    /// appropriate at the Meeus / visualization precision this path targets, not
+    /// for high-accuracy GCRS work. The orbital effect is bounded against Orekit
+    /// by the GCRF oracle tests.
     pub(crate) fn acceleration(
         &self,
         sat_position: &Vector3<f64>,

--- a/orts/tests/oracle_gcrf.rs
+++ b/orts/tests/oracle_gcrf.rs
@@ -227,8 +227,8 @@ fn build_gcrs_system_real_eop(scenario: &Scenario) -> OrbitalSystem<frame::Gcrs>
     build_gcrs_system_with_eop(scenario, GcrsEopStorage::new(load_eop_table()))
 }
 
-/// Propagate with Gcrs path and return final position error vs Orekit.
-fn final_pos_err_gcrs(scenario: &Scenario, system: &OrbitalSystem<frame::Gcrs>) -> f64 {
+/// Propagate the Gcrs path and return the final position [km].
+fn final_pos_gcrs(scenario: &Scenario, system: &OrbitalSystem<frame::Gcrs>) -> Vector3<f64> {
     let ic = &scenario.initial_cartesian;
     let initial = OrbitalState::<frame::Gcrs>::new_in_frame(
         Vector3::new(ic.position_km[0], ic.position_km[1], ic.position_km[2]),
@@ -241,24 +241,23 @@ fn final_pos_err_gcrs(scenario: &Scenario, system: &OrbitalSystem<frame::Gcrs>) 
 
     let dp = DormandPrince;
     let duration = scenario.trajectory.last().unwrap().t_seconds;
-    let final_state = dp.integrate(system, initial, 0.0, duration, 30.0, |_, _| {});
+    *dp.integrate(system, initial, 0.0, duration, 30.0, |_, _| {})
+        .position()
+}
 
+/// Final position error of the Gcrs propagation vs the Orekit GCRF fixture.
+fn final_pos_err_gcrs(scenario: &Scenario, system: &OrbitalSystem<frame::Gcrs>) -> f64 {
     let final_orekit = scenario.trajectory.last().unwrap();
     (Vector3::new(
         final_orekit.position_km[0],
         final_orekit.position_km[1],
         final_orekit.position_km[2],
-    ) - *final_state.position())
+    ) - final_pos_gcrs(scenario, system))
     .magnitude()
 }
 
-/// Propagate with SimpleEci path (same initial conditions) and return
-/// final position error vs the GCRF Orekit fixture.
-///
-/// The GCRF fixture and EME2000 differ by ~23 mas (frame bias), which
-/// is sub-meter at LEO. So comparing SimpleEci against the GCRF fixture
-/// gives a meaningful (if slightly pessimistic) error measure.
-fn final_pos_err_simple(scenario: &Scenario) -> f64 {
+/// Propagate the SimpleEci (default) path and return the final position [km].
+fn final_pos_simple(scenario: &Scenario) -> Vector3<f64> {
     let ic = &scenario.initial_cartesian;
     let initial = OrbitalState::new(
         Vector3::new(ic.position_km[0], ic.position_km[1], ic.position_km[2]),
@@ -318,15 +317,57 @@ fn final_pos_err_simple(scenario: &Scenario) -> f64 {
 
     let dp = DormandPrince;
     let duration = scenario.trajectory.last().unwrap().t_seconds;
-    let final_state = dp.integrate(&system, initial, 0.0, duration, 30.0, |_, _| {});
+    *dp.integrate(&system, initial, 0.0, duration, 30.0, |_, _| {})
+        .position()
+}
 
+/// Final position error of the SimpleEci propagation vs the GCRF Orekit fixture.
+///
+/// The GCRF fixture and EME2000 differ by ~23 mas (frame bias), which is
+/// sub-meter at LEO, so comparing SimpleEci against the GCRF fixture gives a
+/// meaningful (if slightly pessimistic) error measure.
+fn final_pos_err_simple(scenario: &Scenario) -> f64 {
     let final_orekit = scenario.trajectory.last().unwrap();
     (Vector3::new(
         final_orekit.position_km[0],
         final_orekit.position_km[1],
         final_orekit.position_km[2],
-    ) - *final_state.position())
+    ) - final_pos_simple(scenario))
     .magnitude()
+}
+
+/// All force models in this scenario — J2 zonal gravity and sun/moon
+/// third-body — read the satellite state and the Meeus ephemeris (`Vec3<Gcrs>`)
+/// as raw `Vector3`, so the integration-frame phantom (`SimpleEci` vs `Gcrs`)
+/// never enters the numbers. This pins that frame-agnostic treatment: the two
+/// propagations of this fixture must be numerically identical. (Drag is the one
+/// force that *does* depend on the frame, via the Earth-fixed rotation, so this
+/// fixture is required to be drag-free.)
+///
+/// Scope: the GCRF fixtures never construct [`SolarRadiationPressure`], so SRP
+/// is not exercised here — but it uses the identical raw-vector pattern (see its
+/// `acceleration` rationale). If any force in this scenario (third-body **or**
+/// J2) is later made frame-aware, this test fails and forces that to be a
+/// deliberate, reviewed decision rather than a silent behavior shift.
+#[test]
+fn j2_thirdbody_propagation_is_frame_agnostic() {
+    let fixtures = load_fixtures();
+    let scenario = find_scenario(&fixtures, "gcrf_j2_thirdbody_iss_10orbits");
+    assert!(
+        scenario.force_model.drag.is_none(),
+        "this invariant only holds without drag; scenario must stay drag-free"
+    );
+
+    let pos_simple = final_pos_simple(scenario);
+    let pos_gcrs = final_pos_gcrs(scenario, &build_gcrs_system(scenario));
+
+    let diff = (pos_simple - pos_gcrs).magnitude();
+    assert!(
+        diff < 1e-6,
+        "J2 + third-body must propagate identically in SimpleEci and Gcrs: \
+         final positions differ by {diff:.3e} km (expected ~0; a real frame \
+         effect would be meters)"
+    );
 }
 
 #[test]

--- a/orts/tests/oracle_gcrf.rs
+++ b/orts/tests/oracle_gcrf.rs
@@ -346,9 +346,12 @@ fn final_pos_err_simple(scenario: &Scenario) -> f64 {
 ///
 /// Scope: the GCRF fixtures never construct [`SolarRadiationPressure`], so SRP
 /// is not exercised here — but it uses the identical raw-vector pattern (see its
-/// `acceleration` rationale). If any force in this scenario (third-body **or**
-/// J2) is later made frame-aware, this test fails and forces that to be a
-/// deliberate, reviewed decision rather than a silent behavior shift.
+/// `acceleration` rationale). This numerical identity is also a known limitation:
+/// the forces ignore the integration-frame orientation, so `Gcrs` is no more
+/// accurate than `SimpleEci` here, and a non-GCRS-aligned frame would be silently
+/// wrong (frame-aware force-model redesign tracked in issue #191). If any force
+/// in this scenario (third-body **or** J2) is later made frame-aware, this test
+/// fails and forces that to be a deliberate, reviewed decision.
 #[test]
 fn j2_thirdbody_propagation_is_frame_agnostic() {
     let fixtures = load_fixtures();


### PR DESCRIPTION
## 背景（調べたこと）

座標系の改善点調査の中で、第三体重力 `ThirdBodyGravity` と SRP `SolarRadiationPressure` が太陽月位置を `Vec3<Gcrs>`（GCRS）で受けつつ、その生ベクトルを既定 `SimpleEci` フレームの軌道積分にそのまま渡しているのに気づいた。フレーム不整合のバグか意図的な近似か、コードからは判断できない（担保は "frame-independent at Meeus precision" という曖昧なコメントだけで、テストも根拠説明も無し）。実際どう振る舞うか調べた。

## 調べた結論

現状、数値的な実害はない。理由は「混在が無害」だからではなく、保存力が積分フレームの向きを使っていないから:

- 力は生ベクトル演算のみで、フレームを表す型パラメータ（phantom）は数値に入らない。
- 大気抵抗なし（J2 + 第三体）を `SimpleEci` / `Gcrs` 両方で伝播すると結果は完全一致（ともに Orekit GCRF 比 2.1m）。
- これは保存力では `Gcrs` が `SimpleEci` 以上の精度を出していない、ということでもある（`ZonalHarmonics` が Z 軸を地球極と決め打ち、エフェメリスを GCRS のまま生使用）。`Gcrs` の精度優位は drag/magnetic だけ。
- oracle も Orekit の重力 body frame を GCRF に揃えて生成しており、J2 を真極でなく GCRS-Z で評価する誤差は未検証。
- 将来 GCRS と向きの違うフレーム（TEME, true-of-date 等）を入れて積分すると、J2 を誤った軸で・太陽月を回さずに使い、コンパイルエラーも警告も出ないまま誤った結果になる。

この根本的な限界とその再設計は #191 に切り出した。

## この PR でやること

挙動は変えない。現状の扱いを回帰テストで固定し、何を仮定しているかを doc に書くだけ:

- 現状の不変条件を回帰テストで固定（drag-free J2+第三体で `SimpleEci` 伝播 == `Gcrs` 伝播。将来いずれかを frame-aware 化したら落ちて #191 を意図的にする）。
- raw-vector 使用が意図的な近似で既知の限界であることを doc 明記し、#191 へリンク。

力モデルの再設計自体は #191 の別 PR で扱う。

## 変更

- `oracle_gcrf.rs`: 伝播ヘルパを最終位置返しに分割し、`j2_thirdbody_propagation_is_frame_agnostic` を追加（SRP は fixture に無い旨も明記）。
- `third_body.rs` / `srp.rs`: GCRS 生使用を意図的な近似（既知の限界, #191）として doc 化。

## 検証

fmt clean / `cargo test -p orts --test oracle_gcrf` 全 pass / CI-scope `cargo clippy -p orts` clean / codex・Copilot レビュー反映済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)