### PR TITLE
feat(cli): machine-readable `orts run --json` summary + fix csv --output path

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -73,6 +73,14 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - WebSocket protocol の TypeScript 型を `ts-rs` で Rust 型から生成
   (protocol enum、`SimConfig`、`SatelliteInfo` 等に `#[derive(TS)]`)。
   `cargo test -p orts-cli` 実行時に viewer へ出力し、ドリフトすると CI が落ちる。([#95](https://github.com/sksat/orts/pull/95))
+- `orts run --json` で機械可読な実行サマリを stdout に出力 — `status`、解決済み
+  の `simulation` パラメータ、各衛星の `samples` 数と `final` 位置/速度、出力
+  `artifacts`。診断ログは stderr に残すので、stdout はちょうど 1 つの機械可読
+  ドキュメントを運ぶ。スクリプトや orts を駆動する coding agent 向け。stdout が
+  JSON を運ぶため、シミュレーションデータはファイルへ出力する必要があり、
+  `--json` とデータの stdout 出力の併用は拒否する。([#214](https://github.com/sksat/orts/pull/214))
+- `orts run --output -` でシミュレーションデータを stdout に出力。`-` を正準の
+  stdout sentinel とし、従来の `stdout` キーワードは alias として残す。([#214](https://github.com/sksat/orts/pull/214))
 
 #### Changed
 - `--tle` を再び TLE 専用 (2LE/3LE、`-` で stdin) とし、新規 `--omm` と
@@ -86,6 +94,9 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   年に繰り上がらず拒否される。([#87](https://github.com/sksat/orts/pull/87))
 
 #### Fixed
+- `orts run --format csv --output <path>` が CSV を `<path>` に書き込むように
+  なった。従来は `--format csv` の実行が `--output` に関わらず常に stdout へ
+  出力し、指定パスを黙って無視していた。([#214](https://github.com/sksat/orts/pull/214))
 - `--config` ファイルで起動した `orts serve` は `[[command]]` タイムラインを
   含む config を明確なエラーで拒否する (コマンドタイムラインは `orts run`
   のみ)。従来は黙って破棄していた。([#58](https://github.com/sksat/orts/pull/58))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,14 @@ section is subdivided by package.
   `ts-rs` (`#[derive(TS)]` on the protocol enums, `SimConfig`, `SatelliteInfo`,
   …). Bindings are emitted into the viewer when `cargo test -p orts-cli` runs,
   and CI fails if they drift. ([#95](https://github.com/sksat/orts/pull/95))
+- `orts run --json` emits a machine-readable run summary on stdout — `status`,
+  the resolved `simulation` parameters, each satellite's `samples` count and
+  `final` position/velocity, and the output `artifacts` — while diagnostics stay
+  on stderr. Aimed at scripts and coding agents driving orts. Because stdout then
+  carries the JSON, the simulation data must be written to a file: combining
+  `--json` with data on stdout is rejected. ([#214](https://github.com/sksat/orts/pull/214))
+- `orts run --output -` writes the simulation data to stdout. `-` is the
+  canonical stdout sentinel; the previous `stdout` keyword is kept as an alias. ([#214](https://github.com/sksat/orts/pull/214))
 
 #### Changed
 - `--tle` is TLE-only again (2LE/3LE; `-` for stdin) and pairs with the new
@@ -93,6 +101,9 @@ section is subdivided by package.
   malformed field is rejected rather than rolling into another year. ([#87](https://github.com/sksat/orts/pull/87))
 
 #### Fixed
+- `orts run --format csv --output <path>` now writes the CSV to `<path>`.
+  Previously every `--format csv` run wrote to stdout regardless of `--output`,
+  silently ignoring the given path. ([#214](https://github.com/sksat/orts/pull/214))
 - `orts serve` started with a `--config` file now rejects a `[[command]]`
   timeline with a clear error (command timelines run only under `orts run`)
   instead of silently dropping it. ([#58](https://github.com/sksat/orts/pull/58))

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -15,13 +15,24 @@ pub enum Commands {
         #[command(flatten)]
         sim: SimArgs,
 
-        /// Output path (use "stdout" to write to standard output)
-        #[arg(long, default_value = "output.rrd")]
-        output: String,
+        /// Output path for the simulation data. Use "-" (or the legacy
+        /// "stdout" alias) to write to standard output. When omitted, the
+        /// default is "output.rrd" for --format rrd and standard output for
+        /// --format csv.
+        #[arg(long)]
+        output: Option<String>,
 
-        /// Output format
+        /// Output data format
         #[arg(long, default_value = "rrd")]
         format: OutputFormat,
+
+        /// Emit a machine-readable run summary as JSON on stdout (status,
+        /// per-satellite final state, and the output artifact). Diagnostics
+        /// and logs stay on stderr. Because stdout then carries the JSON,
+        /// the simulation data must go to a file: combining --json with data
+        /// on stdout is rejected.
+        #[arg(long)]
+        json: bool,
     },
     /// Start WebSocket server for real-time streaming
     Serve {

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -19,7 +19,7 @@ use crate::cli::{IntegratorChoice, OutputFormat, SimArgs};
 use crate::satellite::OrbitSpec;
 use crate::sim::params::SimParams;
 
-pub fn run_simulation_cmd(sim: &SimArgs, output: &str, format: OutputFormat) {
+pub fn run_simulation_cmd(sim: &SimArgs, output: Option<&str>, format: OutputFormat, json: bool) {
     let mut params = if let Some(config_path) = &sim.config {
         let config = crate::config::SimConfig::load(std::path::Path::new(config_path))
             .unwrap_or_else(|e| {
@@ -45,6 +45,11 @@ pub fn run_simulation_cmd(sim: &SimArgs, output: &str, format: OutputFormat) {
             std::process::exit(1);
         }
     };
+    // Resolve and validate the stdout/output contract before running the
+    // (potentially long) simulation, so usage errors fail fast.
+    let sink = resolve_data_sink(output, format);
+    validate_output_contract(&sink, format, json);
+
     // CLI backend flags always override config-file defaults so
     // `orts run --config … --plugin-backend=sync|async` works.
     params.plugin_backend_choice = sim.plugin_backend;
@@ -63,24 +68,267 @@ pub fn run_simulation_cmd(sim: &SimArgs, output: &str, format: OutputFormat) {
         run_simulation(&params)
     };
 
-    match (output, format) {
-        ("stdout", OutputFormat::Csv) | (_, OutputFormat::Csv) => {
-            print_recording_as_csv(&rec, &params);
-        }
-        ("stdout", OutputFormat::Rrd) => {
-            eprintln!(
-                "Error: cannot write .rrd format to stdout. Use --format csv or specify a file path."
-            );
+    let artifact = write_simulation_output(&rec, &params, &sink, format);
+
+    if json {
+        let summary = build_run_summary(&params, &rec, artifact);
+        serde_json::to_writer_pretty(std::io::stdout(), &summary).unwrap_or_else(|e| {
+            eprintln!("Error serializing run summary: {e}");
             std::process::exit(1);
+        });
+        // Trailing newline so the JSON document is its own line on stdout.
+        println!();
+    }
+}
+
+/// stdout/output contract for `orts run`: stdout carries exactly one of the
+/// simulation data or (with `--json`) the run summary; everything else
+/// (progress, errors) goes to stderr.
+enum DataSink<'a> {
+    Stdout,
+    File(&'a str),
+}
+
+/// `-` is the canonical stdout sentinel; `stdout` is kept as a legacy alias.
+fn is_stdout_sentinel(s: &str) -> bool {
+    s == "-" || s == "stdout"
+}
+
+/// Decide where the simulation data goes. With no `--output`, CSV defaults to
+/// stdout (text) while RRD defaults to `output.rrd` (binary should not land on
+/// a terminal).
+fn resolve_data_sink(output: Option<&str>, format: OutputFormat) -> DataSink<'_> {
+    match output {
+        Some(s) if is_stdout_sentinel(s) => DataSink::Stdout,
+        Some(path) => DataSink::File(path),
+        None => match format {
+            OutputFormat::Csv => DataSink::Stdout,
+            OutputFormat::Rrd => DataSink::File("output.rrd"),
+        },
+    }
+}
+
+/// Reject contradictory stdout requests before the simulation runs.
+fn validate_output_contract(sink: &DataSink, format: OutputFormat, json: bool) {
+    if matches!(sink, DataSink::Stdout) && matches!(format, OutputFormat::Rrd) {
+        eprintln!(
+            "Error: cannot write .rrd data to stdout. Use --format csv or pass --output <path>."
+        );
+        std::process::exit(2);
+    }
+    if json && matches!(sink, DataSink::Stdout) {
+        eprintln!(
+            "Error: --json writes the run summary to stdout, so simulation data cannot also go \
+             to stdout. Pass --output <path> for the data (e.g. --output result.csv)."
+        );
+        std::process::exit(2);
+    }
+}
+
+/// Write the recording to the resolved sink and return the file artifact (if
+/// any) for inclusion in the JSON summary.
+fn write_simulation_output(
+    rec: &Recording,
+    params: &SimParams,
+    sink: &DataSink,
+    format: OutputFormat,
+) -> Option<Artifact> {
+    match (sink, format) {
+        (DataSink::Stdout, OutputFormat::Csv) => {
+            print_recording_as_csv(rec, params);
+            None
         }
-        (path, OutputFormat::Rrd) => {
-            orts::record::rerun_export::save_as_rrd(&rec, "orts", path).unwrap_or_else(|e| {
+        // Rejected earlier by validate_output_contract.
+        (DataSink::Stdout, OutputFormat::Rrd) => {
+            unreachable!("rrd-to-stdout is rejected by validate_output_contract")
+        }
+        (DataSink::File(path), OutputFormat::Csv) => {
+            let mut file = std::fs::File::create(path).unwrap_or_else(|e| {
+                eprintln!("Error creating {path}: {e}");
+                std::process::exit(1);
+            });
+            write_recording_as_csv(&mut file, rec, Some(params)).unwrap_or_else(|e| {
+                eprintln!("Error writing {path}: {e}");
+                std::process::exit(1);
+            });
+            eprintln!("Saved to {path}");
+            Some(Artifact {
+                kind: "recording",
+                format: "csv",
+                path: (*path).to_string(),
+            })
+        }
+        (DataSink::File(path), OutputFormat::Rrd) => {
+            orts::record::rerun_export::save_as_rrd(rec, "orts", path).unwrap_or_else(|e| {
                 eprintln!("Error saving .rrd: {e}");
                 std::process::exit(1);
             });
             eprintln!("Saved to {path}");
+            Some(Artifact {
+                kind: "recording",
+                format: "rrd",
+                path: (*path).to_string(),
+            })
         }
     }
+}
+
+// --- Machine-readable run summary (`orts run --json`) ----------------------
+//
+// Stable, versioned JSON contract for coding agents and scripts: status,
+// the resolved simulation parameters, each satellite's final state, and the
+// output artifact. The `schema` field is a version tag, not a fetched URL.
+
+#[derive(serde::Serialize)]
+struct RunSummary {
+    schema: &'static str,
+    status: &'static str,
+    command: &'static str,
+    simulation: SimSummary,
+    satellites: Vec<SatSummary>,
+    artifacts: Vec<Artifact>,
+    warnings: Vec<String>,
+}
+
+#[derive(serde::Serialize)]
+struct SimSummary {
+    body: String,
+    epoch: Option<String>,
+    dt_s: f64,
+    output_interval_s: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    duration_s: Option<f64>,
+    integrator: IntegratorSummary,
+}
+
+#[derive(serde::Serialize)]
+struct IntegratorSummary {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    /// Adaptive integrators only (dp45, dop853).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    atol: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rtol: Option<f64>,
+}
+
+#[derive(serde::Serialize)]
+struct SatSummary {
+    id: String,
+    samples: usize,
+    #[serde(rename = "final")]
+    final_state: Option<FinalState>,
+    // NOTE: early-termination reporting (e.g. atmospheric reentry detected by
+    // the event checker) is logged to stderr but not yet threaded into this
+    // summary. Rather than emit an always-null `termination` field that would
+    // let consumers mistake an early stop for normal completion, it is omitted
+    // from v1 and will be added once the reason is carried through accurately.
+}
+
+#[derive(serde::Serialize)]
+struct FinalState {
+    t_s: f64,
+    position_km: [f64; 3],
+    velocity_km_s: [f64; 3],
+}
+
+#[derive(serde::Serialize)]
+struct Artifact {
+    kind: &'static str,
+    format: &'static str,
+    path: String,
+}
+
+/// Assemble the JSON run summary from the resolved parameters and recording.
+fn build_run_summary(
+    params: &SimParams,
+    rec: &Recording,
+    artifact: Option<Artifact>,
+) -> RunSummary {
+    let satellites = params
+        .satellites
+        .iter()
+        .map(|s| {
+            let (samples, final_state) = satellite_final_state(rec, &s.entity_path());
+            SatSummary {
+                id: s.id.clone(),
+                samples,
+                final_state,
+            }
+        })
+        .collect();
+
+    let (integrator_type, adaptive) = match params.integrator {
+        IntegratorChoice::Rk4 => ("rk4", false),
+        IntegratorChoice::Dp45 => ("dp45", true),
+        IntegratorChoice::Dop853 => ("dop853", true),
+    };
+
+    RunSummary {
+        schema: "orts.run-summary/v1",
+        status: "ok",
+        command: "run",
+        simulation: SimSummary {
+            body: params.body.properties().name.to_lowercase(),
+            epoch: params.epoch.as_ref().map(|e| e.to_datetime().to_string()),
+            dt_s: params.dt,
+            output_interval_s: params.output_interval,
+            duration_s: params.duration,
+            integrator: IntegratorSummary {
+                kind: integrator_type,
+                atol: adaptive.then_some(params.tolerances.atol),
+                rtol: adaptive.then_some(params.tolerances.rtol),
+            },
+        },
+        satellites,
+        artifacts: artifact.into_iter().collect(),
+        warnings: Vec::new(),
+    }
+}
+
+/// Read a satellite's sample count and final position/velocity out of the
+/// recording. Returns `(0, None)` when the satellite has no recorded samples.
+fn satellite_final_state(rec: &Recording, sat_path: &EntityPath) -> (usize, Option<FinalState>) {
+    use orts::record::component::Component;
+    use orts::record::components::{Position3D, Velocity3D};
+    use orts::record::timeline::{TimeIndex, TimelineName};
+
+    let Some(store) = rec.entity(sat_path) else {
+        return (0, None);
+    };
+    let Some(pos_col) = store.columns.get(&Position3D::component_name()) else {
+        return (0, None);
+    };
+    let samples = pos_col.num_rows();
+    if samples == 0 {
+        return (0, None);
+    }
+    let i = samples - 1;
+
+    let t_s = store
+        .timelines
+        .get(&TimelineName::SimTime)
+        .and_then(|tl| tl.get(i))
+        .map(|ti| match ti {
+            TimeIndex::Seconds(s) => *s,
+            _ => 0.0,
+        })
+        .unwrap_or(0.0);
+
+    let vel_row = store
+        .columns
+        .get(&Velocity3D::component_name())
+        .and_then(|c| c.get_row(i));
+    let final_state = match (pos_col.get_row(i), vel_row) {
+        (Some(pos), Some(vel)) => Some(FinalState {
+            t_s,
+            position_km: [pos[0], pos[1], pos[2]],
+            velocity_km_s: [vel[0], vel[1], vel[2]],
+        }),
+        _ => None,
+    };
+
+    (samples, final_state)
 }
 
 /// Build one visibility monitor per satellite, or `None` when ground

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,7 +21,8 @@ fn main() {
             sim,
             output,
             format,
-        } => commands::run::run_simulation_cmd(&sim, &output, format),
+            json,
+        } => commands::run::run_simulation_cmd(&sim, output.as_deref(), format, json),
         Commands::Serve {
             sim,
             port,

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -673,3 +673,189 @@ fn test_csv_convert_roundtrip_headers_match() {
 
     let _ = std::fs::remove_file(&rrd_path);
 }
+
+// --- Agent-friendly output contract ---------------------------------------
+// stdout carries exactly one of: simulation data XOR a JSON run summary.
+// Logs/diagnostics go to stderr. `--output -` (and the legacy "stdout"
+// alias) select stdout; any other value is a file path.
+
+/// Bug fix: `orts run --format csv --output <path>` must write the CSV to the
+/// file, not stdout. Previously every `--format csv` invocation went to stdout
+/// regardless of `--output`, silently ignoring the path.
+#[test]
+fn test_cli_csv_output_to_file() {
+    let binary = env!("CARGO_BIN_EXE_orts");
+    let dir = std::env::temp_dir().join(format!("orts-e2e-csv-file-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let csv_path = dir.join("out.csv");
+
+    let output = Command::new(binary)
+        .args([
+            "run",
+            "--sat",
+            "altitude=400",
+            "--format",
+            "csv",
+            "--output",
+            csv_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to execute orts");
+
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // Data went to the file, so stdout must be empty.
+    assert!(
+        output.stdout.is_empty(),
+        "stdout should be empty when writing CSV to a file, got {} bytes",
+        output.stdout.len()
+    );
+    let contents = std::fs::read_to_string(&csv_path).expect("CSV file was not created");
+    assert!(
+        contents.contains("# orts simulation"),
+        "CSV file missing metadata header"
+    );
+    let data_lines: Vec<&str> = contents.lines().filter(|l| !l.starts_with('#')).collect();
+    assert!(
+        data_lines.len() > 10,
+        "expected many data lines in file, got {}",
+        data_lines.len()
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// `--output -` is the canonical stdout sentinel.
+#[test]
+fn test_cli_csv_output_dash_is_stdout() {
+    let binary = env!("CARGO_BIN_EXE_orts");
+    let output = Command::new(binary)
+        .args([
+            "run",
+            "--sat",
+            "altitude=400",
+            "--format",
+            "csv",
+            "--output",
+            "-",
+        ])
+        .output()
+        .expect("failed to execute orts");
+
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("# orts simulation"),
+        "expected CSV on stdout for `--output -`"
+    );
+}
+
+/// `orts run --json` emits a machine-readable run summary on stdout while the
+/// recording data is written to the `--output` file.
+#[test]
+fn test_cli_run_json_summary() {
+    let binary = env!("CARGO_BIN_EXE_orts");
+    let dir = std::env::temp_dir().join(format!("orts-e2e-json-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let csv_path = dir.join("data.csv");
+
+    let output = Command::new(binary)
+        .args([
+            "run",
+            "--sat",
+            "altitude=400",
+            "--epoch",
+            "2026-01-01T00:00:00Z",
+            "--json",
+            "--format",
+            "csv",
+            "--output",
+            csv_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to execute orts");
+
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\nstdout={stdout}"));
+
+    assert_eq!(v["status"], "ok");
+    assert_eq!(v["command"], "run");
+    assert_eq!(v["simulation"]["body"], "earth");
+    assert_eq!(v["simulation"]["epoch"], "2026-01-01T00:00:00Z");
+
+    let sat0 = &v["satellites"][0];
+    assert!(
+        sat0["samples"].as_u64().unwrap() > 10,
+        "expected many samples"
+    );
+    let pos = sat0["final"]["position_km"]
+        .as_array()
+        .expect("final.position_km should be an array");
+    assert_eq!(pos.len(), 3);
+    let r = (pos[0].as_f64().unwrap().powi(2)
+        + pos[1].as_f64().unwrap().powi(2)
+        + pos[2].as_f64().unwrap().powi(2))
+    .sqrt();
+    assert!(
+        (r - 6778.0).abs() < 50.0,
+        "final radius {r:.1} km out of range"
+    );
+
+    let artifact = &v["artifacts"][0];
+    assert_eq!(artifact["format"], "csv");
+    assert!(
+        artifact["path"].as_str().unwrap().ends_with("data.csv"),
+        "artifact path should point to the CSV file"
+    );
+
+    assert!(csv_path.exists(), "CSV data file should exist");
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// `--json` plus simulation data destined for stdout is a usage error: both
+/// would collide on stdout. (`--format csv --output -` sends CSV to stdout.)
+#[test]
+fn test_cli_json_and_data_stdout_conflict() {
+    let binary = env!("CARGO_BIN_EXE_orts");
+    let output = Command::new(binary)
+        .args([
+            "run",
+            "--sat",
+            "altitude=400",
+            "--json",
+            "--format",
+            "csv",
+            "--output",
+            "-",
+        ])
+        .output()
+        .expect("failed to execute orts");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for --json with data on stdout"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "stdout should be empty on usage error"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+    assert!(
+        stderr.contains("stdout"),
+        "error should mention the stdout conflict, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## TL;DR

`orts run` gets a predictable, machine-parseable output contract for scripts and
coding agents: a `--json` run summary, a fix for an `--output` path bug, and one
rule — **stdout carries either the data or the JSON summary, never both; logs go
to stderr.**

## The bug (fixed)

`orts run --format csv --output <path>` ignored `<path>` and always printed the
CSV to stdout — while still exiting 0. So it *looked* like it worked but created
no file:

```console
$ orts run --sat altitude=400 --format csv --output result.csv
# CSV text is dumped to the terminal; result.csv is never created; exit code 0
```

Cause: the output match arm `(_, OutputFormat::Csv)` caught every CSV run
regardless of `--output`. RRD output already honored the path; only CSV was
broken. After this PR, `--output result.csv` writes to `result.csv`.

## New: `--json` run summary

`orts run --json` prints a versioned JSON summary to **stdout** while logs stay
on **stderr**:

```console
$ orts run --sat altitude=400 --json --format csv --output result.csv
#   stdout    → the JSON summary (below)
#   result.csv → the CSV data
#   stderr    → "Saved to result.csv"
```

```json
{
  "schema": "orts.run-summary/v1",
  "status": "ok",
  "command": "run",
  "simulation": {
    "body": "earth", "epoch": "2026-01-01T00:00:00Z", "dt_s": 10.0,
    "output_interval_s": 10.0,
    "integrator": { "type": "dp45", "atol": 1e-10, "rtol": 1e-8 }
  },
  "satellites": [
    { "id": "sat-0", "samples": 557,
      "final": { "t_s": 5553.6, "position_km": [6777.0, 122.8, 0.0],
                 "velocity_km_s": [-0.139, 7.667, 0.0] } }
  ],
  "artifacts": [ { "kind": "recording", "format": "csv", "path": "result.csv" } ],
  "warnings": []
}
```

(`schema` is a version tag, not a URL it fetches.)

## Where the output goes

`--output -` is the canonical stdout sentinel; the old `stdout` keyword still
works as an alias. The single rule is **stdout = data XOR JSON summary**:

| invocation | data goes to | stdout | exit |
|---|---|---|---|
| `--format rrd` (default, no `--output`) | `output.rrd` | empty | 0 |
| `--format csv` (no `--output`) | stdout | CSV | 0 |
| `--format csv --output f.csv` | `f.csv` | empty | 0 |
| `--output -` / `--output stdout` | stdout | data | 0 |
| `--json --output f.csv` | `f.csv` | JSON summary | 0 |
| `--json` with data on stdout (e.g. `--output -`) | — | — | **2** (rejected) |
| `--format rrd --output -` (binary → stdout) | — | — | **2** (rejected) |

Existing invocations are unchanged: `--output stdout` still works, and bare
`orts run` still writes `output.rrd`.

## Tests

E2E tests pin the CSV-to-file fix, `--output -` → stdout, the `--json` summary
shape, and the exit-2 conflict behavior. Full `orts-cli` suite is green; clippy
clean (CI toolchain).

## Out of scope (follow-ups)

- `termination` is intentionally omitted from summary v1: early termination is
  only logged to stderr today, and an always-null field would let consumers
  mistake an early stop for normal completion. It will be added once the reason
  is threaded through accurately. (Raised by external review.)
- Next agent-ergonomics steps discussed: `orts config example|schema|validate`,
  `after_long_help` examples, and structured JSON errors with a fuller exit-code
  taxonomy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
