### PR TITLE
ci(renovate): group kble crates into a single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,11 @@
       "matchPackageNames": ["three", "@types/three", "/^@react-three//"]
     },
     {
+      "description": "Group the arkedge/kble workspace crates (released in lockstep) into one PR. Matched by source URL, not name, so a third-party kble-* squatter can't slip in; spans both the cargo dep kble-socket and the custom-regex kble binary (KBLE_VERSION). Anchored regex tolerates a .git suffix / trailing slash in the resolved repository URL",
+      "groupName": "kble",
+      "matchSourceUrls": ["/^https:\\/\\/github\\.com\\/arkedge\\/kble(?:\\.git)?\\/?$/"]
+    },
+    {
       "description": "Auto-merge patch-level updates once required CI checks pass",
       "matchUpdateTypes": ["patch"],
       "automerge": true


### PR DESCRIPTION
## 背景

orts は `kble` を2経路で依存している:
- cargo 依存 `kble-socket`（ブリッジの wire protocol）
- CI バイナリ `kble`（`KBLE_VERSION` を custom regex manager が管理）

両者は `arkedge/kble` ワークスペースから lockstep で同一バージョンがリリースされる。Renovate は別々に PR を立てるため、片方だけ上がってバイナリ/ライブラリのバージョンが食い違い、ブリッジ E2E を壊しうる。

## 変更点

`wasmtime` / `three` と同じ lockstep グループを kble にも追加:

```jsonc
{
  "groupName": "kble",
  "matchSourceUrls": ["/^https:\\/\\/github\\.com\\/arkedge\\/kble(?:\\.git)?\\/?$/"]
}
```

- 名前一致 (`/^kble/`) ではなく **source URL** でマッチするので、第三者の `kble-hoge` 等は紛れ込まず、同リポジトリの将来の `kble-*` は自動でグループ化される。
- `SourceUrlsMatcher` は sourceUrl を正規化せず生で照合するため、exact 文字列だと上流が repository URL に `.git`/末尾スラッシュを付けた途端サイレントに外れる。**anchored regex** にして `.git`/末尾スラッシュを許容しつつ、末尾 `$` で `kble-foo` のような別リポジトリは排除する。
- manager 非限定で cargo + custom regex を横断する。

マージ後、Renovate が `kble` + `kble-socket` を同時 bump する単一 PR を立てる。

## 検証

- `renovate-config-validator`（renovate 43.236.0）で `Config validated successfully`（スキーマ検証）。
- 実マッチは Renovate の regex パース手順を再現して確認: `…/kble`・`…/kble.git`・`…/kble/` に一致、`…/kble-foo` は不一致。

---
first-party 依存の `minimumReleaseAge` soak 除外は別 PR。codex review は spend cap で不可のため Copilot に依頼済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)