### PR TITLE
feat(arika): precision tier in the type — Epoch<S, P: Precision>

### DIFF
--- a/arika/src/epoch/convert.rs
+++ b/arika/src/epoch/convert.rs
@@ -29,8 +29,9 @@ use core::f64::consts::TAU;
 use crate::math::F64Ext;
 
 use super::TimeScale;
-use super::jd2::TwoPartJd;
+use super::jd2::JdRepr;
 use super::leap::tai_minus_utc_at_mjd;
+use super::precision::{Precise, Precision};
 use super::{Epoch, Gps, Tai, Tdb, Tt, Utc};
 use super::{GPS_MINUS_TAI_SEC, J2000_JD, JULIAN_CENTURY, MJD_OFFSET, TT_MINUS_TAI_SEC};
 
@@ -69,23 +70,25 @@ impl FixedOffsetFromTai for Gps {
 // full precision in between. (UT1 is not in the family — it needs EOP — so it
 // has no lens; see `Ut1Epoch`.)
 
-/// Data-free lens between canonical TAI and a scale's own Julian Date.
-/// Crate-internal: the canonical-TAI `Epoch<S>` accessors call it per scale.
+/// Data-free lens between canonical TAI and a scale's own Julian Date. Generic
+/// over the JD storage [`R: JdRepr`](JdRepr) so one implementation serves every
+/// [`Precision`] tier. Crate-internal: the canonical-TAI `Epoch` accessors call
+/// it per scale.
 pub(crate) trait TaiLens: TimeScale {
     /// This scale's JD → the canonical TAI JD.
-    fn tai_from_scale(scale_jd: TwoPartJd) -> TwoPartJd;
+    fn tai_from_scale<R: JdRepr>(scale_jd: R) -> R;
     /// Canonical TAI JD → this scale's JD.
-    fn scale_from_tai(tai: TwoPartJd) -> TwoPartJd;
+    fn scale_from_tai<R: JdRepr>(tai: R) -> R;
 }
 
 /// Derive [`TaiLens`] for a [`FixedOffsetFromTai`] scale: `scale = TAI + off`.
 macro_rules! impl_tai_lens_fixed {
     ($scale:ty) => {
         impl TaiLens for $scale {
-            fn tai_from_scale(scale_jd: TwoPartJd) -> TwoPartJd {
+            fn tai_from_scale<R: JdRepr>(scale_jd: R) -> R {
                 scale_jd.add_days(-<$scale as FixedOffsetFromTai>::SECONDS_AFTER_TAI / 86400.0)
             }
-            fn scale_from_tai(tai: TwoPartJd) -> TwoPartJd {
+            fn scale_from_tai<R: JdRepr>(tai: R) -> R {
                 tai.add_days(<$scale as FixedOffsetFromTai>::SECONDS_AFTER_TAI / 86400.0)
             }
         }
@@ -96,11 +99,11 @@ impl_tai_lens_fixed!(Tt);
 impl_tai_lens_fixed!(Gps);
 
 impl TaiLens for Utc {
-    fn tai_from_scale(utc: TwoPartJd) -> TwoPartJd {
+    fn tai_from_scale<R: JdRepr>(utc: R) -> R {
         let leap = tai_minus_utc_at_mjd(utc.jd() - MJD_OFFSET);
         utc.add_days(leap / 86400.0)
     }
-    fn scale_from_tai(tai: TwoPartJd) -> TwoPartJd {
+    fn scale_from_tai<R: JdRepr>(tai: R) -> R {
         // Seed the leap-count search with the current maximum TAI − UTC; any
         // seed within one leap step of the true offset converges in 3 iters.
         const LEAP_SEED_SEC: f64 = 37.0; // TAI − UTC since 2017-01-01
@@ -114,46 +117,46 @@ impl TaiLens for Utc {
 }
 
 impl TaiLens for Tdb {
-    fn tai_from_scale(tdb: TwoPartJd) -> TwoPartJd {
+    fn tai_from_scale<R: JdRepr>(tdb: R) -> R {
         // TDB → TT (single-step inversion, |TDB − TT| < 2 ms) → TAI.
         let tt = tdb.add_days(-tdb_minus_tt(tdb.jd()) / 86400.0);
         tt.add_days(-TT_MINUS_TAI_SEC / 86400.0)
     }
-    fn scale_from_tai(tai: TwoPartJd) -> TwoPartJd {
+    fn scale_from_tai<R: JdRepr>(tai: R) -> R {
         // TAI → TT → TDB (Fairhead-Bretagnon periodic).
         let tt = tai.add_days(TT_MINUS_TAI_SEC / 86400.0);
         tt.add_days(tdb_minus_tt(tt.jd()) / 86400.0)
     }
 }
 
-/// Construct an `Epoch<S>` from a JD interpreted in scale `S`, converting to
-/// the stored canonical TAI instant via the lens.
-pub(crate) fn from_scale_jd<S: TaiLens>(scale_jd: f64) -> Epoch<S> {
-    Epoch::<S>::from_tai_raw(S::tai_from_scale(TwoPartJd::from_jd(scale_jd)))
+/// Construct an `Epoch<S, P>` from a JD interpreted in scale `S`, converting to
+/// the stored canonical TAI instant (at precision tier `P`) via the lens.
+pub(crate) fn from_scale_jd<S: TaiLens, P: Precision>(scale_jd: f64) -> Epoch<S, P> {
+    Epoch::<S, P>::from_tai_raw(S::tai_from_scale(<P::Repr as JdRepr>::from_jd(scale_jd)))
 }
 
 // UTC outbound conversions (re-tags of the shared canonical TAI instant)
 
-impl Epoch<Utc> {
+impl<P: Precision> Epoch<Utc, P> {
     /// Convert to TAI (re-tag of the shared canonical instant).
-    pub fn to_tai(&self) -> Epoch<Tai> {
-        Epoch::<Tai>::from_tai_raw(self.tai_raw())
+    pub fn to_tai(&self) -> Epoch<Tai, P> {
+        Epoch::<Tai, P>::from_tai_raw(self.tai_raw())
     }
 
     /// Convert to TT (re-tag of the shared canonical instant).
-    pub fn to_tt(&self) -> Epoch<Tt> {
-        Epoch::<Tt>::from_tai_raw(self.tai_raw())
+    pub fn to_tt(&self) -> Epoch<Tt, P> {
+        Epoch::<Tt, P>::from_tai_raw(self.tai_raw())
     }
 
     /// Convert to TDB (re-tag of the shared canonical instant).
-    pub fn to_tdb(&self) -> Epoch<Tdb> {
-        Epoch::<Tdb>::from_tai_raw(self.tai_raw())
+    pub fn to_tdb(&self) -> Epoch<Tdb, P> {
+        Epoch::<Tdb, P>::from_tai_raw(self.tai_raw())
     }
 
     /// Convert to GPS Time (re-tag of the shared canonical instant).
     /// `GPS − UTC` equals the current leap count minus 19 s (18 s since 2017).
-    pub fn to_gps(&self) -> Epoch<Gps> {
-        Epoch::<Gps>::from_tai_raw(self.tai_raw())
+    pub fn to_gps(&self) -> Epoch<Gps, P> {
+        Epoch::<Gps, P>::from_tai_raw(self.tai_raw())
     }
 
     /// Convert to UT1 assuming UT1 ≈ UTC (naive, legacy behavior).
@@ -184,7 +187,7 @@ impl Epoch<Utc> {
     ///
     /// For a naive `dUT1 = 0` conversion used by the legacy simple rotation
     /// path, use [`Epoch::<Utc>::to_ut1_naive`] instead.
-    pub fn to_ut1<P: crate::earth::eop::Ut1Offset + ?Sized>(&self, eop: &P) -> Ut1Epoch {
+    pub fn to_ut1<E: crate::earth::eop::Ut1Offset + ?Sized>(&self, eop: &E) -> Ut1Epoch {
         let mjd = self.jd() - MJD_OFFSET;
         let dut1 = eop.dut1(mjd);
         Ut1Epoch::from_jd_ut1(self.jd() + dut1 / 86400.0)
@@ -196,22 +199,24 @@ impl Epoch<Utc> {
 impl Epoch<Tai> {
     /// Create a TAI epoch from a Julian Date value interpreted as TAI JD.
     pub fn from_jd_tai(jd: f64) -> Self {
-        from_scale_jd::<Tai>(jd)
+        from_scale_jd::<Tai, Precise>(jd)
     }
+}
 
+impl<P: Precision> Epoch<Tai, P> {
     /// Convert to UTC (re-tag of the shared canonical instant).
-    pub fn to_utc(&self) -> Epoch<Utc> {
-        Epoch::<Utc>::from_tai_raw(self.tai_raw())
+    pub fn to_utc(&self) -> Epoch<Utc, P> {
+        Epoch::<Utc, P>::from_tai_raw(self.tai_raw())
     }
 
     /// Convert to TT (re-tag of the shared canonical instant).
-    pub fn to_tt(&self) -> Epoch<Tt> {
-        Epoch::<Tt>::from_tai_raw(self.tai_raw())
+    pub fn to_tt(&self) -> Epoch<Tt, P> {
+        Epoch::<Tt, P>::from_tai_raw(self.tai_raw())
     }
 
     /// Convert to GPS Time (re-tag of the shared canonical instant).
-    pub fn to_gps(&self) -> Epoch<Gps> {
-        Epoch::<Gps>::from_tai_raw(self.tai_raw())
+    pub fn to_gps(&self) -> Epoch<Gps, P> {
+        Epoch::<Gps, P>::from_tai_raw(self.tai_raw())
     }
 }
 
@@ -220,17 +225,19 @@ impl Epoch<Tai> {
 impl Epoch<Gps> {
     /// Create a GPS epoch from a Julian Date value interpreted as GPS JD.
     pub fn from_jd_gps(jd: f64) -> Self {
-        from_scale_jd::<Gps>(jd)
+        from_scale_jd::<Gps, Precise>(jd)
     }
+}
 
+impl<P: Precision> Epoch<Gps, P> {
     /// Convert to TAI (re-tag of the shared canonical instant).
-    pub fn to_tai(&self) -> Epoch<Tai> {
-        Epoch::<Tai>::from_tai_raw(self.tai_raw())
+    pub fn to_tai(&self) -> Epoch<Tai, P> {
+        Epoch::<Tai, P>::from_tai_raw(self.tai_raw())
     }
 
     /// Convert to UTC (re-tag of the shared canonical instant).
-    pub fn to_utc(&self) -> Epoch<Utc> {
-        Epoch::<Utc>::from_tai_raw(self.tai_raw())
+    pub fn to_utc(&self) -> Epoch<Utc, P> {
+        Epoch::<Utc, P>::from_tai_raw(self.tai_raw())
     }
 }
 
@@ -239,9 +246,11 @@ impl Epoch<Gps> {
 impl Epoch<Tt> {
     /// Create a TT epoch from a Julian Date value interpreted as TT JD.
     pub fn from_jd_tt(jd: f64) -> Self {
-        from_scale_jd::<Tt>(jd)
+        from_scale_jd::<Tt, Precise>(jd)
     }
+}
 
+impl<P: Precision> Epoch<Tt, P> {
     /// Return TT Julian centuries since J2000.0.
     ///
     /// この値が IAU 2006 precession / IAU 2000A/B nutation の独立変数。
@@ -250,13 +259,13 @@ impl Epoch<Tt> {
     }
 
     /// Convert to TAI (re-tag of the shared canonical instant).
-    pub fn to_tai(&self) -> Epoch<Tai> {
-        Epoch::<Tai>::from_tai_raw(self.tai_raw())
+    pub fn to_tai(&self) -> Epoch<Tai, P> {
+        Epoch::<Tai, P>::from_tai_raw(self.tai_raw())
     }
 
     /// Convert to TDB (re-tag of the shared canonical instant).
-    pub fn to_tdb(&self) -> Epoch<Tdb> {
-        Epoch::<Tdb>::from_tai_raw(self.tai_raw())
+    pub fn to_tdb(&self) -> Epoch<Tdb, P> {
+        Epoch::<Tdb, P>::from_tai_raw(self.tai_raw())
     }
 }
 
@@ -268,9 +277,11 @@ impl Epoch<Tdb> {
     /// JPL DE ephemerides use `Teph` which is for practical purposes
     /// indistinguishable from TDB (IAU 2006 Resolution B3).
     pub fn from_jd_tdb(jd: f64) -> Self {
-        from_scale_jd::<Tdb>(jd)
+        from_scale_jd::<Tdb, Precise>(jd)
     }
+}
 
+impl<P: Precision> Epoch<Tdb, P> {
     /// Return TDB Julian centuries since J2000.0.
     ///
     /// Meeus / JPL DE ephemeris と IAU 2009 WGCCRE body rotation の独立変数。
@@ -279,8 +290,8 @@ impl Epoch<Tdb> {
     }
 
     /// Convert to TT (re-tag of the shared canonical instant).
-    pub fn to_tt(&self) -> Epoch<Tt> {
-        Epoch::<Tt>::from_tai_raw(self.tai_raw())
+    pub fn to_tt(&self) -> Epoch<Tt, P> {
+        Epoch::<Tt, P>::from_tai_raw(self.tai_raw())
     }
 }
 
@@ -355,11 +366,12 @@ fn tdb_minus_tt(tt_jd: f64) -> f64 {
 
 #[cfg(test)]
 mod lens_tests {
-    //! The `TaiLens` math must agree with the existing one-hop edge methods
-    //! (which it will replace once `Epoch<S>` stores canonical TAI), and must
-    //! round-trip. Agreement is to f64 noise since the lens does the same
-    //! arithmetic in two parts.
+    //! The `TaiLens` math must agree with the one-hop edge `to_*()` methods and
+    //! must round-trip. Agreement is to f64 noise since the lens does the same
+    //! arithmetic. Exercised on the [`TwoPartJd`] representation (the lens is
+    //! generic over [`JdRepr`], so the coarse `f64` path is the same code).
     use super::*;
+    use super::super::jd2::{JdRepr, TwoPartJd};
 
     const TOL_DAY: f64 = 1e-9; // ~86 µs — well above f64 noise, below the regime we care about
 

--- a/arika/src/epoch/convert.rs
+++ b/arika/src/epoch/convert.rs
@@ -370,8 +370,8 @@ mod lens_tests {
     //! must round-trip. Agreement is to f64 noise since the lens does the same
     //! arithmetic. Exercised on the [`TwoPartJd`] representation (the lens is
     //! generic over [`JdRepr`], so the coarse `f64` path is the same code).
-    use super::*;
     use super::super::jd2::{JdRepr, TwoPartJd};
+    use super::*;
 
     const TOL_DAY: f64 = 1e-9; // ~86 µs — well above f64 noise, below the regime we care about
 

--- a/arika/src/epoch/gps.rs
+++ b/arika/src/epoch/gps.rs
@@ -14,7 +14,7 @@
 //! to pick a rollover convention — keeps the constructor unambiguous and makes
 //! broadcast de-rolling an explicit, separately testable step.
 
-use super::{Epoch, GPS_EPOCH_JD, Gps};
+use super::{Epoch, GPS_EPOCH_JD, Gps, Precision};
 // `floor`/`round` resolve to inherent std methods under `std`; this import
 // provides them for `no_std` (libm) and is unused otherwise.
 #[allow(unused_imports)]
@@ -54,7 +54,7 @@ impl GpsWeek {
     /// to be within ~9.8 years (half a rollover period) of the true epoch for
     /// the resolution to be correct — e.g. the receiver's build date or a coarse
     /// current time. A non-finite / pre-epoch `reference` is treated as era 0.
-    pub fn from_broadcast(raw10: u16, reference: &Epoch<Gps>) -> Self {
+    pub fn from_broadcast<P: Precision>(raw10: u16, reference: &Epoch<Gps, P>) -> Self {
         let raw = (raw10 as i64) % BROADCAST_WEEK_MODULUS;
         let r = reference
             .to_week_seconds()
@@ -93,7 +93,9 @@ impl Epoch<Gps> {
     pub fn from_week_seconds(week: GpsWeek, sow: SecondsOfWeek) -> Self {
         Self::from_jd_gps(GPS_EPOCH_JD + week.get() as f64 * 7.0 + sow.get() / 86400.0)
     }
+}
 
+impl<P: Precision> Epoch<Gps, P> {
     /// Decompose into `(continuous week, seconds-of-week)`.
     ///
     /// Returns `None` unless this is a valid GPS instant — finite and at or

--- a/arika/src/epoch/jd2.rs
+++ b/arika/src/epoch/jd2.rs
@@ -23,13 +23,19 @@ fn two_sum(a: f64, b: f64) -> (f64, f64) {
     (s, e)
 }
 
+mod sealed {
+    pub trait Sealed {}
+}
+impl sealed::Sealed for f64 {}
+impl sealed::Sealed for TwoPartJd {}
+
 /// The Julian Date storage behind a canonical-TAI [`Epoch`](super::Epoch): a JD
 /// value plus the day-level arithmetic the epoch applies (lens conversion,
-/// `duration_since`, `add_si_seconds`). Implemented by [`f64`] (the coarse tier)
-/// and [`TwoPartJd`] (the precise tier); which one an `Epoch` stores is selected
-/// by its [`Precision`](super::Precision). The two impls are the only intended
-/// ones.
-pub trait JdRepr: Copy + PartialEq + core::fmt::Debug {
+/// `duration_since`, `add_si_seconds`). Sealed — the only impls are [`f64`] (the
+/// coarse tier) and [`TwoPartJd`] (the precise tier); which one an `Epoch` stores
+/// is selected by its (also sealed) [`Precision`](super::Precision), so this is a
+/// closed set, not a downstream extension point.
+pub trait JdRepr: sealed::Sealed + Copy + PartialEq + core::fmt::Debug {
     /// From a single `f64` JD. For [`TwoPartJd`] the residual is zero — precision
     /// beyond `f64` is only created by the arithmetic methods, never ingested
     /// here.

--- a/arika/src/epoch/jd2.rs
+++ b/arika/src/epoch/jd2.rs
@@ -1,13 +1,17 @@
-//! Two-part Julian Date (`hi + lo`) for sub-nanosecond time precision.
+//! Julian Date storage for the canonical-TAI [`Epoch`](super::Epoch).
 //!
-//! A single `f64` Julian Date floors resolution at tens of µs near modern
-//! epochs (the mantissa is spent on the ~2.46e6 integer part) and cancels
-//! catastrophically when differencing epochs near J2000. Carrying the value as
-//! two `f64`s — a high part plus a small residual, as SOFA's two-part date
-//! arguments do — keeps the full mantissa available for the sub-day fraction.
+//! [`JdRepr`] abstracts the day-level arithmetic an `Epoch` needs over its two
+//! precision tiers (selected by [`Precision`](super::Precision)):
 //!
-//! Internal building block for the canonical-TAI [`Epoch`](super::Epoch); not a
-//! public API.
+//! - [`f64`] — the [`Coarse`](super::Coarse) tier. A single `f64` Julian Date
+//!   floors resolution at tens of µs near modern epochs (the mantissa is spent
+//!   on the ~2.46e6 integer part) and cancels catastrophically when differencing
+//!   epochs near J2000. Lighter (8 bytes, no residual arithmetic) for wasm /
+//!   `no_std` embedded targets that don't need sub-µs time.
+//! - [`TwoPartJd`] — the [`Precise`](super::Precise) tier (the default). Carries
+//!   the value as two `f64`s, a high part plus a small residual, as SOFA's
+//!   two-part date arguments do — keeping the full mantissa available for the
+//!   sub-day fraction (sub-nanosecond resolution, exact J2000-relative diffs).
 
 /// Knuth's two-sum: exact `a + b = s + e` with `s = fl(a+b)` and `e` the
 /// rounding error. No ordering requirement on `|a|`, `|b|`.
@@ -19,58 +23,113 @@ fn two_sum(a: f64, b: f64) -> (f64, f64) {
     (s, e)
 }
 
+/// The Julian Date storage behind a canonical-TAI [`Epoch`](super::Epoch): a JD
+/// value plus the day-level arithmetic the epoch applies (lens conversion,
+/// `duration_since`, `add_si_seconds`). Implemented by [`f64`] (the coarse tier)
+/// and [`TwoPartJd`] (the precise tier); which one an `Epoch` stores is selected
+/// by its [`Precision`](super::Precision). The two impls are the only intended
+/// ones.
+pub trait JdRepr: Copy + PartialEq + core::fmt::Debug {
+    /// From a single `f64` JD. For [`TwoPartJd`] the residual is zero — precision
+    /// beyond `f64` is only created by the arithmetic methods, never ingested
+    /// here.
+    fn from_jd(jd: f64) -> Self;
+
+    /// From an explicit high part and residual. For [`f64`] this collapses to
+    /// `hi + lo`; for [`TwoPartJd`] it retains the residual (renormalized). This
+    /// is the lossless bridge between tiers (see
+    /// [`Epoch::to_precision`](super::Epoch::to_precision)).
+    fn from_parts(hi: f64, lo: f64) -> Self;
+
+    /// The value as a single `f64` (a lossy collapse for the precise tier).
+    fn jd(self) -> f64;
+
+    /// The `(hi, lo)` parts; `lo` is always `0.0` for the coarse `f64` tier.
+    fn parts(self) -> (f64, f64);
+
+    /// Add `days`, keeping whatever precision the representation carries.
+    fn add_days(self, days: f64) -> Self;
+
+    /// Difference `self - other` in days.
+    fn diff_days(self, other: Self) -> f64;
+}
+
+/// Coarse tier: a single `f64` JD. ~tens-of-µs resolution near modern epochs.
+impl JdRepr for f64 {
+    #[inline]
+    fn from_jd(jd: f64) -> Self {
+        jd
+    }
+
+    #[inline]
+    fn from_parts(hi: f64, lo: f64) -> Self {
+        hi + lo
+    }
+
+    #[inline]
+    fn jd(self) -> f64 {
+        self
+    }
+
+    #[inline]
+    fn parts(self) -> (f64, f64) {
+        (self, 0.0)
+    }
+
+    #[inline]
+    fn add_days(self, days: f64) -> Self {
+        self + days
+    }
+
+    #[inline]
+    fn diff_days(self, other: Self) -> f64 {
+        self - other
+    }
+}
+
 /// A Julian Date carried as `hi + lo`, normalized so `hi == fl(hi + lo)` and
 /// `lo` holds the residual. The represented value is exactly `hi + lo` in
-/// extended precision.
+/// extended precision. The [`Precise`](super::Precise) tier's storage.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub(crate) struct TwoPartJd {
+pub struct TwoPartJd {
     hi: f64,
     lo: f64,
 }
 
-impl TwoPartJd {
-    /// From a single `f64` JD (residual zero). This is the f64-precision entry
-    /// point; precision beyond `f64` requires [`from_parts`](Self::from_parts).
+impl JdRepr for TwoPartJd {
     #[inline]
-    pub(crate) fn from_jd(jd: f64) -> Self {
+    fn from_jd(jd: f64) -> Self {
         Self { hi: jd, lo: 0.0 }
     }
 
-    /// From an explicit high part and residual, renormalized so the invariant
-    /// `hi == fl(hi + lo)` holds.
     #[inline]
-    pub(crate) fn from_parts(hi: f64, lo: f64) -> Self {
+    fn from_parts(hi: f64, lo: f64) -> Self {
         let (s, e) = two_sum(hi, lo);
         Self { hi: s, lo: e }
     }
 
-    /// The value as a single `f64` (lossy combine; for back-compat / display).
     #[inline]
-    pub(crate) fn jd(self) -> f64 {
+    fn jd(self) -> f64 {
         self.hi + self.lo
     }
 
-    /// The `(hi, lo)` parts (lossless).
     #[inline]
-    pub(crate) fn parts(self) -> (f64, f64) {
+    fn parts(self) -> (f64, f64) {
         (self.hi, self.lo)
     }
 
-    /// Add `days` (a full-precision `f64`) keeping extended precision.
     #[inline]
-    pub(crate) fn add_days(self, days: f64) -> Self {
+    fn add_days(self, days: f64) -> Self {
         let (s, e) = two_sum(self.hi, days);
-        Self::from_parts(s, e + self.lo)
+        <Self as JdRepr>::from_parts(s, e + self.lo)
     }
 
-    /// Difference `self - other` in days, in extended precision.
-    ///
     /// `two_sum` on the high parts captures their subtraction's rounding error
     /// exactly (for any magnitudes), so no significance is lost even when the
     /// high parts are large and close — the J2000-cancellation case. The
     /// residual difference is then folded into that error term.
     #[inline]
-    pub(crate) fn diff_days(self, other: Self) -> f64 {
+    fn diff_days(self, other: Self) -> f64 {
         let (dh, eh) = two_sum(self.hi, -other.hi);
         // (hi diff) + (hi-diff rounding error) + (lo diff)
         dh + (eh + (self.lo - other.lo))
@@ -142,5 +201,16 @@ mod tests {
         let nan = TwoPartJd::from_jd(f64::NAN);
         let ok = TwoPartJd::from_jd(2_460_000.0);
         assert!(nan.diff_days(ok).is_nan());
+    }
+
+    #[test]
+    fn coarse_f64_tier_collapses_residual() {
+        // The coarse (f64) tier carries no residual: from_parts collapses to
+        // hi+lo and parts() reports lo == 0. (Contrast from_parts_normalizes.)
+        let hi = 2_460_000.0;
+        let lo = 1e-9;
+        let c = <f64 as JdRepr>::from_parts(hi, lo);
+        assert_eq!(c, hi + lo);
+        assert_eq!(<f64 as JdRepr>::parts(c), (hi + lo, 0.0));
     }
 }

--- a/arika/src/epoch/mod.rs
+++ b/arika/src/epoch/mod.rs
@@ -45,18 +45,20 @@ mod duration;
 mod gps;
 mod jd2;
 mod leap;
+mod precision;
 mod scale;
 
 pub use convert::{FixedOffsetFromTai, Ut1Epoch};
 pub use datetime::DateTime;
 pub use duration::Duration;
 pub use gps::{GpsWeek, SecondsOfWeek};
+pub use jd2::{JdRepr, TwoPartJd};
+pub use precision::{Coarse, Precise, Precision};
 pub use scale::{Gps, Tai, Tdb, TimeScale, Tt, Utc};
 
 use convert::TaiLens;
 use convert::era_formula;
 use datetime::to_datetime_from_jd;
-use jd2::TwoPartJd;
 
 /// Julian Date of J2000.0 epoch (JD 2451545.0).
 ///
@@ -88,41 +90,84 @@ pub const GPS_EPOCH_JD: f64 = 2444244.5;
 #[cfg(feature = "std")]
 const UNIX_EPOCH_JD: f64 = 2440587.5;
 
-/// An astronomical epoch represented as Julian Date in scale `S`.
+/// An astronomical epoch represented as Julian Date in scale `S`, stored at
+/// precision tier `P`.
 ///
-/// `S` defaults to [`Utc`] so that `Epoch` (without type parameter) means
-/// `Epoch<Utc>` — the most common user-facing scale.
+/// `S` defaults to [`Utc`] and `P` to [`Precise`], so that `Epoch` (without type
+/// parameters) means `Epoch<Utc, Precise>` — the most common user-facing scale
+/// at sub-nanosecond precision.
 ///
 /// # 内部表現: canonical TAI
 ///
-/// 内部は **canonical な TAI instant を two-part ([`TwoPartJd`]) で保持**し、`S` は
-/// 読み出しレンズである。`jd()` は格納された TAI を scale `S` の JD に変換して返す:
-/// `Epoch<Utc>::from_jd(x).jd() == x` (UTC JD として round-trip)、
+/// 内部は **canonical な TAI instant を精度 tier `P` の表現 ([`P::Repr`](Precision::Repr))
+/// で保持**し、`S` は読み出しレンズである。`P = Precise` なら two-part [`TwoPartJd`]、
+/// `P = Coarse` なら単一 [`f64`]。`jd()` は格納された TAI を scale `S` の JD に
+/// 変換して返す: `Epoch<Utc>::from_jd(x).jd() == x` (UTC JD として round-trip)、
 /// `Epoch<Tdb>::from_jd_tdb(x).jd() == x` (TDB JD として round-trip)。
 ///
 /// scale 変換 (`to_tt()`, `to_tdb()` 等) は同じ TAI instant の **非破壊な再ラベル**で、
 /// leap second / Fairhead 補正は構築時 (`from_*`) と読み出し時 (`jd()`) の lens
 /// ([`TaiLens`]) でのみ適用される。同一物理 instant は同一内部値なので
 /// `duration_since` は leap 跨ぎ・cross-scale でも厳密な SI 秒を返す。
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Epoch<S: TimeScale = Utc> {
-    /// Canonical TAI instant (two-part JD). Read out in scale `S` via the lens.
-    tai: TwoPartJd,
+///
+/// # 精度 tier の選択
+///
+/// 豊富なコンストラクタ (`from_jd`, `from_gregorian`, …) は既定の [`Precise`] を
+/// 作る。[`Coarse`] が欲しい場合は [`to_precision`](Self::to_precision) で
+/// 変換する (例: `epoch.to_precision::<Coarse>()`)。tier は型の一部なので、
+/// 別 tier の `Epoch` 同士の演算は明示的な変換を要する。
+pub struct Epoch<S: TimeScale = Utc, P: Precision = Precise> {
+    /// Canonical TAI instant, stored at precision tier `P`. Read out in scale
+    /// `S` via the lens.
+    tai: P::Repr,
     /// Scale tag (zero-sized).
     _scale: PhantomData<S>,
 }
 
-// Generic accessors (available on all scales)
+// Manual `Copy`/`Clone`/`PartialEq`/`Debug`: `#[derive]` would bound them on
+// `P: Trait` rather than on the stored field `P::Repr`, which doesn't hold. The
+// `P: Precision` bound gives `P::Repr: JdRepr`, hence `Copy + PartialEq + Debug`.
 
-impl<S: TimeScale> Epoch<S> {
+impl<S: TimeScale, P: Precision> Clone for Epoch<S, P> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<S: TimeScale, P: Precision> Copy for Epoch<S, P> {}
+
+impl<S: TimeScale, P: Precision> PartialEq for Epoch<S, P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.tai == other.tai
+    }
+}
+
+impl<S: TimeScale, P: Precision> core::fmt::Debug for Epoch<S, P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Epoch")
+            .field("scale", &S::NAME)
+            .field("precision", &P::NAME)
+            .field("tai", &self.tai)
+            .finish()
+    }
+}
+
+// Generic accessors (available on all scales and precision tiers)
+
+impl<S: TimeScale, P: Precision> Epoch<S, P> {
     /// The human-readable scale name (e.g. "UTC", "TDB").
     pub fn scale_name() -> &'static str {
         S::NAME
     }
 
+    /// The precision-tier name ("precise" / "coarse").
+    pub fn precision_name() -> &'static str {
+        P::NAME
+    }
+
     /// Crate-internal constructor from the canonical TAI instant, tagging scale
     /// `S`. Scale conversions are exactly this (a re-tag of the same `tai`).
-    pub(crate) fn from_tai_raw(tai: TwoPartJd) -> Self {
+    pub(crate) fn from_tai_raw(tai: P::Repr) -> Self {
         Self {
             tai,
             _scale: PhantomData,
@@ -130,26 +175,41 @@ impl<S: TimeScale> Epoch<S> {
     }
 
     /// Crate-internal accessor for the canonical TAI instant.
-    pub(crate) fn tai_raw(&self) -> TwoPartJd {
+    pub(crate) fn tai_raw(&self) -> P::Repr {
         self.tai
     }
 
     /// Exact SI-second interval since `earlier`, measured on the shared TAI
     /// timeline — correct across leap seconds and across *any* scales (both
     /// epochs store canonical TAI, so `earlier` may be in a different scale).
-    pub fn duration_since<T: TimeScale>(&self, earlier: &Epoch<T>) -> Duration {
+    ///
+    /// Both epochs must share the precision tier `P`; difference a mixed pair by
+    /// first aligning tiers with [`to_precision`](Self::to_precision).
+    pub fn duration_since<T: TimeScale>(&self, earlier: &Epoch<T, P>) -> Duration {
         Duration::from_si_seconds(self.tai.diff_days(earlier.tai_raw()) * 86400.0)
+    }
+
+    /// Re-express this epoch at precision tier `Q`, preserving the same scale
+    /// `S` and canonical TAI instant.
+    ///
+    /// The instant is carried across via its `(hi, lo)` parts: [`Precise`] →
+    /// [`Precise`] is exact, [`Coarse`] → [`Precise`] lifts the `f64` (residual
+    /// zero), and [`Precise`] → [`Coarse`] collapses to `hi + lo` (dropping the
+    /// sub-`f64` residual the coarse tier cannot hold).
+    pub fn to_precision<Q: Precision>(&self) -> Epoch<S, Q> {
+        let (hi, lo) = self.tai.parts();
+        Epoch::<S, Q>::from_tai_raw(<Q::Repr as JdRepr>::from_parts(hi, lo))
     }
 }
 
 // Read-out accessors: lens the stored canonical TAI into scale `S`'s JD.
 //
-// Concrete per scale (not a generic `impl<S: TaiLens>`) so the crate-internal
-// `TaiLens` / `TwoPartJd` types stay off the public API — a public generic
-// bounded by them would leak them (`private_interfaces`).
+// Concrete per scale (not a generic `impl<S: TaiLens, P>`) so the crate-internal
+// `TaiLens` trait stays off the public API — a public generic bounded by it
+// would leak it (`private_interfaces`/`private_bounds`).
 macro_rules! impl_jd_accessors {
     ($scale:ty) => {
-        impl Epoch<$scale> {
+        impl<P: Precision> Epoch<$scale, P> {
             /// Return the Julian Date, interpreted in this scale (lens read-out
             /// of the canonical TAI instant; single-`f64` collapse).
             pub fn jd(&self) -> f64 {
@@ -159,10 +219,11 @@ macro_rules! impl_jd_accessors {
             /// The Julian Date as a precise two-part `(hi, lo)` value — for
             /// feeding SOFA-style two-part consumers without the `jd()` collapse.
             ///
-            /// `lo` carries the conversion's sub-`f64` residual; since every
-            /// constructor currently ingests a single `f64`, it reflects the
-            /// lens arithmetic, not user-supplied sub-`f64` input precision (a
-            /// two-part ingestion path is future work).
+            /// On the [`Precise`] tier `lo` carries the conversion's sub-`f64`
+            /// residual; since every constructor currently ingests a single
+            /// `f64`, it reflects the lens arithmetic, not user-supplied sub-`f64`
+            /// input precision (a two-part ingestion path is future work). On the
+            /// [`Coarse`] tier `lo` is always `0.0`.
             pub fn jd_parts(&self) -> (f64, f64) {
                 <$scale as TaiLens>::scale_from_tai(self.tai).parts()
             }
@@ -180,7 +241,14 @@ impl_jd_accessors!(Tt);
 impl_jd_accessors!(Tdb);
 impl_jd_accessors!(Gps);
 
-// Epoch<Utc> API (main user-facing scale)
+// Epoch<Utc> constructors (main user-facing scale).
+//
+// Constructors build the default `Precise` tier. They stay on the concrete
+// `impl Epoch<Utc>` (= `Epoch<Utc, Precise>`) rather than `impl<P> Epoch<Utc, P>`
+// so that bare calls like `Epoch::from_jd(x)` infer the tier — a default type
+// parameter is not a fallback for an unconstrained inference variable in
+// expression position. For a `Coarse` epoch, build `Precise` then
+// [`to_precision`](Self::to_precision).
 
 impl Epoch<Utc> {
     /// Create a UTC epoch from a Julian Date (treated as UTC JD).
@@ -188,7 +256,7 @@ impl Epoch<Utc> {
     /// `Epoch<Utc>::from_jd(x).jd() == x` (round-trip identity). The value is
     /// stored internally as the corresponding canonical TAI instant.
     pub fn from_jd(jd: f64) -> Self {
-        convert::from_scale_jd::<Utc>(jd)
+        convert::from_scale_jd::<Utc, Precise>(jd)
     }
 
     /// Create a UTC epoch from a Modified Julian Date value.
@@ -322,7 +390,12 @@ impl Epoch<Utc> {
         };
         Self::from_year_day_of_year(year, day_of_year)
     }
+}
 
+// Epoch<Utc> methods (available on every precision tier; `P` is inferred from
+// `self`, so these need no concrete-tier pinning).
+
+impl<P: Precision> Epoch<Utc, P> {
     /// Julian centuries since J2000.0, computed directly from the UTC JD.
     ///
     /// **Note**: This treats the UTC JD as if it were a dynamical-time JD,
@@ -340,7 +413,7 @@ impl Epoch<Utc> {
     /// Legacy API. For leap-second-aware (SI-second) arithmetic use
     /// [`add_si_seconds`](Self::add_si_seconds) instead.
     pub fn add_seconds(&self, dt: f64) -> Self {
-        Self::from_jd(self.jd() + dt / 86400.0)
+        convert::from_scale_jd::<Utc, P>(self.jd() + dt / 86400.0)
     }
 
     /// Advance the epoch by `dt` SI seconds, handling leap second boundaries.

--- a/arika/src/epoch/precision.rs
+++ b/arika/src/epoch/precision.rs
@@ -1,0 +1,52 @@
+//! Precision tiers for [`Epoch`](super::Epoch): the storage of its canonical
+//! TAI instant.
+//!
+//! An `Epoch<S, P>` stores its TAI instant as `P::Repr`. The default tier
+//! [`Precise`] carries a two-part JD ([`TwoPartJd`]) for sub-nanosecond
+//! resolution; [`Coarse`] carries a single [`f64`], trading that resolution for
+//! a lighter footprint (8 vs 16 bytes, no two-sum) on wasm / `no_std` embedded
+//! targets where RAM, flash and cycles are scarce and ~tens-of-µs time is
+//! enough. The tier is part of the type, so the choice is visible at every use
+//! site and mixing is explicit — and it is zero runtime cost (monomorphized).
+//!
+//! The rich constructors (`from_jd`, `from_gregorian`, …) build the default
+//! [`Precise`] tier; switch tier with
+//! [`Epoch::to_precision`](super::Epoch::to_precision)
+//! (e.g. `epoch.to_precision::<Coarse>()`).
+
+use super::jd2::{JdRepr, TwoPartJd};
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// The precision tier of an [`Epoch`](super::Epoch): selects the Julian Date
+/// storage [`Repr`](Self::Repr) for its canonical TAI instant. Sealed — the only
+/// tiers are [`Coarse`] and [`Precise`].
+pub trait Precision: sealed::Sealed {
+    /// The Julian Date storage representation for this tier.
+    type Repr: JdRepr;
+
+    /// Human-readable tier name (`"coarse"` / `"precise"`), for diagnostics.
+    const NAME: &'static str;
+}
+
+/// Sub-nanosecond two-part tier (the default): stores a [`TwoPartJd`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Precise;
+
+/// Single-`f64` tier: lighter for wasm / `no_std` embedded, ~tens-of-µs floor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Coarse;
+
+impl sealed::Sealed for Precise {}
+impl Precision for Precise {
+    type Repr = TwoPartJd;
+    const NAME: &'static str = "precise";
+}
+
+impl sealed::Sealed for Coarse {}
+impl Precision for Coarse {
+    type Repr = f64;
+    const NAME: &'static str = "coarse";
+}

--- a/arika/src/epoch/tests.rs
+++ b/arika/src/epoch/tests.rs
@@ -935,8 +935,14 @@ fn coarse_floors_sub_microsecond_step_that_precise_recovers() {
     let coarse = precise.to_precision::<Coarse>();
 
     let dt = 1e-9; // 1 ns
-    let precise_elapsed = precise.add_si_seconds(dt).duration_since(&precise).as_si_seconds();
-    let coarse_elapsed = coarse.add_si_seconds(dt).duration_since(&coarse).as_si_seconds();
+    let precise_elapsed = precise
+        .add_si_seconds(dt)
+        .duration_since(&precise)
+        .as_si_seconds();
+    let coarse_elapsed = coarse
+        .add_si_seconds(dt)
+        .duration_since(&coarse)
+        .as_si_seconds();
 
     assert!(
         (precise_elapsed - dt).abs() < 1e-12,

--- a/arika/src/epoch/tests.rs
+++ b/arika/src/epoch/tests.rs
@@ -888,7 +888,6 @@ fn coarse_and_precise_agree_on_jd_readout() {
     let x = 2_460_390.123_456;
     let precise = Epoch::<Utc>::from_jd(x);
     let coarse = precise.to_precision::<Coarse>();
-    assert_eq!(Epoch::<Utc, Coarse>::precision_name(), "coarse");
     assert!((coarse.jd() - precise.jd()).abs() < 1e-9);
     assert!((coarse.jd() - x).abs() < 1e-9);
 }
@@ -918,6 +917,12 @@ fn conversions_and_arithmetic_preserve_the_tier() {
     // And a Coarse epoch round-trips scale conversions to f64 tolerance.
     let rt = coarse.to_tdb().to_tt().to_tai().to_utc();
     assert!((rt.jd() - coarse.jd()).abs() < 1e-8);
+
+    // `to_precision` is defined on the scale-generic impl, so it must work from
+    // a non-Utc scale too: it preserves the scale `S` and round-trips the JD.
+    let tt = Epoch::<Tt>::from_jd_tt(2_460_390.5);
+    let tt_coarse: Epoch<Tt, Coarse> = tt.to_precision::<Coarse>();
+    assert!((tt_coarse.jd() - tt.jd()).abs() < 1e-9);
 }
 
 /// **Discriminating test**: the tier's whole reason to exist. A 1 ns SI step is

--- a/arika/src/epoch/tests.rs
+++ b/arika/src/epoch/tests.rs
@@ -858,3 +858,87 @@ fn add_si_seconds_is_exact_si_across_leap() {
         );
     }
 }
+
+// Precision tier (Coarse / Precise)
+//
+// The tier is a type parameter (`Epoch<S, P>`, default `Precise`). These tests
+// pin the two payoffs the tier exists for: an 8-vs-16-byte footprint and a
+// `jd()` read-out that agrees with `Precise` to f64 noise, while documenting the
+// resolution it trades away.
+
+#[test]
+fn coarse_tier_has_smaller_footprint() {
+    // The embedded/wasm motivation: a single `f64` (8 B) vs a two-part JD (16 B).
+    assert_eq!(core::mem::size_of::<Epoch<Utc, Coarse>>(), 8);
+    assert_eq!(core::mem::size_of::<Epoch<Utc, Precise>>(), 16);
+}
+
+#[test]
+fn precision_name_reports_the_tier() {
+    assert_eq!(Epoch::<Utc, Coarse>::precision_name(), "coarse");
+    assert_eq!(Epoch::<Utc, Precise>::precision_name(), "precise");
+    // Default tier is Precise.
+    assert_eq!(Epoch::<Utc>::precision_name(), "precise");
+}
+
+#[test]
+fn coarse_and_precise_agree_on_jd_readout() {
+    // Same UTC instant, both tiers: the single-f64 read-out must match (the
+    // coarse tier only loses precision *below* the f64 floor).
+    let x = 2_460_390.123_456;
+    let precise = Epoch::<Utc>::from_jd(x);
+    let coarse = precise.to_precision::<Coarse>();
+    assert_eq!(Epoch::<Utc, Coarse>::precision_name(), "coarse");
+    assert!((coarse.jd() - precise.jd()).abs() < 1e-9);
+    assert!((coarse.jd() - x).abs() < 1e-9);
+}
+
+#[test]
+fn to_precision_preserves_scale_and_is_reversible_to_f64() {
+    // Precise → Coarse → Precise recovers the f64 value (the residual the coarse
+    // tier could not hold is gone, but the single-f64 instant is intact).
+    let utc = Epoch::<Utc>::from_iso8601("2024-06-15T08:30:45Z").unwrap();
+    let back: Epoch<Utc, Precise> = utc.to_precision::<Coarse>().to_precision::<Precise>();
+    assert!((back.jd() - utc.jd()).abs() < 1e-12);
+
+    // Precise → Precise carries the full (hi, lo) parts unchanged (identity).
+    let same = utc.to_precision::<Precise>();
+    assert_eq!(same.jd_parts(), utc.jd_parts());
+}
+
+#[test]
+fn conversions_and_arithmetic_preserve_the_tier() {
+    // Scale conversions on a Coarse epoch stay Coarse (type-level assertion:
+    // these bindings only compile if the tier is threaded through).
+    let coarse = Epoch::<Utc>::from_jd(2_460_390.5).to_precision::<Coarse>();
+    let _tai: Epoch<Tai, Coarse> = coarse.to_tai();
+    let _tt: Epoch<Tt, Coarse> = coarse.to_tt();
+    let _gps: Epoch<Gps, Coarse> = coarse.to_gps();
+    let _stepped: Epoch<Utc, Coarse> = coarse.add_si_seconds(60.0);
+    // And a Coarse epoch round-trips scale conversions to f64 tolerance.
+    let rt = coarse.to_tdb().to_tt().to_tai().to_utc();
+    assert!((rt.jd() - coarse.jd()).abs() < 1e-8);
+}
+
+/// **Discriminating test**: the tier's whole reason to exist. A 1 ns SI step is
+/// below the single-f64 JD floor near modern epochs, so the `Coarse` tier floors
+/// `duration_since` to 0 — while `Precise` (the default) recovers it. Picking the
+/// tier is therefore picking a resolution/footprint trade-off, in the type.
+#[test]
+fn coarse_floors_sub_microsecond_step_that_precise_recovers() {
+    let precise = Epoch::<Utc>::from_iso8601("2024-06-15T08:30:45Z").unwrap();
+    let coarse = precise.to_precision::<Coarse>();
+
+    let dt = 1e-9; // 1 ns
+    let precise_elapsed = precise.add_si_seconds(dt).duration_since(&precise).as_si_seconds();
+    let coarse_elapsed = coarse.add_si_seconds(dt).duration_since(&coarse).as_si_seconds();
+
+    assert!(
+        (precise_elapsed - dt).abs() < 1e-12,
+        "Precise must recover the 1 ns step, got {precise_elapsed} s"
+    );
+    assert_eq!(
+        coarse_elapsed, 0.0,
+        "Coarse floors the sub-f64 step to 0, got {coarse_elapsed} s"
+    );
+}

--- a/arika/tests/trybuild/null_eop_in_to_ut1.stderr
+++ b/arika/tests/trybuild/null_eop_in_to_ut1.stderr
@@ -11,8 +11,8 @@ help: the trait `Ut1Offset` is implemented for `EopTable`
    |
    | impl Ut1Offset for EopTable {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: required by a bound in `epoch::convert::<impl Epoch>::to_ut1`
+note: required by a bound in `epoch::convert::<impl Epoch<Utc, P>>::to_ut1`
   --> src/epoch/convert.rs
    |
-   |     pub fn to_ut1<P: crate::earth::eop::Ut1Offset + ?Sized>(&self, eop: &P) -> Ut1Epoch {
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `epoch::convert::<impl Epoch>::to_ut1`
+   |     pub fn to_ut1<E: crate::earth::eop::Ut1Offset + ?Sized>(&self, eop: &E) -> Ut1Epoch {
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `epoch::convert::<impl Epoch<Utc, P>>::to_ut1`


### PR DESCRIPTION
## What & why

`arika`'s `Epoch` stores a canonical TAI instant and reads it out in a scale `S` via a lens. Today that instant is always a two-part Julian Date (`TwoPartJd`, sub-nanosecond) — 16 bytes plus two-sum arithmetic on every operation. That precision is unnecessary on wasm / `no_std` embedded targets (e.g. on-board FSW) where RAM, flash and cycles are scarce and ~tens-of-µs time resolution is plenty.

This PR adds a **precision tier** as a second type parameter, `Epoch<S = Utc, P: Precision = Precise>`, so the resolution/footprint trade-off is visible in the type and chosen per use site at **zero runtime cost** (monomorphized — no branching, no dynamic dispatch). It is a feature addition, not a bug fix; the default tier keeps existing behavior and the public API unchanged.

- `Precise` (default): stores `TwoPartJd` (16 B, sub-ns).
- `Coarse`: stores a single `f64` (8 B, no two-sum, ~tens-of-µs floor near modern epochs).

## Design

- **`JdRepr`** (new, sealed): the JD storage interface — `from_jd`, `from_parts`, `jd`, `parts`, `add_days`, `diff_days`. Implemented only by `f64` (Coarse) and the now-public `TwoPartJd` (Precise). `from_parts` is the lossless cross-tier bridge.
- **`Precision`** (new, sealed) + markers `Coarse` / `Precise`. `Epoch` stores `tai: P::Repr`.
- **Constructors stay on the concrete `Precise` impls; methods are generic over `P`** (inferred from `self`). A generic-over-`P` constructor breaks bare `Epoch::from_jd(x)` with `E0283` — a default type parameter is *not* an inference fallback for an unconstrained variable in expression position. This mirrors `HashMap::new` (concrete `RandomState`) vs `with_hasher` (generic). Verified against the real compiler.
- A non-default tier is reached via **`Epoch::to_precision::<Q>()`** (parts-based: `Precise→Precise` exact, `Coarse→Precise` lifts, `Precise→Coarse` collapses to `hi+lo`).
- `TaiLens` generalized over `R: JdRepr` so one lens (leap table, fixed offset, Fairhead periodic) serves both tiers. `duration_since` requires a shared tier (mix explicitly via `to_precision`).
- Manual `Clone`/`Copy`/`PartialEq`/`Debug` — `#[derive]` would bound on `P`, not on the stored field `P::Repr`.

## Tests

New tier tests, including the discriminating one: a 1 ns SI step is below the single-`f64` JD floor near modern epochs, so `Coarse` floors `duration_since` to `0` while `Precise` recovers it — picking the tier is picking a resolution/footprint trade-off, in the type. Also: the 8-vs-16-byte footprint, `jd()` agreement between tiers, `to_precision` round-trips (incl. a non-`Utc` scale), tier-preserving conversions. The `to_ut1` trybuild golden was re-blessed for a generic-param rename (still a genuine `NullEop` rejection).

## Verification

- `cargo test -p arika` — lib + integration green
- `cargo clippy -p arika -- -D warnings` — clean (CI-equivalent)
- `cargo build -p arika` for `--no-default-features`, `--features alloc`, and `--features alloc --target wasm32-unknown-unknown` — all green
- `cargo test --workspace` — green (downstream compiles with defaulted `P`)
- Independent code review: mergeable, only nits (all addressed — sealed `JdRepr`, dropped a dead assertion, added non-`Utc` coverage).

## Stacking

Stacked on #205 (canonical-TAI representation); base is `worktree-time-precision-canonical` and the diff here is only this PR's two commits. GitHub will retarget the base to `main` automatically when #205 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)