### PR TITLE
feat(orts-cli): TLE/OMM 初期状態を SGP4 経路に(two-body 誤経路を置換)

### DIFF
--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -483,7 +483,7 @@ pub fn run_simulation(params: &SimParams) -> Recording {
             &third_bodies,
             params.build_atmosphere_model(),
         );
-        let initial = sat.initial_state(params.mu);
+        let initial = sat.initial_state(params.mu, params.epoch);
 
         group = group.add_satellite_until(sat.id.as_str(), initial, sat.period, system);
     }

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -483,7 +483,9 @@ pub fn run_simulation(params: &SimParams) -> Recording {
             &third_bodies,
             params.build_atmosphere_model(),
         );
-        let initial = sat.initial_state(params.mu, params.epoch);
+        let initial = sat
+            .initial_state(params.mu, params.epoch)
+            .unwrap_or_else(|e| panic!("satellite '{}': {e}", sat.id));
 
         group = group.add_satellite_until(sat.id.as_str(), initial, sat.period, system);
     }
@@ -923,10 +925,11 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
             plugin_backend,
         };
         for spec in &params.satellites {
-            let sat = build_controlled_satellite(spec, &mut ctx).unwrap_or_else(|e| {
-                eprintln!("Error building controlled satellite '{}': {e}", spec.id);
-                std::process::exit(1);
-            });
+            let sat =
+                build_controlled_satellite(spec, params.epoch, &mut ctx).unwrap_or_else(|e| {
+                    eprintln!("Error building controlled satellite '{}': {e}", spec.id);
+                    std::process::exit(1);
+                });
             satellites.push(sat);
         }
     }

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -449,8 +449,12 @@ impl ServeEngine {
                 #[cfg(not(feature = "plugin-wasm"))]
                 let mut ctx = crate::sim::controlled::ControlledBuildContext { params: &params };
                 for spec in &params.satellites {
-                    let sat = crate::sim::controlled::build_controlled_satellite(spec, &mut ctx)
-                        .map_err(|e| format!("controlled satellite '{}': {e}", spec.id))?;
+                    let sat = crate::sim::controlled::build_controlled_satellite(
+                        spec,
+                        params.epoch,
+                        &mut ctx,
+                    )
+                    .map_err(|e| format!("controlled satellite '{}': {e}", spec.id))?;
                     controlled_sats.push(sat);
                     metas.push(SatMeta {
                         spec: spec.clone(),
@@ -500,7 +504,9 @@ impl ServeEngine {
                 // Default torque: coupled gravity gradient
                 dynamics = dynamics.with_model(CoupledGravityGradient::new(params.mu, inertia));
 
-                let orbit = spec.initial_state(params.mu, params.epoch);
+                let orbit = spec
+                    .initial_state(params.mu, params.epoch)
+                    .map_err(|e| format!("satellite '{}': {e}", spec.id))?;
                 let plant = SpacecraftState {
                     orbit,
                     attitude: orts::attitude::AttitudeState {
@@ -550,7 +556,9 @@ impl ServeEngine {
                     &third_bodies,
                     params.build_atmosphere_model(),
                 );
-                let initial = spec.initial_state(params.mu, params.epoch);
+                let initial = spec
+                    .initial_state(params.mu, params.epoch)
+                    .map_err(|e| format!("satellite '{}': {e}", spec.id))?;
                 orbit_group = orbit_group.add_satellite(spec.id.as_str(), initial, system);
                 metas.push(SatMeta {
                     spec: spec.clone(),
@@ -801,9 +809,16 @@ impl ServeEngine {
                         {
                             Some((
                                 self.group.sat_id(i),
+                                // Periodic 2-body reset to the orbit's reference
+                                // (epoch) state. The element set was validated
+                                // when the satellite was built, so re-evaluating
+                                // it here cannot fail.
                                 self.metas[i]
                                     .spec
-                                    .initial_state(self.params.mu, self.params.epoch),
+                                    .initial_state(self.params.mu, self.params.epoch)
+                                    .expect(
+                                        "reset of an already-built initial state must not fail",
+                                    ),
                             ))
                         } else {
                             None
@@ -972,6 +987,8 @@ impl ServeEngine {
 
         let sat_index = self.metas.len();
         let spec = satellite.to_satellite_spec(sat_index, self.params.body, self.params.mu);
+        // SGP4/TEME is Earth-centered; reject a TLE/OMM orbit on a non-Earth sim.
+        crate::sim::params::validate_omm_body(self.params.body, std::slice::from_ref(&spec))?;
         let third_bodies = default_third_bodies(&self.params.body);
         let system = build_orbital_system(
             &self.params.body,
@@ -981,7 +998,13 @@ impl ServeEngine {
             &third_bodies,
             self.params.build_atmosphere_model(),
         );
-        let initial = spec.initial_state(self.params.mu, self.params.epoch);
+        // Evaluate the initial state at the instant the satellite enters the
+        // running sim (epoch + current_t), so a TLE/OMM is propagated to "now"
+        // rather than to t = 0. The system above uses epoch (the t = 0 ref).
+        let initial = spec.initial_state(
+            self.params.mu,
+            self.params.epoch.map(|e| e.add_si_seconds(self.current_t)),
+        )?;
         self.group
             .push_orbit_satellite(spec.id.as_str(), initial.clone(), self.current_t, system);
 
@@ -1077,17 +1100,22 @@ impl ServeEngine {
 
         let sat_index = self.metas.len();
         let spec = satellite.to_satellite_spec(sat_index, self.params.body, self.params.mu);
+        // SGP4/TEME is Earth-centered; reject a TLE/OMM orbit on a non-Earth sim.
+        crate::sim::params::validate_omm_body(self.params.body, std::slice::from_ref(&spec))?;
         // Re-use the startup validation so we cannot crash
         // build_controlled_satellite → build_spacecraft_dynamics on
         // a singular inertia tensor or non-positive mass.
         validate_satellite_spec(&spec)?;
+        // Evaluate the initial state at the instant the satellite enters the
+        // running sim (epoch + current_t), so a TLE/OMM is propagated to "now".
+        let initial_epoch = self.params.epoch.map(|e| e.add_si_seconds(self.current_t));
         let new_sat = {
             let mut ctx = crate::sim::controlled::ControlledBuildContext {
                 params: &self.params,
                 wasm_cache,
                 plugin_backend,
             };
-            crate::sim::controlled::build_controlled_satellite(&spec, &mut ctx)
+            crate::sim::controlled::build_controlled_satellite(&spec, initial_epoch, &mut ctx)
                 .map_err(|e| format!("build controlled satellite: {e}"))?
         };
 

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -500,7 +500,7 @@ impl ServeEngine {
                 // Default torque: coupled gravity gradient
                 dynamics = dynamics.with_model(CoupledGravityGradient::new(params.mu, inertia));
 
-                let orbit = spec.initial_state(params.mu);
+                let orbit = spec.initial_state(params.mu, params.epoch);
                 let plant = SpacecraftState {
                     orbit,
                     attitude: orts::attitude::AttitudeState {
@@ -550,7 +550,7 @@ impl ServeEngine {
                     &third_bodies,
                     params.build_atmosphere_model(),
                 );
-                let initial = spec.initial_state(params.mu);
+                let initial = spec.initial_state(params.mu, params.epoch);
                 orbit_group = orbit_group.add_satellite(spec.id.as_str(), initial, system);
                 metas.push(SatMeta {
                     spec: spec.clone(),
@@ -801,7 +801,9 @@ impl ServeEngine {
                         {
                             Some((
                                 self.group.sat_id(i),
-                                self.metas[i].spec.initial_state(self.params.mu),
+                                self.metas[i]
+                                    .spec
+                                    .initial_state(self.params.mu, self.params.epoch),
                             ))
                         } else {
                             None
@@ -979,7 +981,7 @@ impl ServeEngine {
             &third_bodies,
             self.params.build_atmosphere_model(),
         );
-        let initial = spec.initial_state(self.params.mu);
+        let initial = spec.initial_state(self.params.mu, self.params.epoch);
         self.group
             .push_orbit_satellite(spec.id.as_str(), initial.clone(), self.current_t, system);
 

--- a/cli/src/commands/serve/manager.rs
+++ b/cli/src/commands/serve/manager.rs
@@ -224,6 +224,10 @@ fn validate_sim_config(config: &SimConfig) -> Result<(), String> {
         .enumerate()
         .map(|(i, s)| s.to_satellite_spec(i, body, mu))
         .collect();
+    // SGP4/TEME is Earth-centered: reject a non-Earth TLE/OMM config here so a
+    // WebSocket `StartSimulation` returns an error to the client instead of
+    // reaching the panic in `SimParams::from_config`.
+    crate::sim::params::validate_omm_body(body, &specs)?;
     let any_att = specs.iter().any(|s| s.attitude_config.is_some());
     let all_att = !specs.is_empty() && specs.iter().all(|s| s.attitude_config.is_some());
     if any_att && !all_att {
@@ -647,5 +651,36 @@ mod tests {
         assert_eq!(names[0], "moon");
         assert!(names.contains(&"sun".to_string()));
         assert_eq!(names.len(), 2);
+    }
+
+    #[test]
+    fn validate_sim_config_rejects_non_earth_tle() {
+        // A WebSocket `StartSimulation` with a non-Earth body + TLE must be
+        // rejected here (graceful Err), not reach the panic in `from_config`.
+        let mars = r#"{
+            "body": "mars",
+            "satellites": [{
+                "id": "iss",
+                "orbit": {
+                    "type": "tle",
+                    "line1": "1 25544U 98067A   24079.50000000  .00016717  00000-0  30000-4 0  9993",
+                    "line2": "2 25544  51.6400 208.6520 0007417  35.3910 324.7580 15.49561654480000"
+                }
+            }]
+        }"#;
+        let config: SimConfig = serde_json::from_str(mars).unwrap();
+        let err = validate_sim_config(&config)
+            .expect_err("a non-Earth TLE config must be rejected, not panic");
+        assert!(err.contains("Earth-centered"), "unexpected error: {err}");
+
+        // The same satellite on Earth must not trip the body guard.
+        let earth: SimConfig =
+            serde_json::from_str(&mars.replace("\"mars\"", "\"earth\"")).unwrap();
+        if let Err(e) = validate_sim_config(&earth) {
+            assert!(
+                !e.contains("Earth-centered"),
+                "Earth config tripped the body guard: {e}"
+            );
+        }
     }
 }

--- a/cli/src/satellite.rs
+++ b/cli/src/satellite.rs
@@ -1,5 +1,8 @@
 use arika::body::KnownBody;
 use arika::elements::Sgp4Elements;
+use arika::epoch::{Epoch, Utc};
+use arika::frame::{FrameTransform, SimpleEci, Teme};
+use arika::sgp4::Sgp4Propagator;
 use orts::OrbitalState;
 use orts::orbital::kepler::KeplerianElements;
 use orts::record::entity_path::EntityPath;
@@ -69,7 +72,15 @@ pub struct SatelliteSpec {
 }
 
 impl SatelliteSpec {
-    pub fn initial_state(&self, mu: f64) -> OrbitalState {
+    /// Build the satellite's initial Cartesian state (in `SimpleEci`).
+    ///
+    /// For a TLE/OMM orbit this propagates the SGP4 mean elements to `epoch`
+    /// and rotates the resulting TEME state into `SimpleEci` — the physically
+    /// correct path (SGP4 mean elements are *not* osculating Keplerian
+    /// elements). `epoch` is the resolved simulation epoch, which defaults to
+    /// the element-set epoch (tsince = 0); it is required for a TLE/OMM orbit
+    /// and ignored for a circular orbit.
+    pub fn initial_state(&self, mu: f64, epoch: Option<Epoch<Utc>>) -> OrbitalState {
         match &self.orbit {
             OrbitSpec::Circular {
                 r0,
@@ -88,9 +99,19 @@ impl SatelliteSpec {
                 let (pos, vel) = elements.to_state_vector(mu);
                 OrbitalState::new(pos, vel)
             }
-            OrbitSpec::Omm { elements, .. } => {
-                let (pos, vel) = elements.to_state_vector(mu);
-                OrbitalState::new(pos, vel)
+            OrbitSpec::Omm { omm, .. } => {
+                let epoch = epoch
+                    .expect("a TLE/OMM orbit requires a simulation epoch (defaults to the element-set epoch)");
+                let propagator = Sgp4Propagator::from_elements(omm)
+                    .unwrap_or_else(|e| panic!("SGP4 initialization failed: {e}"));
+                let (r_teme, v_teme) = propagator
+                    .propagate(epoch)
+                    .unwrap_or_else(|e| panic!("SGP4 propagation to {epoch:?} failed: {e}"));
+                // TEME → SimpleEci (the integration frame); ω = 0 (both inertial).
+                let (pos, vel) =
+                    FrameTransform::<Teme, SimpleEci>::teme_to_simple_eci(&epoch.to_ut1_naive())
+                        .transform_state(&r_teme, &v_teme);
+                OrbitalState::new(pos.into_inner(), vel.into_inner())
             }
         }
     }
@@ -334,7 +355,7 @@ mod tests {
     fn satellite_spec_initial_state_circular() {
         let spec = parse_sat_spec("altitude=400,id=test", KnownBody::Earth);
         let mu = KnownBody::Earth.properties().mu;
-        let state = spec.initial_state(mu);
+        let state = spec.initial_state(mu, None);
         let r = state.position().magnitude();
         let expected_r = 6378.137 + 400.0;
         assert!(
@@ -350,7 +371,7 @@ mod tests {
             "altitude=800,inclination=98.6,id=sso-test",
             KnownBody::Earth,
         );
-        let state = spec.initial_state(mu);
+        let state = spec.initial_state(mu, None);
 
         let r = state.position().magnitude();
         let expected_r = 6378.137 + 800.0;
@@ -384,7 +405,7 @@ mod tests {
             "altitude=400,inclination=51.6,raan=90,id=iss-like",
             KnownBody::Earth,
         );
-        let state = spec.initial_state(mu);
+        let state = spec.initial_state(mu, None);
 
         let h = state.position().cross(state.velocity());
         let i = (h[2] / h.magnitude()).acos();
@@ -413,7 +434,7 @@ mod tests {
     fn satellite_spec_initial_state_equatorial_default() {
         let mu = KnownBody::Earth.properties().mu;
         let spec = parse_sat_spec("altitude=400,id=test", KnownBody::Earth);
-        let state = spec.initial_state(mu);
+        let state = spec.initial_state(mu, None);
         assert!(
             state.position()[2].abs() < 1e-10,
             "equatorial orbit should have z ≈ 0, got {}",

--- a/cli/src/satellite.rs
+++ b/cli/src/satellite.rs
@@ -79,10 +79,12 @@ impl SatelliteSpec {
     /// correct path (SGP4 mean elements are *not* osculating Keplerian
     /// elements). `epoch` is the wall-clock instant at which the state is
     /// evaluated: for a satellite present from the start it is the simulation
-    /// epoch (which itself defaults to the element-set epoch, so tsince = 0);
-    /// for a satellite added mid-run it is the simulation epoch advanced by
-    /// the current sim time, so SGP4 is propagated to the moment it enters.
-    /// It is required for a TLE/OMM orbit and ignored for a circular orbit.
+    /// epoch (which, absent `--epoch`, defaults to the *first* element set's
+    /// epoch — so tsince = 0 for that satellite, but non-zero for any other
+    /// TLE/OMM whose own epoch differs); for a satellite added mid-run it is
+    /// the simulation epoch advanced by the current sim time, so SGP4 is
+    /// propagated to the moment it enters. It is required for a TLE/OMM orbit
+    /// and ignored for a circular orbit.
     ///
     /// Returns `Err` if SGP4 initialization or propagation fails (e.g. a
     /// malformed element set), so a caller on a fallible boundary — a dynamic

--- a/cli/src/satellite.rs
+++ b/cli/src/satellite.rs
@@ -77,10 +77,23 @@ impl SatelliteSpec {
     /// For a TLE/OMM orbit this propagates the SGP4 mean elements to `epoch`
     /// and rotates the resulting TEME state into `SimpleEci` — the physically
     /// correct path (SGP4 mean elements are *not* osculating Keplerian
-    /// elements). `epoch` is the resolved simulation epoch, which defaults to
-    /// the element-set epoch (tsince = 0); it is required for a TLE/OMM orbit
-    /// and ignored for a circular orbit.
-    pub fn initial_state(&self, mu: f64, epoch: Option<Epoch<Utc>>) -> OrbitalState {
+    /// elements). `epoch` is the wall-clock instant at which the state is
+    /// evaluated: for a satellite present from the start it is the simulation
+    /// epoch (which itself defaults to the element-set epoch, so tsince = 0);
+    /// for a satellite added mid-run it is the simulation epoch advanced by
+    /// the current sim time, so SGP4 is propagated to the moment it enters.
+    /// It is required for a TLE/OMM orbit and ignored for a circular orbit.
+    ///
+    /// Returns `Err` if SGP4 initialization or propagation fails (e.g. a
+    /// malformed element set), so a caller on a fallible boundary — a dynamic
+    /// `add_satellite` over WebSocket — can reject it instead of crashing the
+    /// server. SGP4/TEME is Earth-centered; callers must ensure the central
+    /// body is Earth (see `validate_omm_body`).
+    pub fn initial_state(
+        &self,
+        mu: f64,
+        epoch: Option<Epoch<Utc>>,
+    ) -> Result<OrbitalState, String> {
         match &self.orbit {
             OrbitSpec::Circular {
                 r0,
@@ -97,21 +110,20 @@ impl SatelliteSpec {
                     true_anomaly: 0.0,
                 };
                 let (pos, vel) = elements.to_state_vector(mu);
-                OrbitalState::new(pos, vel)
+                Ok(OrbitalState::new(pos, vel))
             }
             OrbitSpec::Omm { omm, .. } => {
-                let epoch = epoch
-                    .expect("a TLE/OMM orbit requires a simulation epoch (defaults to the element-set epoch)");
+                let epoch = epoch.ok_or("a TLE/OMM orbit requires a simulation epoch")?;
                 let propagator = Sgp4Propagator::from_elements(omm)
-                    .unwrap_or_else(|e| panic!("SGP4 initialization failed: {e}"));
+                    .map_err(|e| format!("SGP4 initialization failed: {e}"))?;
                 let (r_teme, v_teme) = propagator
                     .propagate(epoch)
-                    .unwrap_or_else(|e| panic!("SGP4 propagation to {epoch:?} failed: {e}"));
+                    .map_err(|e| format!("SGP4 propagation to {epoch:?} failed: {e}"))?;
                 // TEME → SimpleEci (the integration frame); ω = 0 (both inertial).
                 let (pos, vel) =
                     FrameTransform::<Teme, SimpleEci>::teme_to_simple_eci(&epoch.to_ut1_naive())
                         .transform_state(&r_teme, &v_teme);
-                OrbitalState::new(pos.into_inner(), vel.into_inner())
+                Ok(OrbitalState::new(pos.into_inner(), vel.into_inner()))
             }
         }
     }
@@ -355,7 +367,7 @@ mod tests {
     fn satellite_spec_initial_state_circular() {
         let spec = parse_sat_spec("altitude=400,id=test", KnownBody::Earth);
         let mu = KnownBody::Earth.properties().mu;
-        let state = spec.initial_state(mu, None);
+        let state = spec.initial_state(mu, None).unwrap();
         let r = state.position().magnitude();
         let expected_r = 6378.137 + 400.0;
         assert!(
@@ -371,7 +383,7 @@ mod tests {
             "altitude=800,inclination=98.6,id=sso-test",
             KnownBody::Earth,
         );
-        let state = spec.initial_state(mu, None);
+        let state = spec.initial_state(mu, None).unwrap();
 
         let r = state.position().magnitude();
         let expected_r = 6378.137 + 800.0;
@@ -405,7 +417,7 @@ mod tests {
             "altitude=400,inclination=51.6,raan=90,id=iss-like",
             KnownBody::Earth,
         );
-        let state = spec.initial_state(mu, None);
+        let state = spec.initial_state(mu, None).unwrap();
 
         let h = state.position().cross(state.velocity());
         let i = (h[2] / h.magnitude()).acos();
@@ -434,7 +446,7 @@ mod tests {
     fn satellite_spec_initial_state_equatorial_default() {
         let mu = KnownBody::Earth.properties().mu;
         let spec = parse_sat_spec("altitude=400,id=test", KnownBody::Earth);
-        let state = spec.initial_state(mu, None);
+        let state = spec.initial_state(mu, None).unwrap();
         assert!(
             state.position()[2].abs() < 1e-10,
             "equatorial orbit should have z ≈ 0, got {}",

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -161,7 +161,7 @@ pub fn build_controlled_satellite(
     };
 
     // 初期状態。
-    let orbit = spec.initial_state(params.mu);
+    let orbit = spec.initial_state(params.mu, params.epoch);
     let plant = SpacecraftState {
         orbit,
         attitude: orts::attitude::AttitudeState {

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -74,8 +74,16 @@ pub struct ControlledSatellite {
 /// 複数衛星をループで構築する場合は、[`ControlledBuildContext`] 内の
 /// `wasm_cache` を使い回すことで WASM コンポーネントのコンパイルが
 /// 1 ファイルにつき 1 回だけで済む。
+/// `initial_epoch` is the wall-clock instant at which the orbital initial
+/// state is evaluated: the simulation epoch for a satellite present from the
+/// start, or the simulation epoch advanced by the current sim time for a
+/// dynamic add (so a TLE/OMM is propagated to the moment it enters). The
+/// dynamics themselves use `params.epoch` as the `t = 0` reference, so
+/// time-dependent force models stay aligned regardless of when the satellite
+/// is added.
 pub fn build_controlled_satellite(
     spec: &SatelliteSpec,
+    initial_epoch: Option<Epoch>,
     ctx: &mut ControlledBuildContext<'_>,
 ) -> Result<ControlledSatellite, String> {
     let params = ctx.params;
@@ -160,8 +168,8 @@ pub fn build_controlled_satellite(
         (Vec::new(), 0.0)
     };
 
-    // 初期状態。
-    let orbit = spec.initial_state(params.mu, params.epoch);
+    // 初期状態。`initial_epoch` で評価（動的追加なら epoch + current_t）。
+    let orbit = spec.initial_state(params.mu, initial_epoch)?;
     let plant = SpacecraftState {
         orbit,
         attitude: orts::attitude::AttitudeState {

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -99,6 +99,17 @@ fn default_auto_threshold() -> usize {
     (cores * DEFAULT_THRESHOLD_PER_CORE).max(32)
 }
 
+/// The element-set epoch of the first TLE/OMM satellite, if any.
+///
+/// Used to default the simulation epoch to the element-set epoch (tsince = 0)
+/// when no `--epoch` is given, so SGP4 is never extrapolated.
+fn element_set_epoch(satellites: &[SatelliteSpec]) -> Option<Epoch> {
+    satellites.iter().find_map(|s| match &s.orbit {
+        OrbitSpec::Omm { omm, .. } => Some(omm.epoch),
+        OrbitSpec::Circular { .. } => None,
+    })
+}
+
 /// Simulation parameters derived from CLI arguments.
 pub struct SimParams {
     pub body: KnownBody,
@@ -181,12 +192,14 @@ impl SimParams {
         let body = parse_body(&args.body);
         let mu = body.properties().mu;
 
-        let epoch = match &args.epoch {
-            Some(s) => Some(Epoch::from_iso8601(s).unwrap_or_else(|| {
+        // An explicit `--epoch` wins; `None` defers the default — a TLE/OMM
+        // orbit without `--epoch` starts at its element-set epoch (resolved
+        // after the satellites are built, below).
+        let epoch = args.epoch.as_ref().map(|s| {
+            Epoch::from_iso8601(s).unwrap_or_else(|| {
                 panic!("Invalid epoch format: {s}. Expected ISO 8601 (e.g. 2024-03-20T12:00:00Z)")
-            })),
-            None => Some(Epoch::now()),
-        };
+            })
+        });
 
         let satellites = if !args.sats.is_empty() {
             // --sat flags provided: parse each spec
@@ -266,6 +279,13 @@ impl SimParams {
             satellites
         };
 
+        // Resolve the deferred epoch: an explicit `--epoch` wins; otherwise a
+        // TLE/OMM orbit starts at its element-set epoch (tsince = 0, no SGP4
+        // extrapolation); otherwise fall back to "now".
+        let epoch = epoch
+            .or_else(|| element_set_epoch(&satellites))
+            .or_else(|| Some(Epoch::now()));
+
         Self {
             body,
             mu,
@@ -298,12 +318,13 @@ impl SimParams {
         let body = config.known_body();
         let mu = body.properties().mu;
 
-        let epoch = match &config.epoch {
-            Some(s) => Some(Epoch::from_iso8601(s).unwrap_or_else(|| {
+        // `None` defers the default; resolved from the element-set epoch after
+        // the satellites are built (see `from_sim_args`).
+        let epoch = config.epoch.as_ref().map(|s| {
+            Epoch::from_iso8601(s).unwrap_or_else(|| {
                 panic!("Invalid epoch format: {s}. Expected ISO 8601 (e.g. 2024-03-20T12:00:00Z)")
-            })),
-            None => Some(Epoch::now()),
-        };
+            })
+        });
 
         let satellites: Vec<SatelliteSpec> = config
             .satellites
@@ -329,6 +350,10 @@ impl SimParams {
         } else {
             satellites
         };
+
+        let epoch = epoch
+            .or_else(|| element_set_epoch(&satellites))
+            .or_else(|| Some(Epoch::now()));
 
         Self {
             body,
@@ -857,7 +882,7 @@ mod tests {
             plugin_backend_async_mode: PluginAsyncModeChoice::Deterministic,
         };
         let params = SimParams::from_sim_args(&args, false);
-        let state = params.satellites[0].initial_state(params.mu);
+        let state = params.satellites[0].initial_state(params.mu, params.epoch);
 
         let r = state.position().magnitude();
         let v = state.velocity().magnitude();

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -101,13 +101,39 @@ fn default_auto_threshold() -> usize {
 
 /// The element-set epoch of the first TLE/OMM satellite, if any.
 ///
-/// Used to default the simulation epoch to the element-set epoch (tsince = 0)
-/// when no `--epoch` is given, so SGP4 is never extrapolated.
+/// Used to default the simulation epoch when no `--epoch` is given. With a
+/// single TLE/OMM this makes tsince = 0 (no SGP4 extrapolation). With several
+/// element sets only the first one is at tsince = 0; the others are propagated
+/// from the shared simulation epoch, so their elements *are* extrapolated by
+/// the epoch difference. An explicit `--epoch` likewise extrapolates all of
+/// them.
 fn element_set_epoch(satellites: &[SatelliteSpec]) -> Option<Epoch> {
     satellites.iter().find_map(|s| match &s.orbit {
         OrbitSpec::Omm { omm, .. } => Some(omm.epoch),
         OrbitSpec::Circular { .. } => None,
     })
+}
+
+/// SGP4/TEME is Earth-centered (WGS72 geopotential, TEME output frame), so a
+/// TLE/OMM initial state is only physically meaningful about Earth. Reject the
+/// combination of a non-Earth central body with any TLE/OMM orbit up front, so
+/// we never integrate an Earth-relative SGP4 state under a foreign body's μ,
+/// radius and perturbation set (which would silently produce nonsense).
+pub(crate) fn validate_omm_body(
+    body: KnownBody,
+    satellites: &[SatelliteSpec],
+) -> Result<(), String> {
+    if body != KnownBody::Earth
+        && satellites
+            .iter()
+            .any(|s| matches!(s.orbit, OrbitSpec::Omm { .. }))
+    {
+        return Err(format!(
+            "TLE/OMM orbits are Earth-centered (SGP4/TEME, WGS72) and cannot be \
+             propagated about {body:?}; use the Earth body or specify Keplerian elements"
+        ));
+    }
+    Ok(())
 }
 
 /// Simulation parameters derived from CLI arguments.
@@ -286,6 +312,8 @@ impl SimParams {
             .or_else(|| element_set_epoch(&satellites))
             .or_else(|| Some(Epoch::now()));
 
+        validate_omm_body(body, &satellites).unwrap_or_else(|e| panic!("{e}"));
+
         Self {
             body,
             mu,
@@ -354,6 +382,8 @@ impl SimParams {
         let epoch = epoch
             .or_else(|| element_set_epoch(&satellites))
             .or_else(|| Some(Epoch::now()));
+
+        validate_omm_body(body, &satellites).unwrap_or_else(|e| panic!("{e}"));
 
         Self {
             body,
@@ -882,7 +912,9 @@ mod tests {
             plugin_backend_async_mode: PluginAsyncModeChoice::Deterministic,
         };
         let params = SimParams::from_sim_args(&args, false);
-        let state = params.satellites[0].initial_state(params.mu, params.epoch);
+        let state = params.satellites[0]
+            .initial_state(params.mu, params.epoch)
+            .unwrap();
 
         let r = state.position().magnitude();
         let v = state.velocity().magnitude();
@@ -895,6 +927,48 @@ mod tests {
         );
         // ISS velocity ~7.66 km/s
         assert!((v - 7.66).abs() < 0.2, "ISS velocity: {v:.3} km/s");
+    }
+
+    #[test]
+    fn validate_omm_body_rejects_non_earth() {
+        let args = SimArgs {
+            body: "earth".to_string(),
+            dt: 10.0,
+            output_interval: None,
+            stream_interval: None,
+            epoch: None,
+            tle: None,
+            omm: None,
+            tle_line1: Some(
+                "1 25544U 98067A   24079.50000000  .00016717  00000-0  30000-4 0  9993".to_string(),
+            ),
+            tle_line2: Some(
+                "2 25544  51.6400 208.6520 0007417  35.3910 324.7580 15.49561654480000".to_string(),
+            ),
+            norad_id: None,
+            sats: vec![],
+            integrator: IntegratorChoice::Dp45,
+            atol: 1e-10,
+            rtol: 1e-8,
+            atmosphere: AtmosphereChoice::Exponential,
+            f107: 150.0,
+            ap: 15.0,
+            space_weather: None,
+            duration: None,
+            config: None,
+            plugin_backend: PluginBackendChoice::Auto,
+            plugin_backend_threshold: None,
+            plugin_backend_async_mode: PluginAsyncModeChoice::Deterministic,
+        };
+        let params = SimParams::from_sim_args(&args, false);
+        assert!(matches!(params.satellites[0].orbit, OrbitSpec::Omm { .. }));
+
+        // The same TLE-backed satellite is valid on Earth (SGP4/TEME is
+        // Earth-centered) but must be rejected about any other body.
+        assert!(validate_omm_body(KnownBody::Earth, &params.satellites).is_ok());
+        let err = validate_omm_body(KnownBody::Mars, &params.satellites)
+            .expect_err("a TLE/OMM orbit about Mars must be rejected");
+        assert!(err.contains("Earth-centered"), "unexpected error: {err}");
     }
 
     #[test]

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -305,9 +305,9 @@ impl SimParams {
             satellites
         };
 
-        // Resolve the deferred epoch: an explicit `--epoch` wins; otherwise a
-        // TLE/OMM orbit starts at its element-set epoch (tsince = 0, no SGP4
-        // extrapolation); otherwise fall back to "now".
+        // Resolve the deferred epoch: an explicit `--epoch` wins; otherwise it
+        // defaults to the first TLE/OMM's element-set epoch (tsince = 0 for
+        // that satellite only — see `element_set_epoch`); otherwise "now".
         let epoch = epoch
             .or_else(|| element_set_epoch(&satellites))
             .or_else(|| Some(Epoch::now()));

--- a/docs/src/content/docs/en/orts/overview.mdx
+++ b/docs/src/content/docs/en/orts/overview.mdx
@@ -9,7 +9,8 @@ and a WASM plugin host runtime.
 Provides the simulation engine at the heart of the
 [orts](https://github.com/sksat/orts) workspace:
 
-- Orbital dynamics (two-body, Brouwer mean-element propagator, TLE/SGP4-equivalent).
+- Orbital dynamics: two-body and perturbed numerical propagation; TLE/OMM
+  ingestion via SGP4/SDP4 (`arika`), rotated from TEME into the integration frame.
 - Attitude dynamics and control (reaction wheels, gravity gradient, PD / B-dot).
 - Force models: gravity harmonics, drag, SRP, third-body, constant thrust.
 - Sensor models: magnetometer, gyroscope, star tracker.


### PR DESCRIPTION
## 概要

cli の TLE/OMM 取り込みを、物理的に誤った two-body 経路(`to_keplerian_elements`)から **SGP4 → TEME → 積分フレーム(SimpleEci)** に差し替える。これで `--tle` / `--omm` / `--norad-id` の初期状態が正しくなり、一連の修正(#230 / #235 / #240)がユーザから見て end-to-end で効く。

## 背景

cli は `SatelliteSpec::initial_state` で、SGP4 平均要素を `to_keplerian_elements` で osculating Keplerian とみなして two-body で初期状態を作っていた(SGP4 平均要素は古典軌道要素ではないので、元期で数十 km ずれる)。[#235](https://github.com/sksat/orts/pull/235) で `arika::sgp4` の SGP4/SDP4 伝播、[#240](https://github.com/sksat/orts/pull/240) で `arika::earth::teme` の TEME↔積分フレーム回転が揃ったので、cli をそこへ繋ぐ。

## 変更内容

- **`initial_state` の Omm 経路**: `Sgp4Propagator::from_elements` → sim epoch へ伝播 → TEME 状態 → `FrameTransform<Teme, SimpleEci>`(ω=0)→ `OrbitalState`。sim epoch を引数で受けるよう変更し、全呼び出し元(serve/run/controlled/params)を更新。
- **epoch 既定**: `--epoch` 未指定かつ TLE/OMM のとき、sim epoch を**要素セットの epoch に既定**(tsince=0、SGP4 を外挿しない)。それ以外は now()(円軌道は epoch を使わない)。`from_sim_args` / `from_config` 両方。
- **doc 修正**: `overview.mdx` の「TLE/SGP4-equivalent」を正確な記述(SGP4/SDP4 取り込み、TEME から積分フレームへ回転)に。

## 設計上の選択

- **積分フレームは現状どおり SimpleEci**(cli にフレーム選択は無い)。`Rotation<Teme, SimpleEci>` / `FrameTransform<Teme, SimpleEci>`(`R3(GMST−ERA)`、ground track 整合)で繋ぐ。Gcrs 積分は将来の別変更。
- **epoch 既定 = 要素セット epoch**: 古い TLE でも SGP4 を外挿せず安全。serve の埋め込み ISS TLE は最近なので「ほぼ現在」のまま。

## 後続(本 PR 範囲外)

`to_keplerian_elements` と `OrbitSpec::Omm { elements: KeplerianElements }` フィールドは表示ラベル(period / altitude)用に残置(doc で「物理的に誤り・表示用」と明記済み)。初期状態が SGP4 になったので、これらの削除・`OrbitSpec::Omm` variant 改名(Copilot #230 指摘)は小さな follow-up で行う。

## 検証

- cli bin テスト **175 通過**(`sim_params_tle_initial_state_plausible`、円軌道 `initial_state` 群、serve engine 含む)。TLE→SGP4→TEME→SimpleEci の初期状態が妥当。
- `cargo clippy --workspace -- -D warnings` clean、`cargo fmt --all --check` clean。
- arika / orts crate は本 PR で不変(cli + docs のみ)。SGP4・TEME 回転自体は #235 / #240 で Vallado・ERFA・Orekit 検証済み。
