### PR TITLE
feat(orts-cli): seed TLE/OMM orbits via SGP4 → TEME → SimpleEci

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -93,11 +93,13 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 #### Changed
 - TLE/OMM 軌道の初期状態を二体変換でなく SGP4 伝播で生成するようにした:
   `SGP4 → TEME → SimpleEci`(位置・速度を回転)で求めるので、エポックで数十 km
-  ずれず SGP4 精度で要素セットに一致する。各衛星は自分の要素エポックから
-  シム開始まで伝播し、`--epoch` 未指定なら裸の TLE は自身のエポックから開始する
-  (要素エポックが無視されていた潜在バグも修正)。表示の period/altitude は不変。
-  `Sgp4Elements::to_keplerian_elements` は `arika` の API として残るが CLI は
-  使わなくなった。([#242](https://github.com/sksat/orts/pull/242))
+  ずれず SGP4 精度で要素セットに一致する。各衛星は自分の要素エポックからシム
+  開始まで伝播する(要素エポックが保持されつつ無視されていた潜在バグも修正)。
+  `--epoch` 未指定時の既定: `run` で単一 TLE/OMM ならその要素エポック開始(裸の
+  TLE は自身のエポックから)、`serve`・複数衛星・埋め込み ISS は現在時刻。実行中の
+  `serve` に追加した衛星は開始時刻でなく現在のシム時刻で seed する。表示の
+  period/altitude は不変。`Sgp4Elements::to_keplerian_elements` は `arika` の
+  API として残るが CLI は使わなくなった。([#242](https://github.com/sksat/orts/pull/242))
 - `--tle` を再び TLE 専用 (2LE/3LE、`-` で stdin) とし、新規 `--omm` と
   対にした。要素セットのパースは削除した `orts::tle` でなく
   `arika::tle` / `arika::omm` を使用 (従来は `--tle` が OMM も自動受理)。([#87](https://github.com/sksat/orts/pull/87))

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -91,6 +91,13 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   追加。よく使う・agent に関係する経路を端末内で発見できるようにした。([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
+- TLE/OMM 軌道の初期状態を二体変換でなく SGP4 伝播で生成するようにした:
+  `SGP4 → TEME → SimpleEci`(位置・速度を回転)で求めるので、エポックで数十 km
+  ずれず SGP4 精度で要素セットに一致する。各衛星は自分の要素エポックから
+  シム開始まで伝播し、`--epoch` 未指定なら裸の TLE は自身のエポックから開始する
+  (要素エポックが無視されていた潜在バグも修正)。表示の period/altitude は不変。
+  `Sgp4Elements::to_keplerian_elements` は `arika` の API として残るが CLI は
+  使わなくなった。([#242](https://github.com/sksat/orts/pull/242))
 - `--tle` を再び TLE 専用 (2LE/3LE、`-` で stdin) とし、新規 `--omm` と
   対にした。要素セットのパースは削除した `orts::tle` でなく
   `arika::tle` / `arika::omm` を使用 (従来は `--tle` が OMM も自動受理)。([#87](https://github.com/sksat/orts/pull/87))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,14 @@ section is subdivided by package.
   are discoverable without leaving the terminal. ([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
+- TLE/OMM orbits are now seeded by SGP4 propagation instead of a two-body
+  conversion: the initial state is `SGP4 → TEME → SimpleEci` (rotating position
+  and velocity), so it matches the element set within SGP4 accuracy rather than
+  being tens of km off at epoch. Each satellite propagates from its own element
+  epoch to the simulation start; with no `--epoch` a bare TLE simulates from its
+  own epoch (this also fixes a latent bug where the element epoch was ignored).
+  Displayed period/altitude are unchanged; `Sgp4Elements::to_keplerian_elements`
+  remains an `arika` API but is no longer used by the CLI. ([#242](https://github.com/sksat/orts/pull/242))
 - `--tle` is TLE-only again (2LE/3LE; `-` for stdin) and pairs with the new
   `--omm`; element-set parsing is now backed by `arika::tle` / `arika::omm`
   instead of the removed `orts::tle`. (Previously `--tle` also auto-accepted OMM.) ([#87](https://github.com/sksat/orts/pull/87))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,10 +104,14 @@ section is subdivided by package.
   conversion: the initial state is `SGP4 → TEME → SimpleEci` (rotating position
   and velocity), so it matches the element set within SGP4 accuracy rather than
   being tens of km off at epoch. Each satellite propagates from its own element
-  epoch to the simulation start; with no `--epoch` a bare TLE simulates from its
-  own epoch (this also fixes a latent bug where the element epoch was ignored).
-  Displayed period/altitude are unchanged; `Sgp4Elements::to_keplerian_elements`
-  remains an `arika` API but is no longer used by the CLI. ([#242](https://github.com/sksat/orts/pull/242))
+  epoch to the simulation start (fixing a latent bug where the element epoch was
+  stored but ignored). Epoch defaulting when `--epoch` is omitted: `run` with a
+  single TLE/OMM starts at that element epoch (so a bare TLE simulates from its
+  own epoch); `serve`, multi-satellite, and the embedded-ISS default use the
+  current time. A satellite added to a running `serve` is seeded at the current
+  simulation time, not the start. Displayed period/altitude are unchanged;
+  `Sgp4Elements::to_keplerian_elements` remains an `arika` API but is no longer
+  used by the CLI. ([#242](https://github.com/sksat/orts/pull/242))
 - `--tle` is TLE-only again (2LE/3LE; `-` for stdin) and pairs with the new
   `--omm`; element-set parsing is now backed by `arika::tle` / `arika::omm`
   instead of the removed `orts::tle`. (Previously `--tle` also auto-accepted OMM.) ([#87](https://github.com/sksat/orts/pull/87))

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -483,7 +483,7 @@ pub fn run_simulation(params: &SimParams) -> Recording {
             &third_bodies,
             params.build_atmosphere_model(),
         );
-        let initial = sat.initial_state(params.mu);
+        let initial = sat.initial_state(params.mu, params.epoch);
 
         group = group.add_satellite_until(sat.id.as_str(), initial, sat.period, system);
     }
@@ -603,12 +603,12 @@ pub fn run_simulation(params: &SimParams) -> Recording {
                 altitude, r0
             )
         }
-        OrbitSpec::Omm { elements, .. } => {
+        OrbitSpec::Omm { omm } => {
             format!(
                 "Initial orbit: from TLE/OMM (a = {:.1} km, e = {:.6}, i = {:.2}°)",
-                elements.semi_major_axis,
-                elements.eccentricity,
-                elements.inclination.to_degrees()
+                omm.semi_major_axis(params.mu),
+                omm.eccentricity,
+                omm.inclination.to_degrees()
             )
         }
     });
@@ -1092,12 +1092,12 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
                 altitude, r0
             )
         }
-        OrbitSpec::Omm { elements, .. } => {
+        OrbitSpec::Omm { omm } => {
             format!(
                 "Initial orbit: from TLE/OMM (a = {:.1} km, e = {:.6}, i = {:.2}°)",
-                elements.semi_major_axis,
-                elements.eccentricity,
-                elements.inclination.to_degrees()
+                omm.semi_major_axis(params.mu),
+                omm.eccentricity,
+                omm.inclination.to_degrees()
             )
         }
     });

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -26,7 +26,7 @@ pub fn run_simulation_cmd(sim: &SimArgs, output: Option<&str>, format: OutputFor
                 eprintln!("Error: {e}");
                 std::process::exit(1);
             });
-        SimParams::from_config(&config)
+        SimParams::from_config(&config, false)
     } else if sim.has_orbit_args() {
         SimParams::from_sim_args(sim, false)
     } else {
@@ -37,7 +37,7 @@ pub fn run_simulation_cmd(sim: &SimArgs, output: Option<&str>, format: OutputFor
                 eprintln!("Error: {e}");
                 std::process::exit(1);
             });
-            SimParams::from_config(&config)
+            SimParams::from_config(&config, false)
         } else {
             eprintln!("Error: no simulation configuration found.");
             eprintln!("Provide --config <path>, place orts.toml in the current directory,");
@@ -483,7 +483,9 @@ pub fn run_simulation(params: &SimParams) -> Recording {
             &third_bodies,
             params.build_atmosphere_model(),
         );
-        let initial = sat.initial_state(params.mu, params.epoch);
+        let initial = sat
+            .initial_state(params.mu, params.epoch)
+            .unwrap_or_else(|e| panic!("{e}"));
 
         group = group.add_satellite_until(sat.id.as_str(), initial, sat.period, system);
     }
@@ -917,6 +919,7 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
     {
         let mut ctx = ControlledBuildContext {
             params,
+            seed_epoch: params.epoch,
             #[cfg(feature = "plugin-wasm")]
             wasm_cache: &mut wasm_cache,
             #[cfg(feature = "plugin-wasm")]

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -440,6 +440,7 @@ impl ServeEngine {
                 #[cfg(feature = "plugin-wasm")]
                 let mut ctx = crate::sim::controlled::ControlledBuildContext {
                     params: &params,
+                    seed_epoch: params.epoch,
                     wasm_cache: wasm_cache
                         .as_mut()
                         .expect("wasm_cache must be Some when has_controller"),
@@ -447,7 +448,10 @@ impl ServeEngine {
                         .expect("plugin_backend must be Some when has_controller"),
                 };
                 #[cfg(not(feature = "plugin-wasm"))]
-                let mut ctx = crate::sim::controlled::ControlledBuildContext { params: &params };
+                let mut ctx = crate::sim::controlled::ControlledBuildContext {
+                    params: &params,
+                    seed_epoch: params.epoch,
+                };
                 for spec in &params.satellites {
                     let sat = crate::sim::controlled::build_controlled_satellite(spec, &mut ctx)
                         .map_err(|e| format!("controlled satellite '{}': {e}", spec.id))?;
@@ -500,7 +504,7 @@ impl ServeEngine {
                 // Default torque: coupled gravity gradient
                 dynamics = dynamics.with_model(CoupledGravityGradient::new(params.mu, inertia));
 
-                let orbit = spec.initial_state(params.mu, params.epoch);
+                let orbit = spec.initial_state(params.mu, params.epoch)?;
                 let plant = SpacecraftState {
                     orbit,
                     attitude: orts::attitude::AttitudeState {
@@ -550,7 +554,7 @@ impl ServeEngine {
                     &third_bodies,
                     params.build_atmosphere_model(),
                 );
-                let initial = spec.initial_state(params.mu, params.epoch);
+                let initial = spec.initial_state(params.mu, params.epoch)?;
                 orbit_group = orbit_group.add_satellite(spec.id.as_str(), initial, system);
                 metas.push(SatMeta {
                     spec: spec.clone(),
@@ -803,7 +807,8 @@ impl ServeEngine {
                                 self.group.sat_id(i),
                                 self.metas[i]
                                     .spec
-                                    .initial_state(self.params.mu, self.params.epoch),
+                                    .initial_state(self.params.mu, self.params.epoch)
+                                    .unwrap_or_else(|e| panic!("{e}")),
                             ))
                         } else {
                             None
@@ -981,7 +986,8 @@ impl ServeEngine {
             &third_bodies,
             self.params.build_atmosphere_model(),
         );
-        let initial = spec.initial_state(self.params.mu, self.params.epoch);
+        let seed_epoch = self.params.epoch.map(|e| e.add_si_seconds(self.current_t));
+        let initial = spec.initial_state(self.params.mu, seed_epoch)?;
         self.group
             .push_orbit_satellite(spec.id.as_str(), initial.clone(), self.current_t, system);
 
@@ -1084,6 +1090,7 @@ impl ServeEngine {
         let new_sat = {
             let mut ctx = crate::sim::controlled::ControlledBuildContext {
                 params: &self.params,
+                seed_epoch: self.params.epoch.map(|e| e.add_si_seconds(self.current_t)),
                 wasm_cache,
                 plugin_backend,
             };
@@ -1287,7 +1294,7 @@ mod tests {
     /// no broadcast channel, and no stream bridge.
     fn engine_from_toml(toml: &str) -> Result<EngineInit, String> {
         let config: crate::config::SimConfig = toml::from_str(toml).expect("valid test toml");
-        let params = Arc::new(SimParams::from_config(&config));
+        let params = Arc::new(SimParams::from_config(&config, true));
         let data_dir = std::env::temp_dir().join(format!(
             "orts-engine-test-{}-{:?}",
             std::process::id(),

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -500,7 +500,7 @@ impl ServeEngine {
                 // Default torque: coupled gravity gradient
                 dynamics = dynamics.with_model(CoupledGravityGradient::new(params.mu, inertia));
 
-                let orbit = spec.initial_state(params.mu);
+                let orbit = spec.initial_state(params.mu, params.epoch);
                 let plant = SpacecraftState {
                     orbit,
                     attitude: orts::attitude::AttitudeState {
@@ -550,7 +550,7 @@ impl ServeEngine {
                     &third_bodies,
                     params.build_atmosphere_model(),
                 );
-                let initial = spec.initial_state(params.mu);
+                let initial = spec.initial_state(params.mu, params.epoch);
                 orbit_group = orbit_group.add_satellite(spec.id.as_str(), initial, system);
                 metas.push(SatMeta {
                     spec: spec.clone(),
@@ -801,7 +801,9 @@ impl ServeEngine {
                         {
                             Some((
                                 self.group.sat_id(i),
-                                self.metas[i].spec.initial_state(self.params.mu),
+                                self.metas[i]
+                                    .spec
+                                    .initial_state(self.params.mu, self.params.epoch),
                             ))
                         } else {
                             None
@@ -979,7 +981,7 @@ impl ServeEngine {
             &third_bodies,
             self.params.build_atmosphere_model(),
         );
-        let initial = spec.initial_state(self.params.mu);
+        let initial = spec.initial_state(self.params.mu, self.params.epoch);
         self.group
             .push_orbit_satellite(spec.id.as_str(), initial.clone(), self.current_t, system);
 

--- a/cli/src/commands/serve/manager.rs
+++ b/cli/src/commands/serve/manager.rs
@@ -299,7 +299,7 @@ pub(super) async fn simulation_manager(
 
     // Main manager loop: start simulation, run until terminated, return to idle.
     while let Some(config) = next_config {
-        let mut params_inner = SimParams::from_config(&config);
+        let mut params_inner = SimParams::from_config(&config, true);
         cli_plugin_overrides.apply(&mut params_inner);
         let params = Arc::new(params_inner);
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -524,18 +524,16 @@ impl SatelliteConfig {
                 let parsed = arika::tle::parse(&text)
                     .unwrap_or_else(|e| panic!("Failed to parse TLE in config: {e}"));
                 let tle = parsed.elements;
-                let elements = tle.to_keplerian_elements(mu);
-                let period = elements.period(mu);
+                let period = crate::satellite::orbital_period(&tle);
                 let tle_name = parsed.object_name.clone();
-                (OrbitSpec::Omm { omm: tle, elements }, period, tle_name)
+                (OrbitSpec::Omm { omm: tle }, period, tle_name)
             }
             OrbitConfig::Norad { norad_id } => {
                 let parsed = fetch_tle_by_norad_id(*norad_id);
                 let tle = parsed.elements;
-                let elements = tle.to_keplerian_elements(mu);
-                let period = elements.period(mu);
+                let period = crate::satellite::orbital_period(&tle);
                 let tle_name = parsed.object_name.clone();
-                (OrbitSpec::Omm { omm: tle, elements }, period, tle_name)
+                (OrbitSpec::Omm { omm: tle }, period, tle_name)
             }
         };
 

--- a/cli/src/satellite.rs
+++ b/cli/src/satellite.rs
@@ -78,7 +78,7 @@ impl SatelliteSpec {
     /// two-body conversion, which is tens of km off at epoch. `epoch` is the
     /// resolved simulation-start epoch; when it is `None` the element-set epoch
     /// is used (propagation Δt = 0), so a bare TLE simulates from its own epoch.
-    pub fn initial_state(&self, mu: f64, epoch: Option<Epoch>) -> OrbitalState {
+    pub fn initial_state(&self, mu: f64, epoch: Option<Epoch>) -> Result<OrbitalState, String> {
         match &self.orbit {
             OrbitSpec::Circular {
                 r0,
@@ -95,28 +95,28 @@ impl SatelliteSpec {
                     true_anomaly: 0.0,
                 };
                 let (pos, vel) = elements.to_state_vector(mu);
-                OrbitalState::new(pos, vel)
+                Ok(OrbitalState::new(pos, vel))
             }
             OrbitSpec::Omm { omm } => {
                 let target = epoch.unwrap_or(omm.epoch);
-                let propagator = Sgp4Propagator::from_elements(omm).unwrap_or_else(|e| {
-                    panic!(
+                let propagator = Sgp4Propagator::from_elements(omm).map_err(|e| {
+                    format!(
                         "SGP4 propagator init failed for NORAD {}: {e}",
                         omm.norad_cat_id
                     )
-                });
-                let (r_teme, v_teme) = propagator.propagate(target).unwrap_or_else(|e| {
-                    panic!(
+                })?;
+                let (r_teme, v_teme) = propagator.propagate(target).map_err(|e| {
+                    format!(
                         "SGP4 propagation failed for NORAD {}: {e}",
                         omm.norad_cat_id
                     )
-                });
+                })?;
                 // SGP4 yields TEME; rotate the state (position+velocity, ω = 0)
                 // into the integration frame `SimpleEci` at the target epoch.
                 let (pos, vel) =
                     FrameTransform::<Teme, SimpleEci>::teme_to_simple_eci(&target.to_ut1_naive())
                         .transform_state(&r_teme, &v_teme);
-                OrbitalState::new(pos.into_inner(), vel.into_inner())
+                Ok(OrbitalState::new(pos.into_inner(), vel.into_inner()))
             }
         }
     }
@@ -367,7 +367,7 @@ mod tests {
     fn satellite_spec_initial_state_circular() {
         let spec = parse_sat_spec("altitude=400,id=test", KnownBody::Earth);
         let mu = KnownBody::Earth.properties().mu;
-        let state = spec.initial_state(mu, None);
+        let state = spec.initial_state(mu, None).unwrap();
         let r = state.position().magnitude();
         let expected_r = 6378.137 + 400.0;
         assert!(
@@ -383,7 +383,7 @@ mod tests {
             "altitude=800,inclination=98.6,id=sso-test",
             KnownBody::Earth,
         );
-        let state = spec.initial_state(mu, None);
+        let state = spec.initial_state(mu, None).unwrap();
 
         let r = state.position().magnitude();
         let expected_r = 6378.137 + 800.0;
@@ -417,7 +417,7 @@ mod tests {
             "altitude=400,inclination=51.6,raan=90,id=iss-like",
             KnownBody::Earth,
         );
-        let state = spec.initial_state(mu, None);
+        let state = spec.initial_state(mu, None).unwrap();
 
         let h = state.position().cross(state.velocity());
         let i = (h[2] / h.magnitude()).acos();
@@ -446,7 +446,7 @@ mod tests {
     fn satellite_spec_initial_state_equatorial_default() {
         let mu = KnownBody::Earth.properties().mu;
         let spec = parse_sat_spec("altitude=400,id=test", KnownBody::Earth);
-        let state = spec.initial_state(mu, None);
+        let state = spec.initial_state(mu, None).unwrap();
         assert!(
             state.position()[2].abs() < 1e-10,
             "equatorial orbit should have z ≈ 0, got {}",
@@ -473,7 +473,7 @@ mod tests {
         };
 
         // No epoch → propagate to the element epoch (Δt = 0), then TEME→SimpleEci.
-        let p = *spec.initial_state(mu, None).position();
+        let p = *spec.initial_state(mu, None).unwrap().position();
 
         // Must equal a direct SGP4 propagation + rotation (pins the wiring).
         let (r_teme, v_teme) = Sgp4Propagator::from_elements(omm)

--- a/cli/src/satellite.rs
+++ b/cli/src/satellite.rs
@@ -1,5 +1,8 @@
 use arika::body::KnownBody;
 use arika::elements::Sgp4Elements;
+use arika::epoch::Epoch;
+use arika::frame::{FrameTransform, SimpleEci, Teme};
+use arika::sgp4::Sgp4Propagator;
 use orts::OrbitalState;
 use orts::orbital::kepler::KeplerianElements;
 use orts::record::entity_path::EntityPath;
@@ -20,11 +23,10 @@ pub enum OrbitSpec {
         raan: f64,
     },
     /// From a parsed element set — TLE or OMM input, both decode into the
-    /// canonical [`Sgp4Elements`] record — plus the derived Keplerian elements.
-    Omm {
-        omm: Sgp4Elements,
-        elements: KeplerianElements,
-    },
+    /// canonical [`Sgp4Elements`] record. The initial Cartesian state is
+    /// produced by SGP4 propagation (not a two-body conversion), so only the
+    /// raw mean elements are carried.
+    Omm { omm: Sgp4Elements },
 }
 
 /// Per-satellite specification.
@@ -69,7 +71,14 @@ pub struct SatelliteSpec {
 }
 
 impl SatelliteSpec {
-    pub fn initial_state(&self, mu: f64) -> OrbitalState {
+    /// Build the integrator's initial [`OrbitalState`] (frame `SimpleEci`).
+    ///
+    /// For an element set ([`OrbitSpec::Omm`]) the state comes from SGP4
+    /// propagation to `epoch`, then a TEME→`SimpleEci` rotation — not the
+    /// two-body conversion, which is tens of km off at epoch. `epoch` is the
+    /// resolved simulation-start epoch; when it is `None` the element-set epoch
+    /// is used (propagation Δt = 0), so a bare TLE simulates from its own epoch.
+    pub fn initial_state(&self, mu: f64, epoch: Option<Epoch>) -> OrbitalState {
         match &self.orbit {
             OrbitSpec::Circular {
                 r0,
@@ -88,9 +97,26 @@ impl SatelliteSpec {
                 let (pos, vel) = elements.to_state_vector(mu);
                 OrbitalState::new(pos, vel)
             }
-            OrbitSpec::Omm { elements, .. } => {
-                let (pos, vel) = elements.to_state_vector(mu);
-                OrbitalState::new(pos, vel)
+            OrbitSpec::Omm { omm } => {
+                let target = epoch.unwrap_or(omm.epoch);
+                let propagator = Sgp4Propagator::from_elements(omm).unwrap_or_else(|e| {
+                    panic!(
+                        "SGP4 propagator init failed for NORAD {}: {e}",
+                        omm.norad_cat_id
+                    )
+                });
+                let (r_teme, v_teme) = propagator.propagate(target).unwrap_or_else(|e| {
+                    panic!(
+                        "SGP4 propagation failed for NORAD {}: {e}",
+                        omm.norad_cat_id
+                    )
+                });
+                // SGP4 yields TEME; rotate the state (position+velocity, ω = 0)
+                // into the integration frame `SimpleEci` at the target epoch.
+                let (pos, vel) =
+                    FrameTransform::<Teme, SimpleEci>::teme_to_simple_eci(&target.to_ut1_naive())
+                        .transform_state(&r_teme, &v_teme);
+                OrbitalState::new(pos.into_inner(), vel.into_inner())
             }
         }
     }
@@ -99,8 +125,11 @@ impl SatelliteSpec {
     pub fn altitude(&self, body: &KnownBody) -> f64 {
         match &self.orbit {
             OrbitSpec::Circular { altitude, .. } => *altitude,
-            OrbitSpec::Omm { elements, .. } => {
-                let perigee_r = elements.semi_major_axis * (1.0 - elements.eccentricity);
+            OrbitSpec::Omm { omm } => {
+                // Perigee altitude from the mean elements' two-body semi-major
+                // axis (display only; the propagated state is SGP4).
+                let perigee_r =
+                    omm.semi_major_axis(body.properties().mu) * (1.0 - omm.eccentricity);
                 perigee_r - body.properties().radius
             }
         }
@@ -127,6 +156,12 @@ pub struct SatelliteInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub shape: Option<crate::sim::core::MarkerShape>,
+}
+
+/// Orbital period [s] from the SGP4 mean motion (`2π / n`). Equal to the
+/// two-body period of the mean semi-major axis, for display purposes.
+pub(crate) fn orbital_period(omm: &Sgp4Elements) -> f64 {
+    2.0 * std::f64::consts::PI / omm.mean_motion
 }
 
 /// Parse a satellite specification string (key=value,key=value).
@@ -216,19 +251,17 @@ pub fn parse_sat_spec(s: &str, body: KnownBody) -> SatelliteSpec {
     let (orbit, period, derived_name) = if let Some(norad) = norad_id {
         let parsed = fetch_tle_by_norad_id(norad);
         let omm = parsed.elements;
-        let elements = omm.to_keplerian_elements(mu);
-        let period = elements.period(mu);
+        let period = orbital_period(&omm);
         let obj_name = parsed.object_name.clone();
-        (OrbitSpec::Omm { omm, elements }, period, obj_name)
+        (OrbitSpec::Omm { omm }, period, obj_name)
     } else if let (Some(l1), Some(l2)) = (tle_line1, tle_line2) {
         let text = format!("{l1}\n{l2}");
         let parsed = arika::tle::parse(&text)
             .unwrap_or_else(|e| panic!("Failed to parse TLE in --sat: {e}"));
         let omm = parsed.elements;
-        let elements = omm.to_keplerian_elements(mu);
-        let period = elements.period(mu);
+        let period = orbital_period(&omm);
         let obj_name = parsed.object_name.clone();
-        (OrbitSpec::Omm { omm, elements }, period, obj_name)
+        (OrbitSpec::Omm { omm }, period, obj_name)
     } else {
         let alt = altitude.unwrap_or(400.0);
         let r0 = body.properties().radius + alt;
@@ -334,7 +367,7 @@ mod tests {
     fn satellite_spec_initial_state_circular() {
         let spec = parse_sat_spec("altitude=400,id=test", KnownBody::Earth);
         let mu = KnownBody::Earth.properties().mu;
-        let state = spec.initial_state(mu);
+        let state = spec.initial_state(mu, None);
         let r = state.position().magnitude();
         let expected_r = 6378.137 + 400.0;
         assert!(
@@ -350,7 +383,7 @@ mod tests {
             "altitude=800,inclination=98.6,id=sso-test",
             KnownBody::Earth,
         );
-        let state = spec.initial_state(mu);
+        let state = spec.initial_state(mu, None);
 
         let r = state.position().magnitude();
         let expected_r = 6378.137 + 800.0;
@@ -384,7 +417,7 @@ mod tests {
             "altitude=400,inclination=51.6,raan=90,id=iss-like",
             KnownBody::Earth,
         );
-        let state = spec.initial_state(mu);
+        let state = spec.initial_state(mu, None);
 
         let h = state.position().cross(state.velocity());
         let i = (h[2] / h.magnitude()).acos();
@@ -413,7 +446,7 @@ mod tests {
     fn satellite_spec_initial_state_equatorial_default() {
         let mu = KnownBody::Earth.properties().mu;
         let spec = parse_sat_spec("altitude=400,id=test", KnownBody::Earth);
-        let state = spec.initial_state(mu);
+        let state = spec.initial_state(mu, None);
         assert!(
             state.position()[2].abs() < 1e-10,
             "equatorial orbit should have z ≈ 0, got {}",
@@ -426,5 +459,49 @@ mod tests {
         let spec = parse_sat_spec("altitude=400,id=my-sat", KnownBody::Earth);
         let path = spec.entity_path();
         assert_eq!(path.to_string(), "/world/sat/my-sat");
+    }
+
+    #[test]
+    fn omm_initial_state_is_sgp4_not_two_body() {
+        let mu = KnownBody::Earth.properties().mu;
+        let spec = parse_sat_spec(
+            "tle-line1=1 25544U 98067A   24079.50000000  .00016717  00000-0  30000-4 0  9993,tle-line2=2 25544  51.6400 208.6520 0007417  35.3910 324.7580 15.49561654480000,id=iss",
+            KnownBody::Earth,
+        );
+        let OrbitSpec::Omm { omm } = &spec.orbit else {
+            panic!("expected Omm orbit");
+        };
+
+        // No epoch → propagate to the element epoch (Δt = 0), then TEME→SimpleEci.
+        let p = *spec.initial_state(mu, None).position();
+
+        // Must equal a direct SGP4 propagation + rotation (pins the wiring).
+        let (r_teme, v_teme) = Sgp4Propagator::from_elements(omm)
+            .unwrap()
+            .propagate(omm.epoch)
+            .unwrap();
+        let (r_eci, _) =
+            FrameTransform::<Teme, SimpleEci>::teme_to_simple_eci(&omm.epoch.to_ut1_naive())
+                .transform_state(&r_teme, &v_teme);
+        assert!(
+            (p - r_eci.into_inner()).norm() < 1e-9,
+            "initial_state must be the SGP4→SimpleEci state"
+        );
+
+        // …and differ from the old two-body seed (`to_keplerian_elements` is a
+        // tens-of-km-off approximation): this is the behaviour PR4 fixes.
+        let (r_two_body, _) = omm.to_keplerian_elements(mu).to_state_vector(mu);
+        let diff = (p - r_two_body).norm();
+        assert!(
+            diff > 1.0,
+            "SGP4 seed should differ from the two-body seed by ≫ 1 km, got {diff:.2} km"
+        );
+
+        // Sanity: still a plausible LEO state.
+        assert!(
+            (p.magnitude() - 6778.0).abs() < 200.0,
+            "ISS radius ~6778 km, got {}",
+            p.magnitude()
+        );
     }
 }

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -161,7 +161,7 @@ pub fn build_controlled_satellite(
     };
 
     // 初期状態。
-    let orbit = spec.initial_state(params.mu);
+    let orbit = spec.initial_state(params.mu, params.epoch);
     let plant = SpacecraftState {
         orbit,
         attitude: orts::attitude::AttitudeState {

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -41,6 +41,10 @@ use orts::plugin::wasm::WasmPluginCache;
 /// that 1000 satellites don't each pay the full WASM compilation cost.
 pub struct ControlledBuildContext<'a> {
     pub params: &'a SimParams,
+    /// Absolute epoch at which to seed the orbit (SGP4 propagation target).
+    /// For the initial fleet this is `params.epoch` (t = 0); for a dynamic
+    /// add after the sim has advanced it is `params.epoch + current_t`.
+    pub seed_epoch: Option<Epoch>,
     #[cfg(feature = "plugin-wasm")]
     pub wasm_cache: &'a mut WasmPluginCache,
     /// Which WASM backend to build controllers with. Resolved once by
@@ -161,7 +165,7 @@ pub fn build_controlled_satellite(
     };
 
     // 初期状態。
-    let orbit = spec.initial_state(params.mu, params.epoch);
+    let orbit = spec.initial_state(params.mu, ctx.seed_epoch)?;
     let plant = SpacecraftState {
         orbit,
         attitude: orts::attitude::AttitudeState {

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -217,13 +217,12 @@ impl SimParams {
 
             if let Some(parsed) = omm_opt {
                 let omm = parsed.elements;
-                let elements = omm.to_keplerian_elements(mu);
-                let period = elements.period(mu);
+                let period = crate::satellite::orbital_period(&omm);
                 let sat_name = parsed.object_name.clone();
                 vec![SatelliteSpec {
                     id: "default".to_string(),
                     name: sat_name,
-                    orbit: OrbitSpec::Omm { omm, elements },
+                    orbit: OrbitSpec::Omm { omm },
                     period,
                     ballistic_coeff: None,
                     srp_area_to_mass: None,
@@ -427,16 +426,12 @@ impl SimParams {
             .expect("embedded ISS TLE must be valid")
         });
         let iss_tle = parsed_iss.elements;
-        let elements = iss_tle.to_keplerian_elements(mu);
-        let period = elements.period(mu);
+        let period = crate::satellite::orbital_period(&iss_tle);
         let sat_name = parsed_iss.object_name.clone();
         sats.push(SatelliteSpec {
             id: "iss".to_string(),
             name: sat_name,
-            orbit: OrbitSpec::Omm {
-                omm: iss_tle,
-                elements,
-            },
+            orbit: OrbitSpec::Omm { omm: iss_tle },
             period,
             ballistic_coeff: None,
             srp_area_to_mass: None,
@@ -857,7 +852,7 @@ mod tests {
             plugin_backend_async_mode: PluginAsyncModeChoice::Deterministic,
         };
         let params = SimParams::from_sim_args(&args, false);
-        let state = params.satellites[0].initial_state(params.mu);
+        let state = params.satellites[0].initial_state(params.mu, params.epoch);
 
         let r = state.position().magnitude();
         let v = state.velocity().magnitude();

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -174,6 +174,19 @@ impl SimParams {
     }
 }
 
+/// Default sim-start epoch when none is given explicitly: a `run` (not serve)
+/// with a single TLE/OMM satellite starts at that element-set epoch, so a bare
+/// TLE simulates from its own epoch; otherwise the current wall-clock time.
+fn default_start_epoch(satellites: &[crate::satellite::SatelliteSpec], is_serve: bool) -> Epoch {
+    if !is_serve
+        && let [only] = satellites
+        && let crate::satellite::OrbitSpec::Omm { omm } = &only.orbit
+    {
+        return omm.epoch;
+    }
+    Epoch::now()
+}
+
 impl SimParams {
     /// Build SimParams from CLI arguments.
     /// `is_serve`: when true and no orbit args are given, defaults to SSO+ISS.
@@ -181,12 +194,11 @@ impl SimParams {
         let body = parse_body(&args.body);
         let mu = body.properties().mu;
 
-        let epoch = match &args.epoch {
-            Some(s) => Some(Epoch::from_iso8601(s).unwrap_or_else(|| {
+        let explicit_epoch = args.epoch.as_ref().map(|s| {
+            Epoch::from_iso8601(s).unwrap_or_else(|| {
                 panic!("Invalid epoch format: {s}. Expected ISO 8601 (e.g. 2024-03-20T12:00:00Z)")
-            })),
-            None => Some(Epoch::now()),
-        };
+            })
+        });
 
         let satellites = if !args.sats.is_empty() {
             // --sat flags provided: parse each spec
@@ -265,6 +277,9 @@ impl SimParams {
             satellites
         };
 
+        let epoch =
+            Some(explicit_epoch.unwrap_or_else(|| default_start_epoch(&satellites, is_serve)));
+
         Self {
             body,
             mu,
@@ -293,16 +308,15 @@ impl SimParams {
     }
 
     /// Build SimParams from a config file.
-    pub fn from_config(config: &SimConfig) -> Self {
+    pub fn from_config(config: &SimConfig, is_serve: bool) -> Self {
         let body = config.known_body();
         let mu = body.properties().mu;
 
-        let epoch = match &config.epoch {
-            Some(s) => Some(Epoch::from_iso8601(s).unwrap_or_else(|| {
+        let explicit_epoch = config.epoch.as_ref().map(|s| {
+            Epoch::from_iso8601(s).unwrap_or_else(|| {
                 panic!("Invalid epoch format: {s}. Expected ISO 8601 (e.g. 2024-03-20T12:00:00Z)")
-            })),
-            None => Some(Epoch::now()),
-        };
+            })
+        });
 
         let satellites: Vec<SatelliteSpec> = config
             .satellites
@@ -328,6 +342,9 @@ impl SimParams {
         } else {
             satellites
         };
+
+        let epoch =
+            Some(explicit_epoch.unwrap_or_else(|| default_start_epoch(&satellites, is_serve)));
 
         Self {
             body,
@@ -852,7 +869,9 @@ mod tests {
             plugin_backend_async_mode: PluginAsyncModeChoice::Deterministic,
         };
         let params = SimParams::from_sim_args(&args, false);
-        let state = params.satellites[0].initial_state(params.mu, params.epoch);
+        let state = params.satellites[0]
+            .initial_state(params.mu, params.epoch)
+            .unwrap();
 
         let r = state.position().magnitude();
         let v = state.velocity().magnitude();


### PR DESCRIPTION
## What & why

The CLI built a satellite's initial Cartesian state from a TLE/OMM by treating the SGP4 **mean** elements as osculating Keplerian elements (`Sgp4Elements::to_keplerian_elements` → `to_state_vector`). SGP4 mean elements are *not* Keplerian elements, so the seed was **tens of km off at epoch**. This is the final step of the SGP4/TEME ingestion effort (#230 parsing → #235 SGP4 propagator → #240 TEME↔GCRS/SimpleEci rotation → this PR wires them into the CLI).

## What changed (cli only)

- `OrbitSpec::Omm` now carries only the raw `Sgp4Elements` (dropped the derived two-body `KeplerianElements` field).
- `SatelliteSpec::initial_state(mu, epoch)` gains the resolved sim-start epoch and builds the TLE/OMM initial state via **SGP4 → TEME → SimpleEci**:
  `Sgp4Propagator::from_elements(omm).propagate(target)` (TEME state) → `FrameTransform::<Teme, SimpleEci>::teme_to_simple_eci(target.to_ut1_naive())` (ω = 0, rotates position **and** velocity).
- **Epoch semantics**: `target = epoch.unwrap_or(omm.epoch)`. With no `--epoch`, a bare TLE simulates from its own element epoch (Δt = 0); with an explicit epoch, each satellite propagates from its own element epoch to the common start. This also fixes a **latent bug** — the element epoch was stored but never used, so the state was placed at the sim start regardless of the gap.
- Threaded the resolved epoch through all 6 production `initial_state` call sites (run, controlled, serve ×4).

## Display

Period, perigee altitude, and the orbit-description string are now read straight from the mean elements (`2π/n`, `semi_major_axis(mu)·(1−e)`) — **numerically identical** to the previous `to_keplerian_elements`-routed values (same two-body `a`), just no longer going through that conversion. Only the **initial state** changes (→ SGP4).

## API

`Sgp4Elements::to_keplerian_elements` is **kept as an arika API** (a valid general two-body conversion); the CLI simply no longer uses it.

## Tests

- Added `omm_initial_state_is_sgp4_not_two_body`: the SGP4 seed equals a direct `SGP4 → SimpleEci` computation **and** differs from the old two-body seed (proving the path is wired and the fix matters).
- The existing ISS plausibility test (`sim_params_tle_initial_state_plausible`) still passes — the SGP4 seed is still a plausible ~LEO state (~6778 km, ~7.66 km/s).
- All 234 cli tests pass; `cargo clippy --workspace -- -D warnings` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)