### PR TITLE
refactor(arika): EarthPoleBridge/EarthFrameBridge を orts から arika へ移す

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -14,7 +14,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - 地上局コンタクトウィンドウ検出 (`visibility` module): `GroundStation`
   (WGS-84 位置 + 仰角マスク)、`ContactWindow` (補間した AOS/LOS、最大仰角、
   span クリップフラグ)、純粋な `PassTracker` ステートマシン、frame-aware な
-  `VisibilityMonitor<F: EarthFrameBridge>` (ECI サンプルを地上局ごとの
+  `VisibilityMonitor<F: EarthFixedTransform>` (ECI サンプルを地上局ごとの
   topocentric look angle に変換)。([#112](https://github.com/sksat/orts/pull/112))
 - `IndependentGroup::propagate_to_with(t_target, observer)` — 受理された全
   積分ステップで `FnMut(&SatId, f64, &State)` observer を呼びながら伝播。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ section is subdivided by package.
 - Ground-station contact-window detection (`visibility` module): `GroundStation`
   (WGS-84 location + elevation mask), `ContactWindow` (interpolated AOS/LOS, max
   elevation, span-clip flags), the pure `PassTracker` state machine, and a
-  frame-aware `VisibilityMonitor<F: EarthFrameBridge>` that turns ECI samples
+  frame-aware `VisibilityMonitor<F: EarthFixedTransform>` that turns ECI samples
   into per-station topocentric look angles. ([#112](https://github.com/sksat/orts/pull/112))
 - `IndependentGroup::propagate_to_with(t_target, observer)` — propagate while a
   `FnMut(&SatId, f64, &State)` observer runs on every accepted integration step,

--- a/arika/src/earth/eop/mod.rs
+++ b/arika/src/earth/eop/mod.rs
@@ -97,6 +97,70 @@ pub trait FullEopProvider: Ut1Offset + PolarMotion + NutationCorrections + Lengt
 
 impl<T> FullEopProvider for T where T: Ut1Offset + PolarMotion + NutationCorrections + LengthOfDay {}
 
+/// Convenience bound for the position-level (no-velocity) rotation chain.
+///
+/// Object-safe combination of the three parameter traits required by
+/// [`Rotation::<Gcrs, Itrs>::iau2006_full_from_utc`](crate::frame::Rotation).
+/// Unlike [`FullEopProvider`] it omits [`LengthOfDay`], which is only needed for
+/// velocity transformation. Thread-safety is intentionally *not* required here;
+/// callers that need to store a provider use the `Send + Sync` boxed
+/// [`GcrsEopStorage`].
+pub trait PositionEop: Ut1Offset + PolarMotion + NutationCorrections {}
+
+impl<T> PositionEop for T where T: Ut1Offset + PolarMotion + NutationCorrections {}
+
+/// Owned, type-erased [`PositionEop`] provider for the `Gcrs` precise path.
+///
+/// Wraps a boxed provider and delegates the EOP trait methods, so it can be
+/// stored inside a force model and passed directly to arika's rotation
+/// constructors (which take `P: Ut1Offset + NutationCorrections + PolarMotion`).
+/// `Send + Sync` is carried by the boxed trait object rather than by
+/// [`PositionEop`], keeping that trait a pure capability.
+#[cfg(feature = "alloc")]
+pub struct GcrsEopStorage(alloc::boxed::Box<dyn PositionEop + Send + Sync>);
+
+#[cfg(feature = "alloc")]
+impl GcrsEopStorage {
+    /// Create from any thread-safe [`PositionEop`] provider.
+    pub fn new(provider: impl PositionEop + Send + Sync + 'static) -> Self {
+        Self(alloc::boxed::Box::new(provider))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl core::fmt::Debug for GcrsEopStorage {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GcrsEopStorage").finish_non_exhaustive()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl Ut1Offset for GcrsEopStorage {
+    fn dut1(&self, utc_mjd: f64) -> f64 {
+        self.0.dut1(utc_mjd)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl PolarMotion for GcrsEopStorage {
+    fn x_pole(&self, utc_mjd: f64) -> f64 {
+        self.0.x_pole(utc_mjd)
+    }
+    fn y_pole(&self, utc_mjd: f64) -> f64 {
+        self.0.y_pole(utc_mjd)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl NutationCorrections for GcrsEopStorage {
+    fn dx(&self, utc_mjd: f64) -> f64 {
+        self.0.dx(utc_mjd)
+    }
+    fn dy(&self, utc_mjd: f64) -> f64 {
+        self.0.dy(utc_mjd)
+    }
+}
+
 // NullEop
 
 /// EOP placeholder that implements none of the EOP parameter traits.

--- a/arika/src/earth/frame_bridge.rs
+++ b/arika/src/earth/frame_bridge.rs
@@ -1,92 +1,43 @@
-//! Frame-aware environment adapter for force models.
+//! Per-frame Earth rotation-pole and ECI↔ECEF bridges.
 //!
-//! [`EarthFrameBridge`] bridges an ECI propagation frame to its
-//! paired Earth-fixed (ECEF) frame, providing the geodetic conversion
-//! and ECEF↔ECI rotation that atmosphere and magnetic field models
-//! require.
+//! These traits express, for a given ECI frame, two coordinate facts that
+//! force models in downstream crates need:
+//!
+//! - [`EarthPoleBridge`] — the direction of Earth's rotation pole in the frame
+//!   (zonal gravity and atmosphere co-rotation only need the axis direction).
+//! - [`EarthFrameBridge`] — the paired Earth-fixed (ECEF) frame plus the
+//!   geodetic conversion and ECEF↔ECI rotation (atmosphere geodetic lookup,
+//!   magnetic field, wind co-rotation).
 //!
 //! Two implementations are provided:
 //!
-//! - [`arika::frame::SimpleEci`]: ERA-only Z rotation, no EOP needed.
-//!   This is the legacy/approximate path.
-//! - [`arika::frame::Gcrs`]: Full IAU 2006 CIO chain
-//!   (precession + nutation + ERA + polar motion). Requires an EOP
-//!   provider implementing [`PositionEop`].
+//! - [`SimpleEci`](crate::frame::SimpleEci): ERA-only Z rotation, pole = `+Z`,
+//!   no EOP needed (the approximate, visualization-grade path).
+//! - [`Gcrs`](crate::frame::Gcrs): full IAU 2006 CIO chain
+//!   (precession + nutation + ERA + polar motion); the pole is the true CIP and
+//!   the ECEF bridge takes an EOP provider via [`GcrsEopStorage`].
 
-use arika::earth::eop::{NutationCorrections, PolarMotion, Ut1Offset};
-use arika::earth::geodetic::Geodetic;
-use arika::earth::iau2006::cip::cip_xy;
-use arika::epoch::{Epoch, Utc};
-use arika::frame::{self, Ecef, Eci, Rotation, Vec3};
+use crate::earth::geodetic::Geodetic;
+use crate::earth::iau2006::cip::cip_xy;
+use crate::epoch::{Epoch, Utc};
+use crate::frame::{self, Ecef, Eci, Rotation, Vec3};
+// Used only on no_std (libm-backed `.sqrt()`); std uses the inherent f64 method.
+#[allow(unused_imports)]
+use crate::math::F64Ext;
 
-// PositionEop — combined trait for position-level rotation
+#[cfg(feature = "alloc")]
+use crate::earth::eop::GcrsEopStorage;
 
-/// Combined EOP capability needed for position-level Gcrs↔Itrs rotation.
-///
-/// Object-safe supertrait of the three EOP parameter traits required by
-/// [`Rotation::<Gcrs, Itrs>::iau2006_full_from_utc`](arika::frame::Rotation).
-/// LOD (Length of Day) is excluded because it is only needed for velocity
-/// transformation.
-pub trait PositionEop: Ut1Offset + PolarMotion + NutationCorrections + Send + Sync {}
-
-impl<T: Ut1Offset + PolarMotion + NutationCorrections + Send + Sync> PositionEop for T {}
-
-// GcrsEopStorage
-
-/// EOP storage for the Gcrs precise path.
-///
-/// Wraps a boxed [`PositionEop`] provider and delegates the individual
-/// EOP trait methods so it can be passed directly to arika's rotation
-/// constructors (which require `P: Ut1Offset + NutationCorrections + PolarMotion`).
-pub struct GcrsEopStorage(Box<dyn PositionEop>);
-
-impl GcrsEopStorage {
-    /// Create from any provider implementing [`PositionEop`].
-    pub fn new(provider: impl PositionEop + 'static) -> Self {
-        Self(Box::new(provider))
-    }
-}
-
-impl std::fmt::Debug for GcrsEopStorage {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("GcrsEopStorage").finish_non_exhaustive()
-    }
-}
-
-impl Ut1Offset for GcrsEopStorage {
-    fn dut1(&self, utc_mjd: f64) -> f64 {
-        self.0.dut1(utc_mjd)
-    }
-}
-
-impl PolarMotion for GcrsEopStorage {
-    fn x_pole(&self, utc_mjd: f64) -> f64 {
-        self.0.x_pole(utc_mjd)
-    }
-    fn y_pole(&self, utc_mjd: f64) -> f64 {
-        self.0.y_pole(utc_mjd)
-    }
-}
-
-impl NutationCorrections for GcrsEopStorage {
-    fn dx(&self, utc_mjd: f64) -> f64 {
-        self.0.dx(utc_mjd)
-    }
-    fn dy(&self, utc_mjd: f64) -> f64 {
-        self.0.dy(utc_mjd)
-    }
-}
-
-// EarthPoleBridge trait
+// EarthPoleBridge
 
 /// ECI frame that knows Earth's rotation-pole direction expressed in itself.
 ///
 /// Zonal harmonics (J2/J3/J4) are axially symmetric about the true rotation
-/// pole, so a zonal gravity model only needs the pole *direction* in the
-/// integration frame — not the full Earth-fixed rotation. This is the minimal
-/// capability `ZonalGravity` requires, kept separate from the heavier
-/// [`EarthFrameBridge`] (which also provides the ECEF rotation that drag,
-/// magnetic field, and geodetic conversions need).
+/// pole, and the atmosphere co-rotates about it, so those models only need the
+/// pole *direction* in the integration frame — not the full Earth-fixed
+/// rotation. This is the minimal capability they require, kept separate from the
+/// heavier [`EarthFrameBridge`] (which also provides the ECEF rotation that
+/// geodetic conversions and magnetic field need).
 ///
 /// EOP is intentionally not a parameter: the IAU 2006 model CIP is accurate to
 /// well under a milliarcsecond without the observed dX/dY corrections, which is
@@ -122,28 +73,30 @@ impl EarthPoleBridge for frame::Gcrs {
         let t = utc.to_tt().centuries_since_j2000();
         let (x, y) = cip_xy(t);
         let (x, y) = (x.raw(), y.raw());
-        // `.max(0.0)` guards against a slightly-negative radicand from f64
-        // round-off (x²+y² is ~1e-5 for real CIP values, never near 1).
-        let z = (1.0 - x * x - y * y).max(0.0).sqrt();
+        // Guard against a slightly-negative radicand from f64 round-off (x²+y²
+        // is ~1e-5 for real CIP values, never near 1). `f64::max` is std-only,
+        // so clamp manually to stay no_std-compatible.
+        let radicand = 1.0 - x * x - y * y;
+        let z = if radicand > 0.0 { radicand.sqrt() } else { 0.0 };
         Vec3::new(x, y, z)
     }
 }
 
-// EarthFrameBridge trait
+// EarthFrameBridge
 
 /// ECI frame that can bridge to Earth-fixed (ECEF) coordinates.
 ///
-/// This trait is the type-level dispatch point for force models that need
-/// geodetic coordinates (atmosphere, magnetic field) or ECEF↔ECI
-/// rotation (atmosphere wind velocity, magnetic field vector
-/// transformation).
+/// The type-level dispatch point for code that needs geodetic coordinates
+/// (atmosphere, magnetic field) or an ECEF↔ECI rotation (atmosphere wind
+/// velocity, magnetic field vector transformation).
 ///
 /// # Implementations
 ///
 /// - `SimpleEci`: ERA-only Z rotation (`Rotation<SimpleEci, SimpleEcef>`),
 ///   no EOP needed (`EopStorage = ()`).
-/// - `Gcrs`: Full IAU 2006 CIO chain (`Rotation<Gcrs, Itrs>`),
-///   requires EOP provider (`EopStorage = GcrsEopStorage`).
+/// - `Gcrs`: full IAU 2006 CIO chain (`Rotation<Gcrs, Itrs>`), requires an EOP
+///   provider (`EopStorage = GcrsEopStorage`, available with the `alloc`
+///   feature).
 pub trait EarthFrameBridge: EarthPoleBridge {
     /// The ECEF frame paired with this ECI frame.
     type Fixed: Ecef;
@@ -160,8 +113,6 @@ pub trait EarthFrameBridge: EarthPoleBridge {
     /// atmosphere co-rotation velocity) back into the propagation frame.
     fn fixed_to_inertial(utc: &Epoch<Utc>, eop: &Self::EopStorage) -> Rotation<Self::Fixed, Self>;
 }
-
-// SimpleEci implementation
 
 impl EarthFrameBridge for frame::SimpleEci {
     type Fixed = frame::SimpleEcef;
@@ -182,8 +133,7 @@ impl EarthFrameBridge for frame::SimpleEci {
     }
 }
 
-// Gcrs implementation
-
+#[cfg(feature = "alloc")]
 impl EarthFrameBridge for frame::Gcrs {
     type Fixed = frame::Itrs;
     type EopStorage = GcrsEopStorage;
@@ -201,12 +151,11 @@ impl EarthFrameBridge for frame::Gcrs {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "alloc"))]
 mod tests {
     use super::*;
-    use arika::earth::R as R_EARTH;
-    use arika::earth::eop::LengthOfDay;
-    use arika::epoch::Epoch;
+    use crate::earth::R as R_EARTH;
+    use crate::earth::eop::{LengthOfDay, NutationCorrections, PolarMotion, Ut1Offset};
 
     /// Minimal EOP provider for testing.
     struct ZeroEop;
@@ -317,8 +266,6 @@ mod tests {
             geo_gcrs.altitude
         );
     }
-
-    // EarthPoleBridge
 
     #[test]
     fn simple_eci_pole_is_plus_z() {

--- a/arika/src/earth/mod.rs
+++ b/arika/src/earth/mod.rs
@@ -19,12 +19,17 @@
 
 pub mod ellipsoid;
 pub mod eop;
+pub mod frame_bridge;
 pub mod geodetic;
 pub mod iau2006;
 pub mod rotation;
 pub mod topocentric;
 
 pub use ellipsoid::{WGS84_A, WGS84_B, WGS84_E2, WGS84_F};
+#[cfg(feature = "alloc")]
+pub use eop::GcrsEopStorage;
+pub use eop::PositionEop;
+pub use frame_bridge::{EarthFrameBridge, EarthPoleBridge};
 pub use geodetic::{Geodetic, geodetic_altitude};
 pub use topocentric::{LookAngles, TopocentricSite};
 

--- a/arika/src/earth/mod.rs
+++ b/arika/src/earth/mod.rs
@@ -16,22 +16,26 @@
 //!   nutation polynomials) plus the `Rotation<Gcrs, Cirs>::iau2006` /
 //!   `Rotation<Cirs, Tirs>::from_era` / `Rotation<Tirs, Itrs>::polar_motion`
 //!   constructors that consume the [`eop`] traits.
+//! - [`transform`] — per-frame Earth rotation pole
+//!   ([`EarthRotationPole`](transform::EarthRotationPole)) and ECI ↔ ECEF
+//!   transform ([`EarthFixedTransform`](transform::EarthFixedTransform)) for
+//!   `SimpleEci` / `Gcrs`, used by frame-aware force models
 
 pub mod ellipsoid;
 pub mod eop;
-pub mod frame_bridge;
 pub mod geodetic;
 pub mod iau2006;
 pub mod rotation;
 pub mod topocentric;
+pub mod transform;
 
 pub use ellipsoid::{WGS84_A, WGS84_B, WGS84_E2, WGS84_F};
 #[cfg(feature = "alloc")]
 pub use eop::GcrsEopStorage;
 pub use eop::PositionEop;
-pub use frame_bridge::{EarthFrameBridge, EarthPoleBridge};
 pub use geodetic::{Geodetic, geodetic_altitude};
 pub use topocentric::{LookAngles, TopocentricSite};
+pub use transform::{EarthFixedTransform, EarthRotationPole};
 
 // Physical constants
 

--- a/arika/src/earth/transform.rs
+++ b/arika/src/earth/transform.rs
@@ -1,11 +1,11 @@
-//! Per-frame Earth rotation-pole and ECI↔ECEF bridges.
+//! Per-frame Earth rotation pole and ECI↔ECEF transforms.
 //!
 //! These traits express, for a given ECI frame, two coordinate facts that
 //! force models in downstream crates need:
 //!
-//! - [`EarthPoleBridge`] — the direction of Earth's rotation pole in the frame
+//! - [`EarthRotationPole`] — the direction of Earth's rotation pole in the frame
 //!   (zonal gravity and atmosphere co-rotation only need the axis direction).
-//! - [`EarthFrameBridge`] — the paired Earth-fixed (ECEF) frame plus the
+//! - [`EarthFixedTransform`] — the paired Earth-fixed (ECEF) frame plus the
 //!   geodetic conversion and ECEF↔ECI rotation (atmosphere geodetic lookup,
 //!   magnetic field, wind co-rotation).
 //!
@@ -15,7 +15,7 @@
 //!   no EOP needed (the approximate, visualization-grade path).
 //! - [`Gcrs`](crate::frame::Gcrs): full IAU 2006 CIO chain
 //!   (precession + nutation + ERA + polar motion); the pole is the true CIP and
-//!   the ECEF bridge takes an EOP provider via [`GcrsEopStorage`].
+//!   the ECEF transform takes an EOP provider via [`GcrsEopStorage`].
 
 use crate::earth::geodetic::Geodetic;
 use crate::earth::iau2006::cip::cip_xy;
@@ -28,7 +28,7 @@ use crate::math::F64Ext;
 #[cfg(feature = "alloc")]
 use crate::earth::eop::GcrsEopStorage;
 
-// EarthPoleBridge
+// EarthRotationPole
 
 /// ECI frame that knows Earth's rotation-pole direction expressed in itself.
 ///
@@ -36,7 +36,7 @@ use crate::earth::eop::GcrsEopStorage;
 /// pole, and the atmosphere co-rotates about it, so those models only need the
 /// pole *direction* in the integration frame — not the full Earth-fixed
 /// rotation. This is the minimal capability they require, kept separate from the
-/// heavier [`EarthFrameBridge`] (which also provides the ECEF rotation that
+/// heavier [`EarthFixedTransform`] (which also provides the ECEF rotation that
 /// geodetic conversions and magnetic field need).
 ///
 /// EOP is intentionally not a parameter: the IAU 2006 model CIP is accurate to
@@ -47,19 +47,21 @@ use crate::earth::eop::GcrsEopStorage;
 /// # Implementations
 ///
 /// - `SimpleEci`: pole = `+Z` (the simple frame defines its Z axis as the pole).
-/// - `Gcrs`: pole = the IAU 2006 CIP direction `(X, Y, √(1−X²−Y²))` at the epoch.
-pub trait EarthPoleBridge: Eci + Sized + 'static {
+/// - `Gcrs`: the IAU 2006 **model** CIP — precession + nutation, no observed
+///   dX/dY, no polar motion — as `(X, Y, √(1−X²−Y²))` at the epoch. For an
+///   exact observed pole, a separate EOP-taking API would be needed.
+pub trait EarthRotationPole: Eci + Sized + 'static {
     /// Unit vector along Earth's rotation pole, expressed in this frame.
     fn earth_pole(utc: &Epoch<Utc>) -> Vec3<Self>;
 }
 
-impl EarthPoleBridge for frame::SimpleEci {
+impl EarthRotationPole for frame::SimpleEci {
     fn earth_pole(_utc: &Epoch<Utc>) -> Vec3<frame::SimpleEci> {
         Vec3::new(0.0, 0.0, 1.0)
     }
 }
 
-impl EarthPoleBridge for frame::Gcrs {
+impl EarthRotationPole for frame::Gcrs {
     fn earth_pole(utc: &Epoch<Utc>) -> Vec3<frame::Gcrs> {
         // CIP direction cosines (X, Y) in GCRS from the IAU 2006 model; Z closes
         // the unit vector. The model (no observed dX/dY) is sub-mas accurate.
@@ -82,9 +84,9 @@ impl EarthPoleBridge for frame::Gcrs {
     }
 }
 
-// EarthFrameBridge
+// EarthFixedTransform
 
-/// ECI frame that can bridge to Earth-fixed (ECEF) coordinates.
+/// ECI frame with a transform to its paired Earth-fixed (ECEF) frame.
 ///
 /// The type-level dispatch point for code that needs geodetic coordinates
 /// (atmosphere, magnetic field) or an ECEF↔ECI rotation (atmosphere wind
@@ -97,7 +99,7 @@ impl EarthPoleBridge for frame::Gcrs {
 /// - `Gcrs`: full IAU 2006 CIO chain (`Rotation<Gcrs, Itrs>`), requires an EOP
 ///   provider (`EopStorage = GcrsEopStorage`, available with the `alloc`
 ///   feature).
-pub trait EarthFrameBridge: EarthPoleBridge {
+pub trait EarthFixedTransform: EarthRotationPole {
     /// The ECEF frame paired with this ECI frame.
     type Fixed: Ecef;
 
@@ -114,7 +116,7 @@ pub trait EarthFrameBridge: EarthPoleBridge {
     fn fixed_to_inertial(utc: &Epoch<Utc>, eop: &Self::EopStorage) -> Rotation<Self::Fixed, Self>;
 }
 
-impl EarthFrameBridge for frame::SimpleEci {
+impl EarthFixedTransform for frame::SimpleEci {
     type Fixed = frame::SimpleEcef;
     type EopStorage = ();
 
@@ -134,7 +136,7 @@ impl EarthFrameBridge for frame::SimpleEci {
 }
 
 #[cfg(feature = "alloc")]
-impl EarthFrameBridge for frame::Gcrs {
+impl EarthFixedTransform for frame::Gcrs {
     type Fixed = frame::Itrs;
     type EopStorage = GcrsEopStorage;
 
@@ -192,7 +194,7 @@ mod tests {
         let utc = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
         let alt_km = 400.0;
         let pos = Vec3::<frame::SimpleEci>::new(R_EARTH + alt_km, 0.0, 0.0);
-        let geo = <frame::SimpleEci as EarthFrameBridge>::to_geodetic(&pos, &utc, &());
+        let geo = <frame::SimpleEci as EarthFixedTransform>::to_geodetic(&pos, &utc, &());
         // Altitude should be close to 400 km (not exact due to ERA rotation
         // and WGS84 ellipsoidal correction)
         assert!(
@@ -208,7 +210,7 @@ mod tests {
         let alt_km = 400.0;
         let pos = Vec3::<frame::Gcrs>::new(R_EARTH + alt_km, 0.0, 0.0);
         let eop = GcrsEopStorage::new(ZeroEop);
-        let geo = <frame::Gcrs as EarthFrameBridge>::to_geodetic(&pos, &utc, &eop);
+        let geo = <frame::Gcrs as EarthFixedTransform>::to_geodetic(&pos, &utc, &eop);
         assert!(
             (geo.altitude - alt_km).abs() < 1.0,
             "expected ~{alt_km} km, got {}",
@@ -220,7 +222,7 @@ mod tests {
     fn simple_eci_fixed_to_inertial_roundtrip() {
         let utc = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
         let v_ecef = Vec3::<frame::SimpleEcef>::new(1.0, 2.0, 3.0);
-        let rot = <frame::SimpleEci as EarthFrameBridge>::fixed_to_inertial(&utc, &());
+        let rot = <frame::SimpleEci as EarthFixedTransform>::fixed_to_inertial(&utc, &());
         let v_eci = rot.transform(&v_ecef);
         // Magnitude should be preserved
         assert!(
@@ -234,7 +236,7 @@ mod tests {
         let utc = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
         let v_itrs = Vec3::<frame::Itrs>::new(1.0, 2.0, 3.0);
         let eop = GcrsEopStorage::new(ZeroEop);
-        let rot = <frame::Gcrs as EarthFrameBridge>::fixed_to_inertial(&utc, &eop);
+        let rot = <frame::Gcrs as EarthFixedTransform>::fixed_to_inertial(&utc, &eop);
         let v_gcrs = rot.transform(&v_itrs);
         assert!(
             (v_gcrs.magnitude() - v_itrs.magnitude()).abs() < 1e-14,
@@ -252,11 +254,11 @@ mod tests {
 
         let pos_simple = Vec3::<frame::SimpleEci>::new(R_EARTH + alt_km, 0.0, 0.0);
         let geo_simple =
-            <frame::SimpleEci as EarthFrameBridge>::to_geodetic(&pos_simple, &utc, &());
+            <frame::SimpleEci as EarthFixedTransform>::to_geodetic(&pos_simple, &utc, &());
 
         let pos_gcrs = Vec3::<frame::Gcrs>::new(R_EARTH + alt_km, 0.0, 0.0);
         let eop = GcrsEopStorage::new(ZeroEop);
-        let geo_gcrs = <frame::Gcrs as EarthFrameBridge>::to_geodetic(&pos_gcrs, &utc, &eop);
+        let geo_gcrs = <frame::Gcrs as EarthFixedTransform>::to_geodetic(&pos_gcrs, &utc, &eop);
 
         // Altitudes should agree within a few km (different rotation chains)
         assert!(
@@ -270,11 +272,11 @@ mod tests {
     #[test]
     fn simple_eci_pole_is_plus_z() {
         let utc = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
-        let p = <frame::SimpleEci as EarthPoleBridge>::earth_pole(&utc);
+        let p = <frame::SimpleEci as EarthRotationPole>::earth_pole(&utc);
         assert_eq!(p, Vec3::<frame::SimpleEci>::new(0.0, 0.0, 1.0));
     }
 
-    fn pole_offset_from_z_deg<F: EarthPoleBridge>(utc: &Epoch<Utc>) -> f64 {
+    fn pole_offset_from_z_deg<F: EarthRotationPole>(utc: &Epoch<Utc>) -> f64 {
         let p = F::earth_pole(utc);
         let z = Vec3::<F>::new(0.0, 0.0, 1.0);
         assert!(

--- a/arika/src/earth/transform.rs
+++ b/arika/src/earth/transform.rs
@@ -75,11 +75,11 @@ impl EarthRotationPole for frame::Gcrs {
         let t = utc.to_tt().centuries_since_j2000();
         let (x, y) = cip_xy(t);
         let (x, y) = (x.raw(), y.raw());
-        // Guard against a slightly-negative radicand from f64 round-off (x²+y²
-        // is ~1e-5 for real CIP values, never near 1). `f64::max` is std-only,
-        // so clamp manually to stay no_std-compatible.
-        let radicand = 1.0 - x * x - y * y;
-        let z = if radicand > 0.0 { radicand.sqrt() } else { 0.0 };
+        // `.max(0.0)` guards against a slightly-negative radicand from f64
+        // round-off (x²+y² is ~1e-5 for real CIP values, never near 1).
+        // `.sqrt()` is the only std-only float op here; `F64Ext` (libm) supplies
+        // it on no_std, while `f64::max` is available in `core`.
+        let z = (1.0 - x * x - y * y).max(0.0).sqrt();
         Vec3::new(x, y, z)
     }
 }

--- a/arika/tests/trybuild/null_eop_in_iau2006.stderr
+++ b/arika/tests/trybuild/null_eop_in_iau2006.stderr
@@ -6,11 +6,16 @@ error[E0277]: the trait bound `NullEop: NutationCorrections` is not satisfied
    |              |
    |              required by a bound introduced by this call
    |
-help: the trait `NutationCorrections` is implemented for `EopTable`
-  --> src/earth/eop/table.rs
+help: the following other types implement trait `NutationCorrections`
+  --> src/earth/eop/mod.rs
+   |
+   | impl NutationCorrections for GcrsEopStorage {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `GcrsEopStorage`
+   |
+  ::: src/earth/eop/table.rs
    |
    | impl NutationCorrections for EopTable {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `EopTable`
 note: required by a bound in `cio_chain::<impl Rotation<arika::frame::Gcrs, arika::frame::Cirs>>::iau2006`
   --> src/earth/iau2006/cio_chain.rs
    |

--- a/arika/tests/trybuild/null_eop_in_iau2006_full_from_utc.stderr
+++ b/arika/tests/trybuild/null_eop_in_iau2006_full_from_utc.stderr
@@ -6,11 +6,16 @@ error[E0277]: the trait bound `NullEop: Ut1Offset` is not satisfied
    |              |
    |              required by a bound introduced by this call
    |
-help: the trait `Ut1Offset` is implemented for `EopTable`
-  --> src/earth/eop/table.rs
+help: the following other types implement trait `Ut1Offset`
+  --> src/earth/eop/mod.rs
+   |
+   | impl Ut1Offset for GcrsEopStorage {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `GcrsEopStorage`
+   |
+  ::: src/earth/eop/table.rs
    |
    | impl Ut1Offset for EopTable {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `EopTable`
 note: required by a bound in `cio_chain::<impl Rotation<arika::frame::Gcrs, arika::frame::Itrs>>::iau2006_full_from_utc`
   --> src/earth/iau2006/cio_chain.rs
    |
@@ -28,11 +33,16 @@ error[E0277]: the trait bound `NullEop: NutationCorrections` is not satisfied
    |              |
    |              required by a bound introduced by this call
    |
-help: the trait `NutationCorrections` is implemented for `EopTable`
-  --> src/earth/eop/table.rs
+help: the following other types implement trait `NutationCorrections`
+  --> src/earth/eop/mod.rs
+   |
+   | impl NutationCorrections for GcrsEopStorage {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `GcrsEopStorage`
+   |
+  ::: src/earth/eop/table.rs
    |
    | impl NutationCorrections for EopTable {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `EopTable`
 note: required by a bound in `cio_chain::<impl Rotation<arika::frame::Gcrs, arika::frame::Itrs>>::iau2006_full_from_utc`
   --> src/earth/iau2006/cio_chain.rs
    |
@@ -50,11 +60,16 @@ error[E0277]: the trait bound `NullEop: PolarMotion` is not satisfied
    |              |
    |              required by a bound introduced by this call
    |
-help: the trait `PolarMotion` is implemented for `EopTable`
-  --> src/earth/eop/table.rs
+help: the following other types implement trait `PolarMotion`
+  --> src/earth/eop/mod.rs
+   |
+   | impl PolarMotion for GcrsEopStorage {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `GcrsEopStorage`
+   |
+  ::: src/earth/eop/table.rs
    |
    | impl PolarMotion for EopTable {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `EopTable`
 note: required by a bound in `cio_chain::<impl Rotation<arika::frame::Gcrs, arika::frame::Itrs>>::iau2006_full_from_utc`
   --> src/earth/iau2006/cio_chain.rs
    |

--- a/arika/tests/trybuild/null_eop_in_polar_motion.stderr
+++ b/arika/tests/trybuild/null_eop_in_polar_motion.stderr
@@ -6,11 +6,16 @@ error[E0277]: the trait bound `NullEop: PolarMotion` is not satisfied
    |              |
    |              required by a bound introduced by this call
    |
-help: the trait `PolarMotion` is implemented for `EopTable`
-  --> src/earth/eop/table.rs
+help: the following other types implement trait `PolarMotion`
+  --> src/earth/eop/mod.rs
+   |
+   | impl PolarMotion for GcrsEopStorage {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `GcrsEopStorage`
+   |
+  ::: src/earth/eop/table.rs
    |
    | impl PolarMotion for EopTable {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `EopTable`
 note: required by a bound in `cio_chain::<impl Rotation<arika::frame::Tirs, arika::frame::Itrs>>::polar_motion`
   --> src/earth/iau2006/cio_chain.rs
    |

--- a/arika/tests/trybuild/null_eop_in_to_ut1.stderr
+++ b/arika/tests/trybuild/null_eop_in_to_ut1.stderr
@@ -6,11 +6,16 @@ error[E0277]: the trait bound `NullEop: Ut1Offset` is not satisfied
    |                    |
    |                    required by a bound introduced by this call
    |
-help: the trait `Ut1Offset` is implemented for `EopTable`
-  --> src/earth/eop/table.rs
+help: the following other types implement trait `Ut1Offset`
+  --> src/earth/eop/mod.rs
+   |
+   | impl Ut1Offset for GcrsEopStorage {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `GcrsEopStorage`
+   |
+  ::: src/earth/eop/table.rs
    |
    | impl Ut1Offset for EopTable {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `EopTable`
 note: required by a bound in `epoch::convert::<impl Epoch<Utc, P>>::to_ut1`
   --> src/epoch/convert.rs
    |

--- a/orts/src/attitude/control/bdot.rs
+++ b/orts/src/attitude/control/bdot.rs
@@ -60,7 +60,7 @@ impl<F: MagneticFieldModel> BdotCross<F> {
 }
 
 // TODO: SimpleEci constraint comes from magnetic::field_eci. To make
-// frame-generic, BdotCross needs EarthFrameBridge<Fr> (like
+// frame-generic, BdotCross needs EarthFixedTransform<Fr> (like
 // AtmosphericDrag<Fr>) and should use magnetic::field_inertial<Fr>.
 impl<F: MagneticFieldModel, S: HasAttitude + HasOrbit<Frame = arika::frame::SimpleEci>> Model<S>
     for BdotCross<F>

--- a/orts/src/lib.rs
+++ b/orts/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod attitude;
 pub mod control;
 pub mod effector;
-pub mod environment;
 pub mod events;
 pub mod group;
 pub mod magnetic;

--- a/orts/src/magnetic.rs
+++ b/orts/src/magnetic.rs
@@ -3,10 +3,10 @@
 //! The model's [`MagneticFieldModel::field_ecef`] returns the field in
 //! ECEF Cartesian coordinates. Callers inside orts work in an ECI frame,
 //! so this module provides [`field_inertial`] which handles the full
-//! round-trip via [`EarthFrameBridge`]:
+//! round-trip via [`EarthFixedTransform`]:
 //!
 //! ```text
-//! ECI position → ECEF (via EarthFrameBridge) → geodetic
+//! ECI position → ECEF (via EarthFixedTransform) → geodetic
 //!   → field_ecef → ECEF field vector → ECI (inverse rotation)
 //! ```
 
@@ -14,14 +14,14 @@ use arika::epoch::{Epoch, Utc};
 use arika::frame::Vec3;
 use tobari::magnetic::{MagneticFieldInput, MagneticFieldModel};
 
-use arika::earth::EarthFrameBridge;
+use arika::earth::EarthFixedTransform;
 
 /// Evaluate a magnetic field model and return the result in the
 /// propagation frame `F`.
 ///
-/// Uses [`EarthFrameBridge`] for the ECI↔ECEF conversion, so it works
+/// Uses [`EarthFixedTransform`] for the ECI↔ECEF conversion, so it works
 /// with both `SimpleEci` (ERA rotation) and `Gcrs` (IAU 2006 chain).
-pub fn field_inertial<F: EarthFrameBridge>(
+pub fn field_inertial<F: EarthFixedTransform>(
     model: &dyn MagneticFieldModel,
     position: &Vec3<F>,
     epoch: &Epoch<Utc>,

--- a/orts/src/magnetic.rs
+++ b/orts/src/magnetic.rs
@@ -14,7 +14,7 @@ use arika::epoch::{Epoch, Utc};
 use arika::frame::Vec3;
 use tobari::magnetic::{MagneticFieldInput, MagneticFieldModel};
 
-use crate::environment::EarthFrameBridge;
+use arika::earth::EarthFrameBridge;
 
 /// Evaluate a magnetic field model and return the result in the
 /// propagation frame `F`.

--- a/orts/src/perturbations/drag.rs
+++ b/orts/src/perturbations/drag.rs
@@ -10,7 +10,7 @@ use tobari::{AtmosphereInput, AtmosphereModel, Exponential};
 use crate::model::ExternalLoads;
 use crate::model::{HasOrbit, Model};
 use crate::orbital::OrbitalState;
-use arika::earth::EarthFrameBridge;
+use arika::earth::EarthFixedTransform;
 
 /// Default ballistic coefficient for LEO satellites \[m²/kg\].
 ///
@@ -30,7 +30,7 @@ pub const DEFAULT_BALLISTIC_COEFF: f64 = 0.01;
 /// which spin axis the atmosphere co-rotates about. `SimpleEci` uses the
 /// ERA-only ECEF rotation and a +Z spin axis; `Gcrs` uses the full IAU 2006
 /// CIO chain and the true CIP spin axis.
-pub struct AtmosphericDrag<F: EarthFrameBridge = frame::SimpleEci> {
+pub struct AtmosphericDrag<F: EarthFixedTransform = frame::SimpleEci> {
     /// Central body (enables WGS-84 geodetic altitude for Earth)
     pub body: Option<KnownBody>,
     /// Central body equatorial radius [km] (fallback for non-Earth bodies)
@@ -88,7 +88,7 @@ impl AtmosphericDrag<frame::SimpleEci> {
     }
 }
 
-impl<F: EarthFrameBridge> AtmosphericDrag<F> {
+impl<F: EarthFixedTransform> AtmosphericDrag<F> {
     /// Create drag model for Earth orbit in any frame.
     pub fn for_earth_in_frame(ballistic_coeff: Option<f64>, eop: F::EopStorage) -> Self {
         Self {
@@ -108,7 +108,7 @@ impl<F: EarthFrameBridge> AtmosphericDrag<F> {
     }
 }
 
-impl<F: EarthFrameBridge> AtmosphericDrag<F> {
+impl<F: EarthFixedTransform> AtmosphericDrag<F> {
     /// Compute drag acceleration [km/s²] from orbital state.
     pub(crate) fn acceleration(
         &self,
@@ -158,7 +158,7 @@ impl<F: EarthFrameBridge> AtmosphericDrag<F> {
 
         // Atmosphere co-rotation velocity Ω × r, with Ω along the central body's
         // spin axis (magnitude `omega_body`). For Earth the spin axis is the IAU
-        // 2006 CIP, which `EarthPoleBridge` expresses in the integration frame
+        // 2006 CIP, which `EarthRotationPole` expresses in the integration frame
         // `F`: +Z for `SimpleEci` (so this reduces exactly to the classic
         // [0, 0, ω] × r), the true CIP for `Gcrs` (correcting the ~0.1–0.3°
         // offset of the spin axis from the GCRS Z axis that a +Z assumption
@@ -195,7 +195,7 @@ impl<F: EarthFrameBridge> AtmosphericDrag<F> {
     }
 }
 
-impl<F: EarthFrameBridge, S: HasOrbit<Frame = F>> Model<S, F> for AtmosphericDrag<F> {
+impl<F: EarthFixedTransform, S: HasOrbit<Frame = F>> Model<S, F> for AtmosphericDrag<F> {
     fn name(&self) -> &str {
         "drag"
     }
@@ -387,9 +387,9 @@ mod tests {
         // The atmosphere co-rotates about Earth's spin axis. For `Gcrs` that axis
         // is the IAU 2006 CIP, offset from the GCRS Z axis by precession/nutation.
         // Pin that drag computes the co-rotation velocity about the CIP (not +Z)
-        // by reconstructing the acceleration from `EarthPoleBridge::earth_pole`.
+        // by reconstructing the acceleration from `EarthRotationPole::earth_pole`.
         use arika::earth::eop::{NutationCorrections, PolarMotion, Ut1Offset};
-        use arika::earth::{EarthPoleBridge, GcrsEopStorage};
+        use arika::earth::{EarthRotationPole, GcrsEopStorage};
 
         // Zero-EOP: model CIP only (no observed dX/dY, dUT1, polar motion) — the
         // same provider oracle_gcrf uses; keeps the CIP at sub-mas accuracy.
@@ -419,7 +419,7 @@ mod tests {
         let utc = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
 
         // The check is only meaningful if the CIP differs from +Z at this epoch.
-        let pole = <frame::Gcrs as EarthPoleBridge>::earth_pole(&utc).into_inner();
+        let pole = <frame::Gcrs as EarthRotationPole>::earth_pole(&utc).into_inner();
         let off_axis = (pole - vector![0.0, 0.0, 1.0]).norm();
         assert!(
             off_axis > 1e-9,
@@ -442,7 +442,7 @@ mod tests {
         // Reconstruct the expected acceleration with Ω along the CIP spin axis.
         let omega = pole * OMEGA_EARTH;
         let v_rel = vel - omega.cross(&pos);
-        let geod = <frame::Gcrs as EarthFrameBridge>::to_geodetic(
+        let geod = <frame::Gcrs as EarthFixedTransform>::to_geodetic(
             &Vec3::from_raw(pos),
             &utc,
             &GcrsEopStorage::new(ZeroEop),

--- a/orts/src/perturbations/drag.rs
+++ b/orts/src/perturbations/drag.rs
@@ -7,10 +7,10 @@ use arika::frame::{self, Vec3};
 use nalgebra::Vector3;
 use tobari::{AtmosphereInput, AtmosphereModel, Exponential};
 
-use crate::environment::EarthFrameBridge;
 use crate::model::ExternalLoads;
 use crate::model::{HasOrbit, Model};
 use crate::orbital::OrbitalState;
+use arika::earth::EarthFrameBridge;
 
 /// Default ballistic coefficient for LEO satellites \[m²/kg\].
 ///
@@ -388,8 +388,8 @@ mod tests {
         // is the IAU 2006 CIP, offset from the GCRS Z axis by precession/nutation.
         // Pin that drag computes the co-rotation velocity about the CIP (not +Z)
         // by reconstructing the acceleration from `EarthPoleBridge::earth_pole`.
-        use crate::environment::{EarthPoleBridge, GcrsEopStorage};
         use arika::earth::eop::{NutationCorrections, PolarMotion, Ut1Offset};
+        use arika::earth::{EarthPoleBridge, GcrsEopStorage};
 
         // Zero-EOP: model CIP only (no observed dX/dY, dUT1, polar motion) — the
         // same provider oracle_gcrf uses; keeps the CIP at sub-mas accuracy.

--- a/orts/src/perturbations/zonal_gravity.rs
+++ b/orts/src/perturbations/zonal_gravity.rs
@@ -4,7 +4,7 @@
 //! ([`PointMass`](crate::orbital::gravity::PointMass)), the zonal harmonics are
 //! symmetric about the central body's *rotation pole*, so the acceleration
 //! depends on the orientation of the integration frame relative to that pole.
-//! [`ZonalGravity`] therefore takes the pole direction from [`EarthPoleBridge`]
+//! [`ZonalGravity`] therefore takes the pole direction from [`EarthRotationPole`]
 //! instead of assuming the frame's Z axis is the pole.
 //!
 //! - `SimpleEci`: pole = `+Z`, reproducing the classic frame-Z formula (for a
@@ -24,11 +24,11 @@ use nalgebra::Vector3;
 
 use crate::model::ExternalLoads;
 use crate::model::{HasOrbit, Model};
-use arika::earth::EarthPoleBridge;
+use arika::earth::EarthRotationPole;
 
 /// Zonal harmonics (J2, optional J3/J4) gravity perturbation about the
-/// rotation pole supplied by [`EarthPoleBridge`].
-pub struct ZonalGravity<F: EarthPoleBridge = arika::frame::SimpleEci> {
+/// rotation pole supplied by [`EarthRotationPole`].
+pub struct ZonalGravity<F: EarthRotationPole = arika::frame::SimpleEci> {
     /// Gravitational parameter of the central body [km³/s²].
     pub mu: f64,
     /// Equatorial radius of the central body [km].
@@ -45,7 +45,7 @@ pub struct ZonalGravity<F: EarthPoleBridge = arika::frame::SimpleEci> {
     _frame: PhantomData<fn() -> F>,
 }
 
-impl<F: EarthPoleBridge> ZonalGravity<F> {
+impl<F: EarthRotationPole> ZonalGravity<F> {
     /// Create a zonal gravity perturbation for a central body.
     pub fn new(mu: f64, r_body: f64, j2: f64, j3: Option<f64>, j4: Option<f64>) -> Self {
         Self {
@@ -106,7 +106,7 @@ impl<F: EarthPoleBridge> ZonalGravity<F> {
     }
 }
 
-impl<F: EarthPoleBridge, S: HasOrbit<Frame = F>> Model<S, F> for ZonalGravity<F> {
+impl<F: EarthRotationPole, S: HasOrbit<Frame = F>> Model<S, F> for ZonalGravity<F> {
     fn name(&self) -> &str {
         "zonal_gravity"
     }

--- a/orts/src/perturbations/zonal_gravity.rs
+++ b/orts/src/perturbations/zonal_gravity.rs
@@ -22,9 +22,9 @@ use std::marker::PhantomData;
 use arika::epoch::{Epoch, Utc};
 use nalgebra::Vector3;
 
-use crate::environment::EarthPoleBridge;
 use crate::model::ExternalLoads;
 use crate::model::{HasOrbit, Model};
+use arika::earth::EarthPoleBridge;
 
 /// Zonal harmonics (J2, optional J3/J4) gravity perturbation about the
 /// rotation pole supplied by [`EarthPoleBridge`].

--- a/orts/src/setup.rs
+++ b/orts/src/setup.rs
@@ -32,7 +32,7 @@ fn build_gravity_field() -> Box<dyn GravityField> {
 
 /// Zonal (J2/J3/J4) perturbation for the body, if it has an oblateness model.
 ///
-/// These builders produce `SimpleEci` systems, where `EarthPoleBridge` returns
+/// These builders produce `SimpleEci` systems, where `EarthRotationPole` returns
 /// the frame's `+Z` axis as the pole — the legacy frame-Z convention. So
 /// `ZonalGravity` reproduces the previous frame-Z behaviour for every
 /// body; for a non-Earth body that is correct only insofar as its state is

--- a/orts/src/spacecraft/surface.rs
+++ b/orts/src/spacecraft/surface.rs
@@ -303,7 +303,7 @@ impl PanelDrag {
 
 // PanelDrag remains SimpleEci-constrained because loads_from_state uses
 // ERA-based geodetic conversion internally (same as AtmosphericDrag before
-// EarthFrameBridge). To support Gcrs, PanelDrag needs EarthFrameBridge<F>
+// EarthFixedTransform). To support Gcrs, PanelDrag needs EarthFixedTransform<F>
 // with EOP storage, like AtmosphericDrag<F>.
 impl<S: HasAttitude + HasOrbit<Frame = arika::frame::SimpleEci> + HasMass> Model<S> for PanelDrag {
     fn name(&self) -> &str {

--- a/orts/src/visibility.rs
+++ b/orts/src/visibility.rs
@@ -10,7 +10,7 @@ use arika::earth::{Geodetic, TopocentricSite};
 use arika::epoch::{Epoch, Utc};
 use arika::frame::Vec3;
 
-use arika::earth::EarthFrameBridge;
+use arika::earth::EarthFixedTransform;
 
 /// A ground station with an elevation mask.
 #[derive(Debug, Clone)]
@@ -168,22 +168,22 @@ pub struct StationContact {
 /// Streaming visibility monitor: ECI samples in, contact windows out.
 ///
 /// Wraps one [`PassTracker`] per station and performs the ECI → ECEF
-/// conversion at each sample via the [`EarthFrameBridge`] for `F`
+/// conversion at each sample via the [`EarthFixedTransform`] for `F`
 /// (`SimpleEci` = ERA-only rotation, `Gcrs` = full IAU 2006 chain).
-pub struct VisibilityMonitor<F: EarthFrameBridge> {
+pub struct VisibilityMonitor<F: EarthFixedTransform> {
     /// Simulation start epoch (`t = 0`).
     epoch: Epoch<Utc>,
     eop: F::EopStorage,
     stations: Vec<StationState<F>>,
 }
 
-struct StationState<F: EarthFrameBridge> {
+struct StationState<F: EarthFixedTransform> {
     station: GroundStation,
     site: TopocentricSite<F::Fixed>,
     tracker: PassTracker,
 }
 
-impl<F: EarthFrameBridge> VisibilityMonitor<F> {
+impl<F: EarthFixedTransform> VisibilityMonitor<F> {
     /// Create a monitor. `epoch` anchors simulation time `t = 0` (contact
     /// windows depend on Earth rotation, so it is required).
     pub fn new(epoch: Epoch<Utc>, eop: F::EopStorage, stations: Vec<GroundStation>) -> Self {

--- a/orts/src/visibility.rs
+++ b/orts/src/visibility.rs
@@ -10,7 +10,7 @@ use arika::earth::{Geodetic, TopocentricSite};
 use arika::epoch::{Epoch, Utc};
 use arika::frame::Vec3;
 
-use crate::environment::EarthFrameBridge;
+use arika::earth::EarthFrameBridge;
 
 /// A ground station with an elevation mask.
 #[derive(Debug, Clone)]

--- a/orts/tests/oracle.rs
+++ b/orts/tests/oracle.rs
@@ -2157,9 +2157,9 @@ fn j2_omega_precession_dp45_500_orbits() {
 
 #[test]
 fn gcrs_propagation_close_to_simple_eci() {
+    use arika::earth::GcrsEopStorage;
     use arika::earth::eop::{NutationCorrections, PolarMotion, Ut1Offset};
     use arika::frame;
-    use orts::environment::GcrsEopStorage;
     use orts::orbital::gravity::PointMass;
 
     /// Zero EOP provider for testing.

--- a/orts/tests/oracle.rs
+++ b/orts/tests/oracle.rs
@@ -2153,7 +2153,7 @@ fn j2_omega_precession_dp45_500_orbits() {
 // Validates that OrbitalSystem<Gcrs> compiles, runs, and produces
 // physically reasonable results. With zero EOP, SimpleEci and Gcrs
 // paths should agree closely (difference comes from precession/nutation
-// in the IAU 2006 chain used by EarthFrameBridge<Gcrs>).
+// in the IAU 2006 chain used by EarthFixedTransform<Gcrs>).
 
 #[test]
 fn gcrs_propagation_close_to_simple_eci() {

--- a/orts/tests/oracle_gcrf.rs
+++ b/orts/tests/oracle_gcrf.rs
@@ -6,7 +6,7 @@
 //! Key differences from the EME2000 fixtures (oracle_orekit.rs):
 //! - **Frame**: GCRF (includes IAU frame bias) vs EME2000 (J2000 mean equator)
 //! - **Drag geodetic**: Orekit uses ITRF via full IAU 2006 chain with real EOP;
-//!   our Gcrs path uses EarthFrameBridge<Gcrs> with ZeroEop (no dUT1, xp=yp=0)
+//!   our Gcrs path uses EarthFixedTransform<Gcrs> with ZeroEop (no dUT1, xp=yp=0)
 //! - **Known EOP gap**: ZeroEop vs real EOP introduces ~arcsec-level rotation
 //!   difference (~meter-level position error per orbit)
 

--- a/orts/tests/oracle_gcrf.rs
+++ b/orts/tests/oracle_gcrf.rs
@@ -10,13 +10,13 @@
 //! - **Known EOP gap**: ZeroEop vs real EOP introduces ~arcsec-level rotation
 //!   difference (~meter-level position error per orbit)
 
+use arika::earth::GcrsEopStorage;
 use arika::earth::eop::{NutationCorrections, PolarMotion, Ut1Offset};
 use arika::earth::{J2 as J2_EARTH, J3 as J3_EARTH, J4 as J4_EARTH};
 use arika::earth::{MU as MU_EARTH, R as R_EARTH};
 use arika::epoch::Epoch;
 use arika::frame;
 use nalgebra::Vector3;
-use orts::environment::GcrsEopStorage;
 use orts::orbital::OrbitalState;
 use orts::orbital::OrbitalSystem;
 use orts::orbital::gravity::PointMass;

--- a/tools/generate_gcrf_propagation_fixtures.py
+++ b/tools/generate_gcrf_propagation_fixtures.py
@@ -11,7 +11,7 @@ as the propagation frame.
 Key differences from the EME2000 fixtures:
   - Frame: GCRF (includes frame bias) vs EME2000 (J2000 mean equator)
   - Drag geodetic: Orekit uses ITRF via IERS 2010 internally (proper
-    IAU 2006 chain), matching our EarthFrameBridge<Gcrs> implementation
+    IAU 2006 chain), matching our EarthFixedTransform<Gcrs> implementation
   - Gravity body frame: CIRF (pole = IAU 2006 CIP), matching our Rust
     ZonalGravity<Gcrs> which evaluates the zonal harmonics about the CIP
     (polar motion excluded; zonal terms are longitude-independent)


### PR DESCRIPTION
## 概要

orts にあった2つのトレイト — 地球の自転極方向（`EarthPoleBridge`）と ECI↔ECEF 変換（`EarthFrameBridge`）— を arika へ移し、合わせて `EarthRotationPole` / `EarthFixedTransform` に改名する。挙動は変えず、責務の置き場所を正すレイヤリングの整理。

## 背景

この2トレイトはフレーム・回転・EOP（地球姿勢パラメータ）に関する純粋な座標系の事実を表すが、置き場所は orts（シミュレーション側）だった。中身は arika のプリミティブ（`cip_xy` / `Rotation` / `Geodetic` / EOP トレイト）への薄いラッパで、シミュレーション固有の要素は無い。フレーム・回転・EOP トレイトを定義しているのは arika なので、これらも arika が持つのが自然。

## 変更内容

- 新規 `arika::earth::transform` に `EarthRotationPole` / `EarthFixedTransform`（＋ `SimpleEci` / `Gcrs` の実装）。
- `arika::earth::eop` に `PositionEop`（既存 `FullEopProvider` の位置変換専用版）と `GcrsEopStorage`（EOP provider を保持する所有ラッパ）。
- orts は import を `arika::earth` に向け直し、`orts/src/environment.rs` を削除。

`orts::environment` は公開モジュールだったので削除は API の破壊的変更にあたるが、利用者はワークスペース全体で orts 自身のみ（外部・他クレートの参照なし）で、次は 0.3 リリースのため許容範囲。互換用の shim は置かない。

## 設計の要点

自明でない選択とその理由:

- **EOP provider のストレージ（`GcrsEopStorage`）も arika に置く。** arika の回転 API は provider を呼び出しごとに借用する形（`Rotation::<Gcrs, Itrs>::iau2006_full_from_utc<P>(.., &P)`）で、それは維持。`GcrsEopStorage` はその上で provider を1つ保持するための所有ラッパにすぎず、arika が既に `EopTable` などの EOP データ型を持っているのと同じ層に収まる。`Send + Sync` は中の boxed object 側にだけ付ける。
- **トレイトは provider をジェネリック引数にせず、`EopStorage` 連想型にした。** これで force model（`AtmosphericDrag<F>` など）がフレーム `F` だけで provider 型を決められ、ジェネリックを1つ増やさずに済む。
- **`Gcrs` の自転極は EOP-free の IAU 2006 model CIP**（歳差＋章動。観測 dX/dY なし、極運動なし）。zonal 重力や大気の共回転は sub-mas の補正を必要としないので、これらを EOP 依存にしないための選択。exact な観測極が要るときは別 API を足す。
- 命名は「Bridge」（実装上の繋ぎ役という含み）を避け、扱う対象を表す `EarthRotationPole` / `EarthFixedTransform` にした。モジュールも `transform`（座標変換）に。

## no_std 対応

- `GcrsEopStorage` と `Gcrs` の `EarthFixedTransform` 実装は `Box` を使うので `#[cfg(feature = "alloc")]` で囲み、arika の no_std（alloc 無し）ビルドを保つ。
- `earth_pole` は std 専用の `f64::max`/`f64::sqrt` を避け、`crate::math::F64Ext`（libm）＋手動クランプを使う（`cip.rs` / `geodetic.rs` と同じやり方）。

## 検証

- arika ビルド: std / no_std+alloc / no_std / wasm32 すべて警告なし。
- arika 全テスト、orts lib（646 件）、oracle_gcrf すべて pass（数値は完全に不変）。`clippy --workspace -- -D warnings` / `cargo fmt` clean。
- `NullEop` の trybuild `.stderr` を更新（`GcrsEopStorage` が「この trait を実装する他の型」の診断メッセージに出るようになるため。`NullEop` が高精度 API に弾かれる性質自体は変わらない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
