### PR TITLE
refactor(orts): frame-aware zonal gravity (EarthPoleBridge + ZonalGravity)

### DIFF
--- a/orts/src/environment.rs
+++ b/orts/src/environment.rs
@@ -15,6 +15,7 @@
 
 use arika::earth::eop::{NutationCorrections, PolarMotion, Ut1Offset};
 use arika::earth::geodetic::Geodetic;
+use arika::earth::iau2006::cip::cip_xy;
 use arika::epoch::{Epoch, Utc};
 use arika::frame::{self, Ecef, Eci, Rotation, Vec3};
 
@@ -76,6 +77,49 @@ impl NutationCorrections for GcrsEopStorage {
     }
 }
 
+// EarthPoleBridge trait
+
+/// ECI frame that knows Earth's rotation-pole direction expressed in itself.
+///
+/// Zonal harmonics (J2/J3/J4) are axially symmetric about the true rotation
+/// pole, so a zonal gravity model only needs the pole *direction* in the
+/// integration frame — not the full Earth-fixed rotation. This is the minimal
+/// capability `ZonalGravity` requires, kept separate from the heavier
+/// [`EarthFrameBridge`] (which also provides the ECEF rotation that drag,
+/// magnetic field, and geodetic conversions need).
+///
+/// EOP is intentionally not a parameter: the IAU 2006 model CIP is accurate to
+/// well under a milliarcsecond without the observed dX/dY corrections, which is
+/// negligible next to the ~0.1–0.3° offset of the true pole from the GCRS Z
+/// axis that this captures.
+///
+/// # Implementations
+///
+/// - `SimpleEci`: pole = `+Z` (the simple frame defines its Z axis as the pole).
+/// - `Gcrs`: pole = the IAU 2006 CIP direction `(X, Y, √(1−X²−Y²))` at the epoch.
+pub trait EarthPoleBridge: Eci + Sized + 'static {
+    /// Unit vector along Earth's rotation pole, expressed in this frame.
+    fn earth_pole(utc: &Epoch<Utc>) -> Vec3<Self>;
+}
+
+impl EarthPoleBridge for frame::SimpleEci {
+    fn earth_pole(_utc: &Epoch<Utc>) -> Vec3<frame::SimpleEci> {
+        Vec3::new(0.0, 0.0, 1.0)
+    }
+}
+
+impl EarthPoleBridge for frame::Gcrs {
+    fn earth_pole(utc: &Epoch<Utc>) -> Vec3<frame::Gcrs> {
+        // CIP direction cosines (X, Y) in GCRS from the IAU 2006 model; Z closes
+        // the unit vector. The model (no observed dX/dY) is sub-mas accurate.
+        let t = utc.to_tt().centuries_since_j2000();
+        let (x, y) = cip_xy(t);
+        let (x, y) = (x.raw(), y.raw());
+        let z = (1.0 - x * x - y * y).sqrt();
+        Vec3::new(x, y, z)
+    }
+}
+
 // EarthFrameBridge trait
 
 /// ECI frame that can bridge to Earth-fixed (ECEF) coordinates.
@@ -91,7 +135,7 @@ impl NutationCorrections for GcrsEopStorage {
 ///   no EOP needed (`EopStorage = ()`).
 /// - `Gcrs`: Full IAU 2006 CIO chain (`Rotation<Gcrs, Itrs>`),
 ///   requires EOP provider (`EopStorage = GcrsEopStorage`).
-pub trait EarthFrameBridge: Eci + Sized + 'static {
+pub trait EarthFrameBridge: EarthPoleBridge {
     /// The ECEF frame paired with this ECI frame.
     type Fixed: Ecef;
 
@@ -262,6 +306,57 @@ mod tests {
             "simple alt={}, gcrs alt={}",
             geo_simple.altitude,
             geo_gcrs.altitude
+        );
+    }
+
+    // EarthPoleBridge
+
+    #[test]
+    fn simple_eci_pole_is_plus_z() {
+        let utc = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
+        let p = <frame::SimpleEci as EarthPoleBridge>::earth_pole(&utc);
+        assert_eq!(p, Vec3::<frame::SimpleEci>::new(0.0, 0.0, 1.0));
+    }
+
+    fn pole_offset_from_z_deg<F: EarthPoleBridge>(utc: &Epoch<Utc>) -> f64 {
+        let p = F::earth_pole(utc);
+        let z = Vec3::<F>::new(0.0, 0.0, 1.0);
+        assert!(
+            (p.magnitude() - 1.0).abs() < 1e-12,
+            "pole must be a unit vector, got {}",
+            p.magnitude()
+        );
+        p.dot(&z).clamp(-1.0, 1.0).acos().to_degrees()
+    }
+
+    #[test]
+    fn gcrs_pole_offset_from_z_is_precession_scale_at_2024() {
+        // The true CIP is offset from the GCRS Z axis by precession + nutation;
+        // at 2024 this is ~0.1°. This is exactly the J2 axis error the simple
+        // (frame-Z) treatment ignores.
+        let utc = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
+        let angle = pole_offset_from_z_deg::<frame::Gcrs>(&utc);
+        assert!(
+            angle > 0.05 && angle < 0.5,
+            "2024 CIP offset from GCRS Z should be ~0.1°, got {angle}°"
+        );
+    }
+
+    #[test]
+    fn gcrs_pole_offset_grows_with_precession() {
+        // The CIP offset from GCRS Z is precession-dominated and grows with
+        // time: ~arcsec (nutation only) near J2000, ~0.1° (precession) by 2024.
+        let j2000 =
+            pole_offset_from_z_deg::<frame::Gcrs>(&Epoch::from_gregorian(2000, 1, 1, 12, 0, 0.0));
+        let y2024 =
+            pole_offset_from_z_deg::<frame::Gcrs>(&Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0));
+        assert!(
+            j2000 < 0.01,
+            "J2000 CIP offset should be arcsec-scale, got {j2000}°"
+        );
+        assert!(
+            y2024 > 10.0 * j2000,
+            "CIP offset should grow with precession: 2024={y2024}°, J2000={j2000}°"
         );
     }
 }

--- a/orts/src/environment.rs
+++ b/orts/src/environment.rs
@@ -115,7 +115,9 @@ impl EarthPoleBridge for frame::Gcrs {
         let t = utc.to_tt().centuries_since_j2000();
         let (x, y) = cip_xy(t);
         let (x, y) = (x.raw(), y.raw());
-        let z = (1.0 - x * x - y * y).sqrt();
+        // `.max(0.0)` guards against a slightly-negative radicand from f64
+        // round-off (x²+y² is ~1e-5 for real CIP values, never near 1).
+        let z = (1.0 - x * x - y * y).max(0.0).sqrt();
         Vec3::new(x, y, z)
     }
 }

--- a/orts/src/environment.rs
+++ b/orts/src/environment.rs
@@ -112,6 +112,13 @@ impl EarthPoleBridge for frame::Gcrs {
     fn earth_pole(utc: &Epoch<Utc>) -> Vec3<frame::Gcrs> {
         // CIP direction cosines (X, Y) in GCRS from the IAU 2006 model; Z closes
         // the unit vector. The model (no observed dX/dY) is sub-mas accurate.
+        //
+        // This is the CIP (precession + nutation), NOT the ITRS figure axis: it
+        // omits polar motion, which offsets the figure axis from the CIP by
+        // < ~0.3″. That is ~5 orders of magnitude below the ~0.1° precession
+        // offset this captures, and keeping it out is what lets the pole be
+        // EOP-free. (When cross-validating zonal gravity against Orekit, match
+        // its gravity body frame to the CIP rather than full ITRF accordingly.)
         let t = utc.to_tt().centuries_since_j2000();
         let (x, y) = cip_xy(t);
         let (x, y) = (x.raw(), y.raw());

--- a/orts/src/orbital/system.rs
+++ b/orts/src/orbital/system.rs
@@ -97,9 +97,10 @@ impl<F: Eci> DynamicalSystem for OrbitalSystem<F> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::orbital::gravity::{PointMass, ZonalHarmonics};
+    use crate::orbital::gravity::PointMass;
     use crate::orbital::kepler::KeplerianElements;
     use crate::orbital::two_body::TwoBodySystem;
+    use crate::perturbations::ZonalGravity;
     use arika::earth::{J2 as J2_EARTH, MU as MU_EARTH, R as R_EARTH};
     use nalgebra::vector;
     use std::f64::consts::PI;
@@ -154,15 +155,8 @@ mod tests {
     }
 
     fn earth_j2_system() -> OrbitalSystem {
-        OrbitalSystem::new(
-            MU_EARTH,
-            Box::new(ZonalHarmonics {
-                r_body: R_EARTH,
-                j2: J2_EARTH,
-                j3: None,
-                j4: None,
-            }),
-        )
+        OrbitalSystem::new(MU_EARTH, Box::new(PointMass))
+            .with_model(ZonalGravity::new(MU_EARTH, R_EARTH, J2_EARTH, None, None))
     }
 
     /// Propagate and return the final RAAN after duration seconds.
@@ -302,15 +296,13 @@ mod tests {
     }
 
     fn earth_j2_j3_j4_system() -> OrbitalSystem {
-        OrbitalSystem::new(
+        OrbitalSystem::new(MU_EARTH, Box::new(PointMass)).with_model(ZonalGravity::new(
             MU_EARTH,
-            Box::new(ZonalHarmonics {
-                r_body: R_EARTH,
-                j2: J2_EARTH,
-                j3: Some(arika::earth::J3),
-                j4: Some(arika::earth::J4),
-            }),
-        )
+            R_EARTH,
+            J2_EARTH,
+            Some(arika::earth::J3),
+            Some(arika::earth::J4),
+        ))
     }
 
     #[test]

--- a/orts/src/perturbations/mod.rs
+++ b/orts/src/perturbations/mod.rs
@@ -2,9 +2,11 @@ mod constant_thrust;
 mod drag;
 mod srp;
 mod third_body;
+mod zonal_gravity;
 
 pub use arika::earth::OMEGA as OMEGA_EARTH;
 pub use constant_thrust::ConstantThrust;
 pub use drag::{AtmosphericDrag, DEFAULT_BALLISTIC_COEFF};
 pub use srp::{DEFAULT_AREA_TO_MASS, DEFAULT_CR, SOLAR_RADIATION_PRESSURE, SolarRadiationPressure};
 pub use third_body::ThirdBodyGravity;
+pub use zonal_gravity::ZonalGravity;

--- a/orts/src/perturbations/zonal_gravity.rs
+++ b/orts/src/perturbations/zonal_gravity.rs
@@ -1,0 +1,215 @@
+//! Zonal gravity (J2/J3/J4) as a frame-aware perturbation.
+//!
+//! Unlike the spherically symmetric central term
+//! ([`PointMass`](crate::orbital::gravity::PointMass)), the zonal harmonics are
+//! symmetric about Earth's *rotation pole*, so the acceleration depends on the
+//! orientation of the integration frame relative to that pole. [`ZonalGravity`]
+//! therefore takes the pole direction from [`EarthPoleBridge`] instead of
+//! assuming the frame's Z axis is the pole.
+//!
+//! - `SimpleEci`: pole = `+Z`, reproducing the classic frame-Z formula.
+//! - `Gcrs`: pole = the IAU 2006 CIP, so J2 is evaluated about the true pole
+//!   (offset ~0.1° from GCRS Z by 2024), more accurate than `SimpleEci`.
+//!
+//! Add it to a system that already carries a central
+//! [`PointMass`](crate::orbital::gravity::PointMass) gravity field — this model
+//! contributes the oblateness perturbation only, not the point-mass term.
+
+use std::marker::PhantomData;
+
+use arika::epoch::{Epoch, Utc};
+use nalgebra::Vector3;
+
+use crate::environment::EarthPoleBridge;
+use crate::model::ExternalLoads;
+use crate::model::{HasOrbit, Model};
+
+/// Zonal harmonics (J2, optional J3/J4) gravity perturbation about the
+/// rotation pole supplied by [`EarthPoleBridge`].
+pub struct ZonalGravity<F: EarthPoleBridge = arika::frame::SimpleEci> {
+    /// Gravitational parameter of the central body [km³/s²].
+    pub mu: f64,
+    /// Equatorial radius of the central body [km].
+    pub r_body: f64,
+    /// J2 coefficient (dimensionless).
+    pub j2: f64,
+    /// J3 coefficient (dimensionless, optional).
+    pub j3: Option<f64>,
+    /// J4 coefficient (dimensionless, optional).
+    pub j4: Option<f64>,
+    // `fn() -> F` so the marker never imposes `Send`/`Sync` (or variance)
+    // requirements on `F`; `ZonalGravity<F>` is unconditionally `Send + Sync`.
+    _frame: PhantomData<fn() -> F>,
+}
+
+impl<F: EarthPoleBridge> ZonalGravity<F> {
+    /// Create a zonal gravity perturbation for a central body.
+    pub fn new(mu: f64, r_body: f64, j2: f64, j3: Option<f64>, j4: Option<f64>) -> Self {
+        Self {
+            mu,
+            r_body,
+            j2,
+            j3,
+            j4,
+            _frame: PhantomData,
+        }
+    }
+
+    /// Zonal perturbation acceleration [km/s²] about the pole direction in
+    /// frame `F` at `utc`.
+    ///
+    /// Each zonal term is `A·r + B·p̂` where `p̂` is the pole unit vector,
+    /// `ζ = r·p̂`, and `s² = (ζ/r)²`. For `p̂ = +Z` this reduces to the classic
+    /// `position.z`-based formula (pinned by the characterization test).
+    fn acceleration(&self, position: &Vector3<f64>, utc: &Epoch<Utc>) -> Vector3<f64> {
+        let pole = F::earth_pole(utc).into_inner();
+        let r = *position;
+
+        let r2 = r.norm_squared();
+        let r_mag = r2.sqrt();
+        let r5 = r2 * r2 * r_mag;
+        let zeta = r.dot(&pole); // component along the pole
+        let s2 = (zeta * zeta) / r2; // sin²(latitude measured from pole)
+        let re2 = self.r_body * self.r_body;
+
+        // J2: a = c2·(5s²−1)·r − 2·c2·ζ·p̂
+        let c2 = 1.5 * self.j2 * self.mu * re2 / r5;
+        let mut accel = c2 * (5.0 * s2 - 1.0) * r - (2.0 * c2 * zeta) * pole;
+
+        let r7 = r5 * r2;
+
+        // J3: a = A3·r + B3·p̂
+        if let Some(j3) = self.j3 {
+            let re3 = re2 * self.r_body;
+            let c3 = 0.5 * j3 * self.mu * re3;
+            let a3 = -5.0 * c3 * zeta / r7 * (3.0 - 7.0 * s2);
+            let b3 = 3.0 * c3 * (1.0 - 5.0 * s2) / r5;
+            accel += a3 * r + b3 * pole;
+        }
+
+        // J4: a = A4·r + B4·p̂
+        if let Some(j4) = self.j4 {
+            let re4 = re2 * re2;
+            let s4 = s2 * s2;
+            let c4 = j4 * self.mu * re4;
+            let a4 = (15.0 / 8.0) * c4 / r7 * (1.0 - 14.0 * s2 + 21.0 * s4);
+            let b4 = (5.0 / 2.0) * c4 * zeta / r7 * (3.0 - 7.0 * s2);
+            accel += a4 * r + b4 * pole;
+        }
+
+        accel
+    }
+}
+
+impl<F: EarthPoleBridge, S: HasOrbit<Frame = F>> Model<S, F> for ZonalGravity<F> {
+    fn name(&self) -> &str {
+        "zonal_gravity"
+    }
+
+    fn eval(&self, _t: f64, state: &S, epoch: Option<&Epoch>) -> ExternalLoads<F> {
+        // The pole is epoch-independent for `SimpleEci`; for `Gcrs` without an
+        // epoch, fall back to J2000 (mirrors the drag model's convention).
+        let dummy = Epoch::from_jd(2451545.0);
+        let utc = epoch.unwrap_or(&dummy);
+        ExternalLoads::acceleration(self.acceleration(state.orbit().position(), utc))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::OrbitalState;
+    use crate::orbital::gravity::{GravityField, PointMass, ZonalHarmonics};
+    use arika::earth::{J2 as J2_E, J3 as J3_E, J4 as J4_E, MU as MU_E, R as R_E};
+    use arika::frame::SimpleEci;
+
+    fn legacy(j3: Option<f64>, j4: Option<f64>) -> ZonalHarmonics {
+        ZonalHarmonics {
+            r_body: R_E,
+            j2: J2_E,
+            j3,
+            j4,
+        }
+    }
+
+    fn zonal(j3: Option<f64>, j4: Option<f64>) -> ZonalGravity<SimpleEci> {
+        ZonalGravity::new(MU_E, R_E, J2_E, j3, j4)
+    }
+
+    /// The legacy `ZonalHarmonics` returns point-mass + zonal; `ZonalGravity`
+    /// returns the zonal perturbation only. So the reference is the difference.
+    fn legacy_zonal_only(zh: &ZonalHarmonics, pos: &Vector3<f64>) -> Vector3<f64> {
+        zh.acceleration(MU_E, pos) - PointMass.acceleration(MU_E, pos)
+    }
+
+    /// Characterization: with pole = +Z (`SimpleEci`), `ZonalGravity` must
+    /// reproduce the legacy frame-Z `ZonalHarmonics` perturbation to f64
+    /// round-off, across J2 / J3 / J4 variants and representative positions.
+    #[test]
+    fn matches_legacy_zonal_harmonics_for_simple_eci() {
+        let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0); // ignored: SimpleEci pole = +Z
+        let cases = [
+            (None, None),
+            (Some(J3_E), None),
+            (None, Some(J4_E)),
+            (Some(J3_E), Some(J4_E)),
+        ];
+        let positions = [
+            Vector3::new(6778.0, 0.0, 0.0),         // equatorial
+            Vector3::new(0.0, 0.0, 7000.0),         // polar
+            Vector3::new(4000.0, -3000.0, 5000.0),  // generic
+            Vector3::new(42164.0, 0.0, 0.0),        // GEO
+            Vector3::new(-5000.0, 2000.0, -3000.0), // generic
+        ];
+        for (j3, j4) in cases {
+            let zh = legacy(j3, j4);
+            let zg = zonal(j3, j4);
+            for p in positions {
+                let a_ref = legacy_zonal_only(&zh, &p);
+                let a_new = zg.acceleration(&p, &epoch);
+                let rel = (a_new - a_ref).norm() / a_ref.norm().max(1e-30);
+                assert!(
+                    rel < 1e-12,
+                    "j3={j3:?} j4={j4:?} pos={p:?}: rel err {rel:e} (ref={a_ref:?}, new={a_new:?})"
+                );
+            }
+        }
+    }
+
+    /// Garbage in → garbage out: a non-finite or degenerate position must not
+    /// be silently turned into an all-finite (wrong) acceleration (CLAUDE.md:
+    /// pin NaN/∞ behaviour too). The exact NaN pattern differs from the legacy
+    /// frame-Z formula — the pole generalization uses `ζ = r·p̂`, and `inf·0` in
+    /// that dot product yields NaN where component extraction did not — which is
+    /// fine: inf positions are non-physical, and finite inputs are pinned
+    /// exactly by [`matches_legacy_zonal_harmonics_for_simple_eci`].
+    #[test]
+    fn non_finite_inputs_yield_non_finite_output() {
+        let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
+        let zg = zonal(Some(J3_E), Some(J4_E));
+        for p in [
+            Vector3::new(f64::NAN, 0.0, 7000.0),
+            Vector3::new(7000.0, f64::INFINITY, 0.0),
+            Vector3::new(0.0, 0.0, 0.0), // zero radius → 0/0
+        ] {
+            let a = zg.acceleration(&p, &epoch);
+            assert!(
+                !a.iter().all(|c| c.is_finite()),
+                "non-finite/degenerate input {p:?} must not yield an all-finite acceleration, got {a:?}"
+            );
+        }
+    }
+
+    /// The `Model` impl wires `acceleration` into `ExternalLoads`.
+    #[test]
+    fn model_eval_matches_acceleration() {
+        let zg = zonal(None, None);
+        let state = OrbitalState::new(
+            Vector3::new(6778.0, 100.0, 200.0),
+            Vector3::new(0.0, 7.5, 0.0),
+        );
+        let loads = Model::<OrbitalState>::eval(&zg, 0.0, &state, None);
+        let a = zg.acceleration(state.position(), &Epoch::from_jd(2451545.0));
+        assert_eq!(loads.acceleration_inertial.into_inner(), a);
+    }
+}

--- a/orts/src/perturbations/zonal_gravity.rs
+++ b/orts/src/perturbations/zonal_gravity.rs
@@ -2,13 +2,15 @@
 //!
 //! Unlike the spherically symmetric central term
 //! ([`PointMass`](crate::orbital::gravity::PointMass)), the zonal harmonics are
-//! symmetric about Earth's *rotation pole*, so the acceleration depends on the
-//! orientation of the integration frame relative to that pole. [`ZonalGravity`]
-//! therefore takes the pole direction from [`EarthPoleBridge`] instead of
-//! assuming the frame's Z axis is the pole.
+//! symmetric about the central body's *rotation pole*, so the acceleration
+//! depends on the orientation of the integration frame relative to that pole.
+//! [`ZonalGravity`] therefore takes the pole direction from [`EarthPoleBridge`]
+//! instead of assuming the frame's Z axis is the pole.
 //!
-//! - `SimpleEci`: pole = `+Z`, reproducing the classic frame-Z formula.
-//! - `Gcrs`: pole = the IAU 2006 CIP, so J2 is evaluated about the true pole
+//! - `SimpleEci`: pole = `+Z`, reproducing the classic frame-Z formula (for a
+//!   non-Earth body this assumes its state is expressed with `+Z` along that
+//!   body's spin axis).
+//! - `Gcrs`: pole = the IAU 2006 CIP, so J2 is evaluated about Earth's true pole
 //!   (offset ~0.1° from GCRS Z by 2024), more accurate than `SimpleEci`.
 //!
 //! Add it to a system that already carries a central

--- a/orts/src/perturbations/zonal_gravity.rs
+++ b/orts/src/perturbations/zonal_gravity.rs
@@ -69,7 +69,9 @@ impl<F: EarthPoleBridge> ZonalGravity<F> {
         let r_mag = r2.sqrt();
         let r5 = r2 * r2 * r_mag;
         let zeta = r.dot(&pole); // component along the pole
-        let s2 = (zeta * zeta) / r2; // sin²(latitude measured from pole)
+        // ζ/r = cos(colatitude) = sin(geocentric latitude φ from the equator),
+        // so s2 = sin²φ — the same argument as the classic J2 formula.
+        let s2 = (zeta * zeta) / r2;
         let re2 = self.r_body * self.r_body;
 
         // J2: a = c2·(5s²−1)·r − 2·c2·ζ·p̂

--- a/orts/src/perturbations/zonal_gravity.rs
+++ b/orts/src/perturbations/zonal_gravity.rs
@@ -39,8 +39,9 @@ pub struct ZonalGravity<F: EarthPoleBridge = arika::frame::SimpleEci> {
     pub j3: Option<f64>,
     /// J4 coefficient (dimensionless, optional).
     pub j4: Option<f64>,
-    // `fn() -> F` so the marker never imposes `Send`/`Sync` (or variance)
-    // requirements on `F`; `ZonalGravity<F>` is unconditionally `Send + Sync`.
+    // `fn() -> F` (rather than `F`) so the marker carries no auto-trait or
+    // drop obligation tied to `F`: function-pointer types are always
+    // `Send + Sync`, so `ZonalGravity<F>` is `Send + Sync` regardless of `F`.
     _frame: PhantomData<fn() -> F>,
 }
 

--- a/orts/src/perturbations/zonal_gravity.rs
+++ b/orts/src/perturbations/zonal_gravity.rs
@@ -124,6 +124,7 @@ mod tests {
     use crate::orbital::gravity::{GravityField, PointMass, ZonalHarmonics};
     use arika::earth::{J2 as J2_E, J3 as J3_E, J4 as J4_E, MU as MU_E, R as R_E};
     use arika::frame::SimpleEci;
+    use proptest::prelude::*;
 
     fn legacy(j3: Option<f64>, j4: Option<f64>) -> ZonalHarmonics {
         ZonalHarmonics {
@@ -213,5 +214,42 @@ mod tests {
         let loads = Model::<OrbitalState>::eval(&zg, 0.0, &state, None);
         let a = zg.acceleration(state.position(), &Epoch::from_jd(2451545.0));
         assert_eq!(loads.acceleration_inertial.into_inner(), a);
+    }
+
+    proptest! {
+        /// Property generalization of the characterization test: for `SimpleEci`
+        /// (pole = +Z), `ZonalGravity` equals the legacy frame-Z `ZonalHarmonics`
+        /// perturbation at *any* position, for every J2/J3/J4 variant. Bounded
+        /// in absolute terms scaled by the (non-vanishing) point-mass
+        /// acceleration, so the J2 zero-crossing geometry (where the zonal term
+        /// itself vanishes) doesn't blow up a relative error.
+        #[test]
+        fn zonal_gravity_equals_legacy_over_random_positions(
+            x in -60000.0f64..60000.0,
+            y in -60000.0f64..60000.0,
+            z in -60000.0f64..60000.0,
+            j3_on in any::<bool>(),
+            j4_on in any::<bool>(),
+        ) {
+            let r = Vector3::new(x, y, z);
+            prop_assume!(r.norm() > 100.0); // skip near-origin (formula is singular at r=0)
+
+            let j3 = j3_on.then_some(J3_E);
+            let j4 = j4_on.then_some(J4_E);
+            let zh = legacy(j3, j4);
+            let zg = zonal(j3, j4);
+
+            let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0); // ignored: SimpleEci pole = +Z
+            let a_ref = legacy_zonal_only(&zh, &r);
+            let a_new = zg.acceleration(&r, &epoch);
+
+            let pm = PointMass.acceleration(MU_E, &r).norm();
+            let diff = (a_new - a_ref).norm();
+            prop_assert!(
+                diff <= 1e-9 * pm,
+                "diff {diff:e} exceeds 1e-9·|pm| ({:e}) at {r:?}",
+                1e-9 * pm
+            );
+        }
     }
 }

--- a/orts/src/setup.rs
+++ b/orts/src/setup.rs
@@ -31,6 +31,12 @@ fn build_gravity_field() -> Box<dyn GravityField> {
 }
 
 /// Zonal (J2/J3/J4) perturbation for the body, if it has an oblateness model.
+///
+/// These builders produce `SimpleEci` systems, where `EarthPoleBridge` yields
+/// the frame's `+Z` axis — i.e. each body's own assumed spin axis — so
+/// `ZonalGravity` reproduces the legacy frame-Z behaviour for *every* body,
+/// non-Earth included. The Earth-specific CIP in `EarthPoleBridge` only enters
+/// for the geocentric `Gcrs` frame, which is Earth-only by construction.
 fn build_zonal_gravity(body: &KnownBody, mu: f64) -> Option<ZonalGravity> {
     let props = body.properties();
     props

--- a/orts/src/setup.rs
+++ b/orts/src/setup.rs
@@ -32,11 +32,13 @@ fn build_gravity_field() -> Box<dyn GravityField> {
 
 /// Zonal (J2/J3/J4) perturbation for the body, if it has an oblateness model.
 ///
-/// These builders produce `SimpleEci` systems, where `EarthPoleBridge` yields
-/// the frame's `+Z` axis — i.e. each body's own assumed spin axis — so
-/// `ZonalGravity` reproduces the legacy frame-Z behaviour for *every* body,
-/// non-Earth included. The Earth-specific CIP in `EarthPoleBridge` only enters
-/// for the geocentric `Gcrs` frame, which is Earth-only by construction.
+/// These builders produce `SimpleEci` systems, where `EarthPoleBridge` returns
+/// the frame's `+Z` axis as the pole — the legacy frame-Z convention. So
+/// `ZonalGravity` reproduces the previous `ZonalHarmonics` behaviour for every
+/// body; for a non-Earth body that is correct only insofar as its state is
+/// expressed in a frame whose `+Z` is that body's spin axis (the pre-existing
+/// assumption, unchanged here). The Earth-specific CIP only enters for the
+/// geocentric `Gcrs` frame, which is Earth-only by construction.
 fn build_zonal_gravity(body: &KnownBody, mu: f64) -> Option<ZonalGravity> {
     let props = body.properties();
     props

--- a/orts/src/setup.rs
+++ b/orts/src/setup.rs
@@ -6,7 +6,9 @@ use arika::body::KnownBody;
 use arika::epoch::Epoch;
 
 use crate::orbital::OrbitalSystem;
-use crate::perturbations::{AtmosphericDrag, SolarRadiationPressure, ThirdBodyGravity};
+use crate::perturbations::{
+    AtmosphericDrag, SolarRadiationPressure, ThirdBodyGravity, ZonalGravity,
+};
 
 /// Physical parameters of a satellite relevant to force model construction.
 pub struct SatelliteParams {
@@ -20,18 +22,20 @@ pub struct SatelliteParams {
     pub srp_cr: Option<f64>,
 }
 
-/// Build a gravity field model for the given body.
-fn build_gravity_field(body: &KnownBody) -> Box<dyn GravityField> {
+/// Central (point-mass) gravity field. Oblateness is added separately as a
+/// [`ZonalGravity`] perturbation via [`build_zonal_gravity`], because the zonal
+/// terms depend on the rotation-pole orientation in the integration frame and
+/// are no longer frame-independent like the point-mass term.
+fn build_gravity_field() -> Box<dyn GravityField> {
+    Box::new(gravity::PointMass)
+}
+
+/// Zonal (J2/J3/J4) perturbation for the body, if it has an oblateness model.
+fn build_zonal_gravity(body: &KnownBody, mu: f64) -> Option<ZonalGravity> {
     let props = body.properties();
-    match props.j2 {
-        Some(j2) => Box::new(gravity::ZonalHarmonics {
-            r_body: props.radius,
-            j2,
-            j3: props.j3,
-            j4: props.j4,
-        }),
-        None => Box::new(gravity::PointMass),
-    }
+    props
+        .j2
+        .map(|j2| ZonalGravity::new(mu, props.radius, j2, props.j3, props.j4))
 }
 
 /// Return the default third-body perturbations for a given central body.
@@ -66,8 +70,12 @@ pub fn build_orbital_system(
     atmosphere: Option<Box<dyn tobari::AtmosphereModel>>,
 ) -> OrbitalSystem {
     let props = body.properties();
-    let gravity_field = build_gravity_field(body);
-    let mut system = OrbitalSystem::new(mu, gravity_field).with_body_radius(props.radius);
+    let mut system = OrbitalSystem::new(mu, build_gravity_field()).with_body_radius(props.radius);
+
+    // Oblateness (J2/J3/J4) as a pole-aware perturbation.
+    if let Some(zonal) = build_zonal_gravity(body, mu) {
+        system = system.with_model(zonal);
+    }
 
     // Third-body gravity (requires epoch for ephemeris)
     if let Some(epoch) = epoch {
@@ -120,9 +128,13 @@ pub fn build_spacecraft_dynamics(
     atmosphere: Option<Box<dyn tobari::AtmosphereModel>>,
 ) -> SpacecraftDynamics<Box<dyn GravityField>> {
     let props = body.properties();
-    let gravity_field = build_gravity_field(body);
     let mut system =
-        SpacecraftDynamics::new(mu, gravity_field, inertia).with_body_radius(props.radius);
+        SpacecraftDynamics::new(mu, build_gravity_field(), inertia).with_body_radius(props.radius);
+
+    // Oblateness (J2/J3/J4) as a pole-aware perturbation.
+    if let Some(zonal) = build_zonal_gravity(body, mu) {
+        system = system.with_model(zonal);
+    }
 
     // Third-body gravity (requires epoch for ephemeris)
     if let Some(epoch) = epoch {


### PR DESCRIPTION
## 背景

#191（保存力が積分フレームの向きを無視している件）の根本修正の第一段。J2 などの zonal 重力は地球の自転極について軸対称なので、本来は積分フレームでの極方向が要る。従来の `ZonalHarmonics` は `GravityField` として `position.z`（フレーム Z 軸）を極と決め打ちしていた。

## この PR でやること

フレームの極方向を尊重する zonal 重力の土台を入れ、本番経路を載せ替える。挙動は変えない（既定 `SimpleEci` では極 = +Z で従来と数値同一）。

- **`EarthPoleBridge`**: フレームごとの地球自転極方向 `earth_pole(utc)`。`SimpleEci` = +Z、`Gcrs` = IAU 2006 の真 CIP（GCRS-Z から 2024 で ~0.1° ずれる）。EOP 不要（モデル CIP は sub-mas 精度）。`EarthFrameBridge` をそのサブトレイトに。
- **`ZonalGravity<F: EarthPoleBridge>`**: J2/J3/J4 を極方向 `p̂` で計算する perturbation。各項を `A·r + B·p̂` 形に書き直し、`p̂ = +Z` で旧式と恒等。char test で `SimpleEci` 時に旧 `ZonalHarmonics` と数値一致を pin（非有限入力の挙動も検証）。
- **setup 本番配線**（cli/serve）を `PointMass` + `ZonalGravity` に。`SimpleEci` なので挙動不変。
- **system.rs の J2 統合テスト**を `ZonalGravity` に移行。RAAN 歳差が解析値と一致＝伝播も正しいことを確認。

## まだやらないこと（follow-up PR）

`ZonalHarmonics` は oracle テストと examples がまだ使用している。その全廃と、**`Gcrs` を真極 J2 にする精度向上**（oracle_gcrf の Orekit fixture を ITRF 重力で再生成して検証）は次の PR。

## 検証

- orts lib 665 tests pass（新規 `EarthPoleBridge` / `ZonalGravity` / setup / system 含む）
- `cargo fmt` clean、`cargo clippy -p orts -p orts-cli` clean、integration テストもコンパイル OK
- codex review は workspace の spend cap で今回保留（枠回復後に追加実施予定）。Copilot review は依頼済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)