### PR TITLE
ci(renovate): group kble/notalawyer by package name, not source URL

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,15 +54,16 @@
       "matchPackageNames": ["three", "@types/three", "/^@react-three//"]
     },
     {
-      "description": "Group the arkedge/kble workspace crates (released in lockstep) into one PR. Matched by source URL, not name, so a third-party kble-* squatter can't slip in; spans both the cargo dep kble-socket and the custom-regex kble binary (KBLE_VERSION). Anchored regex tolerates a .git suffix / trailing slash in the resolved repository URL",
+      "description": "Group the arkedge/kble crates orts uses (cargo dep kble-socket + the custom-regex kble binary KBLE_VERSION) by exact name on the crate datasource. Exact names — not a kble-* prefix — so a same-named crate from another repo (e.g. an unrelated kble-foo) is never pulled in; matchSourceUrls would scope by repo directly but Renovate doesn't reliably resolve sourceUrl for these crates (depends on a rate-limited crates.io metadata call). Add new arkedge/kble crates here when orts adopts them",
       "groupName": "kble",
-      "matchSourceUrls": ["/^https:\\/\\/github\\.com\\/arkedge\\/kble(?:\\.git)?\\/?$/"]
+      "matchDatasources": ["crate"],
+      "matchPackageNames": ["kble", "kble-socket"]
     },
     {
-      "description": "Group the arkedge/notalawyer crates (released in lockstep). Matched by source URL, not name, to keep notalawyer-* squatters out",
-      "matchManagers": ["cargo"],
+      "description": "Group orts's arkedge/notalawyer crates (notalawyer / -clap / -build) by exact name on the crate datasource — exact, not a notalawyer-* prefix, to exclude an unrelated notalawyer-* from another repo (see the kble rule for why not matchSourceUrls)",
       "groupName": "notalawyer",
-      "matchSourceUrls": ["/^https:\\/\\/github\\.com\\/arkedge\\/notalawyer(?:\\.git)?\\/?$/"]
+      "matchDatasources": ["crate"],
+      "matchPackageNames": ["notalawyer", "notalawyer-clap", "notalawyer-build"]
     },
     {
       "description": "Auto-merge patch-level updates once required CI checks pass",


### PR DESCRIPTION
## 背景

kble（#197）と notalawyer（#199）のグループは `matchSourceUrls` で組んだが、**実際には一度もグループ化されていなかった**（kble 0.5.0 は単独 PR #226 として出て、dashboard では kble-socket と notalawyer 3 crate が別ブランチ）。

## 原因

Renovate の `crate` datasource が `sourceUrl` を解決するには **crates.io の metadata API への追加取得**が要るが、これはレート制限が厳しく頻繁に失敗する。`sourceUrl` が空だと `SourceUrlsMatcher` が false を返し、グループルールがエラーも出さず静かに非マッチ＝非グループ化。hosted Mend と同一の Renovate **v43.242.2** を `--platform=local --dry-run` で実走して再現・確認（regex/config の問題でないことも切り分け済み。クリーンキャッシュでも metadata 取得は全滅）。**matchSourceUrls による repo スコープ grouping は、この追加取得依存ゆえ信頼できない。**

## 要件と方針

- arkedge/kble・arkedge/notalawyer **配下の crate は group したい**
- 別リポジトリの同名プレフィックス（例: 無関係な `kble-foo`）は**含めたくない**

本来この「repo スコープ」は `matchSourceUrls` の役目だが上記理由で不可。名前プレフィックス（`/^kble-/`）だと別 repo の `kble-*` を巻き込むため要件に反する。よって**完全名リスト**で、当該 crate だけを確実に group する。

```jsonc
{ "groupName": "kble",       "matchDatasources": ["crate"], "matchPackageNames": ["kble", "kble-socket"] },
{ "groupName": "notalawyer", "matchDatasources": ["crate"], "matchPackageNames": ["notalawyer", "notalawyer-clap", "notalawyer-build"] }
```

- **完全名**: 列挙した crate のみ group。別 repo の `kble-foo` 等は確実に除外。
- **`matchDatasources: ["crate"]`**（Copilot 指摘）: 別 ecosystem の同名 pkg（npm の `kble` 等）を除外。`crate` は cargo 依存 + custom-regex の kble バイナリ両方を含むので manager 横断は維持。
- **トレードオフ**: これらワークスペースに新 crate が増えて orts が採用したら、リストに1行追加する（wasmtime/three グループと同じ運用）。「将来 crate の自動取り込み」を信頼性と引き換えに諦める形。

## 検証

- `renovate-config-validator`（v43.242.2）で `Config validated successfully`。
- dry-run（リストに無い `kble-c2a` をあえて依存に追加した状態）:
  - `renovate/kble` ← `[kble, kble-socket]`（custom-regex バイナリ + cargo）
  - `kble-c2a` は **group に入らず別ブランチ** ← 別 repo crate を除外できることの実証
  - `renovate/notalawyer` ← `[notalawyer, notalawyer-clap, notalawyer-build]`

## マージ後

次回 Renovate 巡回で `renovate/kble` グループ PR（kble バイナリ + kble-socket）が作り直される。既存 #226（kble 単独）は放置で OK（置き換わる）か close。

🤖 Generated with [Claude Code](https://claude.com/claude-code)