### PR TITLE
refactor(orts): make ThirdBodyGravity/SRP frame-explicit (SimpleEci+Gcrs), not blanket over Eci

### DIFF
--- a/orts/src/perturbations/srp.rs
+++ b/orts/src/perturbations/srp.rs
@@ -4,7 +4,7 @@ use arika::sun;
 use nalgebra::Vector3;
 
 use arika::earth::R as R_EARTH;
-use arika::frame::Eci;
+use arika::frame::{Gcrs, SimpleEci};
 
 use crate::model::ExternalLoads;
 use crate::model::{HasOrbit, Model};
@@ -145,15 +145,27 @@ impl SolarRadiationPressure {
     }
 }
 
-impl<F: Eci, S: HasOrbit<Frame = F>> Model<S, F> for SolarRadiationPressure {
-    fn name(&self) -> &str {
-        "srp"
-    }
+// SRP consumes the Meeus sun ephemeris (`Vec3<Gcrs>`) as a raw vector, so it is
+// implemented only for the frames where that is valid: `SimpleEci`
+// (visualization-grade approximation) and `Gcrs` (exact). Deliberately NOT a
+// blanket `impl<F: Eci>` — a new inertial frame whose axes differ from GCRS
+// (e.g. `Teme`) must add a frame-aware impl rather than silently inherit the
+// raw-vector treatment. See #191.
+macro_rules! impl_srp_model {
+    ($frame:ty) => {
+        impl<S: HasOrbit<Frame = $frame>> Model<S, $frame> for SolarRadiationPressure {
+            fn name(&self) -> &str {
+                "srp"
+            }
 
-    fn eval(&self, _t: f64, state: &S, epoch: Option<&Epoch>) -> ExternalLoads<F> {
-        ExternalLoads::acceleration(self.acceleration(state.orbit().position(), epoch))
-    }
+            fn eval(&self, _t: f64, state: &S, epoch: Option<&Epoch>) -> ExternalLoads<$frame> {
+                ExternalLoads::acceleration(self.acceleration(state.orbit().position(), epoch))
+            }
+        }
+    };
 }
+impl_srp_model!(SimpleEci);
+impl_srp_model!(Gcrs);
 
 #[cfg(test)]
 mod tests {

--- a/orts/src/perturbations/srp.rs
+++ b/orts/src/perturbations/srp.rs
@@ -145,12 +145,12 @@ impl SolarRadiationPressure {
     }
 }
 
-// SRP consumes the Meeus sun ephemeris (`Vec3<Gcrs>`) as a raw vector, so it is
-// implemented only for the frames where that is valid: `SimpleEci`
-// (visualization-grade approximation) and `Gcrs` (exact). Deliberately NOT a
-// blanket `impl<F: Eci>` — a new inertial frame whose axes differ from GCRS
-// (e.g. `Teme`) must add a frame-aware impl rather than silently inherit the
-// raw-vector treatment. See #191.
+// SRP consumes the Meeus sun ephemeris (`Vec3<Gcrs>`) as a raw vector (see
+// `acceleration` above), so it is implemented only for the currently-supported
+// inertial frames that are (approximately) GCRS-aligned: `SimpleEci` and
+// `Gcrs`. Deliberately NOT a blanket `impl<F: Eci>` — a new inertial frame
+// whose axes differ from GCRS (e.g. `Teme`) must add a frame-aware impl rather
+// than silently inherit the raw-vector treatment. See #191.
 macro_rules! impl_srp_model {
     ($frame:ty) => {
         impl<S: HasOrbit<Frame = $frame>> Model<S, $frame> for SolarRadiationPressure {

--- a/orts/src/perturbations/third_body.rs
+++ b/orts/src/perturbations/third_body.rs
@@ -135,11 +135,12 @@ impl ThirdBodyGravity {
 }
 
 // `ThirdBodyGravity` consumes the Meeus ephemeris (`Vec3<Gcrs>`) as a raw
-// vector, so it is implemented only for the frames where that is valid:
-// `SimpleEci` (visualization-grade approximation) and `Gcrs` (exact). This is
-// deliberately NOT a blanket `impl<F: Eci>` — a new inertial frame whose axes
-// differ from GCRS (e.g. `Teme`) must add a frame-aware impl that rotates the
-// ephemeris rather than silently inherit the raw-vector treatment. See #191.
+// vector (see `acceleration` above), so it is implemented only for the
+// currently-supported inertial frames that are (approximately) GCRS-aligned:
+// `SimpleEci` and `Gcrs`. This is deliberately NOT a blanket `impl<F: Eci>` —
+// a new inertial frame whose axes differ from GCRS (e.g. `Teme`) must add a
+// frame-aware impl that rotates the ephemeris rather than silently inherit the
+// raw-vector treatment. See #191.
 macro_rules! impl_third_body_model {
     ($frame:ty) => {
         impl<S: HasOrbit<Frame = $frame>> Model<S, $frame> for ThirdBodyGravity {

--- a/orts/src/perturbations/third_body.rs
+++ b/orts/src/perturbations/third_body.rs
@@ -4,8 +4,6 @@ use arika::epoch::Epoch;
 use arika::frame::{self, Vec3};
 use nalgebra::Vector3;
 
-use arika::frame::Eci;
-
 use crate::model::ExternalLoads;
 use crate::model::{HasOrbit, Model};
 
@@ -136,15 +134,27 @@ impl ThirdBodyGravity {
     }
 }
 
-impl<F: Eci, S: HasOrbit<Frame = F>> Model<S, F> for ThirdBodyGravity {
-    fn name(&self) -> &str {
-        self.name
-    }
+// `ThirdBodyGravity` consumes the Meeus ephemeris (`Vec3<Gcrs>`) as a raw
+// vector, so it is implemented only for the frames where that is valid:
+// `SimpleEci` (visualization-grade approximation) and `Gcrs` (exact). This is
+// deliberately NOT a blanket `impl<F: Eci>` — a new inertial frame whose axes
+// differ from GCRS (e.g. `Teme`) must add a frame-aware impl that rotates the
+// ephemeris rather than silently inherit the raw-vector treatment. See #191.
+macro_rules! impl_third_body_model {
+    ($frame:ty) => {
+        impl<S: HasOrbit<Frame = $frame>> Model<S, $frame> for ThirdBodyGravity {
+            fn name(&self) -> &str {
+                self.name
+            }
 
-    fn eval(&self, _t: f64, state: &S, epoch: Option<&Epoch>) -> ExternalLoads<F> {
-        ExternalLoads::acceleration(self.acceleration(state.orbit().position(), epoch))
-    }
+            fn eval(&self, _t: f64, state: &S, epoch: Option<&Epoch>) -> ExternalLoads<$frame> {
+                ExternalLoads::acceleration(self.acceleration(state.orbit().position(), epoch))
+            }
+        }
+    };
 }
+impl_third_body_model!(frame::SimpleEci);
+impl_third_body_model!(frame::Gcrs);
 
 // Static assertion that `ThirdBodyGravity` can cross thread boundaries.
 // This is required so `OrbitalSystem` remains `Send + Sync` when it contains


### PR DESCRIPTION
## 背景

#191 の最初の一歩。`ThirdBodyGravity` と `SolarRadiationPressure` は Meeus エフェメリス（`Vec3<Gcrs>`）を生ベクトルとして使うが、その `Model` 実装は `impl<F: Eci>`（Eci 全般へのブランケット）だった。そのため将来 GCRS と軸の向きが違う慣性フレーム（例: `Teme`）を足すと、エフェメリスを回さずに使う近似を、コンパイルエラーも出さずに自動的に継いでしまう。

## この PR でやること

両者の `Model` 実装を `SimpleEci` ＋ `Gcrs` の明示 impl に絞る（小マクロで重複回避）。新フレームを足すには、エフェメリスを回す frame-aware な impl を意図的に書く必要が生じ、近似が勝手に伝播しなくなる。既に `EarthFrameBridge` で gated な `AtmosphericDrag` に揃える形（`PanelSrp` と `ConstantThrust` は元から SimpleEci 固定）。

挙動は変えない。既存の系は SimpleEci か Gcrs で両方カバーされ、数値は同一。コンストラクタも call site も変更なし。

#191 の残り（`EarthPoleBridge` ＋ `ZonalGravity` 抽出で zonal 重力を真極評価に、typed `ExternalLoads`、`EarthFrameBridge` の capability trait 分解）は follow-up PR。

## 変更

`third_body.rs` / `srp.rs`: ブランケット `impl<F: Eci>` を `SimpleEci`+`Gcrs` の明示 impl に置換。不要になった `Eci` import を整理。

## 検証

- `cargo check -p orts --all-targets` clean（call site 全て OK）
- `cargo fmt -p orts --check` clean
- CI スコープ `cargo clippy -p orts` clean
- orts lib 659 tests pass、oracle_gcrf の Gcrs テスト pass
- codex review 指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)