### PR TITLE
fix(tools): make Orekit fixture generators find the bundled JDK (JAVA_HOME)

### DIFF
--- a/tools/generate_gcrf_propagation_fixtures.py
+++ b/tools/generate_gcrf_propagation_fixtures.py
@@ -44,7 +44,16 @@ DEFAULT_BALLISTIC_COEFF = 0.01
 
 def setup_orekit():
     """Initialize Orekit JVM and data."""
+    import os
+
+    import jdk4py
     import orekit_jpype as orekit
+
+    # jpype finds the JVM via JAVA_HOME; point it at the bundled jdk4py JDK when
+    # unset or empty so `uv run` needs no system Java install. An explicit,
+    # non-empty JAVA_HOME is respected.
+    if not os.environ.get("JAVA_HOME"):
+        os.environ["JAVA_HOME"] = str(jdk4py.JAVA_HOME)
 
     orekit.initVM()
 

--- a/tools/generate_hp_fixtures.py
+++ b/tools/generate_hp_fixtures.py
@@ -34,7 +34,16 @@ from pathlib import Path
 
 def setup_orekit():
     """Initialize Orekit JVM and data."""
+    import os
+
+    import jdk4py
     import orekit_jpype as orekit
+
+    # jpype finds the JVM via JAVA_HOME; point it at the bundled jdk4py JDK when
+    # unset or empty so `uv run` needs no system Java install. An explicit,
+    # non-empty JAVA_HOME is respected.
+    if not os.environ.get("JAVA_HOME"):
+        os.environ["JAVA_HOME"] = str(jdk4py.JAVA_HOME)
 
     orekit.initVM()
 

--- a/tools/generate_orekit_msise_density_fixtures.py
+++ b/tools/generate_orekit_msise_density_fixtures.py
@@ -24,7 +24,16 @@ from pathlib import Path
 
 def setup_orekit():
     """Initialize Orekit JVM and data."""
+    import os
+
+    import jdk4py
     import orekit_jpype as orekit
+
+    # jpype finds the JVM via JAVA_HOME; point it at the bundled jdk4py JDK when
+    # unset or empty so `uv run` needs no system Java install. An explicit,
+    # non-empty JAVA_HOME is respected.
+    if not os.environ.get("JAVA_HOME"):
+        os.environ["JAVA_HOME"] = str(jdk4py.JAVA_HOME)
 
     orekit.initVM()
 

--- a/tools/generate_orekit_propagation_fixtures.py
+++ b/tools/generate_orekit_propagation_fixtures.py
@@ -51,7 +51,16 @@ DEFAULT_BALLISTIC_COEFF = 0.01      # m²/kg
 
 def setup_orekit():
     """Initialize Orekit JVM and data."""
+    import os
+
+    import jdk4py
     import orekit_jpype as orekit
+
+    # jpype finds the JVM via JAVA_HOME; point it at the bundled jdk4py JDK when
+    # unset or empty so `uv run` needs no system Java install. An explicit,
+    # non-empty JAVA_HOME is respected.
+    if not os.environ.get("JAVA_HOME"):
+        os.environ["JAVA_HOME"] = str(jdk4py.JAVA_HOME)
 
     orekit.initVM()
 


### PR DESCRIPTION
## 背景

Orekit fixture 生成器（`tools/generate_*.py`、4本）は PEP-723 の `uv run` スクリプトで、依存に `orekit-jpype` と `jdk4py`（JDK 同梱）を宣言している。しかし VM 初期化は `orekit.initVM()` を呼ぶだけで、jpype は `JAVA_HOME` から JVM を探すため、**system に `JAVA_HOME` が無い環境では jdk4py 同梱の JDK を見つけられず `JVMNotFoundException` で落ちる**。

## やること

各生成器の `setup_orekit()` で、`JAVA_HOME` が未設定または空のとき jdk4py 同梱 JDK を指すよう設定する（明示的な非空 `JAVA_HOME` は尊重）。これで `uv run tools/generate_*.py` が system の Java install 無しで動く。

## 価値

- ローカルで `uv run` が self-contained（system JDK 不要）。
- 将来 CI に「fixture が再現可能か」を検証するジョブを足す場合、`setup-java` ステップ無しで走らせられる。
  - ※ 現状 CI は Java を install しておらず、生成器も CI で走っていないので、**今削れる CI ステップは無い**。あくまで将来そういうジョブを足すときの前提が一つ減る、という位置づけ。

## 検証

- 4本とも `python -m py_compile` OK
- `uv run` での VM 初期化を smoke test で確認（system `JAVA_HOME` 無しで JVM 起動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)