### PR TITLE
refactor(arika,orts-cli): to_keplerian_elements 削除と表示値の Sgp4Elements 直接導出

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -139,7 +139,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - 要素セットのパース ([#87](https://github.com/sksat/orts/pull/87))。共有の
   no-alloc な `elements::Sgp4Elements` (平均要素セット: カタログ番号、UTC epoch、
   6 個の SGP4 平均要素、B\* drag。角度は rad、平均運動は rad/s) に
-  `semi_major_axis(mu)` / `to_keplerian_elements(mu)`。テキストパーサは
+  表示用ヘルパ `semi_major_axis(mu)` と `period()`。テキストパーサは
   `elements::ParsedElementSet` (要素 + 所有する `OBJECT_NAME` / `OBJECT_ID`
   識別子) を返し、形式判定する `elements::parse` がそれらに振り分ける。
   - `tle` — NORAD TLE / 2LE / 3LE パーサ (`tle::parse`) が `ParsedElementSet` を生成。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,7 @@ section is subdivided by package.
 - Element-set parsing ([#87](https://github.com/sksat/orts/pull/87)). A shared
   no-alloc `elements::Sgp4Elements` mean-element set (catalog number, UTC epoch,
   six SGP4 mean elements, B\* drag; angles in radians, mean motion in rad/s) with
-  `semi_major_axis(mu)` / `to_keplerian_elements(mu)`. The text parsers return
+  `semi_major_axis(mu)` and `period()` display helpers. The text parsers return
   `elements::ParsedElementSet` (the elements plus owned `OBJECT_NAME` /
   `OBJECT_ID` identity); the format-detecting `elements::parse` dispatches to them.
   - `tle` — NORAD TLE / 2LE / 3LE parser (`tle::parse`) → `ParsedElementSet`, with Alpha-5

--- a/arika/src/elements.rs
+++ b/arika/src/elements.rs
@@ -76,12 +76,14 @@ impl Sgp4Elements {
         (mu / (self.mean_motion * self.mean_motion)).cbrt()
     }
 
-    /// Orbital period [s] from the mean motion: `2π / n`.
+    /// Orbital period [s] from the mean motion: `2π / |n|`.
     ///
-    /// Exact for the (Kozai) mean motion the element set carries, and needs no
-    /// `mu` — this is the conventional period reported for a TLE/OMM.
+    /// A non-negative magnitude, so it stays sane even for a malformed element
+    /// set with a non-positive mean motion (the text parsers do not reject one).
+    /// Exact for the (Kozai) mean motion the set carries, and needs no `mu` —
+    /// this is the conventional period reported for a TLE/OMM.
     pub fn period(&self) -> f64 {
-        core::f64::consts::TAU / self.mean_motion
+        core::f64::consts::TAU / self.mean_motion.abs()
     }
 }
 
@@ -249,6 +251,19 @@ mod tests {
         assert!(
             (p - 5575.8).abs() < 2.0,
             "ISS period should be ≈5576 s, got {p}"
+        );
+    }
+
+    #[test]
+    fn period_stays_positive_for_negative_mean_motion() {
+        // A malformed element set with a non-positive mean motion must not yield
+        // a negative period (it flows into run horizons / reset boundaries).
+        let mut el = iss_elements();
+        el.mean_motion = -el.mean_motion;
+        assert!(
+            el.period() > 0.0,
+            "period must stay positive, got {}",
+            el.period()
         );
     }
 

--- a/arika/src/elements.rs
+++ b/arika/src/elements.rs
@@ -78,10 +78,12 @@ impl Sgp4Elements {
 
     /// Orbital period [s] from the mean motion: `2π / |n|`.
     ///
-    /// A non-negative magnitude, so it stays sane even for a malformed element
-    /// set with a non-positive mean motion (the text parsers do not reject one).
     /// Exact for the (Kozai) mean motion the set carries, and needs no `mu` —
-    /// this is the conventional period reported for a TLE/OMM.
+    /// this is the conventional period reported for a TLE/OMM. `|n|` keeps a
+    /// sign-flipped mean motion from producing a negative period (matching the
+    /// magnitude the prior derived path produced). A zero or NaN mean motion
+    /// still propagates to a non-finite result; rejecting such an element set is
+    /// the parser's / SGP4 propagator's job, not this display helper's.
     pub fn period(&self) -> f64 {
         core::f64::consts::TAU / self.mean_motion.abs()
     }
@@ -256,8 +258,8 @@ mod tests {
 
     #[test]
     fn period_stays_positive_for_negative_mean_motion() {
-        // A malformed element set with a non-positive mean motion must not yield
-        // a negative period (it flows into run horizons / reset boundaries).
+        // A sign-flipped (negative) mean motion must not yield a negative
+        // period (it flows into run horizons / reset boundaries).
         let mut el = iss_elements();
         el.mean_motion = -el.mean_motion;
         assert!(

--- a/arika/src/elements.rs
+++ b/arika/src/elements.rs
@@ -14,8 +14,8 @@
 //!
 //! These are **mean** elements in the SGP4 (Brouwer-Kozai) sense, *not*
 //! osculating Keplerian elements: they are only physically meaningful when fed
-//! to the SGP4 propagator. Treating them as classical orbital elements (see
-//! [`Sgp4Elements::to_keplerian_elements`]) introduces tens-of-km error at epoch.
+//! to the SGP4 propagator. Treating them as classical orbital elements (a
+//! two-body interpretation) introduces tens-of-km error at epoch.
 //!
 //! Angles are stored in **radians** and mean motion in **rad/s** (orts
 //! conventions), converted from each format's native units (degrees, rev/day)
@@ -32,7 +32,6 @@ use core::fmt;
 use crate::math::F64Ext;
 
 use crate::epoch::{Epoch, Utc};
-use crate::kepler::{KeplerianElements, mean_to_true_anomaly};
 
 /// SGP4 mean orbital element set (no allocator required).
 ///
@@ -77,22 +76,12 @@ impl Sgp4Elements {
         (mu / (self.mean_motion * self.mean_motion)).cbrt()
     }
 
-    /// Convert to classical Keplerian elements.
+    /// Orbital period [s] from the mean motion: `2π / n`.
     ///
-    /// **Not the SGP4 orbit**: SGP4 mean elements are not osculating Keplerian
-    /// elements, so this two-body interpretation differs from the true SGP4
-    /// state by tens of km at epoch. It is the approximation the current
-    /// (pre-SGP4) ingestion path uses to seed an initial Cartesian state, and
-    /// will be replaced by proper SGP4 propagation.
-    pub fn to_keplerian_elements(&self, mu: f64) -> KeplerianElements {
-        KeplerianElements {
-            semi_major_axis: self.semi_major_axis(mu),
-            eccentricity: self.eccentricity,
-            inclination: self.inclination,
-            raan: self.raan,
-            argument_of_periapsis: self.argument_of_perigee,
-            true_anomaly: mean_to_true_anomaly(self.mean_anomaly, self.eccentricity),
-        }
+    /// Exact for the (Kozai) mean motion the element set carries, and needs no
+    /// `mu` — this is the conventional period reported for a TLE/OMM.
+    pub fn period(&self) -> f64 {
+        core::f64::consts::TAU / self.mean_motion
     }
 }
 
@@ -254,20 +243,12 @@ mod tests {
     }
 
     #[test]
-    fn iss_to_keplerian_elements() {
-        let el = iss_elements();
-        let kep = el.to_keplerian_elements(MU_EARTH);
-
-        assert!((kep.semi_major_axis - el.semi_major_axis(MU_EARTH)).abs() < 1e-9);
-        assert_eq!(kep.eccentricity, el.eccentricity);
-        assert_eq!(kep.inclination, el.inclination);
-        assert_eq!(kep.raan, el.raan);
-        assert_eq!(kep.argument_of_periapsis, el.argument_of_perigee);
-        // Near-circular orbit (e ≈ 0.0007): true anomaly ≈ mean anomaly.
-        let d_nu = (kep.true_anomaly - el.mean_anomaly).abs();
+    fn iss_period() {
+        let p = iss_elements().period();
+        // ISS mean motion ≈ 15.4956 rev/day → period ≈ 92.9 min ≈ 5576 s.
         assert!(
-            d_nu < 0.01,
-            "ν should be ≈ M for near-circular orbit, Δ={d_nu}"
+            (p - 5575.8).abs() < 2.0,
+            "ISS period should be ≈5576 s, got {p}"
         );
     }
 

--- a/arika/src/tle.rs
+++ b/arika/src/tle.rs
@@ -463,41 +463,6 @@ ISS (ZARYA)
     }
 
     #[test]
-    fn iss_keplerian_elements() {
-        let omm = parse(ISS_TLE).unwrap().elements;
-        let elements = omm.to_keplerian_elements(MU_EARTH);
-        let a = omm.semi_major_axis(MU_EARTH);
-        assert!((elements.semi_major_axis - a).abs() < 1e-6);
-        assert!((elements.inclination - omm.inclination).abs() < 1e-12);
-        assert!((elements.eccentricity - omm.eccentricity).abs() < 1e-12);
-    }
-
-    #[test]
-    fn iss_state_vector_plausible() {
-        let omm = parse(ISS_TLE).unwrap().elements;
-        let elements = omm.to_keplerian_elements(MU_EARTH);
-        let (pos, vel) = elements.to_state_vector(MU_EARTH);
-
-        let r = pos.magnitude();
-        let v = vel.magnitude();
-        let earth_radius = KnownBody::Earth.properties().radius;
-
-        let altitude = r - earth_radius;
-        assert!(
-            (400.0 - altitude).abs() < 30.0,
-            "ISS altitude from state vector: {altitude:.1} km"
-        );
-        assert!((v - 7.66).abs() < 0.2, "ISS velocity: {v:.3} km/s");
-
-        let energy = v * v / 2.0 - MU_EARTH / r;
-        let expected_energy = -MU_EARTH / (2.0 * elements.semi_major_axis);
-        assert!(
-            (energy - expected_energy).abs() / expected_energy.abs() < 1e-10,
-            "Energy mismatch: {energy} vs {expected_energy}"
-        );
-    }
-
-    #[test]
     fn geo_semi_major_axis() {
         let omm = parse(GEO_TLE).unwrap().elements;
         let a = omm.semi_major_axis(MU_EARTH);

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -605,12 +605,12 @@ pub fn run_simulation(params: &SimParams) -> Recording {
                 altitude, r0
             )
         }
-        OrbitSpec::Omm { elements, .. } => {
+        OrbitSpec::Omm { omm } => {
             format!(
                 "Initial orbit: from TLE/OMM (a = {:.1} km, e = {:.6}, i = {:.2}°)",
-                elements.semi_major_axis,
-                elements.eccentricity,
-                elements.inclination.to_degrees()
+                omm.semi_major_axis(params.mu),
+                omm.eccentricity,
+                omm.inclination.to_degrees()
             )
         }
     });
@@ -1095,12 +1095,12 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
                 altitude, r0
             )
         }
-        OrbitSpec::Omm { elements, .. } => {
+        OrbitSpec::Omm { omm } => {
             format!(
                 "Initial orbit: from TLE/OMM (a = {:.1} km, e = {:.6}, i = {:.2}°)",
-                elements.semi_major_axis,
-                elements.eccentricity,
-                elements.inclination.to_degrees()
+                omm.semi_major_axis(params.mu),
+                omm.eccentricity,
+                omm.inclination.to_degrees()
             )
         }
     });

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -524,18 +524,16 @@ impl SatelliteConfig {
                 let parsed = arika::tle::parse(&text)
                     .unwrap_or_else(|e| panic!("Failed to parse TLE in config: {e}"));
                 let tle = parsed.elements;
-                let elements = tle.to_keplerian_elements(mu);
-                let period = elements.period(mu);
+                let period = tle.period();
                 let tle_name = parsed.object_name.clone();
-                (OrbitSpec::Omm { omm: tle, elements }, period, tle_name)
+                (OrbitSpec::Omm { omm: tle }, period, tle_name)
             }
             OrbitConfig::Norad { norad_id } => {
                 let parsed = fetch_tle_by_norad_id(*norad_id);
                 let tle = parsed.elements;
-                let elements = tle.to_keplerian_elements(mu);
-                let period = elements.period(mu);
+                let period = tle.period();
                 let tle_name = parsed.object_name.clone();
-                (OrbitSpec::Omm { omm: tle, elements }, period, tle_name)
+                (OrbitSpec::Omm { omm: tle }, period, tle_name)
             }
         };
 

--- a/cli/src/satellite.rs
+++ b/cli/src/satellite.rs
@@ -23,11 +23,8 @@ pub enum OrbitSpec {
         raan: f64,
     },
     /// From a parsed element set — TLE or OMM input, both decode into the
-    /// canonical [`Sgp4Elements`] record — plus the derived Keplerian elements.
-    Omm {
-        omm: Sgp4Elements,
-        elements: KeplerianElements,
-    },
+    /// canonical [`Sgp4Elements`] record (propagated with SGP4).
+    Omm { omm: Sgp4Elements },
 }
 
 /// Per-satellite specification.
@@ -134,8 +131,9 @@ impl SatelliteSpec {
     pub fn altitude(&self, body: &KnownBody) -> f64 {
         match &self.orbit {
             OrbitSpec::Circular { altitude, .. } => *altitude,
-            OrbitSpec::Omm { elements, .. } => {
-                let perigee_r = elements.semi_major_axis * (1.0 - elements.eccentricity);
+            OrbitSpec::Omm { omm } => {
+                let a = omm.semi_major_axis(body.properties().mu);
+                let perigee_r = a * (1.0 - omm.eccentricity);
                 perigee_r - body.properties().radius
             }
         }
@@ -251,19 +249,17 @@ pub fn parse_sat_spec(s: &str, body: KnownBody) -> SatelliteSpec {
     let (orbit, period, derived_name) = if let Some(norad) = norad_id {
         let parsed = fetch_tle_by_norad_id(norad);
         let omm = parsed.elements;
-        let elements = omm.to_keplerian_elements(mu);
-        let period = elements.period(mu);
+        let period = omm.period();
         let obj_name = parsed.object_name.clone();
-        (OrbitSpec::Omm { omm, elements }, period, obj_name)
+        (OrbitSpec::Omm { omm }, period, obj_name)
     } else if let (Some(l1), Some(l2)) = (tle_line1, tle_line2) {
         let text = format!("{l1}\n{l2}");
         let parsed = arika::tle::parse(&text)
             .unwrap_or_else(|e| panic!("Failed to parse TLE in --sat: {e}"));
         let omm = parsed.elements;
-        let elements = omm.to_keplerian_elements(mu);
-        let period = elements.period(mu);
+        let period = omm.period();
         let obj_name = parsed.object_name.clone();
-        (OrbitSpec::Omm { omm, elements }, period, obj_name)
+        (OrbitSpec::Omm { omm }, period, obj_name)
     } else {
         let alt = altitude.unwrap_or(400.0);
         let r0 = body.properties().radius + alt;

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -256,13 +256,12 @@ impl SimParams {
 
             if let Some(parsed) = omm_opt {
                 let omm = parsed.elements;
-                let elements = omm.to_keplerian_elements(mu);
-                let period = elements.period(mu);
+                let period = omm.period();
                 let sat_name = parsed.object_name.clone();
                 vec![SatelliteSpec {
                     id: "default".to_string(),
                     name: sat_name,
-                    orbit: OrbitSpec::Omm { omm, elements },
+                    orbit: OrbitSpec::Omm { omm },
                     period,
                     ballistic_coeff: None,
                     srp_area_to_mass: None,
@@ -482,16 +481,12 @@ impl SimParams {
             .expect("embedded ISS TLE must be valid")
         });
         let iss_tle = parsed_iss.elements;
-        let elements = iss_tle.to_keplerian_elements(mu);
-        let period = elements.period(mu);
+        let period = iss_tle.period();
         let sat_name = parsed_iss.object_name.clone();
         sats.push(SatelliteSpec {
             id: "iss".to_string(),
             name: sat_name,
-            orbit: OrbitSpec::Omm {
-                omm: iss_tle,
-                elements,
-            },
+            orbit: OrbitSpec::Omm { omm: iss_tle },
             period,
             ballistic_coeff: None,
             srp_area_to_mass: None,


### PR DESCRIPTION
## 概要

TLE/OMM の初期状態は #241 で SGP4 経路に移行済み。本 PR は、その結果不要になった「昔の two-body 経路の残骸」を削除する純粋なクリーンアップで、観測できる挙動は変わらない(シミュレーション軌道は既に SGP4、表示値も同値)。バグ修正ではなく整理。

## 背景

`Sgp4Elements::to_keplerian_elements` は SGP4 平均要素を osculating Keplerian とみなす変換で、doc に「物理的に誤り(元期で数十km ずれる)」と明記されている。初期状態が SGP4 化された今、この変換は表示値(period・近点高度・a/e/i)を作るためだけに残っており、「誤りと知らずに再利用される」罠になっていた。`OrbitSpec::Omm` が抱える `elements: KeplerianElements` フィールドも、`omm: Sgp4Elements` から導ける重複データだった。

## 変更内容

### arika
- `Sgp4Elements::to_keplerian_elements` を削除。
- `Sgp4Elements::period(&self) -> f64`(= `2π / mean_motion`、秒、`mu` 不要)を追加。period は平均運動から直接出る量で、誤った変換を経由せずに取れる。
- `semi_major_axis(mu)` は表示用の近似として残置(doc 明記済み)。

### orts-cli
- `OrbitSpec::Omm { omm, elements }` → `Omm { omm }`(冗長な `KeplerianElements` フィールド撤去)。
- period・近点高度・a/e/i 概要を `Sgp4Elements` から直接導出。

## 振る舞い保存

観測出力は不変:
- シミュレーション軌道は既に SGP4(この変更と無関係)。
- period: `2π/mean_motion` は旧 `2π√(a³/μ)`(`a=(μ/n²)^(1/3)`)と代数的に一致(浮動小数の丸め ~1e-12 まで)。
- 近点高度・a/e/i 表示: 同じ `semi_major_axis(mu)`・同じフィールドから出すので同値。

## 検証

- `cargo clippy --locked --workspace -- -D warnings` clean、arika の no_std / alloc / sgp4 tier clippy も clean、`cargo fmt --all --check` clean。
- arika テスト・cli テスト(bin + ws_e2e 等の integration)全 pass。`to_keplerian_elements` の旧テストは削除(two-body 経路の検証であり、SGP4 状態ベクトルは #235 の Vallado fixture が押さえている)。新たに `Sgp4Elements::period()` のテスト(iss_period)を追加。
- `to_keplerian_elements` は未リリース(Unreleased)でのみ追加されていたため、公開済み crate API の破壊ではない。Unreleased CHANGELOG を現 API に更新。

codex review 反映済み(指摘: Unreleased CHANGELOG の記述ずれ → 修正)。
