### PR TITLE
feat(cli): `orts config example` + `orts config validate`

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -81,6 +81,11 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   `--json` とデータの stdout 出力の併用は拒否する。([#214](https://github.com/sksat/orts/pull/214))
 - `orts run --output -` でシミュレーションデータを stdout に出力。`-` を正準の
   stdout sentinel とし、従来の `stdout` キーワードは alias として残す。([#214](https://github.com/sksat/orts/pull/214))
+- `orts config` サブコマンド群。config ファイルを正準入力として誘導する:
+  `config example [--format toml|json|yaml]` で編集可能な example config を出力、
+  `config validate <path> [--json]` で config を検証し結果を報告(人間向けは
+  stderr、`--json` で機械可読 verdict を stdout に。exit 0=valid / 2=invalid)。
+  `--sat` の help もこの経路を案内するようにした。([#216](https://github.com/sksat/orts/pull/216))
 
 #### Changed
 - `--tle` を再び TLE 専用 (2LE/3LE、`-` で stdin) とし、新規 `--omm` と

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,12 @@ section is subdivided by package.
   `--json` with data on stdout is rejected. ([#214](https://github.com/sksat/orts/pull/214))
 - `orts run --output -` writes the simulation data to stdout. `-` is the
   canonical stdout sentinel; the previous `stdout` keyword is kept as an alias. ([#214](https://github.com/sksat/orts/pull/214))
+- `orts config` subcommand group steering users and coding agents toward the
+  config file as canonical input: `config example [--format toml|json|yaml]`
+  prints a ready-to-edit example config, and `config validate <path> [--json]`
+  checks a config and reports the verdict (human-readable on stderr, or a
+  machine-readable JSON verdict on stdout with `--json`; exit 0 valid / 2
+  invalid). The `--sat` help now points to this path. ([#216](https://github.com/sksat/orts/pull/216))
 
 #### Changed
 - `--tle` is TLE-only again (2LE/3LE; `-` for stdin) and pairs with the new

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -73,6 +73,39 @@ pub enum Commands {
         #[arg(long)]
         output: Option<String>,
     },
+    /// Inspect and validate simulation config files
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommands,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ConfigCommands {
+    /// Print an example simulation config to stdout
+    Example {
+        /// Config file format
+        #[arg(long, default_value = "toml")]
+        format: ConfigFormat,
+    },
+    /// Validate a simulation config file and report the result
+    Validate {
+        /// Path to the config file (.toml / .json / .yaml)
+        path: String,
+
+        /// Emit a machine-readable JSON verdict on stdout (the human-readable
+        /// message goes to stderr otherwise). Exit code is 0 when valid, 2
+        /// when invalid, either way.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ConfigFormat {
+    Toml,
+    Json,
+    Yaml,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -124,7 +157,9 @@ pub struct SimArgs {
     pub norad_id: Option<u32>,
 
     /// Satellite specifications (repeatable).
-    /// Format: key=value,key=value (keys: altitude, norad-id, tle-line1, tle-line2, id, name)
+    /// Format: key=value,key=value (keys: altitude, norad-id, tle-line1, tle-line2, id, name).
+    /// Quick shorthand for simple cases; for generated or multi-satellite setups
+    /// prefer a config file via --config (see `orts config example`).
     #[arg(long = "sat", num_args = 1)]
     pub sats: Vec<String>,
 

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -1,0 +1,106 @@
+//! `orts config` — inspect and validate simulation config files.
+//!
+//! `example` prints a ready-to-edit config; `validate` checks a config and
+//! reports the verdict (human-readable on stderr, or machine-readable JSON on
+//! stdout with `--json`). Both steer users and coding agents toward the config
+//! file as the canonical, multi-satellite-capable input (vs. the `--sat`
+//! shorthand).
+
+use crate::cli::{ConfigCommands, ConfigFormat};
+use crate::config::SimConfig;
+
+/// Curated, valid example config in TOML. This is the single source of truth
+/// for `config example`: the JSON and YAML forms are produced by parsing this
+/// and re-serializing, so all three formats stay in sync and always validate.
+const EXAMPLE_TOML: &str = r#"# Example orts simulation config.
+# Validate with: orts config validate <file>
+body = "earth"                    # central body: earth, moon, mars, sun, ...
+dt = 10.0                         # integration step [s]
+epoch = "2026-01-01T00:00:00Z"    # ISO 8601 UTC; omit to use the current time
+duration = 5400.0                 # total sim time [s]; omit for one orbital period
+output_interval = 10.0            # recording cadence [s]; defaults to dt
+atmosphere = "exponential"        # exponential | harris-priester | nrlmsise00
+
+[integrator]
+type = "dp45"                     # rk4 | dp45 | dop853
+atol = 1.0e-10                    # adaptive integrators only
+rtol = 1.0e-8
+
+[[satellites]]
+id = "sat-0"
+
+[satellites.orbit]
+type = "circular"                 # circular | tle | norad
+altitude = 500.0                  # [km]
+inclination = 51.6                # [deg]
+raan = 0.0                        # [deg]
+"#;
+
+pub fn run_config(cmd: ConfigCommands) {
+    match cmd {
+        ConfigCommands::Example { format } => run_example(format),
+        ConfigCommands::Validate { path, json } => run_validate(&path, json),
+    }
+}
+
+fn run_example(format: ConfigFormat) {
+    match format {
+        // Print the curated source verbatim so its comments are preserved.
+        ConfigFormat::Toml => print!("{EXAMPLE_TOML}"),
+        ConfigFormat::Json | ConfigFormat::Yaml => {
+            let config: SimConfig =
+                toml::from_str(EXAMPLE_TOML).expect("built-in example config must parse");
+            let rendered = match format {
+                ConfigFormat::Json => {
+                    serde_json::to_string_pretty(&config).expect("serialize example to JSON")
+                }
+                ConfigFormat::Yaml => {
+                    serde_yaml::to_string(&config).expect("serialize example to YAML")
+                }
+                ConfigFormat::Toml => unreachable!(),
+            };
+            // serde_json has no trailing newline; serde_yaml already ends with
+            // one — print! keeps the YAML output free of a blank trailing line.
+            print!("{rendered}");
+            if !rendered.ends_with('\n') {
+                println!();
+            }
+        }
+    }
+}
+
+fn run_validate(path: &str, json: bool) {
+    match SimConfig::load(std::path::Path::new(path)) {
+        Ok(_) => {
+            if json {
+                emit_verdict(serde_json::json!({
+                    "schema": "orts.config-validate/v1",
+                    "status": "ok",
+                    "path": path,
+                }));
+            } else {
+                eprintln!("OK: {path} is a valid orts config");
+            }
+        }
+        Err(e) => {
+            if json {
+                emit_verdict(serde_json::json!({
+                    "schema": "orts.config-validate/v1",
+                    "status": "error",
+                    "path": path,
+                    "error": e,
+                }));
+            } else {
+                eprintln!("Error: {path} is not a valid orts config: {e}");
+            }
+            std::process::exit(2);
+        }
+    }
+}
+
+fn emit_verdict(value: serde_json::Value) {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&value).expect("serialize validate verdict")
+    );
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod convert;
 pub mod replay;
 pub mod run;

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -615,11 +615,38 @@ impl SatelliteConfig {
 }
 
 impl SimConfig {
-    /// Validate every satellite entry. Idempotent and side-effect-free.
+    /// Validate the config. Idempotent and side-effect-free (no network /
+    /// filesystem access), so it is safe for both `config validate` and the
+    /// `SimConfig::load` path shared by `orts run` / `orts serve`.
+    ///
+    /// Covers the semantic fields that `SimParams::from_config` would otherwise
+    /// panic on (unknown body, malformed epoch, malformed inline TLE). It does
+    /// not resolve `norad` orbits — that requires a network fetch and is left
+    /// to run time.
     pub fn validate(&self) -> Result<(), String> {
+        if crate::satellite::try_parse_body(&self.body).is_none() {
+            return Err(format!(
+                "unknown body '{}' (expected one of: sun, mercury, venus, earth, \
+                 moon, mars, jupiter, saturn, uranus, neptune)",
+                self.body
+            ));
+        }
+        if let Some(epoch) = &self.epoch
+            && arika::epoch::Epoch::from_iso8601(epoch).is_none()
+        {
+            return Err(format!(
+                "invalid epoch '{epoch}': expected ISO 8601 (e.g. 2026-01-01T00:00:00Z)"
+            ));
+        }
         for (i, sat) in self.satellites.iter().enumerate() {
             sat.validate()
                 .map_err(|e| format!("satellites[{i}]: {e}"))?;
+            // Parse inline TLE lines with the same parser `from_config` uses, so
+            // a malformed element set is rejected here rather than panicking.
+            if let OrbitConfig::Tle { line1, line2 } = &sat.orbit {
+                arika::tle::parse(&format!("{line1}\n{line2}"))
+                    .map_err(|e| format!("satellites[{i}]: invalid TLE: {e}"))?;
+            }
         }
         for (i, cmd) in self.commands.iter().enumerate() {
             // A non-finite or negative `t` would never satisfy the

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -34,5 +34,6 @@ fn main() {
             format,
             output,
         } => commands::convert::run_convert(&input, format, output.as_deref()),
+        Commands::Config { command } => commands::config::run_config(command),
     }
 }

--- a/cli/src/satellite.rs
+++ b/cli/src/satellite.rs
@@ -269,7 +269,14 @@ pub fn parse_sat_spec(s: &str, body: KnownBody) -> SatelliteSpec {
 }
 
 pub fn parse_body(s: &str) -> KnownBody {
-    match s {
+    try_parse_body(s).unwrap_or_else(|| panic!("Unknown body: {s}"))
+}
+
+/// Non-panicking body lookup, sharing the same name table as [`parse_body`].
+/// Used by config validation to reject an unknown body up front (with a clear
+/// error) instead of panicking later when the params are built.
+pub fn try_parse_body(s: &str) -> Option<KnownBody> {
+    Some(match s {
         "sun" => KnownBody::Sun,
         "mercury" => KnownBody::Mercury,
         "venus" => KnownBody::Venus,
@@ -280,8 +287,8 @@ pub fn parse_body(s: &str) -> KnownBody {
         "saturn" => KnownBody::Saturn,
         "uranus" => KnownBody::Uranus,
         "neptune" => KnownBody::Neptune,
-        _ => panic!("Unknown body: {s}"),
-    }
+        _ => return None,
+    })
 }
 
 #[cfg(test)]

--- a/cli/tests/config_e2e.rs
+++ b/cli/tests/config_e2e.rs
@@ -1,0 +1,222 @@
+//! E2E tests for the `orts config` subcommand group (example / validate).
+
+use std::process::Command;
+
+fn orts() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_orts"))
+}
+
+fn unique_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("orts-e2e-config-{tag}-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// `config example` (default TOML) prints a config whose round-trip through
+/// `config validate` succeeds — the printed example is always valid.
+#[test]
+fn test_config_example_toml_is_valid() {
+    let out = orts()
+        .args(["config", "example"])
+        .output()
+        .expect("run config example");
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let toml = String::from_utf8_lossy(&out.stdout);
+    assert!(toml.contains("body ="), "example missing body key:\n{toml}");
+    assert!(
+        toml.contains("[[satellites]]"),
+        "example missing satellites table:\n{toml}"
+    );
+
+    let dir = unique_dir("ex-toml");
+    let path = dir.join("example.toml");
+    std::fs::write(&path, toml.as_bytes()).unwrap();
+    let v = orts()
+        .args(["config", "validate", path.to_str().unwrap()])
+        .output()
+        .expect("run config validate");
+    assert!(
+        v.status.success(),
+        "example TOML failed validation: stderr={}",
+        String::from_utf8_lossy(&v.stderr)
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// `config example --format json` prints valid JSON that also validates.
+#[test]
+fn test_config_example_json_is_valid() {
+    let out = orts()
+        .args(["config", "example", "--format", "json"])
+        .output()
+        .expect("run config example --format json");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("example is not valid JSON: {e}\n{stdout}"));
+    assert!(
+        v["satellites"].is_array(),
+        "JSON example missing satellites array"
+    );
+
+    let dir = unique_dir("ex-json");
+    let path = dir.join("example.json");
+    std::fs::write(&path, stdout.as_bytes()).unwrap();
+    let r = orts()
+        .args(["config", "validate", path.to_str().unwrap()])
+        .output()
+        .expect("validate json example");
+    assert!(
+        r.status.success(),
+        "JSON example failed validation: stderr={}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// `config example --format yaml` validates too.
+#[test]
+fn test_config_example_yaml_is_valid() {
+    let out = orts()
+        .args(["config", "example", "--format", "yaml"])
+        .output()
+        .expect("run config example --format yaml");
+    assert!(out.status.success());
+    let yaml = String::from_utf8_lossy(&out.stdout);
+
+    let dir = unique_dir("ex-yaml");
+    let path = dir.join("example.yaml");
+    std::fs::write(&path, yaml.as_bytes()).unwrap();
+    let r = orts()
+        .args(["config", "validate", path.to_str().unwrap()])
+        .output()
+        .expect("validate yaml example");
+    assert!(
+        r.status.success(),
+        "YAML example failed validation: stderr={}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// `config validate <ok> --json` reports a structured ok verdict on stdout.
+#[test]
+fn test_config_validate_ok_json() {
+    let dir = unique_dir("ok");
+    let path = dir.join("ok.toml");
+    std::fs::write(
+        &path,
+        "body = \"earth\"\ndt = 10.0\n\n[[satellites]]\nid = \"a\"\n\n[satellites.orbit]\ntype = \"circular\"\naltitude = 500.0\n",
+    )
+    .unwrap();
+
+    let out = orts()
+        .args(["config", "validate", path.to_str().unwrap(), "--json"])
+        .output()
+        .expect("validate ok --json");
+    assert!(out.status.success(), "expected exit 0 for a valid config");
+    let v: serde_json::Value = serde_json::from_str(&String::from_utf8_lossy(&out.stdout))
+        .expect("validate --json should print JSON");
+    assert_eq!(v["status"], "ok");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// `config validate <bad> --json` exits non-zero with a structured error on
+/// stdout; without `--json` the error is human-readable on stderr.
+#[test]
+fn test_config_validate_bad() {
+    let dir = unique_dir("bad");
+    let path = dir.join("bad.toml");
+    // Unknown orbit type → parse/validation failure.
+    std::fs::write(
+        &path,
+        "body = \"earth\"\n\n[[satellites]]\nid = \"a\"\n\n[satellites.orbit]\ntype = \"banana\"\n",
+    )
+    .unwrap();
+
+    // --json: structured error on stdout, exit 2.
+    let out = orts()
+        .args(["config", "validate", path.to_str().unwrap(), "--json"])
+        .output()
+        .expect("validate bad --json");
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit for bad config"
+    );
+    assert_eq!(out.status.code(), Some(2), "expected exit code 2");
+    let v: serde_json::Value = serde_json::from_str(&String::from_utf8_lossy(&out.stdout))
+        .expect("validate --json should print JSON even on error");
+    assert_eq!(v["status"], "error");
+    assert!(v["error"].is_string(), "error message should be present");
+
+    // Without --json: human error on stderr, stdout empty.
+    let out2 = orts()
+        .args(["config", "validate", path.to_str().unwrap()])
+        .output()
+        .expect("validate bad");
+    assert!(!out2.status.success());
+    assert!(
+        out2.stdout.is_empty(),
+        "stdout should be empty without --json"
+    );
+    assert!(
+        !String::from_utf8_lossy(&out2.stderr).is_empty(),
+        "expected a human error on stderr"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// A syntactically valid config with an unknown central body is rejected — it
+/// would otherwise panic later in `orts run`.
+#[test]
+fn test_config_validate_rejects_unknown_body() {
+    let dir = unique_dir("body");
+    let path = dir.join("body.toml");
+    std::fs::write(
+        &path,
+        "body = \"pluto\"\n\n[[satellites]]\nid = \"a\"\n\n[satellites.orbit]\ntype = \"circular\"\naltitude = 500.0\n",
+    )
+    .unwrap();
+
+    let out = orts()
+        .args(["config", "validate", path.to_str().unwrap(), "--json"])
+        .output()
+        .expect("validate unknown body");
+    assert_eq!(out.status.code(), Some(2), "unknown body should exit 2");
+    let v: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).expect("json verdict");
+    assert_eq!(v["status"], "error");
+    assert!(
+        v["error"].as_str().unwrap().contains("pluto"),
+        "error should name the bad body: {}",
+        v["error"]
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// A malformed epoch is rejected up front rather than panicking at run time.
+#[test]
+fn test_config_validate_rejects_bad_epoch() {
+    let dir = unique_dir("epoch");
+    let path = dir.join("epoch.toml");
+    std::fs::write(
+        &path,
+        "body = \"earth\"\nepoch = \"not-a-date\"\n\n[[satellites]]\nid = \"a\"\n\n[satellites.orbit]\ntype = \"circular\"\naltitude = 500.0\n",
+    )
+    .unwrap();
+
+    let out = orts()
+        .args(["config", "validate", path.to_str().unwrap()])
+        .output()
+        .expect("validate bad epoch");
+    assert_eq!(out.status.code(), Some(2), "bad epoch should exit 2");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("epoch"),
+        "error should mention epoch"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
## TL;DR

Adds an `orts config` subcommand group so scripts and coding agents can discover
the canonical config-file input and check a config before running: `config
example` prints a ready-to-edit config; `config validate` reports whether a
config is valid (machine-readable with `--json`).

## Why

`orts run` takes a config file (`--config`) as its richest, multi-satellite
input, but there was no way to (a) get a starting example or (b) check a config
without running a full simulation — the `--sat "k=v,..."` string DSL was the most
discoverable path. This makes the config file the obvious one.

## `orts config example`

```console
$ orts config example                  # TOML (default), with comments
$ orts config example --format json    # or json / yaml
```

The TOML form is the curated source of truth (comments preserved); JSON and YAML
are produced by parsing it and re-serializing, so all three stay in sync and
always pass `config validate`.

## `orts config validate <path>`

Checks a config through the same loader `orts run` uses.

```console
$ orts config validate mission.toml
OK: mission.toml is a valid orts config           # on stderr; exit 0

$ orts config validate mission.toml --json
{ "schema": "orts.config-validate/v1", "status": "ok", "path": "mission.toml" }   # stdout; exit 0
```

Invalid configs exit 2; with `--json` the verdict is
`{"status":"error","error":"…","path":…}` on stdout, otherwise a human-readable
message on stderr.

To make the verdict trustworthy, `SimConfig::validate` (the side-effect-free
check shared by `config validate` and the `run` / `serve` load path) now rejects,
up front, semantic errors that used to deserialize cleanly and then **panic** in
`SimParams::from_config`: an unknown body, a malformed epoch, and malformed
inline TLE lines. This improves `orts run --config` too. `norad` orbits still
resolve at run time (that needs a network fetch).

## Tests

E2E tests round-trip each example format through `config validate`, and cover the
ok / invalid-orbit / unknown-body / bad-epoch verdicts and exit codes. Full
`orts-cli` suite green; clippy clean (CI toolchain).

## Follow-ups (out of scope)

- `orts config schema` (JSON Schema) — needs a schema-deriving dependency
  (e.g. `schemars`); deferred.
- Making `SimParams::from_config` return `Result` rather than panicking (the
  broader error-design work) is a separate follow-up; this PR moves the common
  cases to the validate chokepoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
