### PR TITLE
test(arika): pin SGP4 propagate(Epoch) absolute-time conversion

### DIFF
--- a/arika/src/sgp4.rs
+++ b/arika/src/sgp4.rs
@@ -257,6 +257,52 @@ mod tests {
         let (r_min, v_min) = prop.propagate_minutes_since_epoch(0.0).unwrap();
         assert!((r_abs.into_inner() - r_min.into_inner()).norm() < 1.0e-6);
         assert!((v_abs.into_inner() - v_min.into_inner()).norm() < 1.0e-9);
+
+        // A *nonzero* offset pins the `(t − epoch) × 1440` conversion (factor
+        // and sign): 6 h later by the absolute clock must equal +360 minutes.
+        // At delta == 0 above, any broken scale or sign would still pass.
+        let t_6h = elements.epoch.add_seconds(360.0 * 60.0);
+        let (r6_abs, v6_abs) = prop.propagate(t_6h).unwrap();
+        let (r6_min, v6_min) = prop.propagate_minutes_since_epoch(360.0).unwrap();
+        assert!((r6_abs.into_inner() - r6_min.into_inner()).norm() < 1.0e-6);
+        assert!((v6_abs.into_inner() - v6_min.into_inner()).norm() < 1.0e-9);
+    }
+
+    #[test]
+    fn propagate_absolute_epoch_uses_naive_utc_across_leap_second() {
+        // `propagate` counts *naive* UTC minutes — `(t − epoch) × 1440`, ignoring
+        // intervening leap seconds — matching SGP4's leap-agnostic convention.
+        // Pin that by straddling the 2017-01-01 leap (TAI−UTC: 36 → 37 s).
+        // The orbit is arbitrary (Vallado 00005); only the internal consistency
+        // of the two propagate paths matters, not the absolute state.
+        let mut elements = tle::parse(&format!("{L1}\n{L2}")).unwrap().elements;
+        elements.epoch = Epoch::<Utc>::from_gregorian(2016, 12, 31, 23, 59, 0.0);
+        let prop = Sgp4Propagator::from_elements(&elements).unwrap();
+
+        let (r_min, _) = prop.propagate_minutes_since_epoch(2.0).unwrap();
+
+        // Naive +120 s (add_seconds) advances the UTC clock to 00:01:00 — 2 min
+        // by the wrapper's count — so it must match propagate_minutes(2). The
+        // tolerance is 1 m, not bit-exact: the UTC↔TAI leap-second search rounds
+        // the round-tripped epoch by ~7 µs here (≈6 cm of motion), far below the
+        // ~8 km the leap-aware path differs by.
+        let t_naive = elements.epoch.add_seconds(2.0 * 60.0);
+        let (r_naive, _) = prop.propagate(t_naive).unwrap();
+        assert!(
+            (r_naive.into_inner() - r_min.into_inner()).norm() < 1.0e-3,
+            "propagate() must use naive UTC minutes (no leap adjustment)"
+        );
+
+        // Leap-aware +120 SI s (add_si_seconds) lands at 00:00:59 — one second is
+        // consumed by the 23:59:60 leap — so the wrapper sees ~1 s less and the
+        // result must DIFFER. This is what discriminates the naive convention
+        // from a leap-safe one (≈1 s of orbital motion, ≫ 0.1 km).
+        let t_si = elements.epoch.add_si_seconds(2.0 * 60.0);
+        let (r_si, _) = prop.propagate(t_si).unwrap();
+        assert!(
+            (r_si.into_inner() - r_min.into_inner()).norm() > 0.1,
+            "a leap-aware epoch offset should differ from the naive minute count"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What & why

The SGP4 propagator merged in #235 has `Sgp4Propagator::propagate(t: Epoch<Utc>)`, which converts an absolute UTC epoch to elapsed time with `(t.jd() − epoch.jd()) × 1440` and delegates to `propagate_minutes_since_epoch`. A code review (Codex) flagged that the only test of this path used `t == epoch` (delta 0) — at which point a broken scale factor, a flipped sign, or the wrong leap-second convention would *all* still pass. The absolute-time conversion was effectively unpinned.

This is a **test-only** follow-up (no behavior change) that closes that gap.

## What changed

`arika/src/sgp4.rs` (tests only), two additions:

1. **Nonzero offset** — extends `propagate_by_absolute_epoch_matches_minutes`: a +6 h absolute offset must equal `propagate_minutes_since_epoch(360)`. This pins the `×1440` factor and the sign (delta 0 constrains neither).

2. **Leap-second straddle** (`propagate_absolute_epoch_uses_naive_utc_across_leap_second`) — pins the *documented* naive-UTC convention. With the propagator epoch 1 minute before the 2017-01-01 leap second:
   - a naive +120 s offset (`add_seconds`) advances the UTC clock to `00:01:00` and **matches** `propagate_minutes_since_epoch(2)`;
   - a leap-aware +120 SI s offset (`add_si_seconds`) lands at `00:00:59` — one second consumed by the `23:59:60` leap — and so **differs by ~8 km**.

   This discriminates the naive convention from a leap-safe one: a future switch to leap-safe arithmetic in `propagate` would fail loudly. The naive-match tolerance is 1 m rather than bit-exact, because the UTC↔TAI leap-second search rounds the round-tripped epoch by ~7 µs (≈6 cm of motion) near the boundary — far below the ~8 km the leap-aware path differs by.

## Validation

- `cargo test -p arika --features sgp4` — all pass (359 lib + integration tests, 0 failures); the two new/extended tests verified to fail if the conversion's scale/sign or the naive convention is broken.
- `cargo clippy -p arika --no-default-features --features sgp4 -- -D warnings` (the no-alloc SGP4 tier) and `cargo fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)