### PR TITLE
refactor(cli): collapse redundant config-key aliases to one canonical form

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,12 +48,7 @@ thiserror = "2"
 # WebSocket protocol type codegen (Rust → TypeScript). Generated bindings
 # land in viewer/src/protocol/generated/ via TS_RS_EXPORT_DIR (set in
 # .cargo/config.toml) whenever `cargo test -p orts-cli` runs.
-# `no-serde-warnings`: our config types use `#[serde(alias = "...")]` for TOML
-# back-compat (e.g. `[[command]]`/`[[commands]]`). `alias` is deserialize-only —
-# it has no TS representation, so ts-rs correctly ignores it but otherwise warns
-# on every build. Drift between Rust and the generated TS is guarded by the CI
-# diff of viewer/src/protocol/generated/, not by these low-signal warnings.
-ts-rs = { version = "12", features = ["serde-json-impl", "no-serde-warnings"] }
+ts-rs = { version = "12", features = ["serde-json-impl"] }
 
 # wasmtime: Pulley single-backend + Component Model. Cranelift is
 # enabled for runtime compile path (plugin-wasm default), runtime-only

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -625,8 +625,10 @@ impl SimConfig {
             // A non-finite or negative `t` would never satisfy the
             // schedule's `t <= t_due`, silently dropping the command.
             if !cmd.t.is_finite() || cmd.t < 0.0 {
+                // Use the TOML key (`[[command]]`) in the message, not the
+                // Rust field name, so the index matches what the user wrote.
                 return Err(format!(
-                    "commands[{i}]: t must be finite and >= 0 (got {})",
+                    "command[{i}]: t must be finite and >= 0 (got {})",
                     cmd.t
                 ));
             }
@@ -1296,6 +1298,44 @@ kind = "orts.cmd.ping.v1"
         let json = r#"{ "satellites": [] }"#;
         let config: SimConfig = serde_json::from_str(json).unwrap();
         assert!(config.commands.is_empty());
+    }
+
+    #[test]
+    fn deserialize_ground_station() {
+        // Canonical TOML key is the singular `[[ground_station]]` (the
+        // `ground_stations` Rust field is renamed); pin that it parses.
+        let toml = r#"
+[[satellites]]
+[satellites.orbit]
+type = "circular"
+altitude = 500
+
+[[ground_station]]
+name = "tokyo"
+latitude_deg = 35.68
+longitude_deg = 139.69
+"#;
+        let config: SimConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.ground_stations.len(), 1);
+        assert_eq!(config.ground_stations[0].name, "tokyo");
+    }
+
+    #[test]
+    fn deserialize_magnetorquers() {
+        // The MTQ block's canonical TOML key is `magnetorquers` (the `mtq`
+        // Rust field is renamed to match the sibling `reaction_wheels`).
+        let toml = r#"
+[[satellites]]
+[satellites.orbit]
+type = "circular"
+altitude = 500
+
+[satellites.magnetorquers]
+type = "three_axis"
+max_moment = 10.0
+"#;
+        let config: SimConfig = toml::from_str(toml).unwrap();
+        assert!(config.satellites[0].mtq.is_some());
     }
 
     #[test]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -50,13 +50,13 @@ pub struct SimConfig {
     pub satellites: Vec<SatelliteConfig>,
     /// 時刻指定コマンドシーケンス（FSW への C&T アップリンク）。
     /// 各エントリは指定 sim 時刻に対象衛星のコントローラへ配送される。
-    /// TOML では `[[command]]`（単数）/ `[[commands]]`（複数）の両方可。
-    #[serde(default, alias = "command")]
+    /// TOML では array-of-tables の慣習に従い `[[command]]`（単数）で宣言する。
+    #[serde(default, rename = "command")]
     #[ts(as = "Option<_>", optional)]
     pub commands: Vec<CommandConfig>,
     /// 地上局定義（contact window 検出用）。Earth 中心のシミュレーション
-    /// でのみ有効。TOML では `[[ground_station]]` / `[[ground_stations]]`。
-    #[serde(default, alias = "ground_station")]
+    /// でのみ有効。TOML では `[[ground_station]]`（単数）で宣言する。
+    #[serde(default, rename = "ground_station")]
     #[ts(as = "Option<_>", optional)]
     pub ground_stations: Vec<GroundStationConfig>,
 }
@@ -397,12 +397,11 @@ pub struct SatelliteConfig {
     /// リアクションホイール設定。
     #[ts(optional)]
     pub reaction_wheels: Option<ReactionWheelConfig>,
-    /// MTQ 設定。
-    #[serde(alias = "magnetorquers")]
+    /// MTQ 設定。TOML キーは隣の `reaction_wheels` に揃えてフルワード `magnetorquers`。
+    #[serde(rename = "magnetorquers")]
     #[ts(optional)]
     pub mtq: Option<MtqConfig>,
     /// 推進器 (thruster) 設定。
-    #[serde(alias = "thrusters")]
     #[ts(optional)]
     pub thruster: Option<ThrusterConfig>,
     /// stream-io の名前付きバイトストリーム宣言（kble 統合）。
@@ -1491,26 +1490,6 @@ offset_body = [0.1, 0.0, 0.0]
         assert!(t.thrusters[0].offset_body.is_none());
         assert_eq!(t.thrusters[1].offset_body.unwrap(), [0.1, 0.0, 0.0]);
         t.validate().expect("valid");
-    }
-
-    #[test]
-    fn thruster_config_alias_thrusters() {
-        // `[satellites.thrusters]` (plural) is accepted as an alias.
-        let toml = r#"
-[[satellites]]
-[satellites.orbit]
-type = "circular"
-altitude = 500
-
-[satellites.thrusters]
-
-[[satellites.thrusters.thrusters]]
-thrust_n = 1.0
-isp_s = 200.0
-direction_body = [1.0, 0.0, 0.0]
-"#;
-        let config: SimConfig = toml::from_str(toml).expect("parse");
-        assert!(config.satellites[0].thruster.is_some());
     }
 
     #[test]

--- a/viewer/src/protocol/generated/ClientMessage.ts
+++ b/viewer/src/protocol/generated/ClientMessage.ts
@@ -39,9 +39,9 @@ sensors?: Array<SensorChoice>,
  */
 reaction_wheels?: ReactionWheelConfig, 
 /**
- * MTQ 設定。
+ * MTQ 設定。TOML キーは隣の `reaction_wheels` に揃えてフルワード `magnetorquers`。
  */
-mtq?: MtqConfig, 
+magnetorquers?: MtqConfig, 
 /**
  * 推進器 (thruster) 設定。
  */

--- a/viewer/src/protocol/generated/SatelliteConfig.ts
+++ b/viewer/src/protocol/generated/SatelliteConfig.ts
@@ -34,9 +34,9 @@ sensors?: Array<SensorChoice>,
  */
 reaction_wheels?: ReactionWheelConfig, 
 /**
- * MTQ 設定。
+ * MTQ 設定。TOML キーは隣の `reaction_wheels` に揃えてフルワード `magnetorquers`。
  */
-mtq?: MtqConfig, 
+magnetorquers?: MtqConfig, 
 /**
  * 推進器 (thruster) 設定。
  */

--- a/viewer/src/protocol/generated/SimConfig.ts
+++ b/viewer/src/protocol/generated/SimConfig.ts
@@ -15,11 +15,11 @@ export type SimConfig = { body?: string, dt?: number, output_interval?: number, 
 /**
  * 時刻指定コマンドシーケンス（FSW への C&T アップリンク）。
  * 各エントリは指定 sim 時刻に対象衛星のコントローラへ配送される。
- * TOML では `[[command]]`（単数）/ `[[commands]]`（複数）の両方可。
+ * TOML では array-of-tables の慣習に従い `[[command]]`（単数）で宣言する。
  */
-commands?: Array<CommandConfig>, 
+command?: Array<CommandConfig>, 
 /**
  * 地上局定義（contact window 検出用）。Earth 中心のシミュレーション
- * でのみ有効。TOML では `[[ground_station]]` / `[[ground_stations]]`。
+ * でのみ有効。TOML では `[[ground_station]]`（単数）で宣言する。
  */
-ground_stations?: Array<GroundStationConfig>, };
+ground_station?: Array<GroundStationConfig>, };


### PR DESCRIPTION
## 課題

CLI の config 型は各フィールドで `#[serde(alias = "...")]` により **2 通りの綴り**を受け付けていた（array-of-tables の単数/複数、MTQ の略称/フルワード）。この二重受理に実利はなく、しかも ts-rs の `failed to parse serde attribute` 警告の唯一の発生源でもあった（`alias` はデシリアライズ専用で TypeScript 表現を持たないため、ts-rs は無視しつつ警告する）。

機能バグではなく、設定スキーマの整理。

## 対応

各フィールドを **単一の正規 TOML キー**に統一する:

- `[[command]]` / `[[ground_station]]` — 単数のみ。array-of-tables の TOML 慣習（Cargo の `[[bin]]` 等）に従い、docs/テストも既に単数形を使用。`#[serde(rename)]` で実現し、Rust 側の Vec フィールド名は複数形のまま維持。
- `magnetorquers` — 隣接フィールド `reaction_wheels` に揃えたフルワードを正規キーに（`rename`）。略称 `mtq` キーは廃止（`mtq` キーを使う config は存在せず、2 つの example はいずれも既に `magnetorquers` を使用）。
- `thruster` — 単数のみ。`thrusters` 複数 alias は廃止。

`alias` が無くなったため、#196 で追加した ts-rs の `no-serde-warnings` feature を **revert** する（封じ込めより根本対処。feature 無しでもビルドは警告ゼロになる）。

## 挙動への影響

- これらの config キーはすべて **Unreleased**（未リリース）なので、リリース済みの挙動変更は無く、リポジトリ内 config の移行も不要（example は `magnetorquers` / 正規 `thruster` 形のため無変更）。
- 生成 TS バインディングを再生成（`mtq`→`magnetorquers`、`commands`→`command`、`ground_stations`→`ground_station`）。viewer はこれらのフィールドを参照していないため実害なし。CI の生成物 diff guard も満たす。

## 検証

- ビルド: ts-rs 警告 0 / コンパイラ警告 0（`no-serde-warnings` 無しで達成）
- `cargo test -p orts-cli --bins`: 173 passed / 0 failed（不要になった alias 受理テスト 1 件を削除）
- `cargo clippy -p orts-cli -- -D warnings`: クリーン
- 生成 TS は意図した rename のみの差分

本 PR は #196（警告抑止）の後続。#196 が feature flag で警告を黙らせたのに対し、本 PR は警告の発生源（不要な alias）そのものを除去する根本対処。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
