### PR TITLE
fix(pnpm): consolidate build-script policy to workspace root (allowBuilds)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,16 @@ packages:
 # Supply-chain hardening: refuse to resolve a version published less than
 # 7 days ago (10080 minutes), so a compromised release has time to be
 # detected and yanked before it can enter the lockfile. Applies to
-# pnpm add/update and Renovate's lockfile regen; --frozen-lockfile installs
-# (CI) are unaffected. Use minimumReleaseAgeExclude to fast-track a package
+# pnpm add/update, Renovate's lockfile regen, and — under pnpm 11 — the
+# --frozen-lockfile install (CI), which now verifies every lockfile entry
+# against this policy. Use minimumReleaseAgeExclude to fast-track a package
 # when an urgent fix is needed. (pnpm 10.16+; pnpm 11 defaults this to 1 day.)
 minimumReleaseAge: 10080
+
+# pnpm 11 refuses to install unless every dependency build script is
+# explicitly allowed (true) or skipped (false) — pnpm 10 only warned. These
+# native deps ship prebuilt binaries and were never built under pnpm 10, so
+# keep them skipped rather than start running their postinstall scripts.
+allowBuilds:
+  esbuild: false
+  sharp: false

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -66,10 +66,5 @@
     "vite": "^8.0.8",
     "vitest": "^4.1.4",
     "ws": "^8.19.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
   }
 }


### PR DESCRIPTION
## 課題

ワークスペースのビルドスクリプト承認設定が誤った場所に置かれており、pnpm を 11 に上げる(別 PR #136)と CI が壊れる。具体的には:

- `pnpm.onlyBuiltDependencies: ["esbuild"]` が **`viewer/package.json`(nested)** にあり、pnpm はこれを無視する(「workspace root に置け」と警告)。＝実際には esbuild も sharp も**ビルドスクリプトは実行されていなかった**(プリビルドの optionalDependencies で動作)。
- pnpm 10 はこの「未承認スクリプト」を**警告で素通り**するが、**pnpm 11 はハードエラー化**し `pnpm install --frozen-lockfile` が exit 1 になる。

これは pnpm バージョンに依存しない pre-existing な設定 debt なので、pnpm 11 bump(#136)とは分けて修正する。

## 修正

- root `pnpm-workspace.yaml` に **`allowBuilds: { esbuild: false, sharp: false }`** を追加。`false` = postinstall を実行しない(これらはプリビルドの optionalDependencies でバイナリを配るため不要)＝**現行の挙動を保存**。任意の install スクリプトを走らせない方針(supply-chain hardening)とも整合。
- 無効だった `viewer/package.json` の `pnpm.onlyBuiltDependencies` を削除。
- `minimumReleaseAge` のコメントを訂正(pnpm 11 では `--frozen-lockfile` install でも検証される)。

## 検証

- **pnpm 10**: `install --frozen-lockfile` EXIT 0(allowBuilds は pnpm 10 では無視＝挙動不変、警告だけ消える)。
- **pnpm 11**: `install --frozen-lockfile` EXIT 0(ビルドスクリプトのハードエラーが解消)。
- codex review: 指摘なし(pnpm 内部の `allowBuild` ロジックで `false`→`ignoreScripts=true` を確認)。

これにより #136 は純粋な `pnpm/action-setup version: 11` + `constraints.pnpm` の bump だけにできる。
