### PR TITLE
ci(renovate): group notalawyer crates into a single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -59,6 +59,11 @@
       "matchSourceUrls": ["/^https:\\/\\/github\\.com\\/arkedge\\/kble(?:\\.git)?\\/?$/"]
     },
     {
+      "description": "Group the arkedge/notalawyer workspace crates (notalawyer / -clap / -build, released in lockstep) into one PR. Matched by source URL, not name, so a third-party notalawyer-* squatter can't slip in. Anchored regex tolerates a .git suffix / trailing slash in the resolved repository URL",
+      "groupName": "notalawyer",
+      "matchSourceUrls": ["/^https:\\/\\/github\\.com\\/arkedge\\/notalawyer(?:\\.git)?\\/?$/"]
+    },
+    {
       "description": "Auto-merge patch-level updates once required CI checks pass",
       "matchUpdateTypes": ["patch"],
       "automerge": true

--- a/renovate.json
+++ b/renovate.json
@@ -59,7 +59,8 @@
       "matchSourceUrls": ["/^https:\\/\\/github\\.com\\/arkedge\\/kble(?:\\.git)?\\/?$/"]
     },
     {
-      "description": "Group the arkedge/notalawyer workspace crates (notalawyer / -clap / -build, released in lockstep) into one PR. Matched by source URL, not name, so a third-party notalawyer-* squatter can't slip in. Anchored regex tolerates a .git suffix / trailing slash in the resolved repository URL",
+      "description": "Group the arkedge/notalawyer crates (released in lockstep). Matched by source URL, not name, to keep notalawyer-* squatters out",
+      "matchManagers": ["cargo"],
       "groupName": "notalawyer",
       "matchSourceUrls": ["/^https:\\/\\/github\\.com\\/arkedge\\/notalawyer(?:\\.git)?\\/?$/"]
     },


### PR DESCRIPTION
`arkedge/notalawyer` ワークスペースの3 crate（`notalawyer` / `notalawyer-clap` / `notalawyer-build`、cargo 依存）は lockstep でリリースされる。#197 の kble group と同じく source URL でまとめ、別々の PR に分かれないようにする。

```jsonc
{
  "groupName": "notalawyer",
  "matchSourceUrls": ["/^https:\\/\\/github\\.com\\/arkedge\\/notalawyer(?:\\.git)?\\/?$/"]
}
```

source URL マッチなので `notalawyer-foo` 等の squatter は除外、anchored regex で `.git`/末尾スラッシュを許容。`renovate-config-validator` で検証済み。マージ後、Renovate が3 crate を同時 bump する（0.2.0 → 0.3.0）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)