### PR TITLE
fix(orts): 大気抵抗の co-rotation を真の自転軸(CIP)で評価する (Gcrs)

### DIFF
--- a/orts/src/perturbations/drag.rs
+++ b/orts/src/perturbations/drag.rs
@@ -167,8 +167,12 @@ impl<F: EarthFrameBridge> AtmosphericDrag<F> {
         // differs by polar motion); LOD variation in |Ω| is omitted.
         //
         // `earth_pole` is Earth-specific, so for any other central body we keep
-        // the frame Z axis (the pre-existing behavior, matching the spherical
-        // geodetic fallback above — `F` is an Earth ECI frame regardless).
+        // the frame Z axis with that body's `omega_body` (the pre-existing
+        // behavior, matching the spherical geodetic fallback above — `F` is an
+        // Earth ECI frame regardless). A non-Earth body's true spin-axis
+        // orientation is not modeled: it would need a per-body pole and a
+        // body-fixed frame, so non-Earth drag here stays a coarse approximation.
+        // Tracked in #210.
         let omega = match self.body {
             Some(KnownBody::Earth) => F::earth_pole(utc).into_inner() * self.omega_body,
             _ => Vector3::new(0.0, 0.0, self.omega_body),

--- a/orts/src/perturbations/drag.rs
+++ b/orts/src/perturbations/drag.rs
@@ -156,16 +156,23 @@ impl<F: EarthFrameBridge> AtmosphericDrag<F> {
             return Vector3::zeros();
         }
 
-        // Atmosphere co-rotation velocity Ω × r, with Ω along Earth's spin axis
-        // (magnitude `omega_body`). The spin axis is the IAU 2006 CIP, which
-        // `EarthPoleBridge` expresses in the integration frame `F`: +Z for
-        // `SimpleEci` (so this reduces exactly to the classic [0, 0, ω] × r), the
-        // true CIP for `Gcrs` (correcting the ~0.1–0.3° offset of the spin axis
-        // from the GCRS Z axis that a +Z assumption incurs). The CIP is the
-        // rotation axis itself, so this is more faithful than rotating the Itrs
-        // figure axis via `fixed_to_inertial` (which differs by polar motion);
-        // LOD variation in |Ω| is omitted.
-        let omega = F::earth_pole(utc).into_inner() * self.omega_body;
+        // Atmosphere co-rotation velocity Ω × r, with Ω along the central body's
+        // spin axis (magnitude `omega_body`). For Earth the spin axis is the IAU
+        // 2006 CIP, which `EarthPoleBridge` expresses in the integration frame
+        // `F`: +Z for `SimpleEci` (so this reduces exactly to the classic
+        // [0, 0, ω] × r), the true CIP for `Gcrs` (correcting the ~0.1–0.3°
+        // offset of the spin axis from the GCRS Z axis that a +Z assumption
+        // incurs). Using the CIP — the rotation axis itself — is more faithful
+        // than rotating the ITRS figure axis via `fixed_to_inertial` (which
+        // differs by polar motion); LOD variation in |Ω| is omitted.
+        //
+        // `earth_pole` is Earth-specific, so for any other central body we keep
+        // the frame Z axis (the pre-existing behavior, matching the spherical
+        // geodetic fallback above — `F` is an Earth ECI frame regardless).
+        let omega = match self.body {
+            Some(KnownBody::Earth) => F::earth_pole(utc).into_inner() * self.omega_body,
+            _ => Vector3::new(0.0, 0.0, self.omega_body),
+        };
         let v_rel = *state.velocity() - omega.cross(pos);
 
         // Convert v_rel from km/s to m/s for consistent units with ρ [kg/m³] and B [m²/kg]

--- a/orts/src/perturbations/drag.rs
+++ b/orts/src/perturbations/drag.rs
@@ -26,9 +26,10 @@ pub const DEFAULT_BALLISTIC_COEFF: f64 = 0.01;
 /// and a pluggable atmospheric density model.
 ///
 /// The frame parameter `F` selects how ECI positions are converted to
-/// geodetic coordinates (for density lookup) and how the atmosphere
-/// co-rotation velocity is computed. The default `SimpleEci` uses
-/// ERA-only Z rotation; `Gcrs` uses the full IAU 2006 CIO chain.
+/// geodetic coordinates (for density lookup, via the ECEF rotation) and
+/// which spin axis the atmosphere co-rotates about. `SimpleEci` uses the
+/// ERA-only ECEF rotation and a +Z spin axis; `Gcrs` uses the full IAU 2006
+/// CIO chain and the true CIP spin axis.
 pub struct AtmosphericDrag<F: EarthFrameBridge = frame::SimpleEci> {
     /// Central body (enables WGS-84 geodetic altitude for Earth)
     pub body: Option<KnownBody>,
@@ -155,10 +156,16 @@ impl<F: EarthFrameBridge> AtmosphericDrag<F> {
             return Vector3::zeros();
         }
 
-        // Relative velocity: v_rel = v - ω × r (atmosphere co-rotates with body)
-        // TODO: Phase 4D — precise path should use LOD-corrected ω and
-        // proper ECEF velocity transform via F::fixed_to_inertial.
-        let omega = Vector3::new(0.0, 0.0, self.omega_body);
+        // Atmosphere co-rotation velocity Ω × r, with Ω along Earth's spin axis
+        // (magnitude `omega_body`). The spin axis is the IAU 2006 CIP, which
+        // `EarthPoleBridge` expresses in the integration frame `F`: +Z for
+        // `SimpleEci` (so this reduces exactly to the classic [0, 0, ω] × r), the
+        // true CIP for `Gcrs` (correcting the ~0.1–0.3° offset of the spin axis
+        // from the GCRS Z axis that a +Z assumption incurs). The CIP is the
+        // rotation axis itself, so this is more faithful than rotating the Itrs
+        // figure axis via `fixed_to_inertial` (which differs by polar motion);
+        // LOD variation in |Ω| is omitted.
+        let omega = F::earth_pole(utc).into_inner() * self.omega_body;
         let v_rel = *state.velocity() - omega.cross(pos);
 
         // Convert v_rel from km/s to m/s for consistent units with ρ [kg/m³] and B [m²/kg]
@@ -361,6 +368,88 @@ mod tests {
         assert!(
             a.magnitude() > 0.0,
             "HP drag should be non-zero at ISS altitude"
+        );
+    }
+
+    #[test]
+    fn gcrs_co_rotation_uses_true_cip_spin_axis() {
+        // The atmosphere co-rotates about Earth's spin axis. For `Gcrs` that axis
+        // is the IAU 2006 CIP, offset from the GCRS Z axis by precession/nutation.
+        // Pin that drag computes the co-rotation velocity about the CIP (not +Z)
+        // by reconstructing the acceleration from `EarthPoleBridge::earth_pole`.
+        use crate::environment::{EarthPoleBridge, GcrsEopStorage};
+        use arika::earth::eop::{NutationCorrections, PolarMotion, Ut1Offset};
+
+        // Zero-EOP: model CIP only (no observed dX/dY, dUT1, polar motion) — the
+        // same provider oracle_gcrf uses; keeps the CIP at sub-mas accuracy.
+        struct ZeroEop;
+        impl Ut1Offset for ZeroEop {
+            fn dut1(&self, _: f64) -> f64 {
+                0.0
+            }
+        }
+        impl PolarMotion for ZeroEop {
+            fn x_pole(&self, _: f64) -> f64 {
+                0.0
+            }
+            fn y_pole(&self, _: f64) -> f64 {
+                0.0
+            }
+        }
+        impl NutationCorrections for ZeroEop {
+            fn dx(&self, _: f64) -> f64 {
+                0.0
+            }
+            fn dy(&self, _: f64) -> f64 {
+                0.0
+            }
+        }
+
+        let utc = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
+
+        // The check is only meaningful if the CIP differs from +Z at this epoch.
+        let pole = <frame::Gcrs as EarthPoleBridge>::earth_pole(&utc).into_inner();
+        let off_axis = (pole - vector![0.0, 0.0, 1.0]).norm();
+        assert!(
+            off_axis > 1e-9,
+            "Gcrs CIP should be measurably offset from +Z at 2024, got {off_axis:e}"
+        );
+
+        // 3D LEO state (all components non-zero so the spin-axis tilt is exercised).
+        let r = R_EARTH + 400.0;
+        let pos = vector![0.5_f64, 0.3, 0.8].normalize() * r;
+        let v = (MU_EARTH / r).sqrt();
+        let vel = vector![-v * 0.6, v * 0.5, v * 0.2];
+        let state = OrbitalState::<frame::Gcrs>::new_in_frame(pos, vel);
+
+        let drag = AtmosphericDrag::<frame::Gcrs>::for_earth_in_frame(
+            Some(0.005),
+            GcrsEopStorage::new(ZeroEop),
+        );
+        let a = drag.acceleration(&state, Some(&utc));
+
+        // Reconstruct the expected acceleration with Ω along the CIP spin axis.
+        let omega = pole * OMEGA_EARTH;
+        let v_rel = vel - omega.cross(&pos);
+        let geod = <frame::Gcrs as EarthFrameBridge>::to_geodetic(
+            &Vec3::from_raw(pos),
+            &utc,
+            &GcrsEopStorage::new(ZeroEop),
+        );
+        let rho = Exponential.density(&AtmosphereInput {
+            geodetic: geod,
+            utc: &utc,
+        });
+        assert!(rho > 0.0, "expected non-zero density at 400 km");
+        let v_rel_m = v_rel * 1000.0;
+        let expected = (-0.005 * rho * v_rel_m.magnitude() * v_rel_m) / 1000.0;
+
+        // If drag had kept the +Z assumption, it would disagree with this CIP
+        // reconstruction by ~ω·r·offset; a tight match proves the CIP is used.
+        assert!(
+            (a - expected).norm() < 1e-18,
+            "Gcrs drag must use the CIP spin axis for co-rotation; err={:e}",
+            (a - expected).norm()
         );
     }
 }

--- a/orts/tests/oracle_gcrf.rs
+++ b/orts/tests/oracle_gcrf.rs
@@ -599,7 +599,11 @@ fn gcrf_30day_error_floor_is_drag_dominated() {
     let propagate = |system: &OrbitalSystem<frame::Gcrs>| -> Vector3<f64> {
         let initial = OrbitalState::<frame::Gcrs>::new_in_frame(
             Vector3::new(ic.position_km[0], ic.position_km[1], ic.position_km[2]),
-            Vector3::new(ic.velocity_km_s[0], ic.velocity_km_s[1], ic.velocity_km_s[2]),
+            Vector3::new(
+                ic.velocity_km_s[0],
+                ic.velocity_km_s[1],
+                ic.velocity_km_s[2],
+            ),
         );
         *DormandPrince
             .integrate(system, initial, 0.0, duration, 30.0, |_, _| {})

--- a/orts/tests/oracle_gcrf.rs
+++ b/orts/tests/oracle_gcrf.rs
@@ -449,13 +449,25 @@ fn gcrf_j2_msise_cssi_thirdbody_iss_30day() {
     println!("  Simple error: {:.3} km", simple_err);
     println!("  Improvement:  {:.1}x", simple_err / gcrs_err);
 
-    // Measured: Gcrs ~8.9 km, SimpleEci ~22.6 km. Tolerance with ~20% buffer.
+    // Measured: Gcrs ~14.3 km, SimpleEci ~18.4 km.
+    //
+    // The bound reflects an inherent 30-day cross-validation floor, not a frame
+    // error. Decomposing the Gcrs error (correct CIP co-rotation) shows drag
+    // moves the trajectory ~8400 km over 30 days, so the ~0.05-0.3% density
+    // difference between our NRLMSISE-00 and Orekit's independent implementation
+    // amplifies to ~10 km along-track; the third-body Meeus-vs-DE ephemeris adds
+    // ~3.7 km. Both are frame-independent (SimpleEci carries the same gap) — the
+    // Gcrs frame handling itself (geodetic, J2 pole, co-rotation axis) matches
+    // Orekit to sub-km. (An earlier 12 km bound only held because a +Z
+    // co-rotation error happened to cancel part of this floor; the corrected
+    // co-rotation removes that coincidence. Third-body ephemeris fidelity is
+    // tracked separately as the one reducible piece.)
     assert!(
-        gcrs_err < 12.0,
-        "Gcrs final pos error {:.3} km exceeds 12 km",
+        gcrs_err < 15.0,
+        "Gcrs final pos error {:.3} km exceeds 15 km",
         gcrs_err
     );
-    // Gcrs path must be strictly better than SimpleEci for drag scenarios
+    // The frame-validation check: Gcrs must still beat SimpleEci for drag.
     assert!(
         gcrs_err < simple_err,
         "Gcrs ({gcrs_err:.3} km) should be better than SimpleEci ({simple_err:.3} km) for 30-day drag"

--- a/orts/tests/oracle_gcrf.rs
+++ b/orts/tests/oracle_gcrf.rs
@@ -542,3 +542,111 @@ fn gcrf_real_eop_improves_drag_30day() {
         "Real EOP ({real_err:.6} km) should be better than SimpleEci ({simple_err:.6} km)"
     );
 }
+
+/// Decomposes the 30-day Gcrs error into its physical contributors, so the
+/// `gcrf_j2_msise_cssi_thirdbody_iss_30day` floor doesn't have to be
+/// re-investigated by hand. It propagates the scenario three ways (full, no
+/// third-body, no drag) and pins the *structure* of the error budget:
+///
+/// - Drag dominates the 30-day trajectory by orders of magnitude (~8400 km of
+///   along-track motion), so the residual vs Orekit is mostly the inherent
+///   ~0.05-0.3% density difference between our NRLMSISE-00 and Orekit's,
+///   amplified over that arc.
+/// - Third-body (Meeus vs Orekit DE) is a minor contributor (~a few km).
+/// - The Gcrs frame handling itself is not the error source (the full error
+///   stays in the floor band; removing third-body does not blow it up).
+///
+/// `#[ignore]`d: three 30-day propagations take many minutes — too slow for the
+/// default suite. Run on demand to re-verify the floor:
+///   `cargo test -p orts --test oracle_gcrf -- --ignored gcrf_30day_error_floor`
+#[test]
+#[ignore = "three 30-day propagations (~tens of minutes); on-demand floor diagnostic"]
+fn gcrf_30day_error_floor_is_drag_dominated() {
+    let fixtures = load_fixtures();
+    let scenario = find_scenario(&fixtures, "gcrf_j2_msise_cssi_thirdbody_iss_30day");
+    let ic = &scenario.initial_cartesian;
+    let duration = scenario.trajectory.last().unwrap().t_seconds;
+
+    // Build the scenario's force model with individual terms toggled off.
+    let build = |with_third_body: bool, with_drag: bool| -> OrbitalSystem<frame::Gcrs> {
+        let epoch = parse_epoch(&scenario.epoch_utc);
+        let mut system = OrbitalSystem::<frame::Gcrs>::new(MU_EARTH, Box::new(PointMass))
+            .with_epoch(epoch)
+            .with_body_radius(R_EARTH)
+            .with_model(ZonalGravity::<frame::Gcrs>::new(
+                MU_EARTH, R_EARTH, J2_EARTH, None, None,
+            ));
+        if with_third_body {
+            system = system
+                .with_model(ThirdBodyGravity::sun())
+                .with_model(ThirdBodyGravity::moon());
+        }
+        if with_drag {
+            let b = scenario.satellite.ballistic_coeff_m2_kg.unwrap_or(0.01);
+            let cssi_text = include_str!("fixtures/cssi_test_weather.txt");
+            let cssi_data = CssiData::parse(cssi_text).expect("Failed to parse CSSI fixture");
+            let provider = Box::new(CssiSpaceWeather::new(cssi_data));
+            let drag = AtmosphericDrag::<frame::Gcrs>::for_earth_in_frame(
+                Some(b),
+                GcrsEopStorage::new(ZeroEop),
+            )
+            .with_atmosphere(Box::new(Nrlmsise00::new(provider)));
+            system = system.with_model(drag);
+        }
+        system
+    };
+
+    let propagate = |system: &OrbitalSystem<frame::Gcrs>| -> Vector3<f64> {
+        let initial = OrbitalState::<frame::Gcrs>::new_in_frame(
+            Vector3::new(ic.position_km[0], ic.position_km[1], ic.position_km[2]),
+            Vector3::new(ic.velocity_km_s[0], ic.velocity_km_s[1], ic.velocity_km_s[2]),
+        );
+        *DormandPrince
+            .integrate(system, initial, 0.0, duration, 30.0, |_, _| {})
+            .position()
+    };
+
+    let fx = scenario.trajectory.last().unwrap();
+    let fixture_final = Vector3::new(fx.position_km[0], fx.position_km[1], fx.position_km[2]);
+
+    let p_full = propagate(&build(true, true));
+    let p_no_third_body = propagate(&build(false, true));
+    let p_no_drag = propagate(&build(true, false));
+
+    let err_full = (p_full - fixture_final).norm();
+    let err_no_third_body = (p_no_third_body - fixture_final).norm();
+    let third_body_contrib = (p_full - p_no_third_body).norm();
+    let drag_contrib = (p_full - p_no_drag).norm();
+
+    println!("30-day error-floor decomposition (Gcrs, correct CIP co-rotation, ZeroEop):");
+    println!("  err vs Orekit (full):           {err_full:.3} km");
+    println!("  err vs Orekit (no third-body):  {err_no_third_body:.3} km");
+    println!("  drag trajectory contribution:   {drag_contrib:.1} km");
+    println!("  third-body trajectory contrib:  {third_body_contrib:.3} km");
+
+    // Drag dominates the trajectory by orders of magnitude over 30 days.
+    assert!(
+        drag_contrib > 1000.0,
+        "drag should move the 30-day trajectory by >1000 km, got {drag_contrib:.1} km"
+    );
+    assert!(
+        drag_contrib > 100.0 * third_body_contrib,
+        "drag ({drag_contrib:.1} km) should dominate third-body ({third_body_contrib:.3} km) by >100x"
+    );
+    // Third-body (Meeus vs DE) is a minor, bounded contributor.
+    assert!(
+        third_body_contrib < 20.0,
+        "third-body contribution should be a few km, got {third_body_contrib:.3} km"
+    );
+    // The Gcrs frame handling is not the error source: the error stays in the
+    // floor band and third-body is not what dominates it.
+    assert!(
+        err_full < 20.0,
+        "full Gcrs error should sit in the model-fidelity floor band, got {err_full:.3} km"
+    );
+    assert!(
+        (err_full - err_no_third_body).abs() < 10.0,
+        "third-body should not be the dominant error term (Δerr={:.3} km)",
+        (err_full - err_no_third_body).abs()
+    );
+}


### PR DESCRIPTION
## 何が問題だったか

大気抵抗のモデルで、大気が地球とともに回る速度（共回転速度 `Ω×r`）を求めるとき、自転軸を積分フレームの +Z 軸に固定していた（`Ω = [0, 0, ω]`）。`SimpleEci` ではこの Z 軸が定義上の自転極なので正しいが、`Gcrs` では真の自転極（IAU 2006 CIP）が GCRS の Z 軸から約 0.13° ずれているため、共回転速度に約 0.9 m/s の誤差が乗っていた。

Orekit の大気共回転が真の自転軸（CIP）に沿っていることは、`getVelocity` を直接サンプルして確かめた。CIP に沿った共回転速度とは 27 μm/s で一致し、+Z 固定とは 0.9 m/s ずれる。

## 変更内容

共回転の自転軸を `EarthPoleBridge::earth_pole` から取るようにした（`Ω = ω·p̂`、`v_corot = Ω×r`）。

- `SimpleEci`: `p̂` が +Z なので、計算結果は従来とビット単位で一致する（挙動は変わらない）。
- `Gcrs`: 真の CIP を使う。orts の `earth_pole(Gcrs)` は Orekit の CIP と 1e-9 の精度で一致するので、共回転速度も Orekit と一致する。

CIP（自転軸そのもの）を直接使うのは、`fixed_to_inertial` で ITRS の図形軸を回す方法より忠実になる（後者は極運動の分だけ自転軸からずれる）。`Ω` の大きさに効く LOD 変動は今回は扱わない。

## 30日オラクルの扱い（調査結果）

この変更で Gcrs の共回転は Orekit と一致するようになったが、30日シナリオ `gcrf_j2_msise_cssi_thirdbody_iss_30day` の位置誤差が 12 km の閾値を超えて 14.3 km になった。調べたところ、これは共回転を誤らせたのではなく、**従来の +Z 固定がもっていた 0.9 m/s の誤差が、30日スケールのモデル忠実度に由来する誤差の下限を偶然部分的に打ち消していた**ためだった。共回転を正したことで、その下限がそのまま表に出てきた。

下限の内訳は、third-body あり/なし・drag あり/なしで伝播して切り分けた。

- **drag と大気モデル（約 10 km）**: drag は 30日で軌道を約 8400 km 動かすので、orts と Orekit それぞれの NRLMSISE-00 実装がもつ 0.05〜0.3% の密度差が、その 0.2% 弱として最終位置に効く。独立に実装された2つのモデルの差なので、本質的に縮められない。
- **third-body（約 3.7 km）**: orts は Meeus の解析式、Orekit は DE の数値暦という、エフェメリスの違い。
- **フレーム処理（geodetic 変換・J2 の極・共回転軸）**: sub-km で Orekit と一致しており、誤差の主因ではない。`SimpleEci` も同じ約 18 km の下限を抱えることから、フレームに依存しない誤差だと分かる。

したがって、30日の絶対誤差そのものを縮めるのはこの PR の範囲外になる（独立実装どうしの下限のため）。

## テスト

- drag 単体テスト: 既存の `SimpleEci` のテストは結果がビット単位で一致するため変更なし。新規の `gcrs_co_rotation_uses_true_cip_spin_axis` で、Gcrs の共回転が CIP を使うことを固定する。
- `gcrf_j2_msise_cssi_thirdbody_iss_30day`: 閾値を実測の下限に合わせて 12 → 15 km に更新した。単なる緩和ではなく、**偶然の打ち消しに依存していた値を実測の下限に直す**もので、内訳はコメントに書いた。フレーム検証の本体である `Gcrs < SimpleEci` の比較は残してある。
- 新規の `gcrf_30day_error_floor_is_drag_dominated`（`#[ignore]`）: 下限の内訳（drag が100倍以上支配的、third-body は副次的、フレームは主因でない）をアサートで固定する。30日伝播を3回行って重いので CI では走らせず、必要なときに手元で下限を確かめ直すためのもの。

## フォローアップ

- **third-body のエフェメリス忠実度**（#211）: 下限のうち縮められるのはここだけ（Meeus から DE 級へ、約 3.7 km）。`ThirdBodyGravity::moon_with_ephemeris` や `custom` のフックで差し替えられる。
- **地球以外の天体の自転軸**（#210）: 非地球の中心天体では共回転の軸をフレーム +Z と仮定しており、その天体の実際の極の向きはモデル化していない。汎用化には天体ごとの極と body-fixed フレームが要る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
