### PR TITLE
refactor(arika): Sgp4Elements を検証付き型に(不正な要素セットを表現不可能化)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -138,10 +138,13 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 #### Added
 - 要素セットのパース ([#87](https://github.com/sksat/orts/pull/87))。共有の
   no-alloc な `elements::Sgp4Elements` (平均要素セット: カタログ番号、UTC epoch、
-  6 個の SGP4 平均要素、B\* drag。角度は rad、平均運動は rad/s) に
-  表示用ヘルパ `semi_major_axis(mu)` と `period()`。テキストパーサは
-  `elements::ParsedElementSet` (要素 + 所有する `OBJECT_NAME` / `OBJECT_ID`
-  識別子) を返し、形式判定する `elements::parse` がそれらに振り分ける。
+  6 個の SGP4 平均要素、B\* drag。角度は rad、平均運動は rad/s) を**検証付き型**に。
+  `Sgp4Elements::try_new` / `TryFrom<Sgp4ElementsFields>` で構築し、各フィールド
+  有限・mean motion 正・eccentricity ∈ [0,1) を強制(違反は `ElementsError`)。
+  フィールドは `fields()` で読み、表示用ヘルパ `semi_major_axis(mu)` と `period()`
+  を持つ。テキストパーサは `elements::ParsedElementSet` (要素 + 所有する
+  `OBJECT_NAME` / `OBJECT_ID` 識別子) を返し、検証に失敗した要素セットは reject
+  する。形式判定する `elements::parse` がそれらに振り分ける。
   - `tle` — NORAD TLE / 2LE / 3LE パーサ (`tle::parse`) が `ParsedElementSet` を生成。
     Alpha-5 英数字カタログ番号と `OBJECT_ID` 正規化に対応。
   - `omm::json` / `omm::kvn` / `omm::xml` — JSON / KVN / XML 各シリアライズの

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,11 +146,15 @@ section is subdivided by package.
 
 #### Added
 - Element-set parsing ([#87](https://github.com/sksat/orts/pull/87)). A shared
-  no-alloc `elements::Sgp4Elements` mean-element set (catalog number, UTC epoch,
-  six SGP4 mean elements, B\* drag; angles in radians, mean motion in rad/s) with
-  `semi_major_axis(mu)` and `period()` display helpers. The text parsers return
-  `elements::ParsedElementSet` (the elements plus owned `OBJECT_NAME` /
-  `OBJECT_ID` identity); the format-detecting `elements::parse` dispatches to them.
+  no-alloc `elements::Sgp4Elements` — a *validated* mean-element set (catalog
+  number, UTC epoch, six SGP4 mean elements, B\* drag; angles in radians, mean
+  motion in rad/s). Built with `Sgp4Elements::try_new` /
+  `TryFrom<Sgp4ElementsFields>`, which enforce finite fields, a positive mean
+  motion and an eccentricity in `[0, 1)` (returning `ElementsError`); fields are
+  read back with `fields()`, with `semi_major_axis(mu)` and `period()` display
+  helpers. The text parsers return `elements::ParsedElementSet` (the elements
+  plus owned `OBJECT_NAME` / `OBJECT_ID` identity) and reject element sets that
+  fail validation; the format-detecting `elements::parse` dispatches to them.
   - `tle` — NORAD TLE / 2LE / 3LE parser (`tle::parse`) → `ParsedElementSet`, with Alpha-5
     alphanumeric catalog numbers and `OBJECT_ID` normalization.
   - `omm::json` / `omm::kvn` / `omm::xml` — CCSDS OMM parsers for the JSON, KVN,

--- a/arika/src/elements.rs
+++ b/arika/src/elements.rs
@@ -3,8 +3,8 @@
 //!
 //! [`Sgp4Elements`] holds the numeric SGP4 mean elements an SGP4 propagator
 //! consumes — epoch, the six mean elements, the B* drag term, and the catalog
-//! number. It is `Copy` and needs no allocator, so the propagation path works
-//! in `no_std` builds without `alloc`.
+//! number — validated at construction. It needs no allocator, so the
+//! propagation path works in `no_std` builds without `alloc`.
 //!
 //! Owned satellite identity (`OBJECT_NAME` / `OBJECT_ID`) is split off into
 //! [`ParsedElementSet`], the alloc-gated record the text parsers return. Text
@@ -33,26 +33,37 @@ use crate::math::F64Ext;
 
 use crate::epoch::{Epoch, Utc};
 
-/// SGP4 mean orbital element set (no allocator required).
+/// SGP4 mean orbital element set — a *validated* mean-element record.
 ///
-/// The numeric core that an SGP4 propagator consumes. Both the legacy TLE and
-/// the CCSDS OMM (JSON/KVN/XML) carry the same mean-element data, so
-/// [`crate::tle`] and [`crate::omm`] both decode into this type (wrapped with
-/// identity strings in [`ParsedElementSet`]).
+/// Holding a `Sgp4Elements` guarantees the elements are physically usable:
+/// every field is finite, the mean motion is positive, and the eccentricity is
+/// in `[0, 1)`. Build one with [`try_new`](Self::try_new) (or `TryFrom`) from a
+/// [`Sgp4ElementsFields`]; the text parsers ([`crate::tle`], [`crate::omm`]) go
+/// through the same path, so a parsed element set is always valid. Read the
+/// fields back with [`fields`](Self::fields).
 ///
-/// The six elements are **SGP4 mean elements** (Brouwer-Kozai), not osculating
+/// The elements are **SGP4 mean elements** (Brouwer-Kozai), not osculating
 /// Keplerian elements — propagate them with SGP4 rather than converting to a
-/// classical orbit.
-#[derive(Debug, Clone, Copy, PartialEq)]
+/// classical orbit. No allocator required.
+#[derive(Debug, Clone, PartialEq)]
 pub struct Sgp4Elements {
+    fields: Sgp4ElementsFields,
+}
+
+/// The field bundle a [`Sgp4Elements`] wraps: the input to
+/// [`Sgp4Elements::try_new`] and the shape [`Sgp4Elements::fields`] hands back
+/// for reading. Holding a `Sgp4ElementsFields` does **not** imply validity —
+/// only a validated [`Sgp4Elements`] does.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Sgp4ElementsFields {
     /// `NORAD_CAT_ID` — catalog number. Alpha-5 alphanumeric ids are decoded to
     /// their numeric value (e.g. `"A0000"` → `100000`).
     pub norad_cat_id: u32,
     /// Element-set epoch (UTC).
     pub epoch: Epoch<Utc>,
-    /// Mean motion [rad/s].
+    /// Mean motion [rad/s] (positive).
     pub mean_motion: f64,
-    /// Eccentricity (dimensionless).
+    /// Eccentricity (dimensionless), in `[0, 1)`.
     pub eccentricity: f64,
     /// Inclination [rad].
     pub inclination: f64,
@@ -66,26 +77,110 @@ pub struct Sgp4Elements {
     pub bstar: f64,
 }
 
+/// An element field, reported by [`ElementsError`] to say which one is invalid.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ElementField {
+    Epoch,
+    MeanMotion,
+    Eccentricity,
+    Inclination,
+    Raan,
+    ArgumentOfPerigee,
+    MeanAnomaly,
+    Bstar,
+}
+
+/// Why a [`Sgp4ElementsFields`] is not a valid [`Sgp4Elements`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum ElementsError {
+    /// A field was NaN or infinite.
+    NonFinite(ElementField),
+    /// Mean motion was not strictly positive.
+    MeanMotionNotPositive,
+    /// Eccentricity was outside `[0, 1)`.
+    EccentricityOutOfRange,
+}
+
+impl core::fmt::Display for ElementsError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ElementsError::NonFinite(field) => write!(f, "element field {field:?} is not finite"),
+            ElementsError::MeanMotionNotPositive => write!(f, "mean motion must be positive"),
+            ElementsError::EccentricityOutOfRange => write!(f, "eccentricity must be in [0, 1)"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ElementsError {}
+
 impl Sgp4Elements {
+    /// Validate `fields` and wrap them as a `Sgp4Elements`.
+    ///
+    /// Returns an [`ElementsError`] if any field is non-finite, the mean motion
+    /// is not strictly positive, or the eccentricity is outside `[0, 1)`. Angles
+    /// are only checked for finiteness (not normalized — SGP4 reduces them mod
+    /// 2π), and `bstar` may be negative (it occurs in real element sets).
+    pub fn try_new(fields: Sgp4ElementsFields) -> Result<Self, ElementsError> {
+        use ElementField as F;
+        for (field, value) in [
+            (F::Epoch, fields.epoch.jd()),
+            (F::MeanMotion, fields.mean_motion),
+            (F::Eccentricity, fields.eccentricity),
+            (F::Inclination, fields.inclination),
+            (F::Raan, fields.raan),
+            (F::ArgumentOfPerigee, fields.argument_of_perigee),
+            (F::MeanAnomaly, fields.mean_anomaly),
+            (F::Bstar, fields.bstar),
+        ] {
+            if !value.is_finite() {
+                return Err(ElementsError::NonFinite(field));
+            }
+        }
+        if fields.mean_motion <= 0.0 {
+            return Err(ElementsError::MeanMotionNotPositive);
+        }
+        if !(0.0..1.0).contains(&fields.eccentricity) {
+            return Err(ElementsError::EccentricityOutOfRange);
+        }
+        Ok(Self { fields })
+    }
+
+    /// Read-only view of the validated fields.
+    pub fn fields(&self) -> &Sgp4ElementsFields {
+        &self.fields
+    }
+
+    /// Copy out the validated fields.
+    pub fn to_fields(&self) -> Sgp4ElementsFields {
+        self.fields.clone()
+    }
+
     /// Semi-major axis [km] from mean motion: `a = (μ/n²)^(1/3)`.
     ///
     /// A rough two-body estimate for display only — it ignores the J2 secular
     /// correction baked into the SGP4 (Kozai) mean motion, so it is not the
     /// semi-major axis SGP4 itself uses.
     pub fn semi_major_axis(&self, mu: f64) -> f64 {
-        (mu / (self.mean_motion * self.mean_motion)).cbrt()
+        (mu / (self.fields.mean_motion * self.fields.mean_motion)).cbrt()
     }
 
-    /// Orbital period [s] from the mean motion: `2π / |n|`.
+    /// Orbital period [s] from the mean motion: `2π / n`.
     ///
-    /// Exact for the (Kozai) mean motion the set carries, and needs no `mu` —
-    /// this is the conventional period reported for a TLE/OMM. `|n|` keeps a
-    /// sign-flipped mean motion from producing a negative period (matching the
-    /// magnitude the prior derived path produced). A zero or NaN mean motion
-    /// still propagates to a non-finite result; rejecting such an element set is
-    /// the parser's / SGP4 propagator's job, not this display helper's.
+    /// Positive — the mean motion is a validated, strictly-positive invariant
+    /// (so the period never goes negative or NaN; an absurdly tiny mean motion
+    /// could still overflow to `+∞`). Needs no `mu`; this is the conventional
+    /// period reported for a TLE/OMM.
     pub fn period(&self) -> f64 {
-        core::f64::consts::TAU / self.mean_motion.abs()
+        core::f64::consts::TAU / self.fields.mean_motion
+    }
+}
+
+impl TryFrom<Sgp4ElementsFields> for Sgp4Elements {
+    type Error = ElementsError;
+
+    fn try_from(fields: Sgp4ElementsFields) -> Result<Self, Self::Error> {
+        Self::try_new(fields)
     }
 }
 
@@ -223,7 +318,7 @@ mod tests {
 
     /// ISS-like element set, values from the canonical ISS TLE at epoch 2024-079.5.
     fn iss_elements() -> Sgp4Elements {
-        Sgp4Elements {
+        Sgp4Elements::try_new(Sgp4ElementsFields {
             norad_cat_id: 25544,
             epoch: Epoch::from_tle_epoch(24, 79.5),
             mean_motion: 15.49561654 * 2.0 * PI / 86400.0,
@@ -233,7 +328,8 @@ mod tests {
             argument_of_perigee: 35.3910_f64.to_radians(),
             mean_anomaly: 324.7580_f64.to_radians(),
             bstar: 3.0e-5,
-        }
+        })
+        .expect("valid ISS elements")
     }
 
     #[test]
@@ -257,16 +353,56 @@ mod tests {
     }
 
     #[test]
-    fn period_stays_positive_for_negative_mean_motion() {
-        // A sign-flipped (negative) mean motion must not yield a negative
-        // period (it flows into run horizons / reset boundaries).
-        let mut el = iss_elements();
-        el.mean_motion = -el.mean_motion;
-        assert!(
-            el.period() > 0.0,
-            "period must stay positive, got {}",
-            el.period()
+    fn try_new_rejects_invalid_elements() {
+        use ElementField as F;
+        let base = iss_elements().to_fields();
+
+        let bad = |f: Sgp4ElementsFields| Sgp4Elements::try_new(f).unwrap_err();
+        assert_eq!(
+            bad(Sgp4ElementsFields {
+                mean_motion: -base.mean_motion,
+                ..base.clone()
+            }),
+            ElementsError::MeanMotionNotPositive
         );
+        assert_eq!(
+            bad(Sgp4ElementsFields {
+                mean_motion: 0.0,
+                ..base.clone()
+            }),
+            ElementsError::MeanMotionNotPositive
+        );
+        assert_eq!(
+            bad(Sgp4ElementsFields {
+                mean_motion: f64::NAN,
+                ..base.clone()
+            }),
+            ElementsError::NonFinite(F::MeanMotion)
+        );
+        assert_eq!(
+            bad(Sgp4ElementsFields {
+                eccentricity: 1.0,
+                ..base.clone()
+            }),
+            ElementsError::EccentricityOutOfRange
+        );
+        assert_eq!(
+            bad(Sgp4ElementsFields {
+                eccentricity: -0.1,
+                ..base.clone()
+            }),
+            ElementsError::EccentricityOutOfRange
+        );
+        assert_eq!(
+            bad(Sgp4ElementsFields {
+                inclination: f64::INFINITY,
+                ..base.clone()
+            }),
+            ElementsError::NonFinite(F::Inclination)
+        );
+
+        // The unmodified base is valid.
+        assert!(Sgp4Elements::try_new(base).is_ok());
     }
 
     // ── Format detection / dispatch ──────────────────────────────
@@ -318,8 +454,8 @@ NORAD_CAT_ID = 25544";
     fn parse_dispatches_every_format() {
         for src in [TLE_2L, TLE_3L, JSON, KVN, XML] {
             let set = parse(src).unwrap();
-            assert_eq!(set.elements.norad_cat_id, 25544);
-            assert!((set.elements.inclination.to_degrees() - 51.64).abs() < 1e-6);
+            assert_eq!(set.elements.fields().norad_cat_id, 25544);
+            assert!((set.elements.fields().inclination.to_degrees() - 51.64).abs() < 1e-6);
         }
     }
 
@@ -329,7 +465,10 @@ NORAD_CAT_ID = 25544";
         // A UTF-8 BOM (not whitespace!) must not break sniffing or parsing.
         let bom_json = ["\u{feff}", JSON].concat();
         assert_eq!(detect(&bom_json), Some(Format::OmmJson));
-        assert_eq!(parse(&bom_json).unwrap().elements.norad_cat_id, 25544);
+        assert_eq!(
+            parse(&bom_json).unwrap().elements.fields().norad_cat_id,
+            25544
+        );
         let bom_xml = ["\u{feff}", XML].concat();
         assert_eq!(detect(&bom_xml), Some(Format::OmmXml));
         let bom_tle = ["\u{feff}", TLE_2L].concat();

--- a/arika/src/omm/json.rs
+++ b/arika/src/omm/json.rs
@@ -18,7 +18,7 @@ use crate::math::F64Ext;
 
 use serde::Deserialize;
 
-use crate::elements::{ParsedElementSet, Sgp4Elements};
+use crate::elements::{ElementsError, ParsedElementSet, Sgp4Elements, Sgp4ElementsFields};
 
 /// Error type for OMM JSON parsing.
 #[derive(Debug, Clone, PartialEq)]
@@ -28,6 +28,9 @@ pub enum JsonParseError {
     /// `EPOCH` was not a parseable ISO-8601 UTC timestamp (calendar or
     /// ordinal / day-of-year form).
     InvalidEpoch(String),
+    /// The parsed values are not a valid element set (e.g. non-positive mean
+    /// motion or out-of-range eccentricity).
+    InvalidElements(ElementsError),
 }
 
 impl fmt::Display for JsonParseError {
@@ -35,6 +38,7 @@ impl fmt::Display for JsonParseError {
         match self {
             JsonParseError::Malformed(e) => write!(f, "malformed OMM JSON: {e}"),
             JsonParseError::InvalidEpoch(s) => write!(f, "invalid OMM EPOCH: '{s}'"),
+            JsonParseError::InvalidElements(e) => write!(f, "invalid OMM element set: {e}"),
         }
     }
 }
@@ -136,18 +140,21 @@ pub fn parse(json: &str) -> Result<ParsedElementSet, JsonParseError> {
     let epoch = crate::elements::parse_epoch(&raw.epoch)
         .ok_or_else(|| JsonParseError::InvalidEpoch(raw.epoch.clone()))?;
 
+    let elements = Sgp4Elements::try_new(Sgp4ElementsFields {
+        norad_cat_id: raw.norad_cat_id,
+        epoch,
+        mean_motion: raw.mean_motion * 2.0 * PI / 86400.0, // rev/day → rad/s
+        eccentricity: raw.eccentricity,
+        inclination: raw.inclination.to_radians(),
+        raan: raw.ra_of_asc_node.to_radians(),
+        argument_of_perigee: raw.arg_of_pericenter.to_radians(),
+        mean_anomaly: raw.mean_anomaly.to_radians(),
+        bstar: raw.bstar,
+    })
+    .map_err(JsonParseError::InvalidElements)?;
+
     Ok(ParsedElementSet {
-        elements: Sgp4Elements {
-            norad_cat_id: raw.norad_cat_id,
-            epoch,
-            mean_motion: raw.mean_motion * 2.0 * PI / 86400.0, // rev/day → rad/s
-            eccentricity: raw.eccentricity,
-            inclination: raw.inclination.to_radians(),
-            raan: raw.ra_of_asc_node.to_radians(),
-            argument_of_perigee: raw.arg_of_pericenter.to_radians(),
-            mean_anomaly: raw.mean_anomaly.to_radians(),
-            bstar: raw.bstar,
-        },
+        elements,
         object_name: raw.object_name,
         object_id: raw.object_id,
     })
@@ -178,7 +185,7 @@ mod tests {
     #[test]
     fn parse_iss_omm_json() {
         let set = parse(ISS_OMM_JSON).unwrap();
-        let omm = set.elements;
+        let omm = set.elements.to_fields();
         assert_eq!(set.object_name.as_deref(), Some("ISS (ZARYA)"));
         assert_eq!(set.object_id.as_deref(), Some("1998-067A"));
         assert_eq!(omm.norad_cat_id, 25544);
@@ -196,15 +203,15 @@ mod tests {
         assert!((omm.bstar - 3.0e-5).abs() < 1e-10);
 
         // Semi-major axis consistent with the ISS (~6796 km).
-        assert!((omm.semi_major_axis(MU_EARTH) - 6796.0).abs() < 5.0);
+        assert!((set.elements.semi_major_axis(MU_EARTH) - 6796.0).abs() < 5.0);
     }
 
     #[test]
     fn epoch_without_z_suffix_is_accepted() {
         // CelesTrak omits the trailing 'Z'; ensure both forms parse identically.
         let with_z = ISS_OMM_JSON.replace("12:00:00.000000", "12:00:00.000000Z");
-        let a = parse(ISS_OMM_JSON).unwrap().elements;
-        let b = parse(&with_z).unwrap().elements;
+        let a = parse(ISS_OMM_JSON).unwrap().elements.to_fields();
+        let b = parse(&with_z).unwrap().elements.to_fields();
         assert_eq!(a.epoch, b.epoch);
     }
 
@@ -235,7 +242,7 @@ mod tests {
     fn parse_single_element_array() {
         // CelesTrak single-satellite OMM JSON is sometimes a 1-element array.
         let arr = ["[", ISS_OMM_JSON, "]"].concat();
-        assert_eq!(parse(&arr).unwrap().elements.norad_cat_id, 25544);
+        assert_eq!(parse(&arr).unwrap().elements.fields().norad_cat_id, 25544);
     }
 
     #[test]
@@ -260,7 +267,7 @@ mod tests {
             "MEAN_ANOMALY": "324.7580",
             "BSTAR": "0.00003"
         }"#;
-        let omm = parse(j).unwrap().elements;
+        let omm = parse(j).unwrap().elements.to_fields();
         assert_eq!(omm.norad_cat_id, 25544);
         assert!((omm.inclination.to_degrees() - 51.64).abs() < 1e-9);
         assert!((omm.bstar - 3.0e-5).abs() < 1e-10);
@@ -273,6 +280,6 @@ mod tests {
     fn bom_prefixed_json_parses_directly() {
         // Direct calls (not via elements::parse) must also tolerate a leading BOM.
         let bom = ["\u{feff}", ISS_OMM_JSON].concat();
-        assert_eq!(parse(&bom).unwrap().elements.norad_cat_id, 25544);
+        assert_eq!(parse(&bom).unwrap().elements.fields().norad_cat_id, 25544);
     }
 }

--- a/arika/src/omm/kvn.rs
+++ b/arika/src/omm/kvn.rs
@@ -14,7 +14,7 @@ use core::str::FromStr;
 #[allow(unused_imports)]
 use crate::math::F64Ext;
 
-use crate::elements::{ParsedElementSet, Sgp4Elements};
+use crate::elements::{ElementsError, ParsedElementSet, Sgp4Elements, Sgp4ElementsFields};
 
 /// Error type for OMM KVN parsing.
 #[derive(Debug, Clone, PartialEq)]
@@ -26,6 +26,9 @@ pub enum KvnParseError {
     /// `EPOCH` was not a parseable ISO-8601 UTC timestamp (calendar or
     /// ordinal / day-of-year form).
     InvalidEpoch(String),
+    /// The parsed values are not a valid element set (e.g. non-positive mean
+    /// motion or out-of-range eccentricity).
+    InvalidElements(ElementsError),
 }
 
 impl fmt::Display for KvnParseError {
@@ -36,6 +39,7 @@ impl fmt::Display for KvnParseError {
                 write!(f, "invalid value for {key}: '{value}'")
             }
             KvnParseError::InvalidEpoch(s) => write!(f, "invalid OMM EPOCH: '{s}'"),
+            KvnParseError::InvalidElements(e) => write!(f, "invalid OMM element set: {e}"),
         }
     }
 }
@@ -104,18 +108,22 @@ pub fn parse(kvn: &str) -> Result<ParsedElementSet, KvnParseError> {
     let arg_perigee = arg_perigee.ok_or(KvnParseError::MissingField("ARG_OF_PERICENTER"))?;
     let mean_anomaly = mean_anomaly.ok_or(KvnParseError::MissingField("MEAN_ANOMALY"))?;
 
+    let norad_cat_id = norad_cat_id.ok_or(KvnParseError::MissingField("NORAD_CAT_ID"))?;
+    let elements = Sgp4Elements::try_new(Sgp4ElementsFields {
+        norad_cat_id,
+        epoch,
+        mean_motion: mean_motion * 2.0 * PI / 86400.0, // rev/day → rad/s
+        eccentricity,
+        inclination: inclination.to_radians(),
+        raan: raan.to_radians(),
+        argument_of_perigee: arg_perigee.to_radians(),
+        mean_anomaly: mean_anomaly.to_radians(),
+        bstar,
+    })
+    .map_err(KvnParseError::InvalidElements)?;
+
     Ok(ParsedElementSet {
-        elements: Sgp4Elements {
-            norad_cat_id: norad_cat_id.ok_or(KvnParseError::MissingField("NORAD_CAT_ID"))?,
-            epoch,
-            mean_motion: mean_motion * 2.0 * PI / 86400.0, // rev/day → rad/s
-            eccentricity,
-            inclination: inclination.to_radians(),
-            raan: raan.to_radians(),
-            argument_of_perigee: arg_perigee.to_radians(),
-            mean_anomaly: mean_anomaly.to_radians(),
-            bstar,
-        },
+        elements,
         object_name,
         object_id,
     })
@@ -177,7 +185,7 @@ BSTAR = 0.00003
     #[test]
     fn parse_iss_omm_kvn() {
         let set = parse(ISS_OMM_KVN).unwrap();
-        let omm = set.elements;
+        let omm = set.elements.to_fields();
         assert_eq!(set.object_name.as_deref(), Some("ISS (ZARYA)"));
         assert_eq!(set.object_id.as_deref(), Some("1998-067A"));
         assert_eq!(omm.norad_cat_id, 25544);
@@ -194,7 +202,7 @@ BSTAR = 0.00003
         assert!((mm_rev_day - 15.49561654).abs() < 1e-8);
         assert!((omm.bstar - 3.0e-5).abs() < 1e-10);
 
-        assert!((omm.semi_major_axis(MU_EARTH) - 6796.0).abs() < 5.0);
+        assert!((set.elements.semi_major_axis(MU_EARTH) - 6796.0).abs() < 5.0);
     }
 
     #[test]
@@ -241,6 +249,6 @@ NORAD_CAT_ID = 1";
     fn bom_prefixed_kvn_parses_directly() {
         // Direct calls (not via elements::parse) must also tolerate a leading BOM.
         let bom = ["\u{feff}", ISS_OMM_KVN].concat();
-        assert_eq!(parse(&bom).unwrap().elements.norad_cat_id, 25544);
+        assert_eq!(parse(&bom).unwrap().elements.fields().norad_cat_id, 25544);
     }
 }

--- a/arika/src/omm/xml.rs
+++ b/arika/src/omm/xml.rs
@@ -17,7 +17,7 @@ use core::str::FromStr;
 #[allow(unused_imports)]
 use crate::math::F64Ext;
 
-use crate::elements::{ParsedElementSet, Sgp4Elements};
+use crate::elements::{ElementsError, ParsedElementSet, Sgp4Elements, Sgp4ElementsFields};
 
 /// Error type for OMM XML parsing.
 #[derive(Debug, Clone, PartialEq)]
@@ -29,6 +29,9 @@ pub enum XmlParseError {
     /// `EPOCH` was not a parseable ISO-8601 UTC timestamp (calendar or
     /// ordinal / day-of-year form).
     InvalidEpoch(String),
+    /// The parsed values are not a valid element set (e.g. non-positive mean
+    /// motion or out-of-range eccentricity).
+    InvalidElements(ElementsError),
 }
 
 impl fmt::Display for XmlParseError {
@@ -39,6 +42,7 @@ impl fmt::Display for XmlParseError {
                 write!(f, "invalid value for {key}: '{value}'")
             }
             XmlParseError::InvalidEpoch(s) => write!(f, "invalid OMM EPOCH: '{s}'"),
+            XmlParseError::InvalidElements(e) => write!(f, "invalid OMM element set: {e}"),
         }
     }
 }
@@ -66,18 +70,21 @@ pub fn parse(xml: &str) -> Result<ParsedElementSet, XmlParseError> {
         None => 0.0,
     };
 
+    let elements = Sgp4Elements::try_new(Sgp4ElementsFields {
+        norad_cat_id,
+        epoch,
+        mean_motion: mean_motion * 2.0 * PI / 86400.0, // rev/day → rad/s
+        eccentricity,
+        inclination: inclination.to_radians(),
+        raan: raan.to_radians(),
+        argument_of_perigee: arg_perigee.to_radians(),
+        mean_anomaly: mean_anomaly.to_radians(),
+        bstar,
+    })
+    .map_err(XmlParseError::InvalidElements)?;
+
     Ok(ParsedElementSet {
-        elements: Sgp4Elements {
-            norad_cat_id,
-            epoch,
-            mean_motion: mean_motion * 2.0 * PI / 86400.0, // rev/day → rad/s
-            eccentricity,
-            inclination: inclination.to_radians(),
-            raan: raan.to_radians(),
-            argument_of_perigee: arg_perigee.to_radians(),
-            mean_anomaly: mean_anomaly.to_radians(),
-            bstar,
-        },
+        elements,
         object_name: element_text(xml, "OBJECT_NAME").map(String::from),
         object_id: element_text(xml, "OBJECT_ID").map(String::from),
     })
@@ -167,7 +174,7 @@ mod tests {
     #[test]
     fn parse_iss_omm_xml() {
         let set = parse(ISS_OMM_XML).unwrap();
-        let omm = set.elements;
+        let omm = set.elements.to_fields();
         assert_eq!(set.object_name.as_deref(), Some("ISS (ZARYA)"));
         assert_eq!(set.object_id.as_deref(), Some("1998-067A"));
         assert_eq!(omm.norad_cat_id, 25544);
@@ -185,7 +192,7 @@ mod tests {
         assert!((mm_rev_day - 15.49561654).abs() < 1e-8);
         assert!((omm.bstar - 3.0e-5).abs() < 1e-10);
 
-        assert!((omm.semi_major_axis(MU_EARTH) - 6796.0).abs() < 5.0);
+        assert!((set.elements.semi_major_axis(MU_EARTH) - 6796.0).abs() < 5.0);
     }
 
     #[test]

--- a/arika/src/sgp4.rs
+++ b/arika/src/sgp4.rs
@@ -70,53 +70,37 @@ impl Sgp4Propagator {
     ///
     /// Uses AFSPC compatibility mode (WGS72 + AFSPC sidereal time / epoch).
     pub fn from_elements(elements: &Sgp4Elements) -> Result<Self, Sgp4Error> {
-        // Reject non-finite inputs up front: a NaN slips through sgp4's `<= 0`
-        // and range checks (every comparison is false), so guard the public
-        // entry point explicitly. The epoch is checked here too (before
-        // `to_datetime()`, whose float→int casts would otherwise turn a
-        // non-finite Julian date into a garbage calendar date).
-        if ![
-            elements.inclination,
-            elements.raan,
-            elements.eccentricity,
-            elements.argument_of_perigee,
-            elements.mean_anomaly,
-            elements.mean_motion,
-            elements.bstar,
-            elements.epoch.jd(),
-        ]
-        .iter()
-        .all(|x| x.is_finite())
-        {
-            return Err(Sgp4Error::Initialization);
-        }
+        // `Sgp4Elements` is validated at construction (finite fields, positive
+        // mean motion, eccentricity in [0, 1)), so no defensive check is needed
+        // here — feed the fields straight to sgp4.
+        let f = elements.fields();
 
         // arika stores angles in radians and mean motion in rad/s; sgp4's
         // `from_kozai_elements` wants radians and the Kozai mean motion in
         // rad/min (rad/s × 60).
         let orbit = Orbit::from_kozai_elements(
             &WGS72,
-            elements.inclination,
-            elements.raan,
-            elements.eccentricity,
-            elements.argument_of_perigee,
-            elements.mean_anomaly,
-            elements.mean_motion * 60.0,
+            f.inclination,
+            f.raan,
+            f.eccentricity,
+            f.argument_of_perigee,
+            f.mean_anomaly,
+            f.mean_motion * 60.0,
         )
         .map_err(|_| Sgp4Error::Initialization)?;
 
         let constants = Constants::new(
             WGS72,
             afspc_epoch_to_sidereal_time,
-            afspc_years_since_j2000(&elements.epoch.to_datetime()),
-            elements.bstar,
+            afspc_years_since_j2000(&f.epoch.to_datetime()),
+            f.bstar,
             orbit,
         )
         .map_err(|_| Sgp4Error::Initialization)?;
 
         Ok(Self {
             constants,
-            epoch: elements.epoch,
+            epoch: f.epoch,
         })
     }
 
@@ -191,6 +175,7 @@ fn afspc_years_since_j2000(d: &DateTime) -> f64 {
 #[cfg(all(test, feature = "alloc"))]
 mod tests {
     use super::*;
+    use crate::elements::Sgp4ElementsFields;
     use crate::tle;
     use alloc::format;
 
@@ -253,7 +238,7 @@ mod tests {
         let prop = Sgp4Propagator::from_elements(&elements).unwrap();
 
         // propagate(epoch) must agree with propagate_minutes_since_epoch(0).
-        let (r_abs, v_abs) = prop.propagate(elements.epoch).unwrap();
+        let (r_abs, v_abs) = prop.propagate(elements.fields().epoch).unwrap();
         let (r_min, v_min) = prop.propagate_minutes_since_epoch(0.0).unwrap();
         assert!((r_abs.into_inner() - r_min.into_inner()).norm() < 1.0e-6);
         assert!((v_abs.into_inner() - v_min.into_inner()).norm() < 1.0e-9);
@@ -261,7 +246,7 @@ mod tests {
         // A *nonzero* offset pins the `(t − epoch) × 1440` conversion (factor
         // and sign): 6 h later by the absolute clock must equal +360 minutes.
         // At delta == 0 above, any broken scale or sign would still pass.
-        let t_6h = elements.epoch.add_seconds(360.0 * 60.0);
+        let t_6h = elements.fields().epoch.add_seconds(360.0 * 60.0);
         let (r6_abs, v6_abs) = prop.propagate(t_6h).unwrap();
         let (r6_min, v6_min) = prop.propagate_minutes_since_epoch(360.0).unwrap();
         assert!((r6_abs.into_inner() - r6_min.into_inner()).norm() < 1.0e-6);
@@ -275,8 +260,12 @@ mod tests {
         // Pin that by straddling the 2017-01-01 leap (TAI−UTC: 36 → 37 s).
         // The orbit is arbitrary (Vallado 00005); only the internal consistency
         // of the two propagate paths matters, not the absolute state.
-        let mut elements = tle::parse(&format!("{L1}\n{L2}")).unwrap().elements;
-        elements.epoch = Epoch::<Utc>::from_gregorian(2016, 12, 31, 23, 59, 0.0);
+        let parsed = tle::parse(&format!("{L1}\n{L2}")).unwrap().elements;
+        let elements = Sgp4Elements::try_new(Sgp4ElementsFields {
+            epoch: Epoch::<Utc>::from_gregorian(2016, 12, 31, 23, 59, 0.0),
+            ..parsed.to_fields()
+        })
+        .unwrap();
         let prop = Sgp4Propagator::from_elements(&elements).unwrap();
 
         let (r_min, _) = prop.propagate_minutes_since_epoch(2.0).unwrap();
@@ -286,7 +275,7 @@ mod tests {
         // tolerance is 1 m, not bit-exact: the UTC↔TAI leap-second search rounds
         // the round-tripped epoch by ~7 µs here (≈6 cm of motion), far below the
         // ~8 km the leap-aware path differs by.
-        let t_naive = elements.epoch.add_seconds(2.0 * 60.0);
+        let t_naive = elements.fields().epoch.add_seconds(2.0 * 60.0);
         let (r_naive, _) = prop.propagate(t_naive).unwrap();
         assert!(
             (r_naive.into_inner() - r_min.into_inner()).norm() < 1.0e-3,
@@ -297,7 +286,7 @@ mod tests {
         // consumed by the 23:59:60 leap — so the wrapper sees ~1 s less and the
         // result must DIFFER. This is what discriminates the naive convention
         // from a leap-safe one (≈1 s of orbital motion, ≫ 0.1 km).
-        let t_si = elements.epoch.add_si_seconds(2.0 * 60.0);
+        let t_si = elements.fields().epoch.add_si_seconds(2.0 * 60.0);
         let (r_si, _) = prop.propagate(t_si).unwrap();
         assert!(
             (r_si.into_inner() - r_min.into_inner()).norm() > 0.1,
@@ -378,28 +367,6 @@ mod tests {
             assert!(
                 (mine - reference).abs() < 1.0e-12,
                 "{y}-{mo}-{d}T{h}:{mi}:{s}.{ns}: {mine} vs {reference}"
-            );
-        }
-    }
-
-    #[test]
-    fn rejects_non_finite_elements() {
-        let valid = tle::parse(&format!("{L1}\n{L2}")).unwrap().elements;
-        assert!(Sgp4Propagator::from_elements(&valid).is_ok());
-
-        let spoils: [fn(&mut Sgp4Elements); 5] = [
-            |e| e.mean_motion = f64::NAN,
-            |e| e.eccentricity = f64::INFINITY,
-            |e| e.inclination = f64::NAN,
-            |e| e.bstar = f64::NEG_INFINITY,
-            |e| e.epoch = Epoch::<Utc>::from_jd(f64::NAN),
-        ];
-        for spoil in spoils {
-            let mut bad = valid;
-            spoil(&mut bad);
-            assert!(
-                Sgp4Propagator::from_elements(&bad).is_err(),
-                "non-finite element / epoch must be rejected"
             );
         }
     }

--- a/arika/src/tle.rs
+++ b/arika/src/tle.rs
@@ -22,7 +22,7 @@ use core::str::FromStr;
 #[allow(unused_imports)]
 use crate::math::F64Ext;
 
-use crate::elements::{ParsedElementSet, Sgp4Elements};
+use crate::elements::{ElementsError, ParsedElementSet, Sgp4Elements, Sgp4ElementsFields};
 use crate::epoch::Epoch;
 
 /// Error type for TLE parsing failures.
@@ -40,6 +40,9 @@ pub enum TleParseError {
         field: &'static str,
         value: String,
     },
+    /// The parsed values are not a valid element set (e.g. non-positive mean
+    /// motion or out-of-range eccentricity).
+    InvalidElements(ElementsError),
 }
 
 impl fmt::Display for TleParseError {
@@ -51,6 +54,7 @@ impl fmt::Display for TleParseError {
             TleParseError::InvalidField { line, field, value } => {
                 write!(f, "Invalid {field} on line {line}: '{value}'")
             }
+            TleParseError::InvalidElements(e) => write!(f, "invalid TLE element set: {e}"),
         }
     }
 }
@@ -157,18 +161,21 @@ pub fn parse(text: &str) -> Result<ParsedElementSet, TleParseError> {
     let mean_anomaly_deg = parse_field::<f64>(line2, 43, 51, 2, "mean_anomaly")?;
     let mean_motion_rev_day = parse_field::<f64>(line2, 52, 63, 2, "mean_motion")?;
 
+    let elements = Sgp4Elements::try_new(Sgp4ElementsFields {
+        norad_cat_id,
+        epoch,
+        mean_motion: mean_motion_rev_day * 2.0 * PI / 86400.0, // rev/day → rad/s
+        eccentricity,
+        inclination: inclination_deg.to_radians(),
+        raan: raan_deg.to_radians(),
+        argument_of_perigee: arg_perigee_deg.to_radians(),
+        mean_anomaly: mean_anomaly_deg.to_radians(),
+        bstar,
+    })
+    .map_err(TleParseError::InvalidElements)?;
+
     Ok(ParsedElementSet {
-        elements: Sgp4Elements {
-            norad_cat_id,
-            epoch,
-            mean_motion: mean_motion_rev_day * 2.0 * PI / 86400.0, // rev/day → rad/s
-            eccentricity,
-            inclination: inclination_deg.to_radians(),
-            raan: raan_deg.to_radians(),
-            argument_of_perigee: arg_perigee_deg.to_radians(),
-            mean_anomaly: mean_anomaly_deg.to_radians(),
-            bstar,
-        },
+        elements,
         object_name: name,
         object_id,
     })
@@ -362,7 +369,7 @@ ISS (ZARYA)
     #[test]
     fn parse_iss_3line() {
         let set = parse(ISS_TLE).unwrap();
-        let omm = set.elements;
+        let omm = set.elements.to_fields();
         assert_eq!(set.object_name.as_deref(), Some("ISS (ZARYA)"));
         assert_eq!(set.object_id.as_deref(), Some("1998-067A"));
         assert_eq!(omm.norad_cat_id, 25544);
@@ -381,7 +388,7 @@ ISS (ZARYA)
     #[test]
     fn parse_iss_2line() {
         let set = parse(ISS_TLE_2LINE).unwrap();
-        let omm = set.elements;
+        let omm = set.elements.to_fields();
         assert!(set.object_name.is_none());
         assert_eq!(omm.norad_cat_id, 25544);
         assert!((omm.inclination.to_degrees() - 51.64).abs() < 0.01);
@@ -392,7 +399,10 @@ ISS (ZARYA)
         // A leading UTF-8 BOM must not break the line-1 prefix check
         // (matches the BOM tolerance of the unified `elements::parse` entry point).
         let bom_tle = ["\u{feff}", ISS_TLE_2LINE].concat();
-        assert_eq!(parse(&bom_tle).unwrap().elements.norad_cat_id, 25544);
+        assert_eq!(
+            parse(&bom_tle).unwrap().elements.fields().norad_cat_id,
+            25544
+        );
     }
 
     #[test]
@@ -408,7 +418,7 @@ ISS (ZARYA)
 
     #[test]
     fn parse_geo_satellite() {
-        let omm = parse(GEO_TLE).unwrap().elements;
+        let omm = parse(GEO_TLE).unwrap().elements.to_fields();
         assert_eq!(omm.norad_cat_id, 28358);
         assert!(
             omm.inclination.to_degrees() < 1.0,
@@ -433,7 +443,7 @@ ISS (ZARYA)
 
     #[test]
     fn iss_epoch() {
-        let omm = parse(ISS_TLE).unwrap().elements;
+        let omm = parse(ISS_TLE).unwrap().elements.to_fields();
         let dt = omm.epoch.to_datetime();
         assert_eq!(dt.year, 2024);
         assert_eq!(dt.month, 3);
@@ -474,8 +484,8 @@ ISS (ZARYA)
 
     #[test]
     fn three_line_and_two_line_produce_same_result() {
-        let omm3 = parse(ISS_TLE).unwrap().elements;
-        let omm2 = parse(ISS_TLE_2LINE).unwrap().elements;
+        let omm3 = parse(ISS_TLE).unwrap().elements.to_fields();
+        let omm2 = parse(ISS_TLE_2LINE).unwrap().elements.to_fields();
         assert_eq!(omm3.norad_cat_id, omm2.norad_cat_id);
         assert!((omm3.inclination - omm2.inclination).abs() < 1e-15);
         assert!((omm3.raan - omm2.raan).abs() < 1e-15);
@@ -486,7 +496,7 @@ ISS (ZARYA)
     #[test]
     fn iss_bstar() {
         // ISS TLE has "30000-4" → 0.30000e-4 = 3.0e-5
-        let omm = parse(ISS_TLE).unwrap().elements;
+        let omm = parse(ISS_TLE).unwrap().elements.to_fields();
         assert!(
             (omm.bstar - 3.0e-5).abs() < 1e-10,
             "ISS B* should be 3.0e-5, got {:.6e}",
@@ -497,7 +507,7 @@ ISS (ZARYA)
     #[test]
     fn geo_bstar_zero() {
         // GEO TLE has "00000+0" → 0.0
-        let omm = parse(GEO_TLE).unwrap().elements;
+        let omm = parse(GEO_TLE).unwrap().elements.to_fields();
         assert_eq!(omm.bstar, 0.0, "GEO B* should be 0.0, got {}", omm.bstar);
     }
 
@@ -513,7 +523,7 @@ ISS (ZARYA)
     #[test]
     fn alpha5_catalog_number() {
         // Alpha-5: leading 'A' = 10 → 10 * 10000 + 0000 = 100000.
-        let omm = parse(ALPHA5_TLE).unwrap().elements;
+        let omm = parse(ALPHA5_TLE).unwrap().elements.to_fields();
         assert_eq!(omm.norad_cat_id, 100000);
         // The rest of the element set must still parse normally.
         assert!((omm.inclination.to_degrees() - 51.64).abs() < 0.01);

--- a/arika/tests/trybuild/null_eop_in_to_ut1.stderr
+++ b/arika/tests/trybuild/null_eop_in_to_ut1.stderr
@@ -16,7 +16,7 @@ help: the following other types implement trait `Ut1Offset`
    |
    | impl Ut1Offset for EopTable {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `EopTable`
-note: required by a bound in `epoch::convert::<impl Epoch<Utc, P>>::to_ut1`
+note: required by a bound in `epoch::convert::<impl arika::epoch::Epoch<Utc, P>>::to_ut1`
   --> src/epoch/convert.rs
    |
    |     pub fn to_ut1<E: crate::earth::eop::Ut1Offset + ?Sized>(&self, eop: &E) -> Ut1Epoch {

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -609,8 +609,8 @@ pub fn run_simulation(params: &SimParams) -> Recording {
             format!(
                 "Initial orbit: from TLE/OMM (a = {:.1} km, e = {:.6}, i = {:.2}°)",
                 omm.semi_major_axis(params.mu),
-                omm.eccentricity,
-                omm.inclination.to_degrees()
+                omm.fields().eccentricity,
+                omm.fields().inclination.to_degrees()
             )
         }
     });
@@ -1099,8 +1099,8 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
             format!(
                 "Initial orbit: from TLE/OMM (a = {:.1} km, e = {:.6}, i = {:.2}°)",
                 omm.semi_major_axis(params.mu),
-                omm.eccentricity,
-                omm.inclination.to_degrees()
+                omm.fields().eccentricity,
+                omm.fields().inclination.to_degrees()
             )
         }
     });

--- a/cli/src/satellite.rs
+++ b/cli/src/satellite.rs
@@ -133,7 +133,7 @@ impl SatelliteSpec {
             OrbitSpec::Circular { altitude, .. } => *altitude,
             OrbitSpec::Omm { omm } => {
                 let a = omm.semi_major_axis(body.properties().mu);
-                let perigee_r = a * (1.0 - omm.eccentricity);
+                let perigee_r = a * (1.0 - omm.fields().eccentricity);
                 perigee_r - body.properties().radius
             }
         }

--- a/cli/src/sim/core.rs
+++ b/cli/src/sim/core.rs
@@ -176,7 +176,7 @@ pub fn spacecraft_accel_breakdown(
 /// Convert a SatelliteSpec to SatelliteParams for OrbitalSystem construction.
 pub fn sat_params(spec: &SatelliteSpec) -> SatelliteParams {
     let has_bstar_drag =
-        matches!(&spec.orbit, OrbitSpec::Omm { omm, .. } if omm.bstar.abs() > 1e-15);
+        matches!(&spec.orbit, OrbitSpec::Omm { omm, .. } if omm.fields().bstar.abs() > 1e-15);
     SatelliteParams {
         has_drag: has_bstar_drag || spec.ballistic_coeff.is_some(),
         ballistic_coeff: spec.ballistic_coeff,

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -109,7 +109,7 @@ fn default_auto_threshold() -> usize {
 /// them.
 fn element_set_epoch(satellites: &[SatelliteSpec]) -> Option<Epoch> {
     satellites.iter().find_map(|s| match &s.orbit {
-        OrbitSpec::Omm { omm, .. } => Some(omm.epoch),
+        OrbitSpec::Omm { omm, .. } => Some(omm.fields().epoch),
         OrbitSpec::Circular { .. } => None,
     })
 }


### PR DESCRIPTION
## これは何

`Sgp4Elements`(SGP4 平均要素の型)に「妥当な値しか持てない」制約を**型で**持たせる変更です。いまは不正な要素(負の平均運動、`e≥1`、NaN など)を持つ値を作れてしまい、その不正がシミュレーション伝播の段階まで素通りし得ます。これを、要素を作る入口(パーサ)で弾き、**不正な `Sgp4Elements` がそもそも存在できない**ようにします。

正しさのバグ修正ではなく、不正値を作れてしまう設計自体の堅牢化です。

## なぜ

`Sgp4Elements` は全フィールド公開・`Copy` の素のデータ構造で、値が物理的に妥当である保証が型にありませんでした。そのため:

- パーサが NaN や負の平均運動を無検証で受け取り、不正な要素を作れる。
- 表示用の `period()` などは構築時に評価されるため、不正値が伝播より前に流れ得る(先行 PR #243 のレビューで `period()` の符号・非有限が繰り返し問題になった根因がこれ)。

## どう変えるか

「作るときに一度検証する → 以後は型が妥当性を保証する」形にします。

- `Sgp4Elements` は内部フィールドを隠し、`Sgp4Elements::try_new(Sgp4ElementsFields { … })`(または `TryFrom`)でのみ構築する。ここで **各値が有限・平均運動 > 0・離心率 ∈ [0,1)** を検証し、違反は `ElementsError` を返す。
- TLE / OMM(JSON・KVN・XML)の各パーサはこの `try_new` を通すので、**不正な要素セットはパース時点でエラー**になる。
- 値の読み出しは `fields()`(参照)/ `to_fields()`(複製)。

不変条件が立った副産物として:

- `period()` を素直な `2π/n` に戻せた(#243 で入れていた `.abs()` 防御を撤去)。
- `Sgp4Propagator::from_elements` の有限性チェックが不要になり削除。
- `Copy` を外した(80 byte 程度のドメイン型で `Copy` は不要、`Clone` で足りる)。

検証の線引き: 角度(傾斜・RAAN 等)は有限のみ見て正規化しない(SGP4 が mod 2π で吸収するため)、`bstar` は負も許可(実データに存在する)、カタログ番号は無制約。

## 影響(振る舞いの変更)

不正な要素セット(負の平均運動・`e∉[0,1)`・非有限)は、**今までパースできていたものが今後はエラー**になります。妥当な入力の挙動は変わりません。

## 検証

- clippy(workspace + arika の no_std / alloc / sgp4 各 tier)・fmt・arika/cli の全テスト green。
- 追加テスト: `try_new` の拒否(負/0/NaN の平均運動、`e=1.0`/負、非有限角度)。削除テスト: 公開フィールド前提だった propagator の「正常な要素を壊して弾かれるか見る」テスト(不変条件で不能になるため。拒否カバレッジは `try_new` テストへ移動)。
- trybuild: 公開型(`Sgp4ElementsFields` 等)を増やしたことで rustc の診断パス短縮が揺れ、無関係な EOP テストの出力が `Epoch` → `arika::epoch::Epoch` に変化。該当 `.stderr` を 1 行だけ更新(toolchain は `rust-toolchain.toml` の 1.96.0 固定で CI と一致)。

codex review 反映済み(指摘: `period()` doc の "finite" が極小 mean motion で overflow し得る → "positive" に修正)。
