### PR TITLE
feat(arika): canonical-TAI Epoch representation (two-part precision, UT1 isolated)

### DIFF
--- a/arika/src/earth/iau2006/cio_chain.rs
+++ b/arika/src/earth/iau2006/cio_chain.rs
@@ -64,7 +64,7 @@ use crate::math::F64Ext;
 use super::cip::{cio_locator_s, cip_xy, gcrs_to_cirs_matrix, rotation_x, rotation_y, rotation_z};
 use super::{Arcsec, Mas, Rad, Uas};
 use crate::earth::eop::{NutationCorrections, PolarMotion, Ut1Offset};
-use crate::epoch::{Epoch, Tt, Ut1, Utc};
+use crate::epoch::{Epoch, Tt, Ut1Epoch, Utc};
 use crate::frame::{Cirs, Gcrs, Itrs, Rotation, Tirs};
 
 // TIO locator s'(t)
@@ -157,14 +157,14 @@ impl Rotation<Cirs, Tirs> {
     ///
     /// The Earth Rotation Angle `ERA` is a definitional function of
     /// UT1 (TN36 Eq. 5.14 / SOFA `iauEra00`), already implemented by
-    /// [`Epoch::<Ut1>::era`]. The `Rotation<Cirs, Tirs>` is the pure
+    /// [`Ut1Epoch::era`]. The `Rotation<Cirs, Tirs>` is the pure
     /// z-axis rotation by `−ERA`.
     ///
     /// This constructor takes no EOP provider — every quantity is
     /// definitional once `ut1` is known, and the `ut1` epoch was
     /// itself derived from `utc` + `dUT1` upstream (via
     /// [`Epoch::<Utc>::to_ut1`]).
-    pub fn from_era(ut1: &Epoch<Ut1>) -> Self {
+    pub fn from_era(ut1: &Ut1Epoch) -> Self {
         let era = ut1.era();
         let axis = nalgebra::Unit::new_normalize(Vector3::z());
         Self::from_raw(UnitQuaternion::from_axis_angle(&axis, -era))
@@ -228,12 +228,12 @@ impl Rotation<Gcrs, Itrs> {
     /// ```
     ///
     /// Taking three separate epochs is intentional: `Epoch<Tt>`,
-    /// `Epoch<Ut1>`, and `Epoch<Utc>` are **definitionally** distinct
+    /// `Ut1Epoch`, and `Epoch<Utc>` are **definitionally** distinct
     /// time scales (TN36 §5.2) and the compiler enforces that the
     /// caller thought about each one. See
     /// [`Rotation::<Gcrs, Itrs>::iau2006_full_from_utc`] for the
     /// convenience form that derives all three from a single UTC.
-    pub fn iau2006_full<P>(tt: &Epoch<Tt>, ut1: &Epoch<Ut1>, utc: &Epoch<Utc>, eop: &P) -> Self
+    pub fn iau2006_full<P>(tt: &Epoch<Tt>, ut1: &Ut1Epoch, utc: &Epoch<Utc>, eop: &P) -> Self
     where
         P: NutationCorrections + PolarMotion + ?Sized,
     {
@@ -307,7 +307,7 @@ mod tests {
         }
     }
 
-    fn sample_epochs() -> (Epoch<Tt>, Epoch<Ut1>, Epoch<Utc>) {
+    fn sample_epochs() -> (Epoch<Tt>, Ut1Epoch, Epoch<Utc>) {
         // Pick a non-pathological post-J2000 instant.
         let utc = Epoch::<Utc>::from_gregorian(2024, 3, 20, 12, 0, 0.0);
         let tt = utc.to_tt();
@@ -343,12 +343,12 @@ mod tests {
     /// At the J2000.0 UT1 reference instant the ERA is
     /// `2π × 0.7790572732640` ≈ `4.895 rad`, and the resulting
     /// `R_3(−ERA)` matrix has a non-trivial element in (0,1). Pins the
-    /// sign and axis of `from_era` against `Epoch<Ut1>::era`.
+    /// sign and axis of `from_era` against `Ut1Epoch::era`.
     #[test]
     fn from_era_uses_z_axis_with_negative_era() {
         use crate::epoch::J2000_JD;
 
-        let ut1 = Epoch::<Ut1>::from_jd_ut1(J2000_JD);
+        let ut1 = Ut1Epoch::from_jd_ut1(J2000_JD);
         let rot = Rotation::<Cirs, Tirs>::from_era(&ut1);
 
         // Compare with a hand-constructed reference: the underlying

--- a/arika/src/epoch/convert.rs
+++ b/arika/src/epoch/convert.rs
@@ -70,10 +70,7 @@ impl FixedOffsetFromTai for Gps {
 // has no lens; see `Ut1Epoch`.)
 
 /// Data-free lens between canonical TAI and a scale's own Julian Date.
-// Consumed by the canonical-TAI `Epoch<S>` representation in the next commit;
-// the allow is temporary until that integration lands (the lens is currently
-// exercised only by its equivalence tests).
-#[allow(dead_code)]
+/// Crate-internal: the canonical-TAI `Epoch<S>` accessors call it per scale.
 pub(crate) trait TaiLens: TimeScale {
     /// This scale's JD → the canonical TAI JD.
     fn tai_from_scale(scale_jd: TwoPartJd) -> TwoPartJd;
@@ -127,30 +124,34 @@ impl TaiLens for Tdb {
     }
 }
 
-// UTC edges
+/// Construct an `Epoch<S>` from a JD interpreted in scale `S`, converting to
+/// the stored canonical TAI instant via the lens.
+pub(crate) fn from_scale_jd<S: TaiLens>(scale_jd: f64) -> Epoch<S> {
+    Epoch::<S>::from_tai_raw(S::tai_from_scale(TwoPartJd::from_jd(scale_jd)))
+}
+
+// UTC outbound conversions (re-tags of the shared canonical TAI instant)
 
 impl Epoch<Utc> {
-    /// Convert to TAI by applying the current leap-second offset (one hop).
+    /// Convert to TAI (re-tag of the shared canonical instant).
     pub fn to_tai(&self) -> Epoch<Tai> {
-        let utc_mjd = self.jd() - MJD_OFFSET;
-        let leap = tai_minus_utc_at_mjd(utc_mjd);
-        Epoch::<Tai>::from_jd_raw(self.jd() + leap / 86400.0)
+        Epoch::<Tai>::from_tai_raw(self.tai_raw())
     }
 
-    /// Convert to TT. Convenience for the two-edge path `UTC → TAI → TT`.
+    /// Convert to TT (re-tag of the shared canonical instant).
     pub fn to_tt(&self) -> Epoch<Tt> {
-        self.to_tai().to_tt()
+        Epoch::<Tt>::from_tai_raw(self.tai_raw())
     }
 
-    /// Convert to TDB. Convenience for the path `UTC → TAI → TT → TDB`.
+    /// Convert to TDB (re-tag of the shared canonical instant).
     pub fn to_tdb(&self) -> Epoch<Tdb> {
-        self.to_tai().to_tt().to_tdb()
+        Epoch::<Tdb>::from_tai_raw(self.tai_raw())
     }
 
-    /// Convert to GPS Time. Convenience for the path `UTC → TAI → GPS`.
+    /// Convert to GPS Time (re-tag of the shared canonical instant).
     /// `GPS − UTC` equals the current leap count minus 19 s (18 s since 2017).
     pub fn to_gps(&self) -> Epoch<Gps> {
-        self.to_tai().to_gps()
+        Epoch::<Gps>::from_tai_raw(self.tai_raw())
     }
 
     /// Convert to UT1 assuming UT1 ≈ UTC (naive, legacy behavior).
@@ -193,34 +194,22 @@ impl Epoch<Utc> {
 impl Epoch<Tai> {
     /// Create a TAI epoch from a Julian Date value interpreted as TAI JD.
     pub fn from_jd_tai(jd: f64) -> Self {
-        Epoch::<Tai>::from_jd_raw(jd)
+        from_scale_jd::<Tai>(jd)
     }
 
-    /// Convert to UTC by subtracting the current leap-second offset (one hop).
-    ///
-    /// Iterates to land on the correct leap count at the resulting UTC instant.
+    /// Convert to UTC (re-tag of the shared canonical instant).
     pub fn to_utc(&self) -> Epoch<Utc> {
-        let mut guess_utc_jd = self.jd() - 37.0 / 86400.0; // initial guess
-        for _ in 0..3 {
-            let guess_mjd = guess_utc_jd - MJD_OFFSET;
-            let leap = tai_minus_utc_at_mjd(guess_mjd);
-            guess_utc_jd = self.jd() - leap / 86400.0;
-        }
-        Epoch::<Utc>::from_jd_raw(guess_utc_jd)
+        Epoch::<Utc>::from_tai_raw(self.tai_raw())
     }
 
-    /// Convert to TT by adding the constant 32.184 s offset (one hop).
+    /// Convert to TT (re-tag of the shared canonical instant).
     pub fn to_tt(&self) -> Epoch<Tt> {
-        Epoch::<Tt>::from_jd_raw(
-            self.jd() + <Tt as FixedOffsetFromTai>::SECONDS_AFTER_TAI / 86400.0,
-        )
+        Epoch::<Tt>::from_tai_raw(self.tai_raw())
     }
 
-    /// Convert to GPS Time by subtracting the constant 19 s offset (one hop).
+    /// Convert to GPS Time (re-tag of the shared canonical instant).
     pub fn to_gps(&self) -> Epoch<Gps> {
-        Epoch::<Gps>::from_jd_raw(
-            self.jd() + <Gps as FixedOffsetFromTai>::SECONDS_AFTER_TAI / 86400.0,
-        )
+        Epoch::<Gps>::from_tai_raw(self.tai_raw())
     }
 }
 
@@ -229,19 +218,17 @@ impl Epoch<Tai> {
 impl Epoch<Gps> {
     /// Create a GPS epoch from a Julian Date value interpreted as GPS JD.
     pub fn from_jd_gps(jd: f64) -> Self {
-        Epoch::<Gps>::from_jd_raw(jd)
+        from_scale_jd::<Gps>(jd)
     }
 
-    /// Convert to TAI by adding the constant 19 s offset (one hop).
+    /// Convert to TAI (re-tag of the shared canonical instant).
     pub fn to_tai(&self) -> Epoch<Tai> {
-        Epoch::<Tai>::from_jd_raw(
-            self.jd() - <Gps as FixedOffsetFromTai>::SECONDS_AFTER_TAI / 86400.0,
-        )
+        Epoch::<Tai>::from_tai_raw(self.tai_raw())
     }
 
-    /// Convert to UTC. Convenience for the path `GPS → TAI → UTC`.
+    /// Convert to UTC (re-tag of the shared canonical instant).
     pub fn to_utc(&self) -> Epoch<Utc> {
-        self.to_tai().to_utc()
+        Epoch::<Utc>::from_tai_raw(self.tai_raw())
     }
 }
 
@@ -250,7 +237,7 @@ impl Epoch<Gps> {
 impl Epoch<Tt> {
     /// Create a TT epoch from a Julian Date value interpreted as TT JD.
     pub fn from_jd_tt(jd: f64) -> Self {
-        Epoch::<Tt>::from_jd_raw(jd)
+        from_scale_jd::<Tt>(jd)
     }
 
     /// Return TT Julian centuries since J2000.0.
@@ -260,17 +247,14 @@ impl Epoch<Tt> {
         (self.jd() - J2000_JD) / JULIAN_CENTURY
     }
 
-    /// Convert to TAI by subtracting the constant 32.184 s offset (one hop).
+    /// Convert to TAI (re-tag of the shared canonical instant).
     pub fn to_tai(&self) -> Epoch<Tai> {
-        Epoch::<Tai>::from_jd_raw(
-            self.jd() - <Tt as FixedOffsetFromTai>::SECONDS_AFTER_TAI / 86400.0,
-        )
+        Epoch::<Tai>::from_tai_raw(self.tai_raw())
     }
 
-    /// Convert to TDB via the Fairhead-Bretagnon periodic correction (one hop).
+    /// Convert to TDB (re-tag of the shared canonical instant).
     pub fn to_tdb(&self) -> Epoch<Tdb> {
-        let delta = tdb_minus_tt(self.jd());
-        Epoch::<Tdb>::from_jd_raw(self.jd() + delta / 86400.0)
+        Epoch::<Tdb>::from_tai_raw(self.tai_raw())
     }
 }
 
@@ -282,7 +266,7 @@ impl Epoch<Tdb> {
     /// JPL DE ephemerides use `Teph` which is for practical purposes
     /// indistinguishable from TDB (IAU 2006 Resolution B3).
     pub fn from_jd_tdb(jd: f64) -> Self {
-        Epoch::<Tdb>::from_jd_raw(jd)
+        from_scale_jd::<Tdb>(jd)
     }
 
     /// Return TDB Julian centuries since J2000.0.
@@ -292,11 +276,9 @@ impl Epoch<Tdb> {
         (self.jd() - J2000_JD) / JULIAN_CENTURY
     }
 
-    /// Convert to TT by applying the inverse Fairhead-Bretagnon correction
-    /// (one hop). Since `|TDB − TT| < 2 ms`, a single-step inversion suffices.
+    /// Convert to TT (re-tag of the shared canonical instant).
     pub fn to_tt(&self) -> Epoch<Tt> {
-        let delta = tdb_minus_tt(self.jd());
-        Epoch::<Tt>::from_jd_raw(self.jd() - delta / 86400.0)
+        Epoch::<Tt>::from_tai_raw(self.tai_raw())
     }
 }
 

--- a/arika/src/epoch/convert.rs
+++ b/arika/src/epoch/convert.rs
@@ -29,6 +29,7 @@ use core::f64::consts::TAU;
 use crate::math::F64Ext;
 
 use super::TimeScale;
+use super::jd2::TwoPartJd;
 use super::leap::tai_minus_utc_at_mjd;
 use super::{Epoch, Gps, Tai, Tdb, Tt, Utc};
 use super::{GPS_MINUS_TAI_SEC, J2000_JD, JULIAN_CENTURY, MJD_OFFSET, TT_MINUS_TAI_SEC};
@@ -56,6 +57,74 @@ impl FixedOffsetFromTai for Tt {
 }
 impl FixedOffsetFromTai for Gps {
     const SECONDS_AFTER_TAI: f64 = GPS_MINUS_TAI_SEC;
+}
+
+// Canonical-TAI lens
+//
+// Every scale in the `Epoch<S>` family converts to/from canonical TAI without
+// external data. `TaiLens` is that conversion as a pair of pure functions over
+// the two-part [`TwoPartJd`] representation: the math (leap table, fixed
+// offset, Fairhead periodic) that the canonical-TAI `Epoch` will apply once at
+// construction (scale JD → TAI) and once at read-out (TAI → scale JD), keeping
+// full precision in between. (UT1 is not in the family — it needs EOP — so it
+// has no lens; see `Ut1Epoch`.)
+
+/// Data-free lens between canonical TAI and a scale's own Julian Date.
+// Consumed by the canonical-TAI `Epoch<S>` representation in the next commit;
+// the allow is temporary until that integration lands (the lens is currently
+// exercised only by its equivalence tests).
+#[allow(dead_code)]
+pub(crate) trait TaiLens: TimeScale {
+    /// This scale's JD → the canonical TAI JD.
+    fn tai_from_scale(scale_jd: TwoPartJd) -> TwoPartJd;
+    /// Canonical TAI JD → this scale's JD.
+    fn scale_from_tai(tai: TwoPartJd) -> TwoPartJd;
+}
+
+/// Derive [`TaiLens`] for a [`FixedOffsetFromTai`] scale: `scale = TAI + off`.
+macro_rules! impl_tai_lens_fixed {
+    ($scale:ty) => {
+        impl TaiLens for $scale {
+            fn tai_from_scale(scale_jd: TwoPartJd) -> TwoPartJd {
+                scale_jd.add_days(-<$scale as FixedOffsetFromTai>::SECONDS_AFTER_TAI / 86400.0)
+            }
+            fn scale_from_tai(tai: TwoPartJd) -> TwoPartJd {
+                tai.add_days(<$scale as FixedOffsetFromTai>::SECONDS_AFTER_TAI / 86400.0)
+            }
+        }
+    };
+}
+impl_tai_lens_fixed!(Tai);
+impl_tai_lens_fixed!(Tt);
+impl_tai_lens_fixed!(Gps);
+
+impl TaiLens for Utc {
+    fn tai_from_scale(utc: TwoPartJd) -> TwoPartJd {
+        let leap = tai_minus_utc_at_mjd(utc.jd() - MJD_OFFSET);
+        utc.add_days(leap / 86400.0)
+    }
+    fn scale_from_tai(tai: TwoPartJd) -> TwoPartJd {
+        // Converge on the leap count at the resulting UTC instant.
+        let mut utc = tai.add_days(-37.0 / 86400.0); // initial guess
+        for _ in 0..3 {
+            let leap = tai_minus_utc_at_mjd(utc.jd() - MJD_OFFSET);
+            utc = tai.add_days(-leap / 86400.0);
+        }
+        utc
+    }
+}
+
+impl TaiLens for Tdb {
+    fn tai_from_scale(tdb: TwoPartJd) -> TwoPartJd {
+        // TDB → TT (single-step inversion, |TDB − TT| < 2 ms) → TAI.
+        let tt = tdb.add_days(-tdb_minus_tt(tdb.jd()) / 86400.0);
+        tt.add_days(-TT_MINUS_TAI_SEC / 86400.0)
+    }
+    fn scale_from_tai(tai: TwoPartJd) -> TwoPartJd {
+        // TAI → TT → TDB (Fairhead-Bretagnon periodic).
+        let tt = tai.add_days(TT_MINUS_TAI_SEC / 86400.0);
+        tt.add_days(tdb_minus_tt(tt.jd()) / 86400.0)
+    }
 }
 
 // UTC edges
@@ -298,4 +367,70 @@ fn tdb_minus_tt(tt_jd: f64) -> f64 {
     let g_deg = 357.53 + 0.985_600_28 * d;
     let g = g_deg.to_radians();
     0.001_658 * g.sin() + 0.000_014 * (2.0 * g).sin()
+}
+
+#[cfg(test)]
+mod lens_tests {
+    //! The `TaiLens` math must agree with the existing one-hop edge methods
+    //! (which it will replace once `Epoch<S>` stores canonical TAI), and must
+    //! round-trip. Agreement is to f64 noise since the lens does the same
+    //! arithmetic in two parts.
+    use super::*;
+
+    const TOL_DAY: f64 = 1e-9; // ~86 µs — well above f64 noise, below the regime we care about
+
+    fn tpj(jd: f64) -> TwoPartJd {
+        TwoPartJd::from_jd(jd)
+    }
+
+    #[test]
+    fn lens_tai_from_scale_matches_edges() {
+        let x = 2_460_390.5; // 2024-03-20-ish
+        // scale-JD x interpreted in each scale → TAI must match the edge `to_tai` path.
+        let utc_edge = Epoch::<Utc>::from_jd(x).to_tai().jd();
+        assert!((Utc::tai_from_scale(tpj(x)).jd() - utc_edge).abs() < TOL_DAY);
+
+        let tt_edge = Epoch::<Tt>::from_jd_tt(x).to_tai().jd();
+        assert!((Tt::tai_from_scale(tpj(x)).jd() - tt_edge).abs() < TOL_DAY);
+
+        let gps_edge = Epoch::<Gps>::from_jd_gps(x).to_tai().jd();
+        assert!((Gps::tai_from_scale(tpj(x)).jd() - gps_edge).abs() < TOL_DAY);
+
+        // TDB → TAI edge path is tdb.to_tt().to_tai().
+        let tdb_edge = Epoch::<Tdb>::from_jd_tdb(x).to_tt().to_tai().jd();
+        assert!((Tdb::tai_from_scale(tpj(x)).jd() - tdb_edge).abs() < TOL_DAY);
+    }
+
+    #[test]
+    fn lens_scale_from_tai_matches_edges() {
+        let tai = 2_460_390.500_8; // a TAI JD
+        let utc_edge = Epoch::<Tai>::from_jd_tai(tai).to_utc().jd();
+        assert!((Utc::scale_from_tai(tpj(tai)).jd() - utc_edge).abs() < TOL_DAY);
+
+        let tt_edge = Epoch::<Tai>::from_jd_tai(tai).to_tt().jd();
+        assert!((Tt::scale_from_tai(tpj(tai)).jd() - tt_edge).abs() < TOL_DAY);
+
+        let gps_edge = Epoch::<Tai>::from_jd_tai(tai).to_gps().jd();
+        assert!((Gps::scale_from_tai(tpj(tai)).jd() - gps_edge).abs() < TOL_DAY);
+    }
+
+    #[test]
+    fn lens_roundtrips_each_scale() {
+        let x = 2_460_390.123_456;
+        macro_rules! rt {
+            ($s:ty) => {{
+                let back = <$s as TaiLens>::scale_from_tai(<$s as TaiLens>::tai_from_scale(tpj(x)));
+                assert!(
+                    (back.jd() - x).abs() < TOL_DAY,
+                    "{} round-trip diverged",
+                    <$s as TimeScale>::NAME
+                );
+            }};
+        }
+        rt!(Utc);
+        rt!(Tai);
+        rt!(Tt);
+        rt!(Gps);
+        rt!(Tdb);
+    }
 }

--- a/arika/src/epoch/convert.rs
+++ b/arika/src/epoch/convert.rs
@@ -19,7 +19,8 @@
 //! engine.
 //!
 //! `UT1` is reachable only through a `dUT1` provider
-//! ([`Epoch::<Utc>::to_ut1`]); there is no `Epoch<Ut1>::to_tai()`, which keeps
+//! ([`Epoch::<Utc>::to_ut1`]) and lives in its own [`Ut1Epoch`] type — UT1 is
+//! not part of the `Epoch<S>` family at all, which keeps
 //! the Earth-rotation scale isolated from the atomic/dynamical edges.
 
 use core::f64::consts::TAU;
@@ -29,7 +30,7 @@ use crate::math::F64Ext;
 
 use super::TimeScale;
 use super::leap::tai_minus_utc_at_mjd;
-use super::{Epoch, Gps, Tai, Tdb, Tt, Ut1, Utc};
+use super::{Epoch, Gps, Tai, Tdb, Tt, Utc};
 use super::{GPS_MINUS_TAI_SEC, J2000_JD, JULIAN_CENTURY, MJD_OFFSET, TT_MINUS_TAI_SEC};
 
 /// Scales whose offset from TAI is a fixed number of SI seconds:
@@ -88,8 +89,8 @@ impl Epoch<Utc> {
     /// 真の UT1 が必要な場合は [`Epoch::<Utc>::to_ut1`] (`Ut1Offset` provider を
     /// 引数に取る) を使う。本 method は `NullEop` 相当の `dUT1 = 0` 仮定で、
     /// current arika の `gmst()` 実装との bit-level 互換を保つため提供される。
-    pub fn to_ut1_naive(&self) -> Epoch<Ut1> {
-        Epoch::<Ut1>::from_jd_raw(self.jd())
+    pub fn to_ut1_naive(&self) -> Ut1Epoch {
+        Ut1Epoch::from_jd_ut1(self.jd())
     }
 
     /// Convert to UT1 using the `dUT1 = UT1 − UTC` correction provided by
@@ -111,10 +112,10 @@ impl Epoch<Utc> {
     ///
     /// For a naive `dUT1 = 0` conversion used by the legacy simple rotation
     /// path, use [`Epoch::<Utc>::to_ut1_naive`] instead.
-    pub fn to_ut1<P: crate::earth::eop::Ut1Offset + ?Sized>(&self, eop: &P) -> Epoch<Ut1> {
+    pub fn to_ut1<P: crate::earth::eop::Ut1Offset + ?Sized>(&self, eop: &P) -> Ut1Epoch {
         let mjd = self.jd() - MJD_OFFSET;
         let dut1 = eop.dut1(mjd);
-        Epoch::<Ut1>::from_jd_raw(self.jd() + dut1 / 86400.0)
+        Ut1Epoch::from_jd_ut1(self.jd() + dut1 / 86400.0)
     }
 }
 
@@ -230,12 +231,32 @@ impl Epoch<Tdb> {
     }
 }
 
-// UT1 API
+// UT1 — isolated from the Epoch<S> family.
+//
+// UT1 − TAI (ΔUT1) is a *measured* Earth-orientation quantity (EOP), not a
+// data-free offset like the other scales, so UT1 cannot live on the canonical
+// timeline the `Epoch<S>` family shares. It is therefore its own type, reached
+// only through a `dUT1` provider ([`Epoch::<Utc>::to_ut1`]).
 
-impl Epoch<Ut1> {
+/// An epoch on the UT1 (Earth-rotation) time scale, stored as a UT1 Julian Date.
+///
+/// Separate from [`Epoch`] because UT1 is realized by Earth's rotation, not
+/// atomic clocks: reaching it requires a measured `dUT1` (see
+/// [`Epoch::<Utc>::to_ut1`]). Carries the definitional Earth Rotation Angle.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Ut1Epoch {
+    jd: f64,
+}
+
+impl Ut1Epoch {
     /// Create a UT1 epoch from a Julian Date value interpreted as UT1 JD.
     pub fn from_jd_ut1(jd: f64) -> Self {
-        Epoch::<Ut1>::from_jd_raw(jd)
+        Self { jd }
+    }
+
+    /// The UT1 Julian Date.
+    pub fn jd(&self) -> f64 {
+        self.jd
     }
 
     /// Earth Rotation Angle (ERA) in radians.
@@ -244,15 +265,13 @@ impl Epoch<Ut1> {
     /// `ERA(T_u) = 2π × (0.7790572732640 + 1.00273781191135448 × T_u)`
     /// where `T_u = JD_UT1 − 2451545.0`.
     ///
-    /// ERA は UT1 の definitional な関数であり、他の scale で計算することは
-    /// 意味論的に間違い。したがって `era()` method は `Epoch<Ut1>` にのみ
-    /// 提供される (`Epoch<Tdb>::era()` はコンパイルエラー)。
+    /// ERA は UT1 の definitional な関数。`Ut1Epoch` にのみ提供される。
     pub fn era(&self) -> f64 {
-        era_formula(self.jd())
+        era_formula(self.jd)
     }
 }
 
-/// Earth Rotation Angle (ERA) formula, shared by `Epoch<Ut1>::era` and the
+/// Earth Rotation Angle (ERA) formula, shared by `Ut1Epoch::era` and the
 /// legacy `Epoch<Utc>::gmst` method.
 ///
 /// Note: the current arika source value `1.002_737_811_911_354_6` differs

--- a/arika/src/epoch/convert.rs
+++ b/arika/src/epoch/convert.rs
@@ -101,8 +101,10 @@ impl TaiLens for Utc {
         utc.add_days(leap / 86400.0)
     }
     fn scale_from_tai(tai: TwoPartJd) -> TwoPartJd {
-        // Converge on the leap count at the resulting UTC instant.
-        let mut utc = tai.add_days(-37.0 / 86400.0); // initial guess
+        // Seed the leap-count search with the current maximum TAI − UTC; any
+        // seed within one leap step of the true offset converges in 3 iters.
+        const LEAP_SEED_SEC: f64 = 37.0; // TAI − UTC since 2017-01-01
+        let mut utc = tai.add_days(-LEAP_SEED_SEC / 86400.0);
         for _ in 0..3 {
             let leap = tai_minus_utc_at_mjd(utc.jd() - MJD_OFFSET);
             utc = tai.add_days(-leap / 86400.0);

--- a/arika/src/epoch/jd2.rs
+++ b/arika/src/epoch/jd2.rs
@@ -90,9 +90,10 @@ mod tests {
 
     #[test]
     fn from_parts_normalizes() {
-        // hi has no room for a sub-µs residual, but lo carries it exactly.
+        // 1e-9 day ≈ 86 µs — a couple of ulp at this JD (ulp ≈ 40 µs), so it
+        // does not fit in `hi` alone; `lo` retains it where single-f64 would not.
         let hi = 2_460_000.0;
-        let lo = 1e-9; // ~86 µs is 1e-9 day; this is well below single-f64 ulp here
+        let lo = 1e-9;
         let t = TwoPartJd::from_parts(hi, lo);
         let (h, l) = t.parts();
         // The residual survives in lo (single-f64 jd() would lose it).
@@ -120,7 +121,7 @@ mod tests {
 
     #[test]
     fn add_days_accumulates_without_drift() {
-        // Add 1 µs-day a million times; compare to the exact 1e6× value.
+        // Add a micro-day (1e-6 day) a million times → exactly 1.0 day.
         const STEP: f64 = 1e-6;
         let mut t = TwoPartJd::from_jd(2_460_000.5);
         for _ in 0..1_000_000 {

--- a/arika/src/epoch/jd2.rs
+++ b/arika/src/epoch/jd2.rs
@@ -65,13 +65,14 @@ impl TwoPartJd {
 
     /// Difference `self - other` in days, in extended precision.
     ///
-    /// The high parts subtract first (exact by Sterbenz when they are within a
-    /// factor of two — i.e. epochs close together, the case that matters near
-    /// J2000), then the residuals are folded in.
+    /// `two_sum` on the high parts captures their subtraction's rounding error
+    /// exactly (for any magnitudes), so no significance is lost even when the
+    /// high parts are large and close — the J2000-cancellation case. The
+    /// residual difference is then folded into that error term.
     #[inline]
     pub(crate) fn diff_days(self, other: Self) -> f64 {
         let (dh, eh) = two_sum(self.hi, -other.hi);
-        // dh + eh + (self.lo - other.lo)
+        // (hi diff) + (hi-diff rounding error) + (lo diff)
         dh + (eh + (self.lo - other.lo))
     }
 }
@@ -111,7 +112,10 @@ mod tests {
         assert!(rel_err < 1e-6, "1 ns diff lost: got {d}, want {ONE_NS_DAY}");
         // Sanity: naive single-f64 subtraction loses it entirely.
         let naive = (2_451_545.0_f64 + ONE_NS_DAY) - 2_451_545.0_f64;
-        assert_eq!(naive, 0.0, "precondition: single-f64 floors a 1 ns step to 0");
+        assert_eq!(
+            naive, 0.0,
+            "precondition: single-f64 floors a 1 ns step to 0"
+        );
     }
 
     #[test]

--- a/arika/src/epoch/jd2.rs
+++ b/arika/src/epoch/jd2.rs
@@ -1,0 +1,141 @@
+//! Two-part Julian Date (`hi + lo`) for sub-nanosecond time precision.
+//!
+//! A single `f64` Julian Date floors resolution at tens of µs near modern
+//! epochs (the mantissa is spent on the ~2.46e6 integer part) and cancels
+//! catastrophically when differencing epochs near J2000. Carrying the value as
+//! two `f64`s — a high part plus a small residual, as SOFA's two-part date
+//! arguments do — keeps the full mantissa available for the sub-day fraction.
+//!
+//! Internal building block for the canonical-TAI [`Epoch`](super::Epoch); not a
+//! public API.
+
+/// Knuth's two-sum: exact `a + b = s + e` with `s = fl(a+b)` and `e` the
+/// rounding error. No ordering requirement on `|a|`, `|b|`.
+#[inline]
+fn two_sum(a: f64, b: f64) -> (f64, f64) {
+    let s = a + b;
+    let bb = s - a;
+    let e = (a - (s - bb)) + (b - bb);
+    (s, e)
+}
+
+/// A Julian Date carried as `hi + lo`, normalized so `hi == fl(hi + lo)` and
+/// `lo` holds the residual. The represented value is exactly `hi + lo` in
+/// extended precision.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct TwoPartJd {
+    hi: f64,
+    lo: f64,
+}
+
+impl TwoPartJd {
+    /// From a single `f64` JD (residual zero). This is the f64-precision entry
+    /// point; precision beyond `f64` requires [`from_parts`](Self::from_parts).
+    #[inline]
+    pub(crate) fn from_jd(jd: f64) -> Self {
+        Self { hi: jd, lo: 0.0 }
+    }
+
+    /// From an explicit high part and residual, renormalized so the invariant
+    /// `hi == fl(hi + lo)` holds.
+    #[inline]
+    pub(crate) fn from_parts(hi: f64, lo: f64) -> Self {
+        let (s, e) = two_sum(hi, lo);
+        Self { hi: s, lo: e }
+    }
+
+    /// The value as a single `f64` (lossy combine; for back-compat / display).
+    #[inline]
+    pub(crate) fn jd(self) -> f64 {
+        self.hi + self.lo
+    }
+
+    /// The `(hi, lo)` parts (lossless).
+    #[inline]
+    pub(crate) fn parts(self) -> (f64, f64) {
+        (self.hi, self.lo)
+    }
+
+    /// Add `days` (a full-precision `f64`) keeping extended precision.
+    #[inline]
+    pub(crate) fn add_days(self, days: f64) -> Self {
+        let (s, e) = two_sum(self.hi, days);
+        Self::from_parts(s, e + self.lo)
+    }
+
+    /// Difference `self - other` in days, in extended precision.
+    ///
+    /// The high parts subtract first (exact by Sterbenz when they are within a
+    /// factor of two — i.e. epochs close together, the case that matters near
+    /// J2000), then the residuals are folded in.
+    #[inline]
+    pub(crate) fn diff_days(self, other: Self) -> f64 {
+        let (dh, eh) = two_sum(self.hi, -other.hi);
+        // dh + eh + (self.lo - other.lo)
+        dh + (eh + (self.lo - other.lo))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_jd_roundtrips() {
+        let x = 2_460_000.123_456;
+        assert_eq!(TwoPartJd::from_jd(x).jd(), x);
+        assert_eq!(TwoPartJd::from_jd(x).parts(), (x, 0.0));
+    }
+
+    #[test]
+    fn from_parts_normalizes() {
+        // hi has no room for a sub-µs residual, but lo carries it exactly.
+        let hi = 2_460_000.0;
+        let lo = 1e-9; // ~86 µs is 1e-9 day; this is well below single-f64 ulp here
+        let t = TwoPartJd::from_parts(hi, lo);
+        let (h, l) = t.parts();
+        // The residual survives in lo (single-f64 jd() would lose it).
+        assert_eq!(h + l, hi + lo);
+        assert!(l != 0.0, "residual must be retained in lo");
+    }
+
+    #[test]
+    fn diff_near_j2000_is_exact() {
+        // Two epochs 1 ns apart near a large JD: single-f64 difference floors to
+        // 0, two-part keeps it.
+        const ONE_NS_DAY: f64 = 1.0 / 86_400.0 / 1e9;
+        let a = TwoPartJd::from_parts(2_451_545.0, 0.0);
+        let b = a.add_days(ONE_NS_DAY);
+        let d = b.diff_days(a);
+        let rel_err = ((d - ONE_NS_DAY) / ONE_NS_DAY).abs();
+        assert!(rel_err < 1e-6, "1 ns diff lost: got {d}, want {ONE_NS_DAY}");
+        // Sanity: naive single-f64 subtraction loses it entirely.
+        let naive = (2_451_545.0_f64 + ONE_NS_DAY) - 2_451_545.0_f64;
+        assert_eq!(naive, 0.0, "precondition: single-f64 floors a 1 ns step to 0");
+    }
+
+    #[test]
+    fn add_days_accumulates_without_drift() {
+        // Add 1 µs-day a million times; compare to the exact 1e6× value.
+        const STEP: f64 = 1e-6;
+        let mut t = TwoPartJd::from_jd(2_460_000.5);
+        for _ in 0..1_000_000 {
+            t = t.add_days(STEP);
+        }
+        let elapsed = t.diff_days(TwoPartJd::from_jd(2_460_000.5));
+        assert!(
+            (elapsed - 1.0).abs() < 1e-9,
+            "accumulated {elapsed}, want 1.0 day"
+        );
+    }
+
+    #[test]
+    fn non_finite_propagates() {
+        assert!(TwoPartJd::from_jd(f64::NAN).jd().is_nan());
+        assert!(TwoPartJd::from_jd(f64::INFINITY).jd().is_infinite());
+        // diff with NaN is NaN, not a silent finite value.
+        let nan = TwoPartJd::from_jd(f64::NAN);
+        let ok = TwoPartJd::from_jd(2_460_000.0);
+        assert!(nan.diff_days(ok).is_nan());
+    }
+}

--- a/arika/src/epoch/mod.rs
+++ b/arika/src/epoch/mod.rs
@@ -134,10 +134,11 @@ impl<S: TimeScale> Epoch<S> {
         self.tai
     }
 
-    /// Exact SI-second interval since `earlier`, measured on the TAI timeline
-    /// (correct across leap seconds and regardless of `S`).
-    pub fn duration_since(&self, earlier: &Epoch<S>) -> Duration {
-        Duration::from_si_seconds(self.tai.diff_days(earlier.tai) * 86400.0)
+    /// Exact SI-second interval since `earlier`, measured on the shared TAI
+    /// timeline — correct across leap seconds and across *any* scales (both
+    /// epochs store canonical TAI, so `earlier` may be in a different scale).
+    pub fn duration_since<T: TimeScale>(&self, earlier: &Epoch<T>) -> Duration {
+        Duration::from_si_seconds(self.tai.diff_days(earlier.tai_raw()) * 86400.0)
     }
 }
 

--- a/arika/src/epoch/mod.rs
+++ b/arika/src/epoch/mod.rs
@@ -43,9 +43,6 @@ mod convert;
 mod datetime;
 mod duration;
 mod gps;
-// Consumed by the canonical-TAI Epoch representation in a follow-up commit;
-// the allow is temporary until that integration lands.
-#[allow(dead_code)]
 mod jd2;
 mod leap;
 mod scale;
@@ -56,8 +53,11 @@ pub use duration::Duration;
 pub use gps::{GpsWeek, SecondsOfWeek};
 pub use scale::{Gps, Tai, Tdb, TimeScale, Tt, Utc};
 
+use convert::TaiLens;
 use convert::era_formula;
 use datetime::to_datetime_from_jd;
+use jd2::TwoPartJd;
+#[allow(unused_imports)]
 use leap::tai_minus_utc_at_mjd;
 
 /// Julian Date of J2000.0 epoch (JD 2451545.0).
@@ -95,18 +95,21 @@ const UNIX_EPOCH_JD: f64 = 2440587.5;
 /// `S` defaults to [`Utc`] so that `Epoch` (without type parameter) means
 /// `Epoch<Utc>` — the most common user-facing scale.
 ///
-/// # Scale 解釈
+/// # 内部表現: canonical TAI
 ///
-/// 内部表現は単一の `jd: f64` だが、その値は **scale `S` で解釈される** JD である。
-/// つまり `Epoch<Utc>::from_jd(x).jd() == x` (UTC JD として round-trip)、
-/// `Epoch<Tdb>::from_jd_tdb(x).jd() == x` (TDB JD として round-trip) となる。
+/// 内部は **canonical な TAI instant を two-part ([`TwoPartJd`]) で保持**し、`S` は
+/// 読み出しレンズである。`jd()` は格納された TAI を scale `S` の JD に変換して返す:
+/// `Epoch<Utc>::from_jd(x).jd() == x` (UTC JD として round-trip)、
+/// `Epoch<Tdb>::from_jd_tdb(x).jd() == x` (TDB JD として round-trip)。
 ///
-/// Scale 間の変換 (`to_tdb()`, `to_tt()` 等) は内部で TAI を経由し leap second や
-/// Fairhead 補正を適用して別 scale の JD を計算する。
+/// scale 変換 (`to_tt()`, `to_tdb()` 等) は同じ TAI instant の **非破壊な再ラベル**で、
+/// leap second / Fairhead 補正は構築時 (`from_*`) と読み出し時 (`jd()`) の lens
+/// ([`TaiLens`]) でのみ適用される。同一物理 instant は同一内部値なので
+/// `duration_since` は leap 跨ぎ・cross-scale でも厳密な SI 秒を返す。
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Epoch<S: TimeScale = Utc> {
-    /// JD interpreted in scale `S`.
-    jd: f64,
+    /// Canonical TAI instant (two-part JD). Read out in scale `S` via the lens.
+    tai: TwoPartJd,
     /// Scale tag (zero-sized).
     _scale: PhantomData<S>,
 }
@@ -114,51 +117,78 @@ pub struct Epoch<S: TimeScale = Utc> {
 // Generic accessors (available on all scales)
 
 impl<S: TimeScale> Epoch<S> {
-    /// Return the Julian Date value, interpreted in scale `S`.
-    pub fn jd(&self) -> f64 {
-        self.jd
-    }
-
-    /// Return the Modified Julian Date value, interpreted in scale `S`.
-    pub fn mjd(&self) -> f64 {
-        self.jd - MJD_OFFSET
-    }
-
     /// The human-readable scale name (e.g. "UTC", "TDB").
     pub fn scale_name() -> &'static str {
         S::NAME
     }
 
-    /// Crate-internal constructor from raw JD (bypasses scale semantics).
-    /// Used for scale-conversion helpers and tests.
-    pub(crate) fn from_jd_raw(jd: f64) -> Self {
+    /// Crate-internal constructor from the canonical TAI instant, tagging scale
+    /// `S`. Scale conversions are exactly this (a re-tag of the same `tai`).
+    pub(crate) fn from_tai_raw(tai: TwoPartJd) -> Self {
         Self {
-            jd,
+            tai,
             _scale: PhantomData,
         }
     }
+
+    /// Crate-internal accessor for the canonical TAI instant.
+    pub(crate) fn tai_raw(&self) -> TwoPartJd {
+        self.tai
+    }
+
+    /// Exact SI-second interval since `earlier`, measured on the TAI timeline
+    /// (correct across leap seconds and regardless of `S`).
+    pub fn duration_since(&self, earlier: &Epoch<S>) -> Duration {
+        Duration::from_si_seconds(self.tai.diff_days(earlier.tai) * 86400.0)
+    }
 }
+
+// Read-out accessors: lens the stored canonical TAI into scale `S`'s JD.
+//
+// Concrete per scale (not a generic `impl<S: TaiLens>`) so the crate-internal
+// `TaiLens` / `TwoPartJd` types stay off the public API — a public generic
+// bounded by them would leak them (`private_interfaces`).
+macro_rules! impl_jd_accessors {
+    ($scale:ty) => {
+        impl Epoch<$scale> {
+            /// Return the Julian Date, interpreted in this scale (lens read-out
+            /// of the canonical TAI instant; single-`f64` collapse).
+            pub fn jd(&self) -> f64 {
+                <$scale as TaiLens>::scale_from_tai(self.tai).jd()
+            }
+
+            /// The Julian Date as a precise two-part `(hi, lo)` value.
+            pub fn jd_parts(&self) -> (f64, f64) {
+                <$scale as TaiLens>::scale_from_tai(self.tai).parts()
+            }
+
+            /// Return the Modified Julian Date, interpreted in this scale.
+            pub fn mjd(&self) -> f64 {
+                self.jd() - MJD_OFFSET
+            }
+        }
+    };
+}
+impl_jd_accessors!(Utc);
+impl_jd_accessors!(Tai);
+impl_jd_accessors!(Tt);
+impl_jd_accessors!(Tdb);
+impl_jd_accessors!(Gps);
 
 // Epoch<Utc> API (main user-facing scale)
 
 impl Epoch<Utc> {
-    /// Create a UTC epoch from a raw Julian Date (treated as UTC JD).
+    /// Create a UTC epoch from a Julian Date (treated as UTC JD).
     ///
-    /// Legacy API matching the pre-refactor `Epoch::from_jd`. The resulting
-    /// `Epoch<Utc>::jd()` returns `jd` unchanged (round-trip identity).
+    /// `Epoch<Utc>::from_jd(x).jd() == x` (round-trip identity). The value is
+    /// stored internally as the corresponding canonical TAI instant.
     pub fn from_jd(jd: f64) -> Self {
-        Epoch {
-            jd,
-            _scale: PhantomData,
-        }
+        convert::from_scale_jd::<Utc>(jd)
     }
 
     /// Create a UTC epoch from a Modified Julian Date value.
     pub fn from_mjd(mjd: f64) -> Self {
-        Epoch {
-            jd: mjd + MJD_OFFSET,
-            _scale: PhantomData,
-        }
+        Self::from_jd(mjd + MJD_OFFSET)
     }
 
     /// The J2000.0 reference epoch (JD 2451545.0).
@@ -167,10 +197,7 @@ impl Epoch<Utc> {
     /// UTC scale で JD 2451545.0 を返す (後方互換のため)。厳密な TT J2000
     /// を得るには [`Epoch::<Tt>::from_jd_tt`] を使う。
     pub fn j2000() -> Self {
-        Epoch {
-            jd: J2000_JD,
-            _scale: PhantomData,
-        }
+        Self::from_jd(J2000_JD)
     }
 
     /// Create a UTC epoch from a [`DateTime`] value.
@@ -200,10 +227,7 @@ impl Epoch<Utc> {
             - 1524.5
             + (hour as f64 + min as f64 / 60.0 + sec / 3600.0) / 24.0;
 
-        Epoch {
-            jd,
-            _scale: PhantomData,
-        }
+        Self::from_jd(jd)
     }
 
     /// Parse a UTC epoch from ISO 8601 (CCSDS-compatible).
@@ -266,21 +290,15 @@ impl Epoch<Utc> {
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system clock before Unix epoch")
             .as_secs_f64();
-        Epoch {
-            jd: UNIX_EPOCH_JD + unix_secs / 86400.0,
-            _scale: PhantomData,
-        }
+        Self::from_jd(UNIX_EPOCH_JD + unix_secs / 86400.0)
     }
 
     /// Create a UTC epoch from a 4-digit year and a fractional day of year
     /// (`1.0` = Jan 1 00:00, `1.5` = Jan 1 12:00, …).
     pub fn from_year_day_of_year(year: i32, day_of_year: f64) -> Self {
         // JD of Jan 1 00:00 of that year, offset by the fractional day.
-        let jan1 = Self::from_gregorian(year, 1, 1, 0, 0, 0.0);
-        Epoch {
-            jd: jan1.jd + (day_of_year - 1.0),
-            _scale: PhantomData,
-        }
+        let jan1_jd = Self::from_gregorian(year, 1, 1, 0, 0, 0.0).jd();
+        Self::from_jd(jan1_jd + (day_of_year - 1.0))
     }
 
     /// Gregorian leap-year test.
@@ -308,52 +326,32 @@ impl Epoch<Utc> {
     /// This method is kept for legacy bit-level compatibility where UTC
     /// centuries were used interchangeably with dynamical-time centuries.
     pub fn centuries_since_j2000(&self) -> f64 {
-        (self.jd - J2000_JD) / JULIAN_CENTURY
+        (self.jd() - J2000_JD) / JULIAN_CENTURY
     }
 
-    /// Advance the epoch by `dt` seconds using naive JD arithmetic
-    /// (`jd + dt/86400`). Does NOT handle leap second boundaries.
+    /// Advance the epoch by `dt` seconds using naive UTC-JD arithmetic
+    /// (`utc_jd + dt/86400`). Does NOT handle leap second boundaries.
     ///
-    /// Legacy API for bit-level compatibility with pre-refactor `Epoch::add_seconds`.
-    /// For leap-second-aware arithmetic use [`add_si_seconds`](Self::add_si_seconds)
-    /// instead.
+    /// Legacy API. For leap-second-aware (SI-second) arithmetic use
+    /// [`add_si_seconds`](Self::add_si_seconds) instead.
     pub fn add_seconds(&self, dt: f64) -> Self {
-        Epoch {
-            jd: self.jd + dt / 86400.0,
-            _scale: PhantomData,
-        }
+        Self::from_jd(self.jd() + dt / 86400.0)
     }
 
     /// Advance the epoch by `dt` SI seconds, handling leap second boundaries.
     ///
-    /// Internally converts UTC → TAI, adds `dt` TAI seconds, and converts
-    /// back to UTC. Crossing a leap second boundary correctly absorbs the
-    /// extra second: 5 SI seconds from 2016-12-31T23:59:58 lands at
-    /// 2017-01-01T00:00:02 (not 00:00:03), because one SI second is "consumed"
-    /// by the 2017-01-01 leap.
+    /// Adds `dt` directly on the stored canonical TAI instant (a uniform SI
+    /// timeline), so leap seconds are handled automatically on read-out:
+    /// 5 SI seconds from 2016-12-31T23:59:58 lands at 2017-01-01T00:00:02
+    /// (not 00:00:03), because one SI second is "consumed" by the 2017-01-01
+    /// leap.
     pub fn add_si_seconds(&self, dt: f64) -> Self {
-        let utc_mjd = self.jd - MJD_OFFSET;
-        let leap_before = tai_minus_utc_at_mjd(utc_mjd);
-        let tai_jd = self.jd + leap_before / 86400.0;
-        let new_tai_jd = tai_jd + dt / 86400.0;
-
-        // Converge on the correct leap count at the new instant.
-        let mut guess_utc_jd = new_tai_jd - leap_before / 86400.0;
-        for _ in 0..3 {
-            let guess_mjd = guess_utc_jd - MJD_OFFSET;
-            let new_leap = tai_minus_utc_at_mjd(guess_mjd);
-            guess_utc_jd = new_tai_jd - new_leap / 86400.0;
-        }
-
-        Epoch {
-            jd: guess_utc_jd,
-            _scale: PhantomData,
-        }
+        Self::from_tai_raw(self.tai_raw().add_days(dt / 86400.0))
     }
 
     /// Convert to Gregorian calendar date and time (UTC).
     pub fn to_datetime(&self) -> DateTime {
-        to_datetime_from_jd(self.jd)
+        to_datetime_from_jd(self.jd())
     }
 
     /// Convert to Gregorian calendar date and time (UTC), with leap second
@@ -376,7 +374,7 @@ impl Epoch<Utc> {
     /// `Epoch::gmst` method. Will be removed when downstream callers migrate
     /// to [`Ut1Epoch::era`].
     pub fn gmst(&self) -> f64 {
-        era_formula(self.jd)
+        era_formula(self.jd())
     }
 }
 

--- a/arika/src/epoch/mod.rs
+++ b/arika/src/epoch/mod.rs
@@ -57,8 +57,6 @@ use convert::TaiLens;
 use convert::era_formula;
 use datetime::to_datetime_from_jd;
 use jd2::TwoPartJd;
-#[allow(unused_imports)]
-use leap::tai_minus_utc_at_mjd;
 
 /// Julian Date of J2000.0 epoch (JD 2451545.0).
 ///
@@ -157,7 +155,13 @@ macro_rules! impl_jd_accessors {
                 <$scale as TaiLens>::scale_from_tai(self.tai).jd()
             }
 
-            /// The Julian Date as a precise two-part `(hi, lo)` value.
+            /// The Julian Date as a precise two-part `(hi, lo)` value — for
+            /// feeding SOFA-style two-part consumers without the `jd()` collapse.
+            ///
+            /// `lo` carries the conversion's sub-`f64` residual; since every
+            /// constructor currently ingests a single `f64`, it reflects the
+            /// lens arithmetic, not user-supplied sub-`f64` input precision (a
+            /// two-part ingestion path is future work).
             pub fn jd_parts(&self) -> (f64, f64) {
                 <$scale as TaiLens>::scale_from_tai(self.tai).parts()
             }

--- a/arika/src/epoch/mod.rs
+++ b/arika/src/epoch/mod.rs
@@ -3,8 +3,12 @@
 //! # 概要
 //!
 //! `Epoch<S>` は scale `S` で解釈される瞬間を表す。`S` は [`TimeScale`] trait を
-//! 実装した marker (`Utc`, `Tai`, `Tt`, `Ut1`, `Tdb` のいずれか) で、
-//! 時刻体系 (UTC, TAI, TT, UT1, TDB) をコンパイル時に区別する。
+//! 実装した marker (`Utc`, `Tai`, `Tt`, `Tdb`, `Gps` のいずれか) で、
+//! 時刻体系をコンパイル時に区別する。
+//!
+//! UT1 は EOP (測定された dUT1) 依存で他の scale と data-free に換算できないため
+//! `Epoch<S>` の仲間ではなく独立型 [`Ut1Epoch`] として扱う ([`Epoch<Utc>::to_ut1`]
+//! 経由で生成)。
 //!
 //! 既存コードとの互換性のため、型パラメータはデフォルト値 `Utc` を持ち、
 //! `Epoch` という bare 名は `Epoch<Utc>` と等価。
@@ -25,8 +29,8 @@
 //!   [`Epoch<Utc>::from_datetime`], [`Epoch<Utc>::now`],
 //!   [`Epoch<Utc>::from_tle_epoch`] — UTC 入口
 //! - [`Epoch<Tt>::from_jd_tt`], [`Epoch<Tdb>::from_jd_tdb`],
-//!   [`Epoch<Ut1>::from_jd_ut1`], [`Epoch<Tai>::from_jd_tai`] — scale 固有 JD 入口
-//! - [`Epoch<Ut1>::era`] — Earth Rotation Angle (IAU 2000 B1.8)
+//!   [`Epoch<Tai>::from_jd_tai`], [`Ut1Epoch::from_jd_ut1`] — scale 固有 JD 入口
+//! - [`Ut1Epoch::era`] — Earth Rotation Angle (IAU 2000 B1.8)
 //!
 //! 変換は `to_tai()` / `to_tt()` / `to_tdb()` 等の method で明示的に行う。
 
@@ -39,18 +43,18 @@ mod convert;
 mod datetime;
 mod duration;
 mod gps;
-// TODO(phase2): consumed by the canonical-TAI Epoch representation next; the
-// allow is temporary until that integration lands.
+// Consumed by the canonical-TAI Epoch representation in a follow-up commit;
+// the allow is temporary until that integration lands.
 #[allow(dead_code)]
 mod jd2;
 mod leap;
 mod scale;
 
-pub use convert::FixedOffsetFromTai;
+pub use convert::{FixedOffsetFromTai, Ut1Epoch};
 pub use datetime::DateTime;
 pub use duration::Duration;
 pub use gps::{GpsWeek, SecondsOfWeek};
-pub use scale::{Gps, Tai, Tdb, TimeScale, Tt, Ut1, Utc};
+pub use scale::{Gps, Tai, Tdb, TimeScale, Tt, Utc};
 
 use convert::era_formula;
 use datetime::to_datetime_from_jd;
@@ -365,12 +369,12 @@ impl Epoch<Utc> {
     ///
     /// Actually computes the Earth Rotation Angle (IAU 2000 B1.8 / SOFA
     /// `iauEra00`) assuming UT1 ≈ UTC (ignores dUT1). For the proper
-    /// canonical form use [`Epoch::<Ut1>::era`] after an explicit UT1
+    /// canonical form use [`Ut1Epoch::era`] after an explicit UT1
     /// conversion via a proper EOP provider.
     ///
     /// Kept on `Epoch<Utc>` for bit-level compatibility with the pre-refactor
     /// `Epoch::gmst` method. Will be removed when downstream callers migrate
-    /// to `Epoch<Ut1>::era`.
+    /// to [`Ut1Epoch::era`].
     pub fn gmst(&self) -> f64 {
         era_formula(self.jd)
     }

--- a/arika/src/epoch/mod.rs
+++ b/arika/src/epoch/mod.rs
@@ -39,6 +39,10 @@ mod convert;
 mod datetime;
 mod duration;
 mod gps;
+// TODO(phase2): consumed by the canonical-TAI Epoch representation next; the
+// allow is temporary until that integration lands.
+#[allow(dead_code)]
+mod jd2;
 mod leap;
 mod scale;
 

--- a/arika/src/epoch/scale.rs
+++ b/arika/src/epoch/scale.rs
@@ -43,13 +43,10 @@ define_scale!(
      `dTT/dTCG = 1 - L_G`, `L_G = 6.969290134e-10`; IAU 2000 B1.9). \
      IAU 2006 precession と IAU 2000A/B nutation の独立変数。"
 );
-define_scale!(
-    Ut1,
-    "UT1",
-    "Universal Time (UT1). Earth rotation angle time scale — defining \
-     observable は ERA (IAU 2000 B1.8 / SOFA iauEra00)。atomic clock が \
-     刻む時刻ではなく Earth の瞬間的な向きを時間単位で表現したもの。"
-);
+// UT1 is deliberately NOT a `TimeScale` marker: it is realized by Earth's
+// rotation (a measured EOP quantity, not a data-free offset from TAI), so it
+// cannot share the canonical timeline of the atomic/dynamical scales. It lives
+// in its own type, `Ut1Epoch` (see `convert.rs`), reached via `to_ut1(eop)`.
 define_scale!(
     Tdb,
     "TDB",

--- a/arika/src/epoch/tests.rs
+++ b/arika/src/epoch/tests.rs
@@ -840,3 +840,21 @@ fn duration_since_recovers_sub_microsecond_interval() {
     // Precondition: differencing the f64 read-outs floors the 1 ns to 0.
     assert_eq!((e1.jd() - e0.jd()) * 86400.0, 0.0);
 }
+
+/// `add_si_seconds` is an exact SI add on the uniform TAI line: `duration_since`
+/// recovers exactly the added amount, including across a leap-second boundary.
+/// (The pre-canonical UTC-iteration version drifted by ~1 s for results landing
+/// inside the inserted second; the canonical uniform-TAI add is correct, as the
+/// time-systems guidance prescribes — "do duration math in TAI/TT".)
+#[test]
+fn add_si_seconds_is_exact_si_across_leap() {
+    // Starts just before the 2017-01-01 leap so several steps land in/after it.
+    let e = Epoch::<Utc>::from_iso8601("2016-12-31T23:59:59Z").unwrap();
+    for dt in [0.5_f64, 1.0, 1.5, 2.0, 10.0, 86_400.0] {
+        let elapsed = e.add_si_seconds(dt).duration_since(&e).as_si_seconds();
+        assert!(
+            (elapsed - dt).abs() < 1e-6,
+            "add_si_seconds({dt}) → elapsed {elapsed} s"
+        );
+    }
+}

--- a/arika/src/epoch/tests.rs
+++ b/arika/src/epoch/tests.rs
@@ -738,13 +738,14 @@ fn gps_utc_roundtrip() {
     );
 }
 
-// Behavior-preserving characterization of the scale conversion graph.
+// Characterization of the scale conversion graph against a reference.
 //
-// Each row pins the bit-exact f64 output of every conversion edge for a UTC
-// input given by `cols[0]` (its own `jd()` bits). Captured from the
-// pre-taxonomy-refactor implementation; the taxonomy refactor must keep these
-// bit-for-bit. Inputs include leap-second boundaries, a pre-1972 date, and
-// non-finite values (NaN, ±∞), per the project's behavior-preserving policy.
+// Each row holds the f64 output of every conversion edge for a UTC input given
+// by `cols[0]`, captured from the pre-canonical single-f64 implementation.
+// The canonical-TAI representation computes these in two parts (higher
+// precision), so the values are no longer *bit*-exact — they match the
+// reference within a tight tolerance (~ULP). Inputs include leap-second
+// boundaries, a pre-1972 date, and non-finite values (NaN, ±∞).
 //
 // Column order:
 //   0: utc.jd()                       5: utc.to_tai().to_tt().jd()
@@ -764,7 +765,7 @@ const CONVERSION_GOLDEN: &[(&str, [u64; 10])] = &[
 ];
 
 #[test]
-fn conversion_graph_is_bit_preserving() {
+fn conversion_graph_matches_reference() {
     const LABELS: [&str; 10] = [
         "utc.jd",
         "utc.to_tai",
@@ -777,42 +778,65 @@ fn conversion_graph_is_bit_preserving() {
         "utc.to_tt.to_tdb",
         "utc.to_tdb.to_tt",
     ];
+    // The two-part canonical result differs from the single-f64 reference by at
+    // most ~1 ULP of a modern JD (~5.5e-10 day); 1e-9 day is a safe bound.
+    const TOL_DAY: f64 = 1e-9;
     for (name, want) in CONVERSION_GOLDEN {
         let utc = Epoch::<Utc>::from_jd(f64::from_bits(want[0]));
         let tai = utc.to_tai();
         let tt = utc.to_tt();
         let tdb = utc.to_tdb();
-        let got: [u64; 10] = [
-            utc.jd().to_bits(),
-            tai.jd().to_bits(),
-            tt.jd().to_bits(),
-            tdb.jd().to_bits(),
-            utc.to_ut1_naive().jd().to_bits(),
-            tai.to_tt().jd().to_bits(),
-            tai.to_utc().jd().to_bits(),
-            tt.to_tai().jd().to_bits(),
-            tt.to_tdb().jd().to_bits(),
-            tdb.to_tt().jd().to_bits(),
+        let got: [f64; 10] = [
+            utc.jd(),
+            tai.jd(),
+            tt.jd(),
+            tdb.jd(),
+            utc.to_ut1_naive().jd(),
+            tai.to_tt().jd(),
+            tai.to_utc().jd(),
+            tt.to_tai().jd(),
+            tt.to_tdb().jd(),
+            tdb.to_tt().jd(),
         ];
         for i in 0..10 {
-            // IEEE-754 leaves the NaN sign/payload unspecified, and libm may
-            // emit a different NaN bit pattern across targets/versions. So for
-            // NaN expectations assert only is_nan(); finite and ±∞ values have
-            // well-defined bit patterns and stay bit-exact.
-            if f64::from_bits(want[i]).is_nan() {
+            let want_v = f64::from_bits(want[i]);
+            // Non-finite reference (NaN / ±∞) comes from a non-finite *input*
+            // (the nan/pinf/ninf rows). Two-part arithmetic on non-finite values
+            // yields NaN where single-f64 yielded ±∞ — both are garbage-in /
+            // garbage-out; the meaningful guarantee is that no non-finite input
+            // silently produces a finite result. Finite values match within tol.
+            if !want_v.is_finite() {
                 assert!(
-                    f64::from_bits(got[i]).is_nan(),
-                    "{name}: {} expected NaN, got {:#x}",
+                    !got[i].is_finite(),
+                    "{name}: {} non-finite input produced finite {}",
                     LABELS[i],
                     got[i]
                 );
             } else {
-                assert_eq!(
-                    got[i], want[i],
-                    "{name}: {} diverged: want {:#x}, got {:#x}",
-                    LABELS[i], want[i], got[i]
+                assert!(
+                    (got[i] - want_v).abs() < TOL_DAY,
+                    "{name}: {} diverged from reference: want {want_v}, got {} (Δ {:e} day)",
+                    LABELS[i],
+                    got[i],
+                    got[i] - want_v
                 );
             }
         }
     }
+}
+
+/// The canonical-TAI representation's payoff: `duration_since` recovers a
+/// sub-µs interval that the single-f64 JD floor (~tens of µs near modern
+/// epochs) would lose entirely.
+#[test]
+fn duration_since_recovers_sub_microsecond_interval() {
+    let e0 = Epoch::<Utc>::from_iso8601("2024-06-15T08:30:45Z").unwrap();
+    let e1 = e0.add_si_seconds(1e-9); // 1 ns later
+    let d = e1.duration_since(&e0).as_si_seconds();
+    assert!(
+        (d - 1e-9).abs() < 1e-12,
+        "1 ns interval not recovered: got {d} s"
+    );
+    // Precondition: differencing the f64 read-outs floors the 1 ns to 0.
+    assert_eq!((e1.jd() - e0.jd()) * 86400.0, 0.0);
 }

--- a/arika/src/epoch/tests.rs
+++ b/arika/src/epoch/tests.rs
@@ -15,7 +15,6 @@ fn scale_name_via_type() {
     assert_eq!(Epoch::<Utc>::scale_name(), "UTC");
     assert_eq!(Epoch::<Tai>::scale_name(), "TAI");
     assert_eq!(Epoch::<Tt>::scale_name(), "TT");
-    assert_eq!(Epoch::<Ut1>::scale_name(), "UT1");
     assert_eq!(Epoch::<Tdb>::scale_name(), "TDB");
 }
 
@@ -467,9 +466,9 @@ fn to_ut1_accepts_trait_object_provider() {
     }
     let utc = Epoch::<Utc>::from_gregorian(2024, 3, 20, 12, 0, 0.0);
     let boxed: Box<dyn crate::earth::eop::Ut1Offset> = Box::new(Fixed(-0.100));
-    let _ut1_box: Epoch<Ut1> = utc.to_ut1(boxed.as_ref());
+    let _ut1_box: Ut1Epoch = utc.to_ut1(boxed.as_ref());
     let dyn_ref: &dyn crate::earth::eop::Ut1Offset = &Fixed(-0.100);
-    let _ut1_dyn: Epoch<Ut1> = utc.to_ut1(dyn_ref);
+    let _ut1_dyn: Ut1Epoch = utc.to_ut1(dyn_ref);
 }
 
 #[test]

--- a/arika/src/frame.rs
+++ b/arika/src/frame.rs
@@ -57,7 +57,7 @@ use core::ops::{Add, Div, Mul, Neg, Sub};
 use nalgebra::{UnitQuaternion, Vector3};
 use serde::{Deserialize, Serialize};
 
-use crate::epoch::{Epoch, Ut1, Utc};
+use crate::epoch::{Epoch, Ut1Epoch, Utc};
 
 // Runtime frame descriptor
 
@@ -511,7 +511,7 @@ impl Rotation<SimpleEci, SimpleEcef> {
     /// `SimpleEcef = R_z(−ERA(UT1)) × SimpleEci`. Applies only the ERA Z
     /// rotation — no precession, nutation, or polar motion. For high-precision
     /// work use the IAU 2006 CIO chain ([`Rotation::<Gcrs, Itrs>::iau2006_full`]).
-    pub fn from_ut1(epoch: &Epoch<Ut1>) -> Self {
+    pub fn from_ut1(epoch: &Ut1Epoch) -> Self {
         Self::from_era(epoch.era())
     }
 
@@ -537,7 +537,7 @@ impl Rotation<SimpleEci, SimpleEcef> {
 
 impl Rotation<SimpleEcef, SimpleEci> {
     /// Inverse of [`Rotation::<SimpleEci, SimpleEcef>::from_ut1`].
-    pub fn from_ut1(epoch: &Epoch<Ut1>) -> Self {
+    pub fn from_ut1(epoch: &Ut1Epoch) -> Self {
         Self::from_era(epoch.era())
     }
 
@@ -802,8 +802,7 @@ mod tests {
 
     #[test]
     fn from_ut1_matches_from_era() {
-        use crate::epoch::Epoch;
-        let ut1 = Epoch::<Ut1>::from_jd_ut1(2460390.5);
+        let ut1 = Ut1Epoch::from_jd_ut1(2460390.5);
         let era = ut1.era();
         let r_direct = Rotation::<SimpleEci, SimpleEcef>::from_era(era);
         let r_via_ut1 = Rotation::<SimpleEci, SimpleEcef>::from_ut1(&ut1);

--- a/arika/tests/iau2006_vs_erfa.rs
+++ b/arika/tests/iau2006_vs_erfa.rs
@@ -39,7 +39,7 @@ use arika::earth::eop::{LengthOfDay, NutationCorrections, PolarMotion, Ut1Offset
 use arika::earth::iau2006::cip::{cio_locator_s, cip_xy, gcrs_to_cirs_matrix_at};
 use arika::earth::iau2006::fundamental_arguments::FundamentalArguments;
 use arika::earth::iau2006::precession::{ecliptic_precession_angles, fukushima_williams};
-use arika::epoch::{Epoch, Tt, Ut1, Utc};
+use arika::epoch::{Epoch, Tt, Ut1Epoch, Utc};
 use arika::frame::{Gcrs, Itrs, Rotation, Vec3};
 use serde_json::Value;
 
@@ -342,7 +342,7 @@ fn iau2006_full_matches_erfa_zero_eop_chain() {
         // unit test suite.
         let tt = Epoch::<Tt>::from_jd_tt(2451545.0 + t * 36525.0);
         // With dUT1 = 0, `ut1 = utc` as bit-equal Julian Dates.
-        let ut1 = Epoch::<Ut1>::from_jd_ut1(2451545.0 + t * 36525.0);
+        let ut1 = Ut1Epoch::from_jd_ut1(2451545.0 + t * 36525.0);
         let utc = Epoch::<Utc>::from_jd(2451545.0 + t * 36525.0);
         let rot = Rotation::<Gcrs, Itrs>::iau2006_full(&tt, &ut1, &utc, &ZeroEop);
 

--- a/arika/tests/trybuild/null_eop_in_to_ut1.stderr
+++ b/arika/tests/trybuild/null_eop_in_to_ut1.stderr
@@ -14,5 +14,5 @@ help: the trait `Ut1Offset` is implemented for `EopTable`
 note: required by a bound in `epoch::convert::<impl Epoch>::to_ut1`
   --> src/epoch/convert.rs
    |
-   |     pub fn to_ut1<P: crate::earth::eop::Ut1Offset + ?Sized>(&self, eop: &P) -> Epoch<Ut1> {
+   |     pub fn to_ut1<P: crate::earth::eop::Ut1Offset + ?Sized>(&self, eop: &P) -> Ut1Epoch {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `epoch::convert::<impl Epoch>::to_ut1`

--- a/tobari/src/nrlmsise00/geo.rs
+++ b/tobari/src/nrlmsise00/geo.rs
@@ -18,7 +18,7 @@
 
 use arika::SimpleEci;
 use arika::earth::eop::{NutationCorrections, PolarMotion, Ut1Offset};
-use arika::epoch::{Epoch, Ut1, Utc};
+use arika::epoch::{Epoch, Utc};
 use arika::frame::{self, Rotation, Vec3};
 
 /// Convert a simple-path ECI position to WGS-84 geodetic latitude and
@@ -66,12 +66,6 @@ where
     let geod = pos_itrs.to_geodetic();
     (geod.latitude.to_degrees(), geod.longitude.to_degrees())
 }
-
-/// Unused import suppression helper: keeps `Ut1` in scope for Phase
-/// 4B follow-up work that will accept an explicit `&Epoch<Ut1>` for
-/// users who already performed the UT1 derivation upstream.
-#[allow(dead_code)]
-fn _touch_ut1_for_phase_4b(_: &Epoch<Ut1>) {}
 
 /// Convert epoch to (day_of_year, ut_seconds).
 pub fn epoch_to_day_of_year_and_ut(epoch: &Epoch) -> (u32, f64) {


### PR DESCRIPTION
## What this does

Redesigns `arika`'s `Epoch` **internal representation** to a canonical TAI
instant carried in two parts, fixing the single-`f64` Julian Date precision
floor (~tens of µs near modern epochs) and the catastrophic cancellation when
differencing epochs near J2000 — and isolating UT1 into its own type. The
public API (`jd`/`from_jd`/`to_*`/`from_gregorian`/…) is preserved, so
downstream is unaffected.

> **Stacked on #192** (scale-conversion edges + GPS Time + typed GPS week/sow).
> This PR's base is the `#192` branch so the diff shows only the Phase 2
> changes; review/merge #192 first, then this rebases onto `main`.

## Changes

- **`TwoPartJd`** — two-part (`hi + lo`, Knuth two-sum) Julian Date primitive;
  sub-nanosecond precision, `no_std`-pure.
- **`Ut1Epoch`** — UT1 leaves the `Epoch<S>` family. UT1 − TAI (ΔUT1) is a
  *measured* EOP quantity, not a data-free offset, so UT1 cannot share the
  canonical TAI timeline; it lives in its own type, reached via
  `Epoch::<Utc>::to_ut1(eop)`. `era()` lives there; `from_era` takes `&Ut1Epoch`.
- **`Epoch<S> { tai: TwoPartJd }`** — stores a canonical TAI instant; `S` is a
  read-out lens (`TaiLens`). `from_jd_*`/`from_gregorian` convert the scale JD
  to TAI; `jd()`/`jd_parts()`/`mjd()` lens it back; `to_*` are **non-destructive
  re-tags**; `duration_since()` is an **exact** SI interval (leap-safe,
  cross-scale); `add_si_seconds` adds on the uniform TAI line. `TaiLens` /
  `TwoPartJd` stay crate-internal (the `jd` accessors are concrete per scale).

## Behavior

- `jd()` read-outs match the prior single-`f64` results within ~1 ULP — the
  conversion characterization test is now **tolerance-vs-reference**, not
  bit-exact, because the two-part path is strictly more precise.
- Exact `Epoch − Epoch` via `duration_since` (a 1 ns interval now survives where
  single-`f64` differencing floored it to 0).
- `add_si_seconds` is now an exact uniform-TAI add — correcting a ~1 s drift the
  old UTC-iteration had for results landing inside an inserted leap second.
- Non-finite inputs yield non-finite outputs (garbage-in/out; currently NaN,
  since two-sum turns ±∞ into NaN — the test pins only non-finiteness, not the
  exact flavor, so a future ∞-preserving change stays allowed).

## Testing

- arika 392 tests; full `cargo test --workspace` 1716 passed; `no_std`
  (no alloc), `no_std + alloc`, `wasm32-unknown-unknown`, and
  `cargo clippy --workspace -- -D warnings` all green.
- Two independent code reviews (UT1 isolation; the canonical flip) — no
  blockers; findings addressed (dead import removed, `add_si_seconds`
  SI-exactness pinned, docs).

## Follow-up (separate)

- **Phase 3**: an optional `Coarse`/`Precise` precision *tier* in the type
  (deferred until a concrete coarse consumer and naming are settled).
- ERFA cross-validation of the scale conversions.
- Ephemeris/rotation APIs requiring `Epoch<Tdb>` (the separately-scoped
  call-site migration discussed for #192).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
