### PR TITLE
feat(arika): require Epoch<Tdb> for analytic ephemerides; type the force-model callback scale

### DIFF
--- a/arika/src/moon/ephemeris.rs
+++ b/arika/src/moon/ephemeris.rs
@@ -7,7 +7,7 @@
 #[allow(unused_imports)]
 use crate::math::F64Ext;
 
-use crate::epoch::Epoch;
+use crate::epoch::{Epoch, Tdb};
 use crate::frame::{self, Vec3};
 
 /// Moon position vector in ECI (J2000) frame [km].
@@ -20,12 +20,13 @@ use crate::frame::{self, Vec3};
 ///
 /// # Time scale
 ///
-/// Meeus ephemerides take a dynamical time argument (TDB). The public signature
-/// accepts `&Epoch<Utc>` (the default alias) for backward compatibility; the
-/// UTC epoch is converted to TDB internally via leap seconds + TT offset +
-/// Fairhead-Bretagnon periodic correction.
-pub fn moon_position_eci(epoch: &Epoch) -> Vec3<frame::Gcrs> {
-    let t = epoch.to_tdb().centuries_since_j2000();
+/// Meeus ephemerides take a dynamical time argument (TDB), so this signature
+/// requires `&Epoch<Tdb>` — the caller converts at the boundary
+/// (`utc.to_tdb()`). (The [`MoonEphemeris`] trait, which also abstracts a
+/// UTC-indexed Horizons table, deliberately keeps a `&Epoch<Utc>` interface;
+/// see [`MeeusMoonEphemeris`].)
+pub fn moon_position_eci(epoch: &Epoch<Tdb>) -> Vec3<frame::Gcrs> {
+    let t = epoch.centuries_since_j2000();
     let t2 = t * t;
     let t3 = t2 * t;
     let t4 = t3 * t;
@@ -284,7 +285,9 @@ pub struct MeeusMoonEphemeris;
 
 impl MoonEphemeris for MeeusMoonEphemeris {
     fn position_eci(&self, epoch: &Epoch) -> Vec3<frame::Gcrs> {
-        moon_position_eci(epoch)
+        // The trait is UTC-indexed (shared with the Horizons-backed impl); the
+        // analytic free function requires TDB, so convert at this boundary.
+        moon_position_eci(&epoch.to_tdb())
     }
 
     fn name(&self) -> &str {
@@ -435,7 +438,7 @@ mod tests {
         ];
 
         for epoch in &dates {
-            let pos = moon_position_eci(epoch);
+            let pos = moon_position_eci(&epoch.to_tdb());
             let dist = pos.magnitude();
             assert!(
                 dist > 340_000.0 && dist < 420_000.0,
@@ -452,7 +455,7 @@ mod tests {
         let total_dist: f64 = (0..n)
             .map(|i| {
                 let epoch = epoch0.add_seconds(i as f64 * 86400.0);
-                moon_position_eci(&epoch).magnitude()
+                moon_position_eci(&epoch.to_tdb()).magnitude()
             })
             .sum();
         let mean_dist = total_dist / n as f64;
@@ -466,10 +469,10 @@ mod tests {
     #[test]
     fn moon_orbital_period() {
         let epoch0 = Epoch::from_gregorian(2024, 3, 10, 0, 0, 0.0);
-        let pos0 = moon_position_eci(&epoch0).normalize();
+        let pos0 = moon_position_eci(&epoch0.to_tdb()).normalize();
 
         let epoch1 = epoch0.add_seconds(27.3 * 86400.0);
-        let pos1 = moon_position_eci(&epoch1).normalize();
+        let pos1 = moon_position_eci(&epoch1.to_tdb()).normalize();
 
         let dot = pos0.dot(&pos1);
         assert!(
@@ -478,7 +481,7 @@ mod tests {
         );
 
         let epoch_half = epoch0.add_seconds(13.7 * 86400.0);
-        let pos_half = moon_position_eci(&epoch_half).normalize();
+        let pos_half = moon_position_eci(&epoch_half.to_tdb()).normalize();
         let dot_half = pos0.dot(&pos_half);
         assert!(
             dot_half < 0.0,
@@ -489,13 +492,13 @@ mod tests {
     #[test]
     fn moon_not_in_ecliptic() {
         let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
-        let pos = moon_position_eci(&epoch);
+        let pos = moon_position_eci(&epoch.to_tdb());
         let z_frac = pos.z().abs() / pos.magnitude();
 
         let mut max_z_frac = 0.0_f64;
         for i in 0..28 {
             let ep = epoch.add_seconds(i as f64 * 86400.0);
-            let p = moon_position_eci(&ep);
+            let p = moon_position_eci(&ep.to_tdb());
             max_z_frac = max_z_frac.max(p.z().abs() / p.magnitude());
         }
         assert!(
@@ -509,7 +512,7 @@ mod tests {
     fn moon_distance_apollo11_epoch() {
         // Apollo 11 TLI: 1969-07-16. Moon was near apogee, ~394,000 km (JPL Horizons)
         let epoch = Epoch::from_iso8601("1969-07-16T16:22:03Z").unwrap();
-        let dist = moon_position_eci(&epoch).magnitude();
+        let dist = moon_position_eci(&epoch.to_tdb()).magnitude();
         // Meeus analytical model has ~2-3% distance error
         assert!(
             (dist - 394_000.0).abs() < 15_000.0,
@@ -523,7 +526,10 @@ mod tests {
         // any transformation — trait wrapper should be a zero-cost abstraction.
         let ephem = MeeusMoonEphemeris;
         let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
-        assert_eq!(ephem.position_eci(&epoch), moon_position_eci(&epoch));
+        assert_eq!(
+            ephem.position_eci(&epoch),
+            moon_position_eci(&epoch.to_tdb())
+        );
         assert_eq!(ephem.name(), "meeus");
     }
 
@@ -541,8 +547,8 @@ mod tests {
         );
         // Cross-check against a manual central difference with a larger step.
         let dt = 10.0;
-        let expected = (moon_position_eci(&epoch.add_seconds(dt))
-            - moon_position_eci(&epoch.add_seconds(-dt)))
+        let expected = (moon_position_eci(&epoch.add_seconds(dt).to_tdb())
+            - moon_position_eci(&epoch.add_seconds(-dt).to_tdb()))
             / (2.0 * dt);
         let err = (v - expected).magnitude();
         assert!(
@@ -641,8 +647,14 @@ $$EOE
         // Calls must go through the blanket impl on `Arc<_>`, not through
         // auto-deref, because `moon_with_ephemeris<E: MoonEphemeris>` takes
         // the value by generic bound.
-        assert_eq!(owned.position_eci(&epoch), moon_position_eci(&epoch));
-        assert_eq!(erased.position_eci(&epoch), moon_position_eci(&epoch));
+        assert_eq!(
+            owned.position_eci(&epoch),
+            moon_position_eci(&epoch.to_tdb())
+        );
+        assert_eq!(
+            erased.position_eci(&epoch),
+            moon_position_eci(&epoch.to_tdb())
+        );
         assert_eq!(owned.name(), "meeus");
         assert_eq!(erased.name(), "meeus");
 

--- a/arika/src/moon/rotation.rs
+++ b/arika/src/moon/rotation.rs
@@ -173,7 +173,7 @@ mod tests {
         let epoch_tdb = epoch_utc.to_tdb();
         let q = MOON.orientation(&epoch_tdb);
         let x_body_eci = q * Vector3::new(1.0, 0.0, 0.0);
-        let moon_pos = crate::moon::moon_position_eci(&epoch_utc).into_inner();
+        let moon_pos = crate::moon::moon_position_eci(&epoch_utc.to_tdb()).into_inner();
         let earth_dir = -moon_pos.normalize();
         let angle = x_body_eci.angle(&earth_dir).to_degrees();
         assert!(
@@ -195,7 +195,7 @@ mod tests {
             let epoch_tdb = epoch.to_tdb();
             let q = moon_orientation(&epoch_tdb);
             let x_body_eci = q * Vector3::new(1.0, 0.0, 0.0);
-            let moon_pos = crate::moon::moon_position_eci(epoch).into_inner();
+            let moon_pos = crate::moon::moon_position_eci(&epoch.to_tdb()).into_inner();
             let earth_dir = -moon_pos.normalize();
             let angle = x_body_eci.angle(&earth_dir).to_degrees();
             assert!(

--- a/arika/src/moon/rotation.rs
+++ b/arika/src/moon/rotation.rs
@@ -173,7 +173,7 @@ mod tests {
         let epoch_tdb = epoch_utc.to_tdb();
         let q = MOON.orientation(&epoch_tdb);
         let x_body_eci = q * Vector3::new(1.0, 0.0, 0.0);
-        let moon_pos = crate::moon::moon_position_eci(&epoch_utc.to_tdb()).into_inner();
+        let moon_pos = crate::moon::moon_position_eci(&epoch_tdb).into_inner();
         let earth_dir = -moon_pos.normalize();
         let angle = x_body_eci.angle(&earth_dir).to_degrees();
         assert!(
@@ -195,7 +195,7 @@ mod tests {
             let epoch_tdb = epoch.to_tdb();
             let q = moon_orientation(&epoch_tdb);
             let x_body_eci = q * Vector3::new(1.0, 0.0, 0.0);
-            let moon_pos = crate::moon::moon_position_eci(&epoch.to_tdb()).into_inner();
+            let moon_pos = crate::moon::moon_position_eci(&epoch_tdb).into_inner();
             let earth_dir = -moon_pos.normalize();
             let angle = x_body_eci.angle(&earth_dir).to_degrees();
             assert!(

--- a/arika/src/planets/mod.rs
+++ b/arika/src/planets/mod.rs
@@ -22,7 +22,7 @@ use nalgebra::Vector3;
 #[allow(unused_imports)]
 use crate::math::F64Ext;
 
-use crate::epoch::Epoch;
+use crate::epoch::{Epoch, Tdb};
 use crate::sun::AU_KM;
 
 /// Heliocentric orbital elements at J2000.0 and their century rates.
@@ -172,11 +172,11 @@ fn solve_kepler(mean_anomaly: f64, eccentricity: f64) -> f64 {
 ///
 /// # Time scale
 ///
-/// Meeus ephemerides take a dynamical time argument (TDB). The public signature
-/// accepts `&Epoch<Utc>` for backward compatibility; UTC is converted to TDB
-/// internally.
-pub fn obliquity(epoch: &Epoch) -> f64 {
-    let t = epoch.to_tdb().centuries_since_j2000();
+/// Meeus ephemerides take a dynamical time argument (TDB), so this signature
+/// requires `&Epoch<Tdb>` — the caller converts at the boundary
+/// (`utc.to_tdb()`).
+pub fn obliquity(epoch: &Epoch<Tdb>) -> f64 {
+    let t = epoch.centuries_since_j2000();
     (23.439_291 - 0.013_004_2 * t).to_radians()
 }
 
@@ -200,10 +200,10 @@ pub fn ecliptic_to_equatorial(v: &Vector3<f64>, epsilon: f64) -> Vector3<f64> {
 ///
 /// # Time scale
 ///
-/// Meeus ephemerides take a dynamical time argument (TDB). The public signature
-/// accepts `&Epoch<Utc>` for backward compatibility; UTC is converted to TDB
-/// internally.
-pub fn heliocentric_position_ecliptic(body: &str, epoch: &Epoch) -> Option<Vector3<f64>> {
+/// Meeus ephemerides take a dynamical time argument (TDB), so this signature
+/// requires `&Epoch<Tdb>` — the caller converts at the boundary
+/// (`utc.to_tdb()`).
+pub fn heliocentric_position_ecliptic(body: &str, epoch: &Epoch<Tdb>) -> Option<Vector3<f64>> {
     let elements = match body {
         "mercury" => &MERCURY_ELEMENTS,
         "venus" => &VENUS_ELEMENTS,
@@ -214,7 +214,7 @@ pub fn heliocentric_position_ecliptic(body: &str, epoch: &Epoch) -> Option<Vecto
         _ => return None,
     };
 
-    let t = epoch.to_tdb().centuries_since_j2000();
+    let t = epoch.centuries_since_j2000();
 
     // Compute elements at epoch
     let l = (elements.l0 + elements.l_rate * t).to_radians();
@@ -316,7 +316,7 @@ mod tests {
     #[test]
     fn earth_at_1au() {
         let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
-        let pos = heliocentric_position_ecliptic("earth", &epoch).unwrap();
+        let pos = heliocentric_position_ecliptic("earth", &epoch.to_tdb()).unwrap();
         let dist_au = pos.magnitude() / AU_KM;
         assert!(
             (dist_au - 1.0).abs() < 0.02,
@@ -328,7 +328,7 @@ mod tests {
     fn mars_at_correct_distance() {
         // Mars semi-major axis ~1.524 AU, varies between ~1.38 and ~1.67 AU
         let epoch = Epoch::from_gregorian(2024, 6, 15, 12, 0, 0.0);
-        let pos = heliocentric_position_ecliptic("mars", &epoch).unwrap();
+        let pos = heliocentric_position_ecliptic("mars", &epoch.to_tdb()).unwrap();
         let dist_au = pos.magnitude() / AU_KM;
         assert!(
             dist_au > 1.3 && dist_au < 1.7,
@@ -339,8 +339,8 @@ mod tests {
     #[test]
     fn venus_inside_earth() {
         let epoch = Epoch::from_gregorian(2024, 9, 1, 12, 0, 0.0);
-        let venus = heliocentric_position_ecliptic("venus", &epoch).unwrap();
-        let earth = heliocentric_position_ecliptic("earth", &epoch).unwrap();
+        let venus = heliocentric_position_ecliptic("venus", &epoch.to_tdb()).unwrap();
+        let earth = heliocentric_position_ecliptic("earth", &epoch.to_tdb()).unwrap();
         assert!(
             venus.magnitude() < earth.magnitude(),
             "Venus ({:.4} AU) should be closer than Earth ({:.4} AU)",
@@ -352,7 +352,7 @@ mod tests {
     #[test]
     fn mercury_smallest_orbit() {
         let epoch = Epoch::from_gregorian(2024, 1, 15, 12, 0, 0.0);
-        let pos = heliocentric_position_ecliptic("mercury", &epoch).unwrap();
+        let pos = heliocentric_position_ecliptic("mercury", &epoch.to_tdb()).unwrap();
         let dist_au = pos.magnitude() / AU_KM;
         // Mercury: ~0.31-0.47 AU
         assert!(
@@ -364,7 +364,7 @@ mod tests {
     #[test]
     fn jupiter_outer_planet() {
         let epoch = Epoch::from_gregorian(2024, 6, 1, 12, 0, 0.0);
-        let pos = heliocentric_position_ecliptic("jupiter", &epoch).unwrap();
+        let pos = heliocentric_position_ecliptic("jupiter", &epoch.to_tdb()).unwrap();
         let dist_au = pos.magnitude() / AU_KM;
         // Jupiter: ~4.95-5.46 AU
         assert!(
@@ -376,8 +376,8 @@ mod tests {
     #[test]
     fn unknown_body_returns_none() {
         let epoch = Epoch::from_gregorian(2024, 1, 1, 12, 0, 0.0);
-        assert!(heliocentric_position_ecliptic("pluto", &epoch).is_none());
-        assert!(heliocentric_position_ecliptic("foo", &epoch).is_none());
+        assert!(heliocentric_position_ecliptic("pluto", &epoch.to_tdb()).is_none());
+        assert!(heliocentric_position_ecliptic("foo", &epoch.to_tdb()).is_none());
     }
 
     #[test]
@@ -386,11 +386,11 @@ mod tests {
         use crate::sun;
 
         let epoch = Epoch::from_gregorian(2024, 6, 21, 12, 0, 0.0);
-        let earth_helio = heliocentric_position_ecliptic("earth", &epoch).unwrap();
-        let sun_dir = sun::sun_direction_eci(&epoch).into_inner();
+        let earth_helio = heliocentric_position_ecliptic("earth", &epoch.to_tdb()).unwrap();
+        let sun_dir = sun::sun_direction_eci(&epoch.to_tdb()).into_inner();
 
         // Convert Earth heliocentric to equatorial for comparison
-        let epsilon = obliquity(&epoch);
+        let epsilon = obliquity(&epoch.to_tdb());
         let earth_eq = ecliptic_to_equatorial(&earth_helio, epsilon).normalize();
 
         // They should be roughly anti-parallel (dot product ≈ -1)
@@ -427,7 +427,7 @@ mod tests {
     #[test]
     fn obliquity_near_23_degrees() {
         let epoch = Epoch::from_gregorian(2024, 1, 1, 0, 0, 0.0);
-        let eps = obliquity(&epoch).to_degrees();
+        let eps = obliquity(&epoch.to_tdb()).to_degrees();
         assert!(
             (eps - 23.44).abs() < 0.1,
             "Obliquity should be ~23.44°, got {eps:.2}°"

--- a/arika/src/sun/ephemeris.rs
+++ b/arika/src/sun/ephemeris.rs
@@ -400,9 +400,9 @@ mod tests {
 
     #[test]
     fn sun_position_magnitude_matches_distance() {
-        let epoch = Epoch::from_gregorian(2024, 6, 15, 12, 0, 0.0);
-        let pos = sun_position_eci(&epoch.to_tdb());
-        let dist = sun_distance_km(&epoch.to_tdb());
+        let epoch = Epoch::from_gregorian(2024, 6, 15, 12, 0, 0.0).to_tdb();
+        let pos = sun_position_eci(&epoch);
+        let dist = sun_distance_km(&epoch);
 
         let rel_err = (pos.magnitude() - dist).abs() / dist;
         assert!(

--- a/arika/src/sun/ephemeris.rs
+++ b/arika/src/sun/ephemeris.rs
@@ -9,17 +9,17 @@
 //!
 //! # Time scale
 //!
-//! Meeus ephemerides take a dynamical time argument (TDB). The public
-//! signatures accept `&Epoch<Utc>` (the default alias) for ergonomics; the
-//! UTC epoch is converted to TDB internally via leap seconds + TT offset +
-//! Fairhead-Bretagnon periodic correction.
+//! Meeus ephemerides take a dynamical time argument (TDB), so the public
+//! signatures require `&Epoch<Tdb>` — the caller converts at the boundary
+//! (`utc.to_tdb()`), which keeps the TDB dependency explicit in the type
+//! rather than hidden inside each function.
 
 use nalgebra::Vector3;
 
 #[allow(unused_imports)]
 use crate::math::F64Ext;
 
-use crate::epoch::Epoch;
+use crate::epoch::{Epoch, Tdb};
 use crate::frame::{self, Vec3};
 use crate::planets;
 use crate::sun::AU_KM;
@@ -39,8 +39,8 @@ struct SolarElements {
 /// Compute solar orbital elements at the given epoch.
 ///
 /// Reference: Meeus, "Astronomical Algorithms", Chapter 25.
-fn solar_elements(epoch: &Epoch) -> SolarElements {
-    let t = epoch.to_tdb().centuries_since_j2000();
+fn solar_elements(epoch: &Epoch<Tdb>) -> SolarElements {
+    let t = epoch.centuries_since_j2000();
 
     // Mean longitude (degrees)
     let l0 = 280.46646 + 36000.76983 * t;
@@ -70,7 +70,7 @@ fn solar_elements(epoch: &Epoch) -> SolarElements {
 /// Accuracy is ~1 arcminute, sufficient for visualization purposes.
 ///
 /// Reference: Meeus, "Astronomical Algorithms", Chapter 25.
-pub fn sun_direction_eci(epoch: &Epoch) -> Vec3<frame::Gcrs> {
+pub fn sun_direction_eci(epoch: &Epoch<Tdb>) -> Vec3<frame::Gcrs> {
     let el = solar_elements(epoch);
 
     // Sun direction in ECI (equatorial coordinates)
@@ -89,7 +89,7 @@ pub fn sun_direction_eci(epoch: &Epoch) -> Vec3<frame::Gcrs> {
 /// Range: approximately -0.27 to +0.27 hours (-16 to +16 minutes).
 ///
 /// Reference: Meeus, "Astronomical Algorithms", Chapter 28.
-pub fn equation_of_time(epoch: &Epoch) -> f64 {
+pub fn equation_of_time(epoch: &Epoch<Tdb>) -> f64 {
     let el = solar_elements(epoch);
 
     // Right ascension from ecliptic longitude
@@ -118,9 +118,8 @@ pub fn equation_of_time(epoch: &Epoch) -> f64 {
 /// Accuracy: ~0.01 AU (~1.5 million km), sufficient for perturbation calculations.
 ///
 /// Reference: Meeus, "Astronomical Algorithms", Chapter 25.
-pub fn sun_distance_km(epoch: &Epoch) -> f64 {
-    // Meeus ephemeris uses TDB dynamical time; convert UTC → TDB internally.
-    let t = epoch.to_tdb().centuries_since_j2000();
+pub fn sun_distance_km(epoch: &Epoch<Tdb>) -> f64 {
+    let t = epoch.centuries_since_j2000();
 
     let m_deg = 357.52911 + 35999.05029 * t;
     let m = m_deg.to_radians();
@@ -134,7 +133,7 @@ pub fn sun_distance_km(epoch: &Epoch) -> f64 {
 /// Sun position vector in ECI (J2000) frame [km].
 ///
 /// Returns the geocentric position of the Sun. Combines direction and distance.
-pub fn sun_position_eci(epoch: &Epoch) -> Vec3<frame::Gcrs> {
+pub fn sun_position_eci(epoch: &Epoch<Tdb>) -> Vec3<frame::Gcrs> {
     let direction = sun_direction_eci(epoch);
     let distance = sun_distance_km(epoch);
     direction * distance
@@ -145,7 +144,7 @@ pub fn sun_position_eci(epoch: &Epoch) -> Vec3<frame::Gcrs> {
 /// - `"earth"` / `"moon"`: delegates to [`sun_distance_km`]
 /// - Other known planets: computed from heliocentric orbital elements
 /// - Unknown bodies: fallback to Earth-Sun distance
-pub fn sun_distance_from_body(body: &str, epoch: &Epoch) -> f64 {
+pub fn sun_distance_from_body(body: &str, epoch: &Epoch<Tdb>) -> f64 {
     match body {
         "earth" | "moon" => sun_distance_km(epoch),
         _ => planets::heliocentric_position_ecliptic(body, epoch)
@@ -161,7 +160,7 @@ pub fn sun_distance_from_body(body: &str, epoch: &Epoch) -> f64 {
 /// - Unknown bodies: fallback to +X direction (vernal equinox)
 ///
 /// The returned vector points FROM the body TOWARD the Sun.
-pub fn sun_direction_from_body(body: &str, epoch: &Epoch) -> Vec3<frame::Gcrs> {
+pub fn sun_direction_from_body(body: &str, epoch: &Epoch<Tdb>) -> Vec3<frame::Gcrs> {
     match body {
         "earth" | "moon" => sun_direction_eci(epoch),
         _ => {
@@ -188,7 +187,7 @@ mod tests {
     fn eot_february_negative() {
         // Mid-February: EoT ≈ -14 minutes (sundial slow, apparent sun behind mean sun)
         let epoch = Epoch::from_gregorian(2024, 2, 12, 12, 0, 0.0);
-        let eot_min = equation_of_time(&epoch) * 60.0;
+        let eot_min = equation_of_time(&epoch.to_tdb()) * 60.0;
         assert!(
             (eot_min - (-14.0)).abs() < 2.0,
             "Feb 12: EoT={eot_min:.1} min, expected ~-14"
@@ -199,7 +198,7 @@ mod tests {
     fn eot_november_positive() {
         // Early November: EoT ≈ +16 minutes (sundial fast, apparent sun ahead of mean sun)
         let epoch = Epoch::from_gregorian(2024, 11, 3, 12, 0, 0.0);
-        let eot_min = equation_of_time(&epoch) * 60.0;
+        let eot_min = equation_of_time(&epoch.to_tdb()) * 60.0;
         assert!(
             (eot_min - 16.0).abs() < 2.0,
             "Nov 3: EoT={eot_min:.1} min, expected ~+16"
@@ -210,7 +209,7 @@ mod tests {
     fn eot_april_near_zero() {
         // Mid-April: EoT ≈ 0 minutes (one of the four zero-crossings)
         let epoch = Epoch::from_gregorian(2024, 4, 15, 12, 0, 0.0);
-        let eot_min = equation_of_time(&epoch) * 60.0;
+        let eot_min = equation_of_time(&epoch.to_tdb()) * 60.0;
         assert!(
             eot_min.abs() < 2.0,
             "Apr 15: EoT={eot_min:.1} min, expected ~0"
@@ -222,7 +221,7 @@ mod tests {
         // EoT should stay within ±17 minutes throughout the year
         for month in 1..=12 {
             let epoch = Epoch::from_gregorian(2024, month, 15, 12, 0, 0.0);
-            let eot_min = equation_of_time(&epoch) * 60.0;
+            let eot_min = equation_of_time(&epoch.to_tdb()) * 60.0;
             assert!(
                 eot_min.abs() < 17.0,
                 "Month {month}: EoT={eot_min:.1} min, out of range"
@@ -243,7 +242,7 @@ mod tests {
             Epoch::from_gregorian(2024, 12, 21, 12, 0, 0.0),
         ];
         for epoch in &dates {
-            let dir = sun_direction_eci(epoch);
+            let dir = sun_direction_eci(&epoch.to_tdb());
             let norm = dir.magnitude();
             assert!(
                 (norm - 1.0).abs() < 1e-10,
@@ -257,7 +256,7 @@ mod tests {
     fn march_equinox_sun_near_plus_x() {
         // At March equinox (~2024-03-20), sun is near +X direction (RA ≈ 0°)
         let epoch = Epoch::from_gregorian(2024, 3, 20, 3, 6, 0.0); // ~03:06 UTC is 2024 equinox
-        let dir = sun_direction_eci(&epoch);
+        let dir = sun_direction_eci(&epoch.to_tdb());
 
         // X should be dominant and positive
         assert!(
@@ -282,7 +281,7 @@ mod tests {
     fn june_solstice_sun_positive_z() {
         // At June solstice (~2024-06-20), sun has significant +Z (northern declination ~23.4°)
         let epoch = Epoch::from_gregorian(2024, 6, 20, 20, 51, 0.0);
-        let dir = sun_direction_eci(&epoch);
+        let dir = sun_direction_eci(&epoch.to_tdb());
 
         // Z should be positive and near sin(23.44°) ≈ 0.398
         assert!(
@@ -308,7 +307,7 @@ mod tests {
     fn september_equinox_sun_near_minus_x() {
         // At September equinox (~2024-09-22), sun is near -X direction (RA ≈ 180°)
         let epoch = Epoch::from_gregorian(2024, 9, 22, 12, 44, 0.0);
-        let dir = sun_direction_eci(&epoch);
+        let dir = sun_direction_eci(&epoch.to_tdb());
 
         // X should be dominant and negative
         assert!(
@@ -333,7 +332,7 @@ mod tests {
     fn december_solstice_sun_negative_z() {
         // At December solstice (~2024-12-21), sun has significant -Z (southern declination ~-23.4°)
         let epoch = Epoch::from_gregorian(2024, 12, 21, 9, 21, 0.0);
-        let dir = sun_direction_eci(&epoch);
+        let dir = sun_direction_eci(&epoch.to_tdb());
 
         // Z should be negative and near -sin(23.44°) ≈ -0.398
         assert!(
@@ -354,8 +353,8 @@ mod tests {
         // Verify the sun position actually changes throughout the year
         let epoch1 = Epoch::from_gregorian(2024, 1, 1, 12, 0, 0.0);
         let epoch2 = Epoch::from_gregorian(2024, 7, 1, 12, 0, 0.0);
-        let dir1 = sun_direction_eci(&epoch1);
-        let dir2 = sun_direction_eci(&epoch2);
+        let dir1 = sun_direction_eci(&epoch1.to_tdb());
+        let dir2 = sun_direction_eci(&epoch2.to_tdb());
 
         // Should be significantly different (roughly opposite)
         let dot = dir1.dot(&dir2);
@@ -370,7 +369,7 @@ mod tests {
     #[test]
     fn sun_distance_approximately_1au() {
         let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
-        let d = sun_distance_km(&epoch);
+        let d = sun_distance_km(&epoch.to_tdb());
         let d_au = d / AU_KM;
         assert!(
             (d_au - 1.0).abs() < 0.02,
@@ -384,8 +383,8 @@ mod tests {
         let perihelion = Epoch::from_gregorian(2024, 1, 3, 12, 0, 0.0);
         let aphelion = Epoch::from_gregorian(2024, 7, 5, 12, 0, 0.0);
 
-        let d_peri = sun_distance_km(&perihelion);
-        let d_aph = sun_distance_km(&aphelion);
+        let d_peri = sun_distance_km(&perihelion.to_tdb());
+        let d_aph = sun_distance_km(&aphelion.to_tdb());
 
         assert!(
             d_peri < d_aph,
@@ -402,8 +401,8 @@ mod tests {
     #[test]
     fn sun_position_magnitude_matches_distance() {
         let epoch = Epoch::from_gregorian(2024, 6, 15, 12, 0, 0.0);
-        let pos = sun_position_eci(&epoch);
-        let dist = sun_distance_km(&epoch);
+        let pos = sun_position_eci(&epoch.to_tdb());
+        let dist = sun_distance_km(&epoch.to_tdb());
 
         let rel_err = (pos.magnitude() - dist).abs() / dist;
         assert!(
@@ -422,8 +421,8 @@ mod tests {
             Epoch::from_gregorian(2024, 9, 22, 12, 0, 0.0),
         ];
         for epoch in &dates {
-            let from_body = sun_direction_from_body("earth", epoch);
-            let eci = sun_direction_eci(epoch);
+            let from_body = sun_direction_from_body("earth", &epoch.to_tdb());
+            let eci = sun_direction_eci(&epoch.to_tdb());
             let diff = (from_body - eci).magnitude();
             assert!(
                 diff < 1e-10,
@@ -435,8 +434,8 @@ mod tests {
     #[test]
     fn sun_direction_from_body_moon_matches_eci() {
         let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
-        let from_body = sun_direction_from_body("moon", &epoch);
-        let eci = sun_direction_eci(&epoch);
+        let from_body = sun_direction_from_body("moon", &epoch.to_tdb());
+        let eci = sun_direction_eci(&epoch.to_tdb());
         let diff = (from_body - eci).magnitude();
         assert!(
             diff < 1e-10,
@@ -452,7 +451,7 @@ mod tests {
             Epoch::from_gregorian(2024, 12, 1, 12, 0, 0.0),
         ];
         for epoch in &dates {
-            let dir = sun_direction_from_body("mars", epoch);
+            let dir = sun_direction_from_body("mars", &epoch.to_tdb());
             let norm = dir.magnitude();
             assert!(
                 (norm - 1.0).abs() < 1e-10,
@@ -465,8 +464,8 @@ mod tests {
     fn sun_direction_from_body_mars_varies() {
         let epoch1 = Epoch::from_gregorian(2024, 1, 1, 12, 0, 0.0);
         let epoch2 = Epoch::from_gregorian(2024, 7, 1, 12, 0, 0.0);
-        let dir1 = sun_direction_from_body("mars", &epoch1);
-        let dir2 = sun_direction_from_body("mars", &epoch2);
+        let dir1 = sun_direction_from_body("mars", &epoch1.to_tdb());
+        let dir2 = sun_direction_from_body("mars", &epoch2.to_tdb());
         let dot = dir1.dot(&dir2);
         assert!(
             dot < 0.9,
@@ -477,7 +476,7 @@ mod tests {
     #[test]
     fn sun_direction_from_body_unknown_fallback() {
         let epoch = Epoch::from_gregorian(2024, 1, 1, 12, 0, 0.0);
-        let dir = sun_direction_from_body("pluto", &epoch);
+        let dir = sun_direction_from_body("pluto", &epoch.to_tdb());
         assert!(
             (dir.x() - 1.0).abs() < 1e-10 && dir.y().abs() < 1e-10 && dir.z().abs() < 1e-10,
             "Unknown body should return +X fallback, got ({}, {}, {})",
@@ -492,8 +491,8 @@ mod tests {
     #[test]
     fn sun_distance_from_body_earth_matches() {
         let epoch = Epoch::from_gregorian(2024, 6, 15, 12, 0, 0.0);
-        let from_body = sun_distance_from_body("earth", &epoch);
-        let direct = sun_distance_km(&epoch);
+        let from_body = sun_distance_from_body("earth", &epoch.to_tdb());
+        let direct = sun_distance_km(&epoch.to_tdb());
         assert!(
             (from_body - direct).abs() < 1.0,
             "earth distance should match sun_distance_km: {from_body} vs {direct}"
@@ -503,7 +502,7 @@ mod tests {
     #[test]
     fn sun_distance_from_body_mars() {
         let epoch = Epoch::from_gregorian(2024, 6, 15, 12, 0, 0.0);
-        let dist = sun_distance_from_body("mars", &epoch);
+        let dist = sun_distance_from_body("mars", &epoch.to_tdb());
         let dist_au = dist / AU_KM;
         assert!(
             dist_au > 1.3 && dist_au < 1.7,
@@ -514,7 +513,7 @@ mod tests {
     #[test]
     fn sun_distance_from_body_jupiter() {
         let epoch = Epoch::from_gregorian(2024, 6, 15, 12, 0, 0.0);
-        let dist = sun_distance_from_body("jupiter", &epoch);
+        let dist = sun_distance_from_body("jupiter", &epoch.to_tdb());
         let dist_au = dist / AU_KM;
         assert!(
             dist_au > 4.5 && dist_au < 5.8,
@@ -525,8 +524,8 @@ mod tests {
     #[test]
     fn sun_distance_from_body_unknown_fallback() {
         let epoch = Epoch::from_gregorian(2024, 1, 1, 12, 0, 0.0);
-        let dist = sun_distance_from_body("pluto", &epoch);
-        let earth_dist = sun_distance_km(&epoch);
+        let dist = sun_distance_from_body("pluto", &epoch.to_tdb());
+        let earth_dist = sun_distance_km(&epoch.to_tdb());
         assert!(
             (dist - earth_dist).abs() < 1.0,
             "Unknown body should fall back to Earth distance"
@@ -536,8 +535,8 @@ mod tests {
     #[test]
     fn sun_position_direction_matches() {
         let epoch = Epoch::from_gregorian(2024, 9, 22, 12, 0, 0.0);
-        let pos = sun_position_eci(&epoch);
-        let dir = sun_direction_eci(&epoch);
+        let pos = sun_position_eci(&epoch.to_tdb());
+        let dir = sun_direction_eci(&epoch.to_tdb());
 
         let pos_dir = pos.normalize();
         let diff = (pos_dir - dir).magnitude();

--- a/arika/tests/eclipse_astronomical_events.rs
+++ b/arika/tests/eclipse_astronomical_events.rs
@@ -34,8 +34,8 @@ fn solar_eclipse_2024_04_08_total() {
     // The Moon should be between the spacecraft and the Sun.
     let epoch = Epoch::from_gregorian(2024, 4, 8, 18, 18, 0.0);
 
-    let sun_pos = sun::sun_position_eci(&epoch).into_inner();
-    let moon_pos = moon::moon_position_eci(&epoch).into_inner();
+    let sun_pos = sun::sun_position_eci(&epoch.to_tdb()).into_inner();
+    let moon_pos = moon::moon_position_eci(&epoch.to_tdb()).into_inner();
 
     // Place observer at a point along the Earth-Sun line (subsolar point)
     // at LEO altitude. During a solar eclipse, the Moon passes between
@@ -85,8 +85,8 @@ fn solar_eclipse_2023_10_14_annular() {
     // Greatest eclipse at approximately 17:59 UTC
     let epoch = Epoch::from_gregorian(2023, 10, 14, 17, 59, 0.0);
 
-    let sun_pos = sun::sun_position_eci(&epoch).into_inner();
-    let moon_pos = moon::moon_position_eci(&epoch).into_inner();
+    let sun_pos = sun::sun_position_eci(&epoch.to_tdb()).into_inner();
+    let moon_pos = moon::moon_position_eci(&epoch.to_tdb()).into_inner();
 
     // Observer at subsolar LEO
     let sun_dir = sun_pos.normalize();
@@ -125,8 +125,8 @@ fn lunar_eclipse_2025_03_14() {
     // From the Moon's position, the Earth should occult the Sun.
     let epoch = Epoch::from_gregorian(2025, 3, 14, 6, 58, 0.0);
 
-    let sun_pos = sun::sun_position_eci(&epoch).into_inner();
-    let moon_pos = moon::moon_position_eci(&epoch).into_inner();
+    let sun_pos = sun::sun_position_eci(&epoch.to_tdb()).into_inner();
+    let moon_pos = moon::moon_position_eci(&epoch.to_tdb()).into_inner();
 
     // Observer is at the Moon's position, occulter is Earth (at origin)
     let illum = eclipse::illumination(
@@ -153,8 +153,8 @@ fn no_lunar_eclipse_at_first_quarter() {
     // Pick an arbitrary first quarter date
     let epoch = Epoch::from_gregorian(2024, 5, 15, 12, 0, 0.0);
 
-    let sun_pos = sun::sun_position_eci(&epoch).into_inner();
-    let moon_pos = moon::moon_position_eci(&epoch).into_inner();
+    let sun_pos = sun::sun_position_eci(&epoch.to_tdb()).into_inner();
+    let moon_pos = moon::moon_position_eci(&epoch.to_tdb()).into_inner();
 
     let illum = eclipse::illumination(
         &moon_pos,
@@ -180,7 +180,7 @@ fn leo_orbit_has_eclipse_region() {
     // orbit and verify that there exists at least one shadow region
     // and at least one sunlit region.
     let epoch = Epoch::from_gregorian(2024, 6, 21, 12, 0, 0.0);
-    let sun_pos = sun::sun_position_eci(&epoch).into_inner();
+    let sun_pos = sun::sun_position_eci(&epoch.to_tdb()).into_inner();
 
     let r = EARTH_RADIUS_KM + 400.0;
     let mut has_shadow = false;
@@ -220,7 +220,7 @@ fn leo_eclipse_fraction_reasonable() {
     // For a LEO orbit, approximately 30-40% of the orbit is in shadow
     // (varies with beta angle). We just check it's in a reasonable range.
     let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0); // equinox
-    let sun_pos = sun::sun_position_eci(&epoch).into_inner();
+    let sun_pos = sun::sun_position_eci(&epoch.to_tdb()).into_inner();
 
     let r = EARTH_RADIUS_KM + 400.0;
     let n = 3600; // 1° resolution

--- a/arika/wasm/src/lib.rs
+++ b/arika/wasm/src/lib.rs
@@ -76,7 +76,7 @@ pub fn earth_rotation_angle(epoch_jd: f64, t: f64) -> f64 {
 #[wasm_bindgen]
 pub fn sun_direction_eci(epoch_jd: f64, t: f64) -> Vec<f32> {
     let epoch = Epoch::from_jd(epoch_jd).add_seconds(t);
-    let dir = sun::sun_direction_eci(&epoch);
+    let dir = sun::sun_direction_eci(&epoch.to_tdb());
     vec![dir.x() as f32, dir.y() as f32, dir.z() as f32]
 }
 
@@ -89,7 +89,7 @@ pub fn sun_direction_eci(epoch_jd: f64, t: f64) -> Vec<f32> {
 #[wasm_bindgen]
 pub fn sun_direction_from_body(body: &str, epoch_jd: f64, t: f64) -> Vec<f32> {
     let epoch = Epoch::from_jd(epoch_jd).add_seconds(t);
-    let dir = sun::sun_direction_from_body(body, &epoch);
+    let dir = sun::sun_direction_from_body(body, &epoch.to_tdb());
     vec![dir.x() as f32, dir.y() as f32, dir.z() as f32]
 }
 
@@ -101,7 +101,7 @@ pub fn sun_direction_from_body(body: &str, epoch_jd: f64, t: f64) -> Vec<f32> {
 #[wasm_bindgen]
 pub fn sun_distance_from_body(body: &str, epoch_jd: f64, t: f64) -> f64 {
     let epoch = Epoch::from_jd(epoch_jd).add_seconds(t);
-    sun::sun_distance_from_body(body, &epoch)
+    sun::sun_distance_from_body(body, &epoch.to_tdb())
 }
 
 /// Convert Julian Date + elapsed sim time to a UTC date/time string.

--- a/orts/examples/apollo11/main.rs
+++ b/orts/examples/apollo11/main.rs
@@ -1532,7 +1532,7 @@ mod tests {
     #[test]
     fn moon_position_at_tli_epoch() {
         let epoch = Epoch::from_iso8601(TLI_EPOCH_ISO).unwrap();
-        let moon_pos = arika::moon::moon_position_eci(&epoch);
+        let moon_pos = arika::moon::moon_position_eci(&epoch.to_tdb());
         let moon_dist = moon_pos.magnitude();
 
         // Moon distance should be ~384,400 km ± ~5%
@@ -1546,7 +1546,7 @@ mod tests {
     fn moon_position_at_loi_epoch() {
         let tli_epoch = Epoch::from_iso8601(TLI_EPOCH_ISO).unwrap();
         let loi_epoch = tli_epoch.add_seconds(TLI_TO_LOI_SECONDS);
-        let moon_pos = arika::moon::moon_position_eci(&loi_epoch);
+        let moon_pos = arika::moon::moon_position_eci(&loi_epoch.to_tdb());
         let moon_dist = moon_pos.magnitude();
 
         // Moon should still be at roughly lunar distance
@@ -1560,8 +1560,8 @@ mod tests {
     fn moon_moves_during_transit() {
         let tli_epoch = Epoch::from_iso8601(TLI_EPOCH_ISO).unwrap();
         let loi_epoch = tli_epoch.add_seconds(TLI_TO_LOI_SECONDS);
-        let moon_tli = arika::moon::moon_position_eci(&tli_epoch);
-        let moon_loi = arika::moon::moon_position_eci(&loi_epoch);
+        let moon_tli = arika::moon::moon_position_eci(&tli_epoch.to_tdb());
+        let moon_loi = arika::moon::moon_position_eci(&loi_epoch.to_tdb());
 
         // Moon moves ~13°/day, so in ~3 days it should move ~39° ≈ significant displacement
         let displacement = (moon_loi - moon_tli).magnitude();

--- a/orts/examples/artemis1/main.rs
+++ b/orts/examples/artemis1/main.rs
@@ -216,14 +216,15 @@
 //!    tidal coupling and repeated integration through the eclipse /
 //!    illumination boundary could push this into the low-km range.
 //!    Currently missing from the force model entirely.
-//! 2. **TDB / UTC time-scale handling**: Horizons queries use
-//!    `TIME_TYPE=TDB` while our `Epoch` parses ISO 8601 strings as if
-//!    they were UTC. TDB − UTC ≈ 69 s for modern epochs; at orbital
-//!    velocity ~1 km/s that's ~69 km of position offset at the Horizons
-//!    reference endpoints. Whether this actually produces error depends on
-//!    internal consistency: if every fetch *and* the integrator's clock
-//!    treat the Epoch's JD as TDB uniformly, the offset cancels out. If
-//!    not, there's a hidden ~km error. Worth auditing.
+//! 2. **Horizons table time scale**: the analytic Meeus ephemerides now
+//!    take `Epoch<Tdb>` explicitly (the UTC→TDB conversion happens at the
+//!    call boundary), so the analytic path no longer risks feeding UTC as
+//!    TDB. The JPL-Horizons tables, however, are fetched and indexed in UT
+//!    (`TIME_TYPE=UT`) and looked up here via a UTC bridge. Whether a
+//!    tabulated vector ephemeris indexed in UT rather than its native TDB
+//!    introduces a residual offset (TDB − UTC ≈ 69 s; at ~1 km/s up to ~km
+//!    near the table endpoints) is a property of the Horizons layer that
+//!    still warrants a dedicated scale audit.
 //! 3. **Asymmetric burn profile modelling** (for the chain only): uniform
 //!    continuous thrust has now been tried and is mathematically
 //!    equivalent to impulsive-at-midpoint for symmetric profiles (see
@@ -2737,9 +2738,12 @@ fn build_artemis_system(
     // this closure with a dedicated `SunEphemeris` trait + type in
     // arika.
     let sun_table_for_closure: Arc<HorizonsTable> = Arc::clone(sun_table);
+    // `e` is the TDB callback epoch. The Horizons table is UTC-indexed (see
+    // `arika::horizons`), so bridge back to UTC for the lookup — an exact
+    // canonical-TAI re-tag round-trip. The Meeus fallback takes TDB directly.
     let sun_model = ThirdBodyGravity::custom("third_body_sun", MU_SUN, move |e| {
         sun_table_for_closure
-            .interpolate(e)
+            .interpolate(&e.to_tt().to_tai().to_utc())
             .map(|s| arika::frame::Vec3::from_raw(s.position))
             .unwrap_or_else(|| arika::sun::sun_position_eci(e))
     });

--- a/orts/src/perturbations/srp.rs
+++ b/orts/src/perturbations/srp.rs
@@ -99,7 +99,8 @@ impl SolarRadiationPressure {
             None => return Vector3::zeros(),
         };
 
-        let sun_pos = sun::sun_position_eci(epoch).into_inner();
+        // Solar ephemeris wants TDB; convert the integrator's epoch here.
+        let sun_pos = sun::sun_position_eci(&epoch.to_tdb()).into_inner();
         let sat_to_sun = sun_pos - sat_position;
         let r_sun = sat_to_sun.magnitude();
         let s_hat = sat_to_sun / r_sun;
@@ -196,7 +197,7 @@ mod tests {
         let epoch = test_epoch();
         let a = srp.acceleration(state.position(), Some(&epoch));
 
-        let sun_dir = sun::sun_direction_eci(&epoch).into_inner();
+        let sun_dir = sun::sun_direction_eci(&epoch.to_tdb()).into_inner();
         let cos_angle = a.normalize().dot(&sun_dir);
         assert!(
             cos_angle < -0.5,

--- a/orts/src/perturbations/third_body.rs
+++ b/orts/src/perturbations/third_body.rs
@@ -1,17 +1,20 @@
 use std::sync::Arc;
 
-use arika::epoch::Epoch;
+use arika::epoch::{Epoch, Tdb};
 use arika::frame::{self, Vec3};
 use nalgebra::Vector3;
 
 use crate::model::ExternalLoads;
 use crate::model::{HasOrbit, Model};
 
-/// Type alias for a position function: `Epoch -> ECI position [km]`.
+/// Type alias for a body-position function: `Epoch<Tdb> -> ECI position [km]`.
 ///
-/// Stored as an `Arc<dyn Fn>` so the struct is cheaply cloneable and can hold
-/// closures that capture state (e.g., an interpolated ephemeris table).
-pub type BodyPositionFn = Arc<dyn Fn(&Epoch) -> Vec3<frame::Gcrs> + Send + Sync>;
+/// Takes a TDB epoch because it computes a celestial-body ephemeris (a
+/// dynamical-time quantity); the integration loop converts its UTC epoch with
+/// `.to_tdb()` at the call boundary. Stored as an `Arc<dyn Fn>` so the struct is
+/// cheaply cloneable and can hold closures that capture state (e.g., an
+/// interpolated ephemeris table).
+pub type BodyPositionFn = Arc<dyn Fn(&Epoch<Tdb>) -> Vec3<frame::Gcrs> + Send + Sync>;
 
 /// Third-body gravitational perturbation.
 ///
@@ -80,7 +83,13 @@ impl ThirdBodyGravity {
         Self {
             name: "third_body_moon",
             mu_body: arika::moon::MU,
-            body_position_fn: Arc::new(move |epoch| ephem.position_eci(epoch)),
+            // `MoonEphemeris` is UTC-indexed (shared with the Horizons-backed
+            // impl), so bridge the TDB callback epoch back to UTC. This is an
+            // exact canonical-TAI round-trip (no precision loss): the integrator
+            // passes UTC, `acceleration` re-tags it to TDB, and this undoes it.
+            body_position_fn: Arc::new(move |epoch: &Epoch<Tdb>| {
+                ephem.position_eci(&epoch.to_tt().to_tai().to_utc())
+            }),
         }
     }
 
@@ -91,7 +100,7 @@ impl ThirdBodyGravity {
     /// a higher-accuracy ephemeris source (e.g., a precomputed table).
     pub fn custom<F>(name: &'static str, mu_body: f64, position_fn: F) -> Self
     where
-        F: Fn(&Epoch) -> Vec3<frame::Gcrs> + Send + Sync + 'static,
+        F: Fn(&Epoch<Tdb>) -> Vec3<frame::Gcrs> + Send + Sync + 'static,
     {
         Self {
             name,
@@ -122,7 +131,9 @@ impl ThirdBodyGravity {
             None => return Vector3::zeros(),
         };
 
-        let r_body = (self.body_position_fn)(epoch).into_inner();
+        // The ephemeris callback wants TDB; convert the integrator's epoch at
+        // this boundary (re-tag of the canonical TAI instant).
+        let r_body = (self.body_position_fn)(&epoch.to_tdb()).into_inner();
 
         let r_sat_to_body = r_body - sat_position;
         let d = r_sat_to_body.magnitude();

--- a/orts/src/sensor/sun_sensor.rs
+++ b/orts/src/sensor/sun_sensor.rs
@@ -80,7 +80,7 @@ impl SunSensor {
     /// - `illumination` in \[0, 1\]: actual eclipse-aware illumination fraction
     pub fn measure(&mut self, state: &SpacecraftState, epoch: &Epoch) -> SunSensorOutput {
         // Satellite-to-Sun vector in ECI
-        let sun_eci = sun_position_eci(epoch);
+        let sun_eci = sun_position_eci(&epoch.to_tdb());
         let sc_pos = state.orbit.position_eci();
         let sat_to_sun = sun_eci.into_inner() - sc_pos.into_inner();
         let norm = sat_to_sun.magnitude();
@@ -190,7 +190,7 @@ mod tests {
 
         // With identity quaternion, body == ECI
         use arika::sun::sun_position_eci;
-        let sun_eci = sun_position_eci(&epoch).into_inner();
+        let sun_eci = sun_position_eci(&epoch.to_tdb()).into_inner();
         let sc_pos = state.orbit.position_eci().into_inner();
         let expected = (sun_eci - sc_pos).normalize();
         assert!(

--- a/orts/src/spacecraft/panel_srp.rs
+++ b/orts/src/spacecraft/panel_srp.rs
@@ -91,7 +91,7 @@ impl PanelSrp {
             None => return ExternalLoads::zeros(),
         };
 
-        let sun_pos = sun::sun_position_eci(epoch).into_inner();
+        let sun_pos = sun::sun_position_eci(&epoch.to_tdb()).into_inner();
         let sat_to_sun = sun_pos - *orbit.position();
         let r_sun = sat_to_sun.magnitude();
         let s_hat = sat_to_sun / r_sun;
@@ -272,7 +272,7 @@ mod tests {
         let epoch = test_epoch();
         let loads = srp.eval(0.0, &iss_state(), Some(&epoch));
 
-        let sun_dir = sun::sun_direction_eci(&epoch).into_inner();
+        let sun_dir = sun::sun_direction_eci(&epoch.to_tdb()).into_inner();
         let cos_angle = loads
             .acceleration_inertial
             .into_inner()
@@ -337,7 +337,7 @@ mod tests {
         );
 
         // Direction should be away from Sun (roughly -X)
-        let sun_dir = sun::sun_direction_eci(&epoch).into_inner();
+        let sun_dir = sun::sun_direction_eci(&epoch.to_tdb()).into_inner();
         assert!(
             loads
                 .acceleration_inertial
@@ -410,7 +410,7 @@ mod tests {
     fn panels_different_attitude_different_srp() {
         // Use a panel normal aligned with the actual Sun direction for a clean test.
         let epoch = test_epoch();
-        let sun_dir = sun::sun_direction_eci(&epoch).into_inner();
+        let sun_dir = sun::sun_direction_eci(&epoch.to_tdb()).into_inner();
 
         let panel = SurfacePanel::at_com(10.0, sun_dir, 2.2).with_cr(1.5);
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
@@ -868,7 +868,7 @@ mod tests {
                     // The ratio should be approximately cos(angle), but the Sun
                     // direction is not exactly +X (it's approximately +X at equinox).
                     // So we compute the actual expected cos(θ) from the Sun direction.
-                    let sun_dir = sun::sun_direction_eci(&epoch).into_inner();
+                    let sun_dir = sun::sun_direction_eci(&epoch.to_tdb()).into_inner();
                     // At identity: panel normal in inertial = +X
                     // At rotated: panel normal in inertial = (cos(angle), sin(angle), 0)
                     let rotated_normal = Vector3::new(angle.cos(), angle.sin(), 0.0);

--- a/tobari/src/harris_priester.rs
+++ b/tobari/src/harris_priester.rs
@@ -6,7 +6,7 @@
 //!
 //! Reference: Montenbruck & Gill, "Satellite Orbits" (2000), Section 3.5.2.
 
-use arika::epoch::Epoch;
+use arika::epoch::{Epoch, Tdb};
 use arika::frame;
 use arika::sun;
 
@@ -297,8 +297,10 @@ pub struct HarrisPriester {
     ///
     /// Default: π/6 ≈ 30° (~2 hours in local solar time).
     pub lag_angle: f64,
-    /// Function returning the Sun direction (unit vector) in ECI at a given epoch.
-    sun_direction_fn: fn(&Epoch) -> frame::Vec3<frame::Gcrs>,
+    /// Function returning the Sun direction (unit vector) in ECI at a given
+    /// epoch. Takes a TDB epoch (a solar-ephemeris quantity); the model converts
+    /// its UTC epoch with `.to_tdb()` at the call boundary.
+    sun_direction_fn: fn(&Epoch<Tdb>) -> frame::Vec3<frame::Gcrs>,
 }
 
 impl HarrisPriester {
@@ -326,7 +328,7 @@ impl HarrisPriester {
     }
 
     /// Override the Sun direction function (for testing).
-    pub fn with_sun_direction_fn(mut self, f: fn(&Epoch) -> frame::Vec3<frame::Gcrs>) -> Self {
+    pub fn with_sun_direction_fn(mut self, f: fn(&Epoch<Tdb>) -> frame::Vec3<frame::Gcrs>) -> Self {
         self.sun_direction_fn = f;
         self
     }
@@ -348,7 +350,10 @@ impl HarrisPriester {
     /// and satellite altitude, matching the original 3D vector dot product
     /// to < 1e-10 relative error.
     fn bulge_cos_psi(&self, input: &AtmosphereInput<'_>) -> f64 {
-        let sun_dir = (self.sun_direction_fn)(input.utc);
+        // Sun direction is a solar-ephemeris (TDB) quantity; convert the UTC
+        // input at this boundary. `input.utc` stays UTC for the local-time
+        // geometry below (hour angle / GMST).
+        let sun_dir = (self.sun_direction_fn)(&input.utc.to_tdb());
         let sun_r = sun_dir.inner();
         let sun_mag = sun_r.magnitude();
         if sun_mag < 1e-30 {

--- a/tobari/src/nrlmsise00/geo.rs
+++ b/tobari/src/nrlmsise00/geo.rs
@@ -105,7 +105,9 @@ fn day_of_year(year: i32, month: u32, day: u32) -> u32 {
 /// where EoT accounts for Earth's orbital eccentricity and axial tilt
 /// (up to ±16 minutes correction).
 pub fn local_solar_time(ut_sec: f64, longitude_deg: f64, epoch: &Epoch) -> f64 {
-    let eot_hours = arika::sun::equation_of_time(epoch);
+    // Equation of Time is a solar-ephemeris (TDB) quantity; convert here. The
+    // UTC `epoch` itself supplies the mean-solar-time terms above.
+    let eot_hours = arika::sun::equation_of_time(&epoch.to_tdb());
     let lst = ut_sec / 3600.0 + longitude_deg / 15.0 + eot_hours;
     // Normalize to [0, 24)
     ((lst % 24.0) + 24.0) % 24.0

--- a/tobari/tests/oracle_hp.rs
+++ b/tobari/tests/oracle_hp.rs
@@ -274,7 +274,7 @@ fn hp_sun_direction_vs_orekit() {
         let epoch = parse_epoch(&sun_pt.epoch);
 
         // Our Meeus Sun direction
-        let our_dir = arika::sun::sun_direction_eci(&epoch).into_inner();
+        let our_dir = arika::sun::sun_direction_eci(&epoch.to_tdb()).into_inner();
 
         let orekit_dir = Vector3::new(
             sun_pt.sun_direction_eci[0],


### PR DESCRIPTION
## What & why

arika's analytic Meeus ephemerides — Sun/Moon/planet position, distance, direction, obliquity, equation-of-time — are functions of **dynamical time (TDB)**. They previously took the default `&Epoch<Utc>` and converted to TDB *internally*. That was numerically correct, but the TDB dependency was hidden in each function body, and a caller already holding a dynamical-time epoch had to round-trip through UTC.

This makes the requirement explicit in the type: those functions now take **`&Epoch<Tdb>`**, and the UTC→TDB conversion happens once **at the call boundary** (`utc.to_tdb()`). This brings the ephemeris side in line with the rotation side, which already requires `&Epoch<Tt>` / `&Epoch<Tdb>`.

This is a **type-honesty / API-consistency** change, not a bug fix — the old internal conversion already produced correct numbers. It is **behavior-preserving**: moving `.to_tdb()` from inside the function to the call site is numerically identical (a non-destructive re-tag of the canonical TAI instant), so all existing values and assertions are unchanged.

## Force-model callback scale, typed

Force-model callbacks are typed to match the quantity they compute:
- third-body `BodyPositionFn` → `Fn(&Epoch<Tdb>)` (it is a body ephemeris); the integrator converts its UTC epoch at the call boundary.
- Harris-Priester `sun_direction_fn` → `fn(&Epoch<Tdb>)`; the model still uses its UTC epoch for the local-time (hour-angle / GMST) geometry.
- SRP / panel-SRP / sun-sensor direct ephemeris calls convert at the site.

## Deliberately *not* changed: the `MoonEphemeris` trait + JPL-Horizons layer

These keep a `&Epoch<Utc>` interface on purpose. That layer is intentionally UTC-consistent — it stores the `JDTDB` column via `from_jd` and fetches with `TIME_TYPE=UT` (a prior TDB revision caused a ~69 s offset bug, documented in `horizons.rs`). Aligning it to true TDB is a separate scale-correctness audit, out of scope here.

`ThirdBodyGravity::moon_with_ephemeris` bridges the new TDB callback back to UTC via `tdb.to_tt().to_tai().to_utc()` — an **exact** canonical-TAI round-trip (re-tags of one stored instant), so the ephemeris source still sees the original instant with zero precision loss.

## Note on completeness

Because `.to_tdb()` only exists on `Epoch<Utc>` and the flipped functions require `Epoch<Tdb>`, a missed conversion or a conversion applied to a non-UTC epoch is a **compile error** — the green build is itself the completeness proof.

## Verification

- `cargo test --workspace` — all suites green (incl. doctests and the 30-day Orekit cross-validation E2E that exercises the touched third-body / SRP / drag paths)
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- arika `no_std` / `no_std`+`alloc` / `wasm32-unknown-unknown` builds — green
- Independent code review (codex was at its spend cap; reviewed by a separate Claude agent): mergeable, no blockers — verified behavior preservation, the exact moon bridge, clean binding reuse, and doc accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)