### PR TITLE
feat(arika): ECI↔ECEF 速度（状態）変換 FrameTransform を追加

### DIFF
--- a/arika/src/earth/transform.rs
+++ b/arika/src/earth/transform.rs
@@ -130,8 +130,7 @@ pub trait EarthFixedTransform: EarthRotationPole {
         eop: &Self::EopStorage,
     ) -> FrameTransform<Self, Self::Fixed> {
         // ω of ECEF relative to ECI, expressed in ECI: Earth's spin vector.
-        let omega =
-            Vec3::<Self>::from_raw(Self::earth_pole(utc).into_inner() * crate::earth::OMEGA);
+        let omega = Self::earth_pole(utc) * crate::earth::OMEGA;
         let rotation = Self::fixed_to_inertial(utc, eop).inverse();
         FrameTransform::new(rotation, omega)
     }

--- a/arika/src/earth/transform.rs
+++ b/arika/src/earth/transform.rs
@@ -20,7 +20,7 @@
 use crate::earth::geodetic::Geodetic;
 use crate::earth::iau2006::cip::cip_xy;
 use crate::epoch::{Epoch, Utc};
-use crate::frame::{self, Ecef, Eci, Rotation, Vec3};
+use crate::frame::{self, Ecef, Eci, FrameTransform, Rotation, Vec3};
 // Used only on no_std (libm-backed `.sqrt()`); std uses the inherent f64 method.
 #[allow(unused_imports)]
 use crate::math::F64Ext;
@@ -114,6 +114,35 @@ pub trait EarthFixedTransform: EarthRotationPole {
     /// Used to transform ECEF-frame vectors (e.g., magnetic field,
     /// atmosphere co-rotation velocity) back into the propagation frame.
     fn fixed_to_inertial(utc: &Epoch<Utc>, eop: &Self::EopStorage) -> Rotation<Self::Fixed, Self>;
+
+    /// ECI → ECEF state transform: the orientation plus Earth's spin angular
+    /// velocity, so it transforms velocities (and full position+velocity
+    /// states), not just positions.
+    ///
+    /// The angular velocity is `OMEGA · earth_pole` — Earth's nominal rotation
+    /// rate ([`earth::OMEGA`](crate::earth::OMEGA)) about the spin axis from
+    /// [`EarthRotationPole`]. This models **Earth spin transport only**: it is
+    /// not the full time-derivative of the IAU 2006 W·R·Q chain (the
+    /// precession/nutation/polar-motion rates Q̇/Ẇ, ~sub-µrad/s, are omitted),
+    /// and it uses the nominal rate with no LOD correction.
+    fn inertial_to_fixed_transform(
+        utc: &Epoch<Utc>,
+        eop: &Self::EopStorage,
+    ) -> FrameTransform<Self, Self::Fixed> {
+        // ω of ECEF relative to ECI, expressed in ECI: Earth's spin vector.
+        let omega =
+            Vec3::<Self>::from_raw(Self::earth_pole(utc).into_inner() * crate::earth::OMEGA);
+        let rotation = Self::fixed_to_inertial(utc, eop).inverse();
+        FrameTransform::new(rotation, omega)
+    }
+
+    /// ECEF → ECI state transform (inverse of [`inertial_to_fixed_transform`](Self::inertial_to_fixed_transform)).
+    fn fixed_to_inertial_transform(
+        utc: &Epoch<Utc>,
+        eop: &Self::EopStorage,
+    ) -> FrameTransform<Self::Fixed, Self> {
+        Self::inertial_to_fixed_transform(utc, eop).inverse()
+    }
 }
 
 impl EarthFixedTransform for frame::SimpleEci {
@@ -316,5 +345,59 @@ mod tests {
             y2024 > 10.0 * j2000,
             "CIP offset should grow with precession: 2024={y2024}°, J2000={j2000}°"
         );
+    }
+
+    // State transforms (FrameTransform factories)
+
+    #[test]
+    fn simple_eci_corotating_point_is_static_in_ecef() {
+        // A point on the equator co-rotating with Earth (inertial velocity ω×r)
+        // must be static in ECEF, regardless of ERA — validates the factory's
+        // ω = OMEGA·(+Z) wiring.
+        let utc = Epoch::from_gregorian(2024, 3, 20, 7, 30, 0.0);
+        let ft = <frame::SimpleEci as EarthFixedTransform>::inertial_to_fixed_transform(&utc, &());
+        let r_km = 6378.137;
+        let r = Vec3::<frame::SimpleEci>::new(r_km, 0.0, 0.0);
+        let v = Vec3::<frame::SimpleEci>::new(0.0, crate::earth::OMEGA * r_km, 0.0);
+        let v_ecef = ft.transform_velocity(&r, &v);
+        assert!(
+            v_ecef.inner().norm() < 1e-12,
+            "co-rotating point should be static in ECEF, got {:?}",
+            v_ecef.inner()
+        );
+    }
+
+    #[test]
+    fn gcrs_transform_omega_is_omega_times_cip() {
+        let utc = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
+        let eop = GcrsEopStorage::new(ZeroEop);
+        let ft = <frame::Gcrs as EarthFixedTransform>::inertial_to_fixed_transform(&utc, &eop);
+        // ω of ITRS relative to GCRS, in GCRS, is OMEGA along the CIP.
+        let expected =
+            <frame::Gcrs as EarthRotationPole>::earth_pole(&utc).into_inner() * crate::earth::OMEGA;
+        assert!(
+            (ft.angular_velocity_in_from().inner() - expected).norm() < 1e-18,
+            "Gcrs spin angular velocity should be OMEGA·CIP"
+        );
+        // |ω| ≈ OMEGA (pole is a unit vector).
+        assert!((ft.angular_velocity_in_from().inner().norm() - crate::earth::OMEGA).abs() < 1e-16);
+    }
+
+    #[test]
+    fn gcrs_state_transform_roundtrip() {
+        let utc = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
+        let eop = GcrsEopStorage::new(ZeroEop);
+        let ft = <frame::Gcrs as EarthFixedTransform>::inertial_to_fixed_transform(&utc, &eop);
+        let r = Vec3::<frame::Gcrs>::new(6778.0, 1200.0, -3400.0);
+        let v = Vec3::<frame::Gcrs>::new(-1.2, 7.0, 2.5);
+        let (r_e, v_e) = ft.transform_state(&r, &v);
+        let (r_back, v_back) = ft.inverse().transform_state(&r_e, &v_e);
+        assert!((r_back.inner() - r.inner()).norm() < 1e-9);
+        assert!((v_back.inner() - v.inner()).norm() < 1e-12);
+        // fixed_to_inertial_transform is the inverse of inertial_to_fixed_transform.
+        let ft_inv = <frame::Gcrs as EarthFixedTransform>::fixed_to_inertial_transform(&utc, &eop);
+        let (r2, v2) = ft_inv.transform_state(&r_e, &v_e);
+        assert!((r2.inner() - r.inner()).norm() < 1e-9);
+        assert!((v2.inner() - v.inner()).norm() < 1e-12);
     }
 }

--- a/arika/src/frame.rs
+++ b/arika/src/frame.rs
@@ -520,6 +520,7 @@ impl<From, To> Rotation<From, To> {
 /// [`Rotation`] stays position-only; this is its kinematic (state) companion.
 /// Build Earth ECI↔ECEF instances via the
 /// [`EarthFixedTransform`](crate::earth::EarthFixedTransform) factories.
+#[derive(Clone, Copy, PartialEq)]
 pub struct FrameTransform<From, To> {
     rotation: Rotation<From, To>,
     /// Angular velocity of `To` relative to `From`, expressed in `From` [rad/s].
@@ -555,9 +556,10 @@ impl<From, To> FrameTransform<From, To> {
     ///
     /// The position is required because the rotating-frame correction is `ω × r`.
     pub fn transform_velocity(&self, position: &Vec3<From>, velocity: &Vec3<From>) -> Vec3<To> {
+        // Transport theorem, kept frame-tagged via rotation linearity:
+        // v_to = R·(v_from − ω×r_from) = R·v_from − R·(ω×r_from).
         let corotation = self.angular_velocity.cross(position); // ω × r, in From
-        let relative = Vec3::<From>::from_raw(velocity.inner() - corotation.inner());
-        self.rotation.transform(&relative)
+        self.rotation.transform(velocity) - self.rotation.transform(&corotation)
     }
 
     /// Transform a full state (position, velocity).
@@ -580,7 +582,7 @@ impl<From, To> FrameTransform<From, To> {
         let omega_in_to = self.rotation.transform(&self.angular_velocity); // R·ω, in To
         FrameTransform {
             rotation: self.rotation.inverse(),
-            angular_velocity: Vec3::<To>::from_raw(-omega_in_to.into_inner()),
+            angular_velocity: omega_in_to * -1.0,
         }
     }
 }

--- a/arika/src/frame.rs
+++ b/arika/src/frame.rs
@@ -503,6 +503,88 @@ impl<From, To> Rotation<From, To> {
     }
 }
 
+// ─── FrameTransform: rotation + angular velocity (state transforms) ─
+
+/// A frame transform carrying both the orientation ([`Rotation`]) and the
+/// angular velocity of the `To` frame relative to `From`, so it can transform
+/// **velocities** (and full position+velocity states), not just positions.
+///
+/// The stored angular velocity `ω` is that of `To` relative to `From`,
+/// **expressed in `From`**. Velocities follow the transport theorem:
+///
+/// ```text
+/// r_to = R · r_from
+/// v_to = R · (v_from − ω × r_from)
+/// ```
+///
+/// [`Rotation`] stays position-only; this is its kinematic (state) companion.
+/// Build Earth ECI↔ECEF instances via the
+/// [`EarthFixedTransform`](crate::earth::EarthFixedTransform) factories.
+pub struct FrameTransform<From, To> {
+    rotation: Rotation<From, To>,
+    /// Angular velocity of `To` relative to `From`, expressed in `From` [rad/s].
+    angular_velocity: Vec3<From>,
+}
+
+impl<From, To> FrameTransform<From, To> {
+    /// Build from a rotation and the angular velocity of `To` relative to
+    /// `From`, expressed in `From` [rad/s].
+    pub fn new(rotation: Rotation<From, To>, angular_velocity: Vec3<From>) -> Self {
+        Self {
+            rotation,
+            angular_velocity,
+        }
+    }
+
+    /// The orientation part (`From` → `To`).
+    pub fn rotation(&self) -> &Rotation<From, To> {
+        &self.rotation
+    }
+
+    /// Angular velocity of `To` relative to `From`, expressed in `From` [rad/s].
+    pub fn angular_velocity_in_from(&self) -> &Vec3<From> {
+        &self.angular_velocity
+    }
+
+    /// Transform a position (identical to [`Rotation::transform`]).
+    pub fn transform_position(&self, position: &Vec3<From>) -> Vec3<To> {
+        self.rotation.transform(position)
+    }
+
+    /// Transform a velocity via the transport theorem `v_to = R·(v_from − ω×r_from)`.
+    ///
+    /// The position is required because the rotating-frame correction is `ω × r`.
+    pub fn transform_velocity(&self, position: &Vec3<From>, velocity: &Vec3<From>) -> Vec3<To> {
+        let corotation = self.angular_velocity.cross(position); // ω × r, in From
+        let relative = Vec3::<From>::from_raw(velocity.inner() - corotation.inner());
+        self.rotation.transform(&relative)
+    }
+
+    /// Transform a full state (position, velocity).
+    pub fn transform_state(
+        &self,
+        position: &Vec3<From>,
+        velocity: &Vec3<From>,
+    ) -> (Vec3<To>, Vec3<To>) {
+        (
+            self.transform_position(position),
+            self.transform_velocity(position, velocity),
+        )
+    }
+
+    /// Inverse transform (`To` → `From`).
+    ///
+    /// The inverse angular velocity — of `From` relative to `To`, expressed in
+    /// `To` — is `−R·ω`.
+    pub fn inverse(&self) -> FrameTransform<To, From> {
+        let omega_in_to = self.rotation.transform(&self.angular_velocity); // R·ω, in To
+        FrameTransform {
+            rotation: self.rotation.inverse(),
+            angular_velocity: Vec3::<To>::from_raw(-omega_in_to.into_inner()),
+        }
+    }
+}
+
 // ─── Simple path (SimpleEci ↔ SimpleEcef) rotation constructors ─
 
 impl Rotation<SimpleEci, SimpleEcef> {
@@ -830,5 +912,79 @@ mod tests {
         assert!((a.x() - b.x()).abs() < 1e-14);
         assert!((a.y() - b.y()).abs() < 1e-14);
         assert!((a.z() - b.z()).abs() < 1e-14);
+    }
+
+    // FrameTransform (rotation + angular velocity) ─ state transforms
+
+    const OMEGA_E: f64 = 7.2921159e-5;
+
+    #[test]
+    fn frame_transform_zero_omega_equals_rotation() {
+        // With ω = 0, velocity transforms exactly like position (pure rotation).
+        let rot = Rotation::<SimpleEci, SimpleEcef>::from_era(0.7);
+        let ft = FrameTransform::new(rot, Vec3::<SimpleEci>::zeros());
+        let r = Vec3::<SimpleEci>::new(7000.0, -1200.0, 500.0);
+        let v = Vec3::<SimpleEci>::new(1.0, 7.5, -0.3);
+        let v_ft = ft.transform_velocity(&r, &v);
+        let v_rot = Rotation::<SimpleEci, SimpleEcef>::from_era(0.7).transform(&v);
+        assert!((v_ft.x() - v_rot.x()).abs() < 1e-12);
+        assert!((v_ft.y() - v_rot.y()).abs() < 1e-12);
+        assert!((v_ft.z() - v_rot.z()).abs() < 1e-12);
+    }
+
+    #[test]
+    fn frame_transform_inverse_state_roundtrip() {
+        let ft = FrameTransform::new(
+            Rotation::<SimpleEci, SimpleEcef>::from_era(1.1),
+            Vec3::<SimpleEci>::new(0.0, 0.0, OMEGA_E),
+        );
+        let r = Vec3::<SimpleEci>::new(6778.0, 0.0, 0.0);
+        let v = Vec3::<SimpleEci>::new(0.0, 7.5, 1.0);
+        let (r_e, v_e) = ft.transform_state(&r, &v);
+        let (r_back, v_back) = ft.inverse().transform_state(&r_e, &v_e);
+        assert!((r_back.inner() - r.inner()).norm() < 1e-9);
+        assert!((v_back.inner() - v.inner()).norm() < 1e-12);
+    }
+
+    #[test]
+    fn frame_transform_corotating_point_is_static_in_ecef() {
+        // At ERA = 0 the ECI→ECEF rotation is identity. A point on the equator
+        // co-rotating with Earth (inertial velocity ω × r) is static in ECEF.
+        let ft = FrameTransform::new(
+            Rotation::<SimpleEci, SimpleEcef>::from_era(0.0),
+            Vec3::<SimpleEci>::new(0.0, 0.0, OMEGA_E),
+        );
+        let r_km = 6378.137;
+        let r = Vec3::<SimpleEci>::new(r_km, 0.0, 0.0);
+        let v = Vec3::<SimpleEci>::new(0.0, OMEGA_E * r_km, 0.0); // ω × r
+        let v_ecef = ft.transform_velocity(&r, &v);
+        assert!(
+            v_ecef.inner().norm() < 1e-12,
+            "co-rotating point should be static in ECEF, got {:?}",
+            v_ecef.inner()
+        );
+    }
+
+    #[test]
+    fn frame_transform_velocity_matches_finite_difference() {
+        // For a point fixed in ECI (v = 0), d/dt[R(ERA(t))·r] = transform_velocity(r, 0).
+        let era = 0.9;
+        let r = Vec3::<SimpleEci>::new(7000.0, -1500.0, 800.0);
+        let ft = FrameTransform::new(
+            Rotation::<SimpleEci, SimpleEcef>::from_era(era),
+            Vec3::<SimpleEci>::new(0.0, 0.0, OMEGA_E),
+        );
+        let v_analytic = ft.transform_velocity(&r, &Vec3::<SimpleEci>::zeros());
+
+        let dt = 1.0e-3;
+        let p0 = Rotation::<SimpleEci, SimpleEcef>::from_era(era).transform(&r);
+        let p1 = Rotation::<SimpleEci, SimpleEcef>::from_era(era + OMEGA_E * dt).transform(&r);
+        let v_fd = (p1.inner() - p0.inner()) / dt;
+        assert!(
+            (v_analytic.inner() - v_fd).norm() < 1e-6,
+            "analytic {:?} vs finite-diff {:?}",
+            v_analytic.inner(),
+            v_fd
+        );
     }
 }


### PR DESCRIPTION
## 概要

arika に ECI↔ECEF の**速度（状態）変換**を追加する。既存の `Rotation<From, To>` は位置ベクトルのみを変換でき、回転フレーム間の速度変換（`ω×r` 項）ができなかった。座標ライブラリとして基本的な capability の欠落を埋める。

## 背景

回転するフレーム間（ECI↔ECEF）で速度を正しく変換するには、回転 `R` だけでなく角速度 `ω` と位置 `r` が要る（transport 定理 `v_to = R·(v_from − ω×r_from)`）。`Rotation` は `R` しか持たないため速度を変換できなかった。

## 追加内容

- `arika::frame::FrameTransform<From, To>`: `Rotation` ＋「`To` の `From` に対する角速度 `ω`（`From` 表現）」を保持し、位置・速度・状態(position+velocity)を変換、`inverse()` を持つ。`Rotation` は位置専用のまま据え置き。
- `arika::earth::transform::EarthFixedTransform` に default メソッド `inertial_to_fixed_transform` / `fixed_to_inertial_transform`。角速度は `ω = OMEGA · earth_pole`（`SimpleEci` は +Z、`Gcrs` は真の CIP）。

## 設計上の選択

- **`ω` は新型 `FrameTransform` が持ち、`Rotation` には速度メソッドを足さない。** `Rotation` を位置専用に保つことで、`inverse()` / `then()` の符号規約を呼び出し側に押し付けない。
- **`ω` は `From` フレーム表現**で保持。`inverse()` の角速度は `−R·ω`（`To` 表現）。
- **地球ファクトリは spin-only モデル**: `OMEGA · earth_pole` を使い、IAU 2006 の W·R·Q チェーンの完全な時間微分（Q̇/Ẇ、sub-µrad/s）は含まない。nominal レート（LOD 補正なし）。doc に明記。exact な観測極レートが要るときは将来の別ファクトリで。

## 用途

ライブラリの基本機能の補完であり、現状 in-tree の直接の消費者はまだ無い（その点はあえて明記）。想定用途は ECEF 状態ベクトルの入出力、地表相対速度・レンジレート、および大気抵抗が手計算している `ω×r`（co-rotation）の一般化。

## 検証

- テスト: `ω=0` で `Rotation` に一致／inverse 状態往復／赤道上の co-rotating 点が ECEF で静止（符号）／`R(t)·r` の有限差分が `transform_velocity` に一致／`Gcrs` ファクトリの `ω = OMEGA·CIP`。
- arika 全 tier（std / no_std+alloc / no_std / wasm32）ビルド、`clippy --workspace -- -D warnings` / `cargo fmt` clean。orts は追加 API のため影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)