### PR TITLE
build(cli): silence ts-rs false-positive serde-attr warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,12 @@ thiserror = "2"
 # WebSocket protocol type codegen (Rust → TypeScript). Generated bindings
 # land in viewer/src/protocol/generated/ via TS_RS_EXPORT_DIR (set in
 # .cargo/config.toml) whenever `cargo test -p orts-cli` runs.
-ts-rs = { version = "12", features = ["serde-json-impl"] }
+# `no-serde-warnings`: our config types use `#[serde(alias = "...")]` for TOML
+# back-compat (e.g. `[[command]]`/`[[commands]]`). `alias` is deserialize-only —
+# it has no TS representation, so ts-rs correctly ignores it but otherwise warns
+# on every build. Drift between Rust and the generated TS is guarded by the CI
+# diff of viewer/src/protocol/generated/, not by these low-signal warnings.
+ts-rs = { version = "12", features = ["serde-json-impl", "no-serde-warnings"] }
 
 # wasmtime: Pulley single-backend + Component Model. Cranelift is
 # enabled for runtime compile path (plugin-wasm default), runtime-only


### PR DESCRIPTION
## 課題

`cargo build` / `cargo test` のたびに ts-rs が `warning: failed to parse serde attribute` を **4 件**出していた。ビルドログを汚すだけで、機能上のバグではないノイズ警告。

### なぜ出ていたか

ts-rs は Rust 型から TypeScript 型を生成する derive マクロ。serde の `rename` / `skip` などによる「Rust と JSON 表現のズレ」を生成 TS にも正しく反映するため、ts-rs は（既定で有効な `serde-compat` のもと）各フィールドの `#[serde(...)]` 属性を**自前でパースして読み取る**。

ところが ts-rs 12 のフィールド用 serde パーサが理解できるキーは固定で（`rename` / `skip` / `skip_serializing_if` / `flatten` / `default` / `with` / `borrow`）、**`alias` はそこに入っていない**。未知のキーに当たると ts-rs はその属性を無視したうえで汎用の `warning: failed to parse serde attribute` を出す。

`cli/src/config.rs` には TOML 後方互換のための `#[serde(alias = "...")]` が 4 箇所あり、それぞれが警告源になっていた:

| フィールド | エイリアス | 用途 |
| --- | --- | --- |
| `commands` | `command` | `[[command]]` / `[[commands]]` 両対応 |
| `ground_stations` | `ground_station` | 単複両対応 |
| `mtq` | `magnetorquers` | 略称 / 正式名両対応 |
| `thruster` | `thrusters` | 単複両対応 |

## 対応

workspace の ts-rs 依存に `no-serde-warnings` feature を追加して警告を抑止した。

`alias` はデシリアライズ専用の serde 属性で、シリアライズ出力にも TypeScript 型表現にも影響しない。したがって ts-rs が `alias` を無視するのは正しい挙動であり、警告自体が false positive。`no-serde-warnings` はまさにこの用途のための公式 feature。

なおエイリアス自体を削除する案は、既存の `orts.toml`（`[[command]]` 等）を壊す挙動変更になるため採らない。

## 挙動への影響

なし（完全な behavior-preserving）。

- 生成される TS バインディング（`viewer/src/protocol/generated/`）は**バイト単位で不変**。ts-rs は feature の有無に関わらず `alias` を同じくスキップする（差は警告を出すか出さないかだけ）ため。
- Rust↔TS のプロトコル drift は引き続き CI の生成物 diff が検出する。この警告は drift 検出には寄与していない低シグナルなもの。

## 検証

- ビルド: ts-rs 警告 0 / コンパイラ警告 0
- `cargo test -p orts-cli`: 全 pass、再生成した TS に差分なし
- `cargo clippy -p orts-cli -- -D warnings`: クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
