### PR TITLE
feat(cli): usage examples in `orts --help`

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -86,6 +86,9 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   `config validate <path> [--json]` で config を検証し結果を報告(人間向けは
   stderr、`--json` で機械可読 verdict を stdout に。exit 0=valid / 2=invalid)。
   `--sat` の help もこの経路を案内するようにした。([#216](https://github.com/sksat/orts/pull/216))
+- `orts --help`(および `-h`)の末尾に、主要ワークフロー(ファイルへの run、
+  `--json` 実行サマリ、`config example`/`validate`、`serve`)のコピペ可能な実例を
+  追加。よく使う・agent に関係する経路を端末内で発見できるようにした。([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
 - `--tle` を再び TLE 専用 (2LE/3LE、`-` で stdin) とし、新規 `--omm` と

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,10 @@ section is subdivided by package.
   checks a config and reports the verdict (human-readable on stderr, or a
   machine-readable JSON verdict on stdout with `--json`; exit 0 valid / 2
   invalid). The `--sat` help now points to this path. ([#216](https://github.com/sksat/orts/pull/216))
+- `orts --help` (and `-h`) now ends with copy-pasteable examples covering the
+  main workflows (run to a file, the `--json` run summary, `config
+  example`/`validate`, and `serve`), so the common — and agent-relevant — paths
+  are discoverable without leaving the terminal. ([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
 - `--tle` is TLE-only again (2LE/3LE; `-` for stdin) and pairs with the new

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -3,10 +3,34 @@ use clap::{Parser, Subcommand, ValueEnum};
 /// orts CLI — orbital mechanics simulation tool
 #[derive(Parser, Debug)]
 #[command(name = "orts")]
+#[command(after_help = EXAMPLES)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,
 }
+
+/// Copy-pasteable examples shown at the end of `orts --help` (and `-h`).
+/// Kept here so the most common — and the most agent-relevant — workflows are
+/// discoverable without reading the docs.
+const EXAMPLES: &str = "\
+Examples:
+  # Run a simulation, recording to an .rrd file (the default)
+  orts run --sat altitude=400
+
+  # Run from a config file and write CSV to a path (use '-' for stdout)
+  orts run --config mission.toml --format csv --output orbit.csv
+
+  # Machine-readable run summary on stdout for scripts/agents
+  # (simulation data must go to a file when --json is set)
+  orts run --config mission.toml --json --output result.rrd
+
+  # Get a starting config, then validate it
+  orts config example > mission.toml
+  orts config validate mission.toml
+
+  # Live WebSocket server + embedded 3D viewer at http://localhost:9001
+  orts serve --config mission.toml
+";
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {

--- a/cli/tests/help_e2e.rs
+++ b/cli/tests/help_e2e.rs
@@ -1,0 +1,30 @@
+//! E2E tests for discoverability: `orts --help` carries copy-pasteable
+//! examples covering the main agent-facing workflows.
+
+use std::process::Command;
+
+#[test]
+fn test_top_level_help_has_examples() {
+    let out = Command::new(env!("CARGO_BIN_EXE_orts"))
+        .arg("--help")
+        .output()
+        .expect("run orts --help");
+    assert!(out.status.success());
+    let help = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        help.contains("Examples:"),
+        "--help should include an Examples section:\n{help}"
+    );
+    // The examples should cover the key recently-added workflows so an agent
+    // reading --help discovers them.
+    assert!(help.contains("orts run"), "examples should show `orts run`");
+    assert!(
+        help.contains("--json"),
+        "examples should show the --json run summary workflow"
+    );
+    assert!(
+        help.contains("orts config validate"),
+        "examples should show `orts config validate`"
+    );
+}


### PR DESCRIPTION
## What

`orts --help` (and `-h`) now ends with a copy-pasteable **Examples** section.

## Why

Coding agents — and humans — read `--help` first. The recently added workflows,
the `--json` run summary (#214) and `orts config example` / `validate` (#216),
weren't discoverable from help. This surfaces the common, agent-relevant paths
right in the terminal, no docs trip required.

## Example output

```text
Examples:
  # Run a simulation, recording to an .rrd file (the default)
  orts run --sat altitude=400

  # Run from a config file and write CSV to a path (use '-' for stdout)
  orts run --config mission.toml --format csv --output orbit.csv

  # Machine-readable run summary on stdout for scripts/agents
  # (simulation data must go to a file when --json is set)
  orts run --config mission.toml --json --output result.rrd

  # Get a starting config, then validate it
  orts config example > mission.toml
  orts config validate mission.toml

  # Live WebSocket server + embedded 3D viewer at http://localhost:9001
  orts serve --config mission.toml
```

## Tests

E2E test asserts `--help` includes the Examples section and names the key flows
(`orts run`, `--json`, `orts config validate`). clippy clean (CI toolchain).

## Follow-ups (out of scope)

- Per-subcommand examples (`orts run --help`, etc.).
- `clap-markdown` → docs site → `llms.txt`, to publish the same CLI reference
  for agents that fetch documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
