### PR TITLE
feat(arika): Sgp4Elements を TEME へ伝播する SGP4/SDP4 propagator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,12 @@ jobs:
       - name: Test (all except orts)
         run: cargo test --locked --workspace --exclude orts
 
+      # The SGP4 propagation tests (Vallado verification vectors) live behind
+      # arika's optional `sgp4` feature; run them explicitly so they execute
+      # regardless of which workspace members enable the feature.
+      - name: Test (arika sgp4 feature)
+        run: cargo test --locked -p arika --features sgp4
+
       # The orts-cli export tests above regenerate the ts-rs WebSocket
       # protocol bindings (viewer/src/protocol/generated/). A dirty tree
       # here means the Rust protocol types changed without regenerating

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,11 @@ jobs:
       - name: Clippy (arika no_std + alloc)
         run: cargo clippy --locked -p arika --no-default-features --features alloc -- -D warnings
 
+      # Guards the no-alloc SGP4 propagation path: `sgp4` must build with only
+      # `libm` (no std, no alloc).
+      - name: Clippy (arika no_std + sgp4)
+        run: cargo clippy --locked -p arika --no-default-features --features sgp4 -- -D warnings
+
       - name: Clippy (utsuroi no_std)
         run: cargo clippy --locked -p utsuroi --no-default-features -- -D warnings
 

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -149,6 +149,12 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
     単一衛星 GP) と Space-Track の文字列エンコード数値を受理。
   - `elements::detect` + `elements::parse` — 形式判定 (`elements::Format`) と、TLE / OMM-JSON /
     OMM-KVN / OMM-XML を自動判定して振り分ける BOM 許容の統一エントリ。
+- optional な `sgp4` feature による SGP4 / SDP4 伝播
+  (`propagation::Sgp4Propagator`): `Sgp4Elements` から構築し、epoch の
+  `Constants` を再利用して TEME の `(Vec3<Teme>, Vec3<Teme>)` 状態 (km / km·s)
+  へ伝播。`sgp4` crate を AFSPC compatibility mode (WGS72) でラップ。依存は
+  `libm` のみで引くため no_std-no-alloc ビルドでも動作。Vallado 検証ベクタの
+  near-earth (SGP4) と deep-space (SDP4) で検証済み。([#235](https://github.com/sksat/orts/pull/235))
 - `kepler` module (`orts` から `arika` へ移管): `KeplerianElements`
   (`from_state_vector` / `to_state_vector` / `period` / `energy`) と anomaly
   変換群 (`solve_kepler_equation`、`mean_to_true_anomaly` 等)。公開

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -150,7 +150,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   - `elements::detect` + `elements::parse` — 形式判定 (`elements::Format`) と、TLE / OMM-JSON /
     OMM-KVN / OMM-XML を自動判定して振り分ける BOM 許容の統一エントリ。
 - optional な `sgp4` feature による SGP4 / SDP4 伝播
-  (`propagation::Sgp4Propagator`): `Sgp4Elements` から構築し、epoch の
+  (`sgp4::Sgp4Propagator`): `Sgp4Elements` から構築し、epoch の
   `Constants` を再利用して TEME の `(Vec3<Teme>, Vec3<Teme>)` 状態 (km / km·s)
   へ伝播。`sgp4` crate を AFSPC compatibility mode (WGS72) でラップ。依存は
   `libm` のみで引くため no_std-no-alloc ビルドでも動作。Vallado 検証ベクタの

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,13 @@ section is subdivided by package.
   - `elements::detect` + `elements::parse` — format sniffing (`elements::Format`) plus a
     unified, BOM-tolerant entry point that auto-detects and dispatches
     TLE / OMM-JSON / OMM-KVN / OMM-XML.
+- SGP4 / SDP4 propagation behind the optional `sgp4` feature
+  (`propagation::Sgp4Propagator`): builds from an `Sgp4Elements`, reuses the
+  epoch `Constants`, and propagates to a `(Vec3<Teme>, Vec3<Teme>)` state in km /
+  km·s. Wraps the `sgp4` crate in AFSPC compatibility mode (WGS72). The
+  dependency is pulled with only `libm`, so propagation works in `no_std`
+  builds without `alloc`. Validated against the Vallado verification vectors for
+  near-earth (SGP4) and deep-space (SDP4) satellites. ([#235](https://github.com/sksat/orts/pull/235))
 - `kepler` module (moved into `arika` from `orts`): `KeplerianElements`
   (`from_state_vector` / `to_state_vector` / `period` / `energy`) and the anomaly
   conversions (`solve_kepler_equation`, `mean_to_true_anomaly`, …). Now a public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,7 @@ section is subdivided by package.
     unified, BOM-tolerant entry point that auto-detects and dispatches
     TLE / OMM-JSON / OMM-KVN / OMM-XML.
 - SGP4 / SDP4 propagation behind the optional `sgp4` feature
-  (`propagation::Sgp4Propagator`): builds from an `Sgp4Elements`, reuses the
+  (`sgp4::Sgp4Propagator`): builds from an `Sgp4Elements`, reuses the
   epoch `Constants`, and propagates to a `(Vec3<Teme>, Vec3<Teme>)` state in km /
   km·s. Wraps the `sgp4` crate in AFSPC compatibility mode (WGS72). The
   dependency is pulled with only `libm`, so propagation works in `no_std`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
  "nalgebra",
  "serde",
  "serde_json",
+ "sgp4",
  "trybuild",
  "ureq",
 ]
@@ -4896,6 +4897,16 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sgp4"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9467b9a7be8485ed8be0f336d399c8f32c0fcd60686e7dd2ed3dab75c9a73eb3"
+dependencies = [
+ "chrono",
+ "num-traits",
 ]
 
 [[package]]

--- a/arika/Cargo.toml
+++ b/arika/Cargo.toml
@@ -21,10 +21,11 @@ serde_json = { version = "1", default-features = false, features = [
 ], optional = true }
 libm = "0.2"
 ureq = { workspace = true, optional = true }
-# SGP4/SDP4 propagation (arika::propagation). Pulled with only `libm` (never
-# sgp4's `std`, which conflicts with `libm`), so it builds in every arika tier
+# SGP4/SDP4 propagation (arika::sgp4). Aliased as `sgp4_rs` so the `arika::sgp4`
+# module can own the `sgp4` name. Pulled with only `libm` (never the crate's
+# `std`, which conflicts with `libm`), so it builds in every arika tier
 # including no_std without `alloc`.
-sgp4 = { version = "2.4", default-features = false, features = [
+sgp4_rs = { package = "sgp4", version = "2.4", default-features = false, features = [
     "libm",
 ], optional = true }
 
@@ -37,6 +38,6 @@ default = ["std"]
 std = ["alloc", "nalgebra/std", "serde/std", "serde_json?/std"]
 alloc = ["serde/alloc", "dep:serde_json"]
 fetch-horizons = ["std", "dep:ureq"]
-# SGP4/SDP4 propagation via the `sgp4` crate (arika::propagation). Optional and
-# off by default to keep minimal / wasm builds lean.
-sgp4 = ["dep:sgp4"]
+# SGP4/SDP4 propagation via the `sgp4` crate (arika::sgp4). Optional and off by
+# default to keep minimal / wasm builds lean.
+sgp4 = ["dep:sgp4_rs"]

--- a/arika/Cargo.toml
+++ b/arika/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = { version = "1", default-features = false, features = [
 ], optional = true }
 libm = "0.2"
 ureq = { workspace = true, optional = true }
+# SGP4/SDP4 propagation (arika::propagation). Pulled with only `libm` (never
+# sgp4's `std`, which conflicts with `libm`), so it builds in every arika tier
+# including no_std without `alloc`.
+sgp4 = { version = "2.4", default-features = false, features = [
+    "libm",
+], optional = true }
 
 [dev-dependencies]
 serde_json.workspace = true
@@ -31,3 +37,6 @@ default = ["std"]
 std = ["alloc", "nalgebra/std", "serde/std", "serde_json?/std"]
 alloc = ["serde/alloc", "dep:serde_json"]
 fetch-horizons = ["std", "dep:ureq"]
+# SGP4/SDP4 propagation via the `sgp4` crate (arika::propagation). Optional and
+# off by default to keep minimal / wasm builds lean.
+sgp4 = ["dep:sgp4"]

--- a/arika/src/lib.rs
+++ b/arika/src/lib.rs
@@ -18,6 +18,8 @@ pub mod moon;
 #[cfg(feature = "alloc")]
 pub mod omm;
 pub mod planets;
+#[cfg(feature = "sgp4")]
+pub mod propagation;
 pub mod rotation;
 pub mod sun;
 #[cfg(feature = "alloc")]

--- a/arika/src/lib.rs
+++ b/arika/src/lib.rs
@@ -18,9 +18,9 @@ pub mod moon;
 #[cfg(feature = "alloc")]
 pub mod omm;
 pub mod planets;
-#[cfg(feature = "sgp4")]
-pub mod propagation;
 pub mod rotation;
+#[cfg(feature = "sgp4")]
+pub mod sgp4;
 pub mod sun;
 #[cfg(feature = "alloc")]
 pub mod tle;

--- a/arika/src/propagation.rs
+++ b/arika/src/propagation.rs
@@ -1,0 +1,306 @@
+//! SGP4 / SDP4 propagation of [`Sgp4Elements`] into a TEME state vector.
+//!
+//! Wraps the [`sgp4`] crate (a reference-quality SGP4+SDP4 implementation
+//! validated against Vallado's "Revisiting Spacetrack Report #3"). The
+//! propagator runs in **AFSPC compatibility mode** — the WGS72 geopotential and
+//! the AFSPC sidereal-time / epoch expressions — because that is the convention
+//! TLE/OMM catalog element sets are generated for, and the mode `sgp4` validates
+//! against the official test vectors.
+//!
+//! The propagation path is allocator-free: it feeds the numeric
+//! [`Sgp4Elements`] straight into `sgp4`'s `Orbit` / `Constants` API (the
+//! `sgp4` dependency is pulled with only its `libm` feature), so SGP4
+//! propagation works in `no_std` builds without `alloc`.
+//!
+//! Output is in the True Equator, Mean Equinox ([`Teme`]) frame, in km and
+//! km/s. Rotating TEME into an integration frame ([`Gcrs`](crate::frame::Gcrs) /
+//! [`SimpleEci`](crate::frame::SimpleEci)) is a separate step.
+
+use sgp4::{Constants, MinutesSinceEpoch, Orbit, WGS72, afspc_epoch_to_sidereal_time};
+
+use crate::elements::Sgp4Elements;
+use crate::epoch::{DateTime, Epoch, Utc};
+use crate::frame::{Teme, Vec3};
+
+/// Error raised while building or running an SGP4 propagator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Sgp4Error {
+    /// The mean elements could not initialize a propagator — a non-positive
+    /// mean motion or an epoch eccentricity outside `[0, 1)`.
+    Initialization,
+    /// Propagation to the requested time diverged: orbital decay, a negative
+    /// semi-latus rectum, or a perturbed eccentricity outside `[0, 1)`.
+    Diverged,
+}
+
+impl core::fmt::Display for Sgp4Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Sgp4Error::Initialization => {
+                f.write_str("SGP4 elements could not initialize a propagator")
+            }
+            Sgp4Error::Diverged => f.write_str("SGP4 propagation diverged"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Sgp4Error {}
+
+/// An SGP4 propagator built from a mean element set.
+///
+/// Construction precomputes `sgp4`'s epoch `Constants`; they are not mutated
+/// during propagation, so a single propagator can be reused to generate a whole
+/// trajectory (one `Constants` build amortized over many `propagate` calls).
+#[derive(Debug, Clone)]
+pub struct Sgp4Propagator {
+    constants: Constants,
+    epoch: Epoch<Utc>,
+}
+
+impl Sgp4Propagator {
+    /// Build a propagator from a mean element set.
+    ///
+    /// Uses AFSPC compatibility mode (WGS72 + AFSPC sidereal time / epoch).
+    pub fn from_elements(elements: &Sgp4Elements) -> Result<Self, Sgp4Error> {
+        // Reject non-finite inputs up front: a NaN slips through sgp4's `<= 0`
+        // and range checks (every comparison is false), so guard the public
+        // entry point explicitly.
+        if ![
+            elements.inclination,
+            elements.raan,
+            elements.eccentricity,
+            elements.argument_of_perigee,
+            elements.mean_anomaly,
+            elements.mean_motion,
+            elements.bstar,
+        ]
+        .iter()
+        .all(|x| x.is_finite())
+        {
+            return Err(Sgp4Error::Initialization);
+        }
+
+        // arika stores angles in radians and mean motion in rad/s; sgp4's
+        // `from_kozai_elements` wants radians and the Kozai mean motion in
+        // rad/min (rad/s × 60).
+        let orbit = Orbit::from_kozai_elements(
+            &WGS72,
+            elements.inclination,
+            elements.raan,
+            elements.eccentricity,
+            elements.argument_of_perigee,
+            elements.mean_anomaly,
+            elements.mean_motion * 60.0,
+        )
+        .map_err(|_| Sgp4Error::Initialization)?;
+
+        let constants = Constants::new(
+            WGS72,
+            afspc_epoch_to_sidereal_time,
+            afspc_years_since_j2000(&elements.epoch.to_datetime()),
+            elements.bstar,
+            orbit,
+        )
+        .map_err(|_| Sgp4Error::Initialization)?;
+
+        Ok(Self {
+            constants,
+            epoch: elements.epoch,
+        })
+    }
+
+    /// Propagate to `minutes` after the element-set epoch.
+    ///
+    /// Returns `(position, velocity)` in the [`Teme`] frame, in km and km/s.
+    pub fn propagate_minutes_since_epoch(
+        &self,
+        minutes: f64,
+    ) -> Result<(Vec3<Teme>, Vec3<Teme>), Sgp4Error> {
+        let p = self
+            .constants
+            .propagate_afspc_compatibility_mode(MinutesSinceEpoch(minutes))
+            .map_err(|_| Sgp4Error::Diverged)?;
+        Ok((
+            Vec3::<Teme>::new(p.position[0], p.position[1], p.position[2]),
+            Vec3::<Teme>::new(p.velocity[0], p.velocity[1], p.velocity[2]),
+        ))
+    }
+
+    /// Propagate to the absolute UTC epoch `t`.
+    ///
+    /// The elapsed time is naive UTC minutes (`(t − epoch)`), matching SGP4's
+    /// leap-second-agnostic time convention. Returns `(position, velocity)` in
+    /// the [`Teme`] frame, in km and km/s.
+    pub fn propagate(&self, t: Epoch<Utc>) -> Result<(Vec3<Teme>, Vec3<Teme>), Sgp4Error> {
+        let minutes = (t.jd() - self.epoch.jd()) * 1440.0;
+        self.propagate_minutes_since_epoch(minutes)
+    }
+}
+
+/// Julian years since J2000, AFSPC compatibility expression.
+///
+/// Mirrors `sgp4::julian_years_since_j2000_afspc_compatibility_mode` but reads
+/// arika's [`DateTime`] fields directly, so the no-alloc path avoids
+/// constructing a `chrono` datetime. The integer arithmetic (truncating
+/// division) is preserved exactly so the epoch matches the AFSPC reference.
+fn afspc_years_since_j2000(d: &DateTime) -> f64 {
+    let year = d.year as u32;
+    let month = d.month;
+    let day = d.day;
+    let jd_at_midnight =
+        (367 * year - (7 * (year + (month + 9) / 12)) / 4 + 275 * month / 9 + day) as f64;
+    // Fraction of the day: (((s)/60 + min)/60 + hour)/24, with `sec` already
+    // carrying the sub-second part as a fractional f64.
+    let day_fraction = ((d.sec / 60.0 + d.min as f64) / 60.0 + d.hour as f64) / 24.0;
+    (jd_at_midnight + 1721013.5 + day_fraction - 2451545.0) / 365.25
+}
+
+#[cfg(all(test, feature = "alloc"))]
+mod tests {
+    use super::*;
+    use crate::tle;
+    use alloc::format;
+
+    // Vallado "Revisiting Spacetrack Report #3" TEME verification satellite
+    // (catalog 00005). Expected TEME states (km, km/s) at minutes-since-epoch,
+    // from the official SGP4 test vectors (AFSPC mode).
+    const L1: &str = "1 00005U 58002B   00179.78495062  .00000023  00000-0  28098-4 0  4753";
+    const L2: &str = "2 00005  34.2682 348.7242 1859667 331.7664  19.3264 10.82419157413667";
+
+    #[test]
+    fn vallado_teme_example_sat_00005() {
+        let text = format!("{L1}\n{L2}");
+        let elements = tle::parse(&text).unwrap().elements;
+        let prop = Sgp4Propagator::from_elements(&elements).unwrap();
+
+        // (tsince [min], position [km], velocity [km/s])
+        let cases = [
+            (
+                0.0,
+                [7022.46529266, -1400.08296755, 0.03995155],
+                [1.893841015, 6.405893759, 4.534807250],
+            ),
+            (
+                360.0,
+                [-7154.03120202, -3783.17682504, -3536.19412294],
+                [4.741887409, -4.151817765, -2.093935425],
+            ),
+            (
+                1440.0,
+                [-938.55923943, -6268.18748831, -4294.02924751],
+                [7.536105209, -0.427127707, 0.989878080],
+            ),
+        ];
+
+        for (t, expected_r, expected_v) in cases {
+            let (r, v) = prop.propagate_minutes_since_epoch(t).unwrap();
+            let r = r.into_inner();
+            let v = v.into_inner();
+            for i in 0..3 {
+                assert!(
+                    (r[i] - expected_r[i]).abs() < 1.0e-4,
+                    "position t={t} i={i}: got {} expected {}",
+                    r[i],
+                    expected_r[i]
+                );
+                assert!(
+                    (v[i] - expected_v[i]).abs() < 1.0e-6,
+                    "velocity t={t} i={i}: got {} expected {}",
+                    v[i],
+                    expected_v[i]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn propagate_by_absolute_epoch_matches_minutes() {
+        let text = format!("{L1}\n{L2}");
+        let elements = tle::parse(&text).unwrap().elements;
+        let prop = Sgp4Propagator::from_elements(&elements).unwrap();
+
+        // propagate(epoch) must agree with propagate_minutes_since_epoch(0).
+        let (r_abs, v_abs) = prop.propagate(elements.epoch).unwrap();
+        let (r_min, v_min) = prop.propagate_minutes_since_epoch(0.0).unwrap();
+        assert!((r_abs.into_inner() - r_min.into_inner()).norm() < 1.0e-6);
+        assert!((v_abs.into_inner() - v_min.into_inner()).norm() < 1.0e-9);
+    }
+
+    #[test]
+    fn vallado_deep_space_sat_04632() {
+        // Deep-space (SDP4) Vallado verification satellite: mean motion
+        // 1.20 rev/day (< 2π/225 rad/min) drives the Lyddane deep-space path,
+        // including backward propagation (negative tsince).
+        const DL1: &str = "1 04632U 70093B   04031.91070959 -.00000084  00000-0  10000-3 0  9955";
+        const DL2: &str = "2 04632  11.4628 273.1101 1450506 207.6000 143.9350  1.20231981 44145";
+        let elements = tle::parse(&format!("{DL1}\n{DL2}")).unwrap().elements;
+        let prop = Sgp4Propagator::from_elements(&elements).unwrap();
+
+        let cases = [
+            (
+                0.0,
+                [2334.11450085, -41920.44035349, -0.03867437],
+                [2.826321032, -0.065091664, 0.570936053],
+            ),
+            (
+                -5184.0,
+                [-29020.02587128, 13819.84419063, -5713.33679183],
+                [-1.768068390, -3.235371192, -0.395206135],
+            ),
+            (
+                -4896.0,
+                [-15129.94694545, -36907.74526221, -3487.56256701],
+                [2.581167187, -1.524204737, 0.504805763],
+            ),
+        ];
+
+        for (t, expected_r, expected_v) in cases {
+            let (r, v) = prop.propagate_minutes_since_epoch(t).unwrap();
+            let r = r.into_inner();
+            let v = v.into_inner();
+            for i in 0..3 {
+                assert!(
+                    (r[i] - expected_r[i]).abs() < 1.0e-3,
+                    "position t={t} i={i}: got {} expected {}",
+                    r[i],
+                    expected_r[i]
+                );
+                assert!(
+                    (v[i] - expected_v[i]).abs() < 1.0e-6,
+                    "velocity t={t} i={i}: got {} expected {}",
+                    v[i],
+                    expected_v[i]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn afspc_epoch_matches_sgp4_reference() {
+        use sgp4::chrono::NaiveDate;
+
+        // (year, month, day, hour, min, sec, nanosecond) across Jan/Feb/Mar,
+        // the year-2000 pivot, a leap day with a sub-second, and a far date.
+        let cases = [
+            (2000, 1, 1, 12, 0, 0u32, 0u32),
+            (1999, 12, 31, 23, 59, 59, 0),
+            (2024, 2, 29, 6, 30, 15, 500_000_000),
+            (2056, 3, 1, 0, 0, 0, 0),
+            (1980, 6, 15, 18, 45, 7, 250_000_000),
+        ];
+        for (y, mo, d, h, mi, s, ns) in cases {
+            let dt = DateTime::new(y, mo, d, h, mi, s as f64 + ns as f64 / 1.0e9);
+            let mine = afspc_years_since_j2000(&dt);
+            let ndt = NaiveDate::from_ymd_opt(y, mo, d)
+                .unwrap()
+                .and_hms_nano_opt(h, mi, s, ns)
+                .unwrap();
+            let reference = sgp4::julian_years_since_j2000_afspc_compatibility_mode(&ndt);
+            assert!(
+                (mine - reference).abs() < 1.0e-12,
+                "{y}-{mo}-{d}T{h}:{mi}:{s}.{ns}: {mine} vs {reference}"
+            );
+        }
+    }
+}

--- a/arika/src/propagation.rs
+++ b/arika/src/propagation.rs
@@ -95,10 +95,18 @@ impl Sgp4Propagator {
         )
         .map_err(|_| Sgp4Error::Initialization)?;
 
+        // A non-finite epoch (e.g. an `Epoch` built from a NaN Julian date)
+        // would yield nonsensical datetime fields; reject it rather than
+        // silently initializing with a garbage epoch.
+        let epoch_years = afspc_years_since_j2000(&elements.epoch.to_datetime());
+        if !epoch_years.is_finite() {
+            return Err(Sgp4Error::Initialization);
+        }
+
         let constants = Constants::new(
             WGS72,
             afspc_epoch_to_sidereal_time,
-            afspc_years_since_j2000(&elements.epoch.to_datetime()),
+            epoch_years,
             elements.bstar,
             orbit,
         )
@@ -300,6 +308,26 @@ mod tests {
             assert!(
                 (mine - reference).abs() < 1.0e-12,
                 "{y}-{mo}-{d}T{h}:{mi}:{s}.{ns}: {mine} vs {reference}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_non_finite_elements() {
+        let valid = tle::parse(&format!("{L1}\n{L2}")).unwrap().elements;
+        assert!(Sgp4Propagator::from_elements(&valid).is_ok());
+
+        for spoil in [
+            |e: &mut Sgp4Elements| e.mean_motion = f64::NAN,
+            |e: &mut Sgp4Elements| e.eccentricity = f64::INFINITY,
+            |e: &mut Sgp4Elements| e.inclination = f64::NAN,
+            |e: &mut Sgp4Elements| e.bstar = f64::NEG_INFINITY,
+        ] {
+            let mut bad = valid;
+            spoil(&mut bad);
+            assert!(
+                Sgp4Propagator::from_elements(&bad).is_err(),
+                "non-finite element must be rejected"
             );
         }
     }

--- a/arika/src/sgp4.rs
+++ b/arika/src/sgp4.rs
@@ -1,22 +1,28 @@
 //! SGP4 / SDP4 propagation of [`Sgp4Elements`] into a TEME state vector.
 //!
-//! Wraps the [`sgp4`] crate (a reference-quality SGP4+SDP4 implementation
-//! validated against Vallado's "Revisiting Spacetrack Report #3"). The
-//! propagator runs in **AFSPC compatibility mode** — the WGS72 geopotential and
-//! the AFSPC sidereal-time / epoch expressions — because that is the convention
-//! TLE/OMM catalog element sets are generated for, and the mode `sgp4` validates
-//! against the official test vectors.
+//! Wraps the `sgp4` crate (a reference-quality SGP4+SDP4 implementation
+//! validated against Vallado's "Revisiting Spacetrack Report #3"; aliased as
+//! `sgp4_rs` so this module can own the `sgp4` name). The propagator runs in
+//! **AFSPC compatibility mode** — the WGS72 geopotential and the AFSPC
+//! sidereal-time / epoch expressions — because that is the convention TLE/OMM
+//! catalog element sets are generated for, and the mode the `sgp4` crate
+//! validates against the official test vectors.
+//!
+//! This is *analytical* propagation: it evaluates the closed-form SGP4 model
+//! the element set is defined against (no force models, no numerical
+//! integration), giving the state a TLE/OMM encodes at a given time. It is
+//! distinct from a numerical integrator's propagation.
 //!
 //! The propagation path is allocator-free: it feeds the numeric
-//! [`Sgp4Elements`] straight into `sgp4`'s `Orbit` / `Constants` API (the
-//! `sgp4` dependency is pulled with only its `libm` feature), so SGP4
-//! propagation works in `no_std` builds without `alloc`.
+//! [`Sgp4Elements`] straight into the crate's `Orbit` / `Constants` API (the
+//! dependency is pulled with only its `libm` feature), so SGP4 propagation
+//! works in `no_std` builds without `alloc`.
 //!
 //! Output is in the True Equator, Mean Equinox ([`Teme`]) frame, in km and
 //! km/s. Rotating TEME into an integration frame ([`Gcrs`](crate::frame::Gcrs) /
 //! [`SimpleEci`](crate::frame::SimpleEci)) is a separate step.
 
-use sgp4::{Constants, MinutesSinceEpoch, Orbit, WGS72, afspc_epoch_to_sidereal_time};
+use sgp4_rs::{Constants, MinutesSinceEpoch, Orbit, WGS72, afspc_epoch_to_sidereal_time};
 
 use crate::elements::Sgp4Elements;
 use crate::epoch::{DateTime, Epoch, Utc};
@@ -148,7 +154,7 @@ impl Sgp4Propagator {
 
 /// Julian years since J2000, AFSPC compatibility expression.
 ///
-/// Mirrors `sgp4::julian_years_since_j2000_afspc_compatibility_mode` but reads
+/// Mirrors `sgp4_rs::julian_years_since_j2000_afspc_compatibility_mode` but reads
 /// arika's [`DateTime`] fields directly, so the no-alloc path avoids
 /// constructing a `chrono` datetime. The integer arithmetic (truncating
 /// division) is preserved exactly so the epoch matches the AFSPC reference.
@@ -286,7 +292,7 @@ mod tests {
 
     #[test]
     fn afspc_epoch_matches_sgp4_reference() {
-        use sgp4::chrono::NaiveDate;
+        use sgp4_rs::chrono::NaiveDate;
 
         // (year, month, day, hour, min, sec, nanosecond) across Jan/Feb/Mar,
         // the year-2000 pivot, a leap day with a sub-second, and a far date.
@@ -304,7 +310,7 @@ mod tests {
                 .unwrap()
                 .and_hms_nano_opt(h, mi, s, ns)
                 .unwrap();
-            let reference = sgp4::julian_years_since_j2000_afspc_compatibility_mode(&ndt);
+            let reference = sgp4_rs::julian_years_since_j2000_afspc_compatibility_mode(&ndt);
             assert!(
                 (mine - reference).abs() < 1.0e-12,
                 "{y}-{mo}-{d}T{h}:{mi}:{s}.{ns}: {mine} vs {reference}"

--- a/arika/src/sgp4.rs
+++ b/arika/src/sgp4.rs
@@ -34,8 +34,9 @@ pub enum Sgp4Error {
     /// The mean elements could not initialize a propagator — a non-positive
     /// mean motion or an epoch eccentricity outside `[0, 1)`.
     Initialization,
-    /// Propagation to the requested time diverged: orbital decay, a negative
-    /// semi-latus rectum, or a perturbed eccentricity outside `[0, 1)`.
+    /// Propagation to the requested time could not produce a valid state:
+    /// orbital decay, a negative semi-latus rectum, a perturbed eccentricity
+    /// outside `[0, 1)`, or a non-finite request time.
     Diverged,
 }
 
@@ -71,7 +72,9 @@ impl Sgp4Propagator {
     pub fn from_elements(elements: &Sgp4Elements) -> Result<Self, Sgp4Error> {
         // Reject non-finite inputs up front: a NaN slips through sgp4's `<= 0`
         // and range checks (every comparison is false), so guard the public
-        // entry point explicitly.
+        // entry point explicitly. The epoch is checked here too (before
+        // `to_datetime()`, whose float→int casts would otherwise turn a
+        // non-finite Julian date into a garbage calendar date).
         if ![
             elements.inclination,
             elements.raan,
@@ -80,6 +83,7 @@ impl Sgp4Propagator {
             elements.mean_anomaly,
             elements.mean_motion,
             elements.bstar,
+            elements.epoch.jd(),
         ]
         .iter()
         .all(|x| x.is_finite())
@@ -101,18 +105,10 @@ impl Sgp4Propagator {
         )
         .map_err(|_| Sgp4Error::Initialization)?;
 
-        // A non-finite epoch (e.g. an `Epoch` built from a NaN Julian date)
-        // would yield nonsensical datetime fields; reject it rather than
-        // silently initializing with a garbage epoch.
-        let epoch_years = afspc_years_since_j2000(&elements.epoch.to_datetime());
-        if !epoch_years.is_finite() {
-            return Err(Sgp4Error::Initialization);
-        }
-
         let constants = Constants::new(
             WGS72,
             afspc_epoch_to_sidereal_time,
-            epoch_years,
+            afspc_years_since_j2000(&elements.epoch.to_datetime()),
             elements.bstar,
             orbit,
         )
@@ -131,6 +127,12 @@ impl Sgp4Propagator {
         &self,
         minutes: f64,
     ) -> Result<(Vec3<Teme>, Vec3<Teme>), Sgp4Error> {
+        // Reject a non-finite time before handing it to sgp4: a NaN/±inf target
+        // can spin the deep-space resonance integrator (a fixed-step loop toward
+        // the target time) indefinitely.
+        if !minutes.is_finite() {
+            return Err(Sgp4Error::Diverged);
+        }
         let p = self
             .constants
             .propagate_afspc_compatibility_mode(MinutesSinceEpoch(minutes))
@@ -323,17 +325,38 @@ mod tests {
         let valid = tle::parse(&format!("{L1}\n{L2}")).unwrap().elements;
         assert!(Sgp4Propagator::from_elements(&valid).is_ok());
 
-        for spoil in [
-            |e: &mut Sgp4Elements| e.mean_motion = f64::NAN,
-            |e: &mut Sgp4Elements| e.eccentricity = f64::INFINITY,
-            |e: &mut Sgp4Elements| e.inclination = f64::NAN,
-            |e: &mut Sgp4Elements| e.bstar = f64::NEG_INFINITY,
-        ] {
+        let spoils: [fn(&mut Sgp4Elements); 5] = [
+            |e| e.mean_motion = f64::NAN,
+            |e| e.eccentricity = f64::INFINITY,
+            |e| e.inclination = f64::NAN,
+            |e| e.bstar = f64::NEG_INFINITY,
+            |e| e.epoch = Epoch::<Utc>::from_jd(f64::NAN),
+        ];
+        for spoil in spoils {
             let mut bad = valid;
             spoil(&mut bad);
             assert!(
                 Sgp4Propagator::from_elements(&bad).is_err(),
-                "non-finite element must be rejected"
+                "non-finite element / epoch must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_non_finite_propagation_time() {
+        // A non-finite minutes-since-epoch must error rather than spin the
+        // deep-space resonance integrator. Use the resonant deep-space sat.
+        const DL1: &str = "1 04632U 70093B   04031.91070959 -.00000084  00000-0  10000-3 0  9955";
+        const DL2: &str = "2 04632  11.4628 273.1101 1450506 207.6000 143.9350  1.20231981 44145";
+        let elements = tle::parse(&format!("{DL1}\n{DL2}")).unwrap().elements;
+        let prop = Sgp4Propagator::from_elements(&elements).unwrap();
+        for t in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(
+                matches!(
+                    prop.propagate_minutes_since_epoch(t),
+                    Err(Sgp4Error::Diverged)
+                ),
+                "non-finite minutes ({t}) must be rejected"
             );
         }
     }

--- a/arika/src/sgp4.rs
+++ b/arika/src/sgp4.rs
@@ -123,13 +123,19 @@ impl Sgp4Propagator {
     /// Propagate to `minutes` after the element-set epoch.
     ///
     /// Returns `(position, velocity)` in the [`Teme`] frame, in km and km/s.
+    ///
+    /// `minutes` should stay within SGP4's useful range (the model is fit for
+    /// roughly days-to-weeks around epoch and loses meaning far from it); the
+    /// caller owns that choice. Pathologically large magnitudes also make the
+    /// deep-space resonance integrator (a fixed 720-minute step toward the
+    /// target) iterate proportionally, so very large values are slow as well as
+    /// physically meaningless.
     pub fn propagate_minutes_since_epoch(
         &self,
         minutes: f64,
     ) -> Result<(Vec3<Teme>, Vec3<Teme>), Sgp4Error> {
         // Reject a non-finite time before handing it to sgp4: a NaN/±inf target
-        // can spin the deep-space resonance integrator (a fixed-step loop toward
-        // the target time) indefinitely.
+        // can spin the deep-space resonance integrator indefinitely.
         if !minutes.is_finite() {
             return Err(Sgp4Error::Diverged);
         }
@@ -137,6 +143,16 @@ impl Sgp4Propagator {
             .constants
             .propagate_afspc_compatibility_mode(MinutesSinceEpoch(minutes))
             .map_err(|_| Sgp4Error::Diverged)?;
+        // Guard the output too: a finite-but-extreme element set can drive sgp4
+        // to a non-finite state without tripping its own range checks.
+        if !p
+            .position
+            .iter()
+            .chain(p.velocity.iter())
+            .all(|x| x.is_finite())
+        {
+            return Err(Sgp4Error::Diverged);
+        }
         Ok((
             Vec3::<Teme>::new(p.position[0], p.position[1], p.position[2]),
             Vec3::<Teme>::new(p.velocity[0], p.velocity[1], p.velocity[2]),

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -31,7 +31,7 @@ plugin-wasm-async = ["plugin-wasm", "orts/plugin-wasm-async"]
 nalgebra.workspace = true
 utsuroi.workspace = true
 tobari = { workspace = true, features = ["fetch-cssi"] }
-arika.workspace = true
+arika = { workspace = true, features = ["sgp4"] }
 orts.workspace = true
 log = "0.4.29"
 clap.workspace = true


### PR DESCRIPTION
## 概要

`arika` に SGP4 / SDP4 伝播を追加する。`elements::Sgp4Elements`(TLE/OMM がデコードされる共有平均要素セット)を実際に伝播し、TEME フレームの状態ベクトルを得られるようにする。これまで取り込んだ平均要素は `to_keplerian_elements`(SGP4 平均要素を osculating Keplerian とみなす物理的に誤った two-body 換算)経由でしか Cartesian 状態にできず、元期で数十 km ずれていた。本 PR はその第一段として、正しい伝播器を導入する。

## 背景

SGP4 平均要素は Brouwer-Kozai の平均要素であり、osculating Keplerian 要素ではない。正しい状態を得るには SGP4/SDP4 で伝播する必要がある。自前実装は検証コストが高いため、reference-quality な `sgp4` crate(Vallado「Revisiting Spacetrack Report #3」のテストベクタで検証済み、SGP4+SDP4 フル実装、MIT)を依存採用する。

## 追加内容

- **`arika::propagation::Sgp4Propagator`**: `Sgp4Elements` から `sgp4::Orbit::from_kozai_elements` → `Constants::new` → `propagate` への橋渡し。
  - `from_elements(&Sgp4Elements) -> Result<Self, Sgp4Error>`: epoch の `Constants` を 1 回だけ構築して保持(軌道生成では多数回 propagate するため再利用)。
  - `propagate_minutes_since_epoch(f64)` と `propagate(Epoch<Utc>)`: TEME の `(Vec3<Teme>, Vec3<Teme>)`(位置・速度、km / km·s)を返す。
- **AFSPC compatibility mode** を採用: WGS72 + AFSPC sidereal time + AFSPC epoch 式 + `propagate_afspc_compatibility_mode`。これは TLE/OMM カタログ要素が生成される慣行であり、`sgp4` 自身が公式ベクタ検証に用いるモード。
- **`sgp4` 依存は optional + `libm` のみ**(`std` は決して有効化しない＝sgp4 の std/libm 排他 `compile_error` を回避)。`arika` の `sgp4` feature(default off)で有効化。`cli` がこれを有効化する。

## 設計上の選択

- **no-alloc 伝播を維持**: 伝播コアは allocator を必要としないため、`sgp4` を `libm` のみで引き、伝播経路を no_std-no-alloc ビルドでも使えるようにした。`arika --no-default-features --features sgp4` のビルドを CI で守る。`arika-wasm` は default features のままなので `sgp4`/`chrono` を引かず、wasm ビルドは軽量なまま。
- **epoch 換算は手書きで再現**: `sgp4::julian_years_since_j2000_afspc_compatibility_mode` を `chrono` 経由でなく arika の `DateTime` から直接計算(整数除算の順序を保存)。no-alloc 経路で chrono datetime 構築を避けるため。手書き式は sgp4 の関数との直接比較テストでガード。
- **出力は `(Vec3<Teme>, Vec3<Teme>)` タプル**: 既存の `FrameTransform::transform_state` と同じ規約。TEME→積分フレーム回転(後続 PR)にそのまま渡せる。

## 検証

- **公式ベクタ一致**: Vallado TEME 検証衛星 catalog **00005**(near-earth SGP4)を tsince=0/360/1440 min で position < 1e-4 km / velocity < 1e-6 km/s 一致。
- **SDP4 deep-space**: catalog **04632**(平均運動 1.20 rev/day、Lyddane deep-space 経路)を t=0 と後ろ向き伝播(-5184 / -4896 min)で position < 1e-3 km / velocity < 1e-6 km/s 一致。
- **epoch 式**: 手書き AFSPC 式を `sgp4::julian_years_since_j2000_afspc_compatibility_mode` と Jan/Feb/Mar・2000 境界・閏日(小数秒)・遠未来で 1e-12 一致を確認。
- 非有限入力(`NaN`/`inf`)は `from_elements` 入口で拒否。
- `cargo test --workspace` / `cargo clippy --workspace -- -D warnings` / fmt clean。`arika` の no_std(no alloc) / no_std+alloc / no_std+sgp4 / std 各 tier ビルド clean。

## 後続

TEME↔Gcrs / SimpleEci の回転(状態をこの TEME から積分フレームへ)と、`to_keplerian_elements` 誤経路の削除・cli 統合は後続 PR で行う。
