### PR TITLE
fix(viewer-example): TS6-deprecated baseUrl を削除し example の typecheck を CI ゲート

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -905,6 +905,14 @@ jobs:
       - name: Test viewer
         run: pnpm --filter orts-viewer test
 
+      # The registry-consumer example is only exercised via Playwright (a Vite
+      # build, which does not type-check), so its `tsc --noEmit` was ungated —
+      # a TypeScript 6 deprecation error in its tsconfig slipped through here.
+      # Run its typecheck so config/type regressions fail at build time.
+      - name: Typecheck registry-consumer example
+        working-directory: viewer/examples/orbit-viewer
+        run: pnpm typecheck
+
       # The shadcn registry manifest is generated from the library's import
       # closure; build it (proves it's well-formed) and fail if the committed
       # registry.json drifted from the closure (someone changed imports without

--- a/viewer/examples/orbit-viewer/tsconfig.json
+++ b/viewer/examples/orbit-viewer/tsconfig.json
@@ -8,7 +8,6 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     },


### PR DESCRIPTION
## 課題

TypeScript 6 では `baseUrl` が **deprecated でハードエラー(TS5101)** になり、7.0 で削除される。registry-consumer の example (`viewer/examples/orbit-viewer/tsconfig.json`) が `baseUrl: "."` を設定していたため、その `tsc --noEmit`(`typecheck`) は TS6 で失敗する状態だった。

しかしこのエラーは **CI をすり抜けていた**: この example は CI 上で Playwright (= `vite build`、型チェックしない) でしか動かされず、`tsc --noEmit` がどのジョブでも実行されていなかった。これはバグではなく「型ゲートの欠落」で、TS6 化(#137)で初めて顕在化した。

## 修正

- **`baseUrl` を削除**。この設定は `@/*` の path mapping を張るためだけのものだったが、TS6 は `baseUrl` 無しでも `paths` を tsconfig のディレクトリ基準で解決するため、削除後も `@/*` は機能する（ローカルで `tsc --noEmit` が通ることを確認、codex review でも `tsconfig-paths` による解決を独立検証）。
- **`viewer-build` ジョブに "Typecheck registry-consumer example" ステップを追加**。example の deps が揃った状態で `tsc --noEmit` を実行し、今回のような config/型エラーをビルド時に検出できるようにする（すり抜けの根本対策）。

## 影響範囲・検証

- 監査の結果、`tsc` 系の型チェックが CI 非ゲートだったのは **orbit-viewer だけ**（uneri/orts-viewer/starlight-rustdoc/tobari-example はいずれも `build` に `tsc` を内包し CI がその build を実行している）。
- `tsc --noEmit`（baseUrl 削除後）: EXIT 0 / `@/*` 解決 OK。
- ci.yml: js-yaml で構文検証済み。

> 注: docs(orts-docs) は `astro build` のみで型チェックされない別種の穴があるが、これは `astro check`(別ツール) を要するため別 PR で対応予定。
