### PR TITLE
chore(renovate): group rand and rand_distr updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -48,6 +48,12 @@
       "matchPackageNames": ["/^wasmtime/"]
     },
     {
+      "description": "rand_distr's major hard-depends on the matching rand major (rand_distr 0.6 -> rand ^0.10), so a split bump leaves two rand majors in the tree and fails to build (Distribution trait mismatch); the maintainer co-releases the majors. Not filtered by matchUpdateTypes because Renovate classifies a 0.x breaking bump (0.9->0.10) as minor. Retire if rand_distr's rand dep ever spans two majors.",
+      "matchManagers": ["cargo"],
+      "groupName": "rand",
+      "matchPackageNames": ["rand", "rand_distr"]
+    },
+    {
       "description": "three.js, @types/three and the @react-three/* ecosystem must move in lockstep across all workspaces (viewer, tobari/examples/web, orbit-viewer); a split bump leaves two @types/three versions in the tree and fails the viewer TypeScript build (TS2322)",
       "matchManagers": ["npm"],
       "groupName": "three",


### PR DESCRIPTION
rand 系の Renovate PR が CI で落ち続けている（**#132 rand 0.10 と #133 rand_distr 0.6 が両方赤**）。この PR はその根本原因を Renovate 設定で取り除く。

## 原因

rand_distr は同じ系列の rand を要求する（rand_distr 0.6 は `rand = "^0.10.0"`）。今は別々の PR で更新されるため、**片方だけ上げると rand が 0.9 系と 0.10 系で二重に混ざり、ビルドが通らない**（`Distribution` trait が一致しない）。

## この PR の変更

rand と rand_distr を1つのグループにまとめ、Renovate が**常に1つの PR で一緒に**更新するようにする。これで #132 / #133 は1本のまとまった PR に置き換わる。

## なぜまとめてよいか（片方待ちで PR が止まらないか）

rand と rand_distr は、メンテナが**意図的に足並みをそろえてリリースしている**一組。rand_distr のメジャーは対応する rand のメジャーに合わせて出され（rand_distr 0.6 ⇄ rand 0.10）、別リポジトリに分離した今もこの協調は続いている。たまたまリリース時期が近いのではなく上流の運用方針なので、グループにしても「片方のリリースを待って PR が止まる」ことはない。既存の `wasmtime` グループと同じ前提。

## 想定質問: なぜ「major だけ」に絞らないのか

Renovate は 0.x の更新を semver の桁で分類するため、破壊的な `0.9 → 0.10` を内部的に **"minor"** と扱う。`matchUpdateTypes: ["major"]` で絞ると、まさに今回の更新を取りこぼして設定が無効になる。同じ系列内では更新は互換なので、全更新をまとめても害はない。

将来 rand_distr が複数系列の rand を許すようになったら、このルールは不要になる（その時に削除）。

## この PR だけでは CI は緑にならない（別作業）

- **rand 0.10 へのコード追従**: `orts/src/sensor/noise.rs` の修正（`use rand::RngExt;` の追加など）が別途必要。このグループ設定は「依存どうしの整合」を保証するだけ。
- **getrandom #37**: rand とは無関係の wasm 向け feature の問題で、このグループの対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
