### PR TITLE
docs(changelog): catch [Unreleased] up with main for 0.3.0

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -28,23 +28,80 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   msg-io の `deliver` / `take_outbound`、raw byte stream 用 stream-io の
   `stream_deliver` / `stream_take` / `stream_close`。([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 - WIT v0 plugin interface に msg-io / stream-io チャネルを追加。([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
+- `perturbations::ZonalGravity<F: EarthRotationPole = SimpleEci>` — zonal 調和項
+  (J2 と任意の J3 / J4) を `GravityField` でなく極を意識した摂動 `Model` として
+  扱う。フレームの Z 軸を極と決め打ちせず、中心天体の自転極まわりで評価する
+  (`ZonalGravity::new(mu, r_body, j2, j3, j4)`)。`SimpleEci` では極が `+Z` なので
+  従来の frame-Z 式と数値的に同一、`Gcrs` では IAU 2006 CIP なので J2 が地球の
+  真の極まわりで評価される (2024 epoch で GCRS Z 軸から ~0.1°)。
+  `setup::build_orbital_system` / `build_spacecraft_dynamics` は
+  `PointMass` + `ZonalGravity` を合成する (これらが構築する `SimpleEci` 系では
+  振る舞い保存)。drag なしの J2 + 第三体 ISS クロスバリデーションでは、Orekit に
+  対する `Gcrs` の最終位置誤差が 1 桁以上改善する。([#194](https://github.com/sksat/orts/pull/194), [#204](https://github.com/sksat/orts/pull/204))
+- `PanelSrp` を frame-generic 化。`Model` 実装が `SimpleEci` 固定でなく
+  `F: EphemerisFrameBridge` 境界になり、`GCRS → F` のエフェメリス回転を定義する
+  任意のフレームで姿勢依存の panel SRP が使える。GCRS 整列の
+  `SimpleEci` / `Gcrs` ではビット単位で同一。([#238](https://github.com/sksat/orts/pull/238))
 
 #### Changed
 - `StateEffector` を frame-generic 化 — `StateEffector<S, F: frame::Eci =
   SimpleEci>` で `ExternalLoads<F>` を返す (`Model<S, F>` と同様)。effector は
   host の慣性 frame で荷重を生成するようになった。既定の `F` により既存の
   `StateEffector<S>` 実装はそのままコンパイル可能。([#148](https://github.com/sksat/orts/pull/148))
+- `ThirdBodyGravity` と `SolarRadiationPressure` を、あらゆる `Eci` フレームに
+  blanket 実装するのをやめて frame-correct にした。`Model` 実装を
+  `arika::earth::transform::EphemerisFrameBridge` 境界にし、解析 (GCRS) の
+  太陽 / 月エフェメリスを積分フレームへ回転してから衛星状態と差分を取る。
+  `SimpleEci` / `Gcrs` では数値不変 (identity 回転)、`Cirs` では precession /
+  nutation 回転が適用され、`EphemerisFrameBridge` 実装の無いフレーム (例 `Teme`)
+  は黙った誤フレーム混在でなくコンパイルエラーになる。([#193](https://github.com/sksat/orts/pull/193), [#237](https://github.com/sksat/orts/pull/237), [#191](https://github.com/sksat/orts/issues/191))
+- 大気抵抗の co-rotation 速度 `Ω × r` を、フレームの `+Z` でなく中心天体の真の
+  自転軸まわりで取る。地球では軸を積分フレーム上の
+  `EarthRotationPole::earth_pole` から得る — `SimpleEci` は `+Z` (従来の
+  `[0, 0, ω] × r` とビット単位で同一)、`Gcrs` は IAU 2006 CIP となり、`+Z` 仮定に
+  よる ~0.1–0.3° のずれが解消する。`|Ω|` の LOD 変動は依然未実装。地球以外の
+  中心天体ではフレーム Z 軸とその天体の `omega_body` を維持し、その天体の実際の
+  自転軸の向きはモデル化しない (既知の制限)。([#209](https://github.com/sksat/orts/pull/209), [#210](https://github.com/sksat/orts/issues/210))
+- **BREAKING**: `perturbations::BodyPositionFn` — したがって
+  `ThirdBodyGravity::custom` — が `&Epoch` (`Epoch<Utc>`) でなく `&Epoch<Tdb>` を
+  取る。天体エフェメリスは力学時の量であるため。力モデルの呼び出し境界で
+  `.to_tdb()` 変換する。カスタムエフェメリスのクロージャは型を変更する必要が
+  ある。([#222](https://github.com/sksat/orts/pull/222))
+- **BREAKING**: `magnetic::field_inertial`、`visibility::VisibilityMonitor`、
+  `perturbations::AtmosphericDrag` のフレーム capability 境界が
+  `orts::environment::EarthFrameBridge` から `arika::earth::EarthFixedTransform`
+  になった。関連アイテム (`Fixed`、`EopStorage`、`to_geodetic`、
+  `fixed_to_inertial`) は不変なので、下流は import パスの変更のみで済む。([#213](https://github.com/sksat/orts/pull/213))
 
 #### Fixed
 - `SpacecraftDynamics` の不正な frame 再タグを除去。`ExternalLoads<SimpleEci>`
   とタグ付けされた effector 荷重を変換なしで host frame `F` に貼り替えており、
   `F != SimpleEci` (例: `Gcrs`) で座標を黙って誤ラベルしていた。出荷済み
   effector が torque のみのため潜在的だったが、並進 effector では誤りとなる。([#148](https://github.com/sksat/orts/pull/148), [#103](https://github.com/sksat/orts/issues/103))
+- 力モデルに渡す絶対エポックを、一様 SI タイムライン上の `epoch_0 + t`
+  (`Epoch::add_si_seconds`) にした (`OrbitalSystem`、`SpacecraftDynamics`、
+  `AttitudeSystem`、`DecoupledAttitudeSystem`、`AugmentedAttitudeSystem`、
+  `VisibilityMonitor::update`)。従来の leap 非対応な `add_seconds` は `t` を UTC
+  カレンダー上で進めていたため、leap second を跨ぐステップで物理時間が 1 秒余分に
+  進み、エフェメリス・地球回転・コンタクトウィンドウの幾何を誤った瞬間で評価して
+  いた。([#215](https://github.com/sksat/orts/pull/215))
 
 #### Removed
 - **BREAKING**: `orts::tle` module を削除。TLE パースは `arika::tle`
   (共有 `arika::elements::Sgp4Elements` へデコード) に移管。`orts::tle` を使う
   下流コードは `arika` へ移行が必要。([#87](https://github.com/sksat/orts/pull/87))
+- **BREAKING**: `orts::environment` module を削除。内容は `arika` へ移設・改名
+  した: `EarthFrameBridge` → `arika::earth::EarthFixedTransform`、
+  `EarthPoleBridge` → `arika::earth::EarthRotationPole`、`PositionEop` /
+  `GcrsEopStorage` → `arika::earth::eop::{PositionEop, GcrsEopStorage}`
+  (`arika::earth` からも再エクスポート)。`orts` 側に互換の再エクスポートは
+  残していない。なお `arika` の `PositionEop` は `Send + Sync` を要求しない —
+  スレッド安全性は boxed な `GcrsEopStorage` が担う。([#213](https://github.com/sksat/orts/pull/213))
+- **BREAKING**: `orbital::gravity::ZonalHarmonics` を削除。`GravityField` は真に
+  frame-invariant な `PointMass` のみになった。扁平率は摂動 `Model` として扱う —
+  `OrbitalSystem::new(mu, Box::new(ZonalHarmonics { r_body, j2, j3, j4 }))` を
+  `OrbitalSystem::new(mu, Box::new(PointMass)).with_model(ZonalGravity::new(mu, r_body, j2, j3, j4))`
+  に置き換える (`mu` を摂動側に明示的に渡す点に注意)。([#204](https://github.com/sksat/orts/pull/204))
 
 ### `orts-cli` (Rust, crates.io, binary)
 
@@ -100,6 +157,41 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   は併用不可。`--tle-line1` / `--tle-line2` は両方指定が必須。([#87](https://github.com/sksat/orts/pull/87))
 - TLE epoch の day-of-year を (閏考慮の) 年日数で検証。不正値はそのまま別の
   年に繰り上がらず拒否される。([#87](https://github.com/sksat/orts/pull/87))
+- **BREAKING**: config キーの alias を、キーごとに正準の 1 綴りへ集約した。
+  `[[command]]`、`[[ground_station]]`、`[satellites.magnetorquers]`、
+  `[satellites.thruster]` のみが受理され、従来の `[[commands]]`、
+  `[[ground_stations]]`、`[satellites.mtq]`、`[satellites.thrusters]` は削除。
+  うち `mtq` / `thrusters` はリリース済み 0.2.0 の config での正準綴りだった。
+  未知のキーは拒否されず無視されるため、古い綴りの config はその節を**黙って**
+  失う — キーを改名すること。([#200](https://github.com/sksat/orts/pull/200))
+- **BREAKING**: TLE / OMM 軌道の初期状態を、接触ケプラー要素として読むのでなく
+  実際の SGP4 伝播で求める。要素セットを `arika` の SGP4 で評価エポックまで伝播し、
+  得られた TEME 状態を積分フレームへ回転する (`FrameTransform<Teme, SimpleEci>`)。
+  従来の二体変換はエポックで数十 km 誤っていたため、`--tle` / `--omm` /
+  `--norad-id` / `[satellites.orbit] type = "tle"|"norad"` の軌道は変化する。
+  あわせて `--epoch` (または config の `epoch`) 省略時、最初の衛星が TLE / OMM
+  軌道ならシミュレーションエポックが**その要素セットのエポック**(tsince = 0) を
+  既定にする (従来は「現在時刻」)。要素セットが複数ある場合、tsince = 0 は最初の
+  1 つだけで、残りは共有エポックから外挿される。円軌道は影響を受けない。([#241](https://github.com/sksat/orts/pull/241))
+- **BREAKING**: TLE / OMM 軌道と地球以外の中心天体の組み合わせを事前に拒否する
+  (SGP4 / TEME は地球中心・WGS72)。3 経路すべてで有効: `orts run` / `orts serve`
+  の起動時、WebSocket の `StartSimulation` config (panic でなくクライアントへ
+  エラー)、動的な `add_satellite`。従来は地球基準の SGP4 状態を他天体の μ・半径・
+  摂動セットで積分していた。([#241](https://github.com/sksat/orts/pull/241))
+- `orts serve` のモデル別加速度内訳 (WebSocket `State` メッセージの
+  `accelerations` map) に `zonal_gravity` エントリが加わり、`gravity` は点質量項
+  のみになった。扁平率が重力場から独立した摂動モデルへ移ったため。合計加速度は
+  不変。([#194](https://github.com/sksat/orts/pull/194))
+- 実行中の `orts serve` セッションに追加した衛星は、初期状態を
+  `epoch + current_t` で評価する。TLE / OMM は `t = 0` でなく参加した瞬間まで
+  伝播される。不正な要素セットはサーバをクラッシュさせずエラーとして報告する。([#241](https://github.com/sksat/orts/pull/241))
+- config 検証を厳格化し、config を読む全経路 (`orts run`、
+  `orts serve --config`、`orts config validate`) でシミュレーション開始前に走る
+  ようにした。未知の `body`、不正な `epoch`、不正なインライン
+  `[satellites.orbit] type = "tle"` は後段の panic でなく明確なエラーになる。([#216](https://github.com/sksat/orts/pull/216))
+- `orts run` は矛盾する stdout 要求を (長時間になりうる) シミュレーション実行前に
+  拒否し、これら使用法エラーには exit status 2 を返す。`--format rrd` の stdout
+  出力も対象で、従来はシミュレーション完走後に exit 1 していた。([#214](https://github.com/sksat/orts/pull/214))
 
 #### Fixed
 - `orts run --format csv --output <path>` が CSV を `<path>` に書き込むように
@@ -108,6 +200,9 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - `--config` ファイルで起動した `orts serve` は `[[command]]` タイムラインを
   含む config を明確なエラーで拒否する (コマンドタイムラインは `orts run`
   のみ)。従来は黙って破棄していた。([#58](https://github.com/sksat/orts/pull/58))
+- シミュレーション時刻を一様 SI タイムライン (`Epoch::add_si_seconds`) 上で
+  進めるようにした。leap second を跨ぐ実行でも、力モデル・センサ・plugin tick に
+  渡すエポックが 1 秒余分にずれない。([#215](https://github.com/sksat/orts/pull/215))
 
 ### `orts-plugin-sdk` (Rust, crates.io)
 
@@ -136,7 +231,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 ### `arika` (Rust, crates.io)
 
 #### Added
-- 要素セットのパース ([#87](https://github.com/sksat/orts/pull/87))。共有の
+- 要素セットのパース ([#87](https://github.com/sksat/orts/pull/87), [#230](https://github.com/sksat/orts/pull/230), [#245](https://github.com/sksat/orts/pull/245))。共有の
   no-alloc な `elements::Sgp4Elements` (平均要素セット: カタログ番号、UTC epoch、
   6 個の SGP4 平均要素、B\* drag。角度は rad、平均運動は rad/s) を**検証付き型**に。
   `Sgp4Elements::try_new` / `TryFrom<Sgp4ElementsFields>` で構築し、各フィールド
@@ -153,9 +248,10 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   - `elements::detect` + `elements::parse` — 形式判定 (`elements::Format`) と、TLE / OMM-JSON /
     OMM-KVN / OMM-XML を自動判定して振り分ける BOM 許容の統一エントリ。
 - optional な `sgp4` feature による SGP4 / SDP4 伝播
-  (`sgp4::Sgp4Propagator`): `Sgp4Elements` から構築し、epoch の
-  `Constants` を再利用して TEME の `(Vec3<Teme>, Vec3<Teme>)` 状態 (km / km·s)
-  へ伝播。`sgp4` crate を AFSPC compatibility mode (WGS72) でラップ。依存は
+  (`sgp4::Sgp4Propagator`): `from_elements` が epoch の `Constants` を呼び出し
+  間で再利用し、`propagate_minutes_since_epoch` / `propagate(Epoch<Utc>)` が
+  TEME の `(Vec3<Teme>, Vec3<Teme>)` 状態 (km / km·s) または `Sgp4Error`
+  (`Initialization` / `Diverged`。非有限の要求時刻も含む) を返す。`sgp4` crate を AFSPC compatibility mode (WGS72) でラップ。依存は
   `libm` のみで引くため no_std-no-alloc ビルドでも動作。Vallado 検証ベクタの
   near-earth (SGP4) と deep-space (SDP4) で検証済み。([#235](https://github.com/sksat/orts/pull/235))
 - TEME↔GCRS / TEME↔SimpleEci フレーム回転。SGP4 の `Vec3<Teme>` 状態を積分
@@ -175,11 +271,92 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - `earth::topocentric` — 地上局の look angle: `TopocentricSite<F: Ecef>`
   (WGS-84 `Geodetic` から構築し局所 ENU 基底を事前計算) と `LookAngles`
   (方位 / 仰角 / slant range)。`look_angles(target)` で算出。([#112](https://github.com/sksat/orts/pull/112))
+- GPS Time を first-class な時刻 scale に: `epoch::Gps` marker と `Epoch<Gps>`
+  (`from_jd_gps`)、変換エッジ (`Epoch::<Utc>::to_gps`、`Epoch::<Tai>::to_gps`、
+  `Epoch::<Gps>::to_tai` / `to_utc`)。leap second を持たない固定の TAI − 19 s。
+  GNSS の week / seconds-of-week は生の整数でなく型で表す: `GpsWeek`
+  (1024 週ロールオーバのない連続カウント)、10-bit の航法メッセージ week を解決
+  する `GpsWeek::from_broadcast(raw10, reference)`、範囲検査付き
+  `SecondsOfWeek`、`Epoch::<Gps>::from_week_seconds` / `to_week_seconds`、
+  定数 `GPS_EPOCH_JD`。([#192](https://github.com/sksat/orts/pull/192))
+- `epoch::FixedOffsetFromTai` — TAI からのオフセットが固定 SI 秒である scale の
+  capability trait (`Tai` 0、`Tt` +32.184、`Gps` −19)。`SECONDS_AFTER_TAI` が
+  対応する変換エッジの単一の真実になる。UTC (leap second による区分)、TDB
+  (周期項)、UT1 (EOP 依存) は意図的に実装しないので、「TAI からのオフセットが
+  定数」は規約でなく型レベルの事実になった。([#192](https://github.com/sksat/orts/pull/192))
+- `Epoch::duration_since(&earlier)` — 共有 TAI タイムライン上で測る厳密な SI 秒
+  間隔。leap second を跨いでも、scale が異なっても正しい (`earlier` は別 scale で
+  よい)。([#205](https://github.com/sksat/orts/pull/205))
+- `epoch::TwoPartJd` と sealed な `epoch::JdRepr` — ユリウス日を `hi + lo` の
+  2 部分 (SOFA 形式) で保持し、日内小数に完全な mantissa を残す。
+  `Epoch::jd_parts()` が単一 `f64` へ潰さずに `(hi, lo)` を渡す。([#205](https://github.com/sksat/orts/pull/205), [#208](https://github.com/sksat/orts/pull/208))
+- 精度 tier を型に: `Epoch<S, P: Precision>`。sealed な tier は `Precise`
+  (既定、2 部分 JD、16 バイト、sub-nanosecond) と `Coarse` (単一 `f64`、8 バイト、
+  数十 µs。RAM と cycle が厳しい wasm / no_std ターゲット向け)。
+  `Epoch::to_precision::<Q>()` で変換し `precision_name()` で参照する。tier は
+  monomorphize され、混在には明示変換が必要。`Epoch` / `Epoch<S>` は従来どおり
+  `Epoch<Utc, Precise>` を意味する。([#208](https://github.com/sksat/orts/pull/208))
+- `earth::transform` — フレームごとの地球姿勢 capability trait 群。
+  `orts::environment` から移設・改名した: `EarthRotationPole` (`earth_pole`。
+  zonal 重力と大気の co-rotation が必要とする最小の capability) と
+  `EarthFixedTransform` (対になる `Fixed: Ecef` フレーム、`to_geodetic`、
+  `fixed_to_inertial`、状態変換の factory)。`SimpleEci` (ERA のみの Z 回転、極は
+  `+Z`) と `Gcrs` (IAU 2006 CIO チェーン、極は model CIP) に実装。支える
+  `earth::eop::PositionEop` bound と型消去された `earth::eop::GcrsEopStorage` も
+  一緒に移設。([#213](https://github.com/sksat/orts/pull/213))
+- `frame::FrameTransform<From, To>` — `Rotation` の運動学的な相棒。向きに加えて
+  `From` に対する `To` の角速度を持ち、transport theorem で速度と状態全体を
+  変換する (`transform_position`、`transform_velocity`、`transform_state`、
+  `inverse`、`angular_velocity_in_from`)。地球 ECI↔ECEF の実体は
+  `EarthFixedTransform::inertial_to_fixed_transform` /
+  `fixed_to_inertial_transform` から得る。ω は `OMEGA · earth_pole` で地球スピンの
+  transport のみ (IAU 2006 の precession / nutation / polar motion の rate と LOD
+  補正は省略)。([#219](https://github.com/sksat/orts/pull/219))
+- `earth::transform::EphemerisFrameBridge` — `GCRS → F` の回転。third-body / SRP
+  の力モデルが、GCRS 整列フレームでしか正しくない生ベクトルを消費するのでなく、
+  解析 (Meeus) エフェメリスを積分フレームで表現できるようにする。`Gcrs` と
+  `SimpleEci` は identity、`Cirs` は EOP 不要の IAU 2006 model 回転
+  (`Rotation::<Gcrs, Cirs>::iau2006_model`)。impl の無いフレームはこれらの力と
+  組み合わせられないので、新しい of-date フレームは `GCRS → F` 回転を明示する
+  必要がある。([#237](https://github.com/sksat/orts/pull/237))
 
 #### Changed
 - `Epoch::from_iso8601` が ordinal / day-of-year 形式
   (`YYYY-DDDTHH:MM:SS`、CCSDS OMM で使用) も受理し、末尾の `Z` が任意になった。
   厳密な緩和で、従来受理した入力は引き続きパース可能。([#87](https://github.com/sksat/orts/pull/87))
+- **BREAKING**: `Epoch<S>` は内部で scale 固有のユリウス日でなく **正準 TAI の
+  瞬間**を保持する。scale 変換 (`to_tai`、`to_tt`、`to_tdb`、`to_gps` 等) は同一の
+  瞬間への非破壊な再タグになり、leap second テーブル・固定 TAI オフセット・TDB の
+  周期項は構築時 (`from_*`) と読み出し時 (`jd()`) にのみ適用される。
+  `from_jd_*(x).jd() == x` の往復は維持され `TimeScale` は sealed のままだが、
+  `Epoch` はもはや透過的な JD ラッパではない — `jd()` は保持フィールドでなく
+  scale ごとの読み出しであり、異なる経路で構築した同一の物理的瞬間が等しく
+  比較されるようになった。([#205](https://github.com/sksat/orts/pull/205))
+- **BREAKING**: 解析エフェメリスは `&Epoch<Utc>` を受けて内部変換するのをやめ、
+  `&Epoch<Tdb>` を要求する — `sun::sun_direction_eci`、`sun_position_eci`、
+  `sun_distance_km`、`equation_of_time`、`sun_direction_from_body`、
+  `sun_distance_from_body`、`moon::moon_position_eci`、`planets::obliquity`、
+  `planets::heliocentric_position_ecliptic`。これら Meeus モデルが定義される
+  力学時が型に現れる。呼び出し側が境界で `.to_tdb()` すれば数値は同一。UTC で
+  索引する `MoonEphemeris` trait は意図的に `&Epoch<Utc>` を維持。([#222](https://github.com/sksat/orts/pull/222))
+
+#### Fixed
+- `Epoch::<Utc>::add_si_seconds` が一様 TAI タイムライン上の厳密な SI 加算に
+  なった。従来の UTC を反復する実装は、結果が挿入された leap second の内側に
+  落ちる場合に最大 1 秒ずれていた。`add_si_seconds(dt)` の後に
+  `duration_since` で `dt` が復元されることを 2017-01-01 の leap で回帰テストに
+  固定した。([#205](https://github.com/sksat/orts/pull/205))
+
+#### Removed
+- **BREAKING**: `epoch::Ut1` scale marker を削除。UT1 は地球の自転で実現される
+  **観測量**(EOP) であって TAI からのデータ不要なオフセットではないため、
+  `Epoch<S>` が保持するようになった正準 TAI タイムラインを共有できない。
+  独立した `epoch::Ut1Epoch` (`from_jd_ut1`、`jd`、`era`) に移し、
+  `Epoch::<Utc>::to_ut1(eop)` / `to_ut1_naive()` からのみ到達する。
+  `&Epoch<Ut1>` を取っていたシグネチャは `&Ut1Epoch` を取る:
+  `Rotation::<SimpleEci, SimpleEcef>::from_ut1`、
+  `Rotation::<SimpleEcef, SimpleEci>::from_ut1`、
+  `Rotation::<Cirs, Tirs>::from_era`、`Rotation::<Gcrs, Itrs>::iau2006_full`。([#205](https://github.com/sksat/orts/pull/205))
 
 ### `utsuroi` (Rust, crates.io)
 
@@ -194,6 +371,18 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   `fetch-<source>` 規約(`fetch-igrf`、arika の `fetch-horizons`)に揃えた。
   `fetch` は全 `fetch-*` 源を束ねる傘 feature として存続するため、
   `features = ["fetch"]` は引き続きビルド可能(加えて `fetch-igrf` も有効化)。([#150](https://github.com/sksat/orts/pull/150))
+- **BREAKING**: `HarrisPriester::with_sun_direction_fn` が
+  `fn(&Epoch) -> Vec3<Gcrs>` (すなわち `Epoch<Utc>`) でなく
+  `fn(&Epoch<Tdb>) -> Vec3<Gcrs>` を取る。TDB エポックを要求するようになった
+  `arika` の解析エフェメリスに合わせたもの。モデル自身は UTC 入力を保ち、呼び出し
+  境界で `.to_tdb()` 変換する。太陽方向 hook を差し替えている場合は関数の型を
+  変更する必要がある。([#222](https://github.com/sksat/orts/pull/222))
+
+#### Fixed
+- 太陽エフェメリスの量を正しい時刻 scale で評価するようにした。Harris-Priester の
+  密度バルジ頂点は太陽方向を問う前に UTC エポックを TDB へ変換し、
+  `nrlmsise00::geo::local_solar_time` も均時差で同様にする。従来は UTC エポックを
+  TDB 引数のエフェメリスへそのまま渡していた (~69 秒の scale 誤差)。([#222](https://github.com/sksat/orts/pull/222))
 
 ### `viewer`
 
@@ -255,6 +444,12 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   init コストを払わない (固定の Sun 方向、天体回転なし)。([#89](https://github.com/sksat/orts/pull/89))
 - WS protocol 型は `ts-rs` 生成 binding になった (`orts-cli` 参照)。手書きの
   wire 型を置き換え、`satellite_added` variant を追加。([#95](https://github.com/sksat/orts/pull/95))
+- **BREAKING**: `ts-rs` の wire binding が正準化された config キーに追従した —
+  `SatelliteConfig.mtq` → `magnetorquers` (`start_simulation` の `SimConfig`
+  payload と、flatten された `add_satellite` メッセージの両方)、
+  `SimConfig.commands` → `command`、`SimConfig.ground_stations` →
+  `ground_station`。古いキーは拒否されず無視されるため、`mtq` を送り続ける WS
+  クライアントはエラーなしに magnetorquer 設定を失う。([#200](https://github.com/sksat/orts/pull/200))
 
 #### Fixed
 - static deploy での既定 WebSocket URL を、`window.location` から到達不能な
@@ -303,17 +498,40 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   — 例: <https://sksat.github.io/orts/llms.txt> を agent に渡す。`llms-full.txt`
   は全文、`llms-small.txt` は自動生成 API リファレンスを除いた要約版。([#225](https://github.com/sksat/orts/pull/225))
 
+#### Changed
+- ドキュメントサイトを Astro 7 + Starlight 0.40 (および `@astrojs/react` 6) で
+  動かすようにした。sidebar の `autogenerate` グループは Starlight 0.40 の
+  ネスト schema へ移行 (そのままでは 0.40 が受理しない)。自動生成の rustdoc /
+  typedoc API セクションは従来どおり折りたたみのまま。([#126](https://github.com/sksat/orts/pull/126), [#180](https://github.com/sksat/orts/pull/180), [#250](https://github.com/sksat/orts/pull/250))
+- docs サイトを CI で gate するようにした。ドキュメントに影響する PR で Astro /
+  Starlight のフルビルドを走らせ (従来は main への push のみで、ビルド退行が
+  マージ後に判明していた)、サイトの `.astro` / `.ts` ソースを `astro check` で
+  型検査する (`astro build` では検査されない)。([#180](https://github.com/sksat/orts/pull/180), [#233](https://github.com/sksat/orts/pull/233))
+
 ### Dependencies
 
-- Rust toolchain → 1.96.0。
+- Rust toolchain → 1.96.1。
+- 新規 Rust 依存: `sgp4` 2.4。`arika` の optional な `sgp4` feature 経由で、
+  `libm` のみを引くため no_std / no-alloc tier も引き続きビルドできる。
+  `orts-cli` が有効化する。
 - Rust: `wasmtime` / `wasmtime-wasi` 44 (security)、`rerun` 0.33、
-  `tokio-tungstenite` 0.29、`nalgebra` 0.35、`tokio` 1.52、`axum` 0.8.9。
+  `tokio-tungstenite` 0.29、`nalgebra` 0.35、`tokio` 1.52、`axum` 0.8.9、
+  `kble-socket` 0.5 (E2E job の `kble` CLI も 0.5)、`rand` 0.10 /
+  `rand_distr` 0.6、`wit-bindgen` 0.58 (`orts-plugin-sdk` の binding 生成)、
+  `clap` 4.6、`thiserror` 2.0、`toml` 1.1。
 - `notalawyer` 0.3 — 埋め込む third-party ライセンス NOTICE を、`cargo about`
   バイナリでなく cargo-about **ライブラリ**(`orts-cli` の build-dependency)で
   生成するようにした。CI でのバイナリ install と cross ビルドイメージへの
   埋め込みが不要になった。
 - npm: `vite` 8、`@vitejs/plugin-react` 6、React monorepo、`ws` 8.21
-  (security)、`mermaid` 11.15 (security)。
+  (security)、`mermaid` 11.16 (security)、Astro 7 (`@astrojs/starlight` 0.40 +
+  `@astrojs/react` 6。Astro 7.1.0 は security リリース)、TypeScript 6、
+  Biome 2.5、`vite-plugin-dts` 5、`three` 0.184、docs の `llms.txt` 生成に使う
+  `starlight-llms-txt` 0.10。
+- ツール: pnpm 11 — workspace は `allowBuilds` を明示的に宣言し (pnpm 11 は
+  さもなければ install を拒否する)、`minimumReleaseAge` の供給網フロアが
+  `--frozen-lockfile` install でも強制される。加えて Node.js 24 と
+  wasi-sdk 33 (`nos3-adcs` example のビルド)。
 
 ## [0.2.0](https://github.com/sksat/orts/releases/tag/v0.2.0) - 2026-04-20
 

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -34,7 +34,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   (`ZonalGravity::new(mu, r_body, j2, j3, j4)`)。`SimpleEci` では極が `+Z` なので
   従来の frame-Z 式と数値的に同一、`Gcrs` では IAU 2006 CIP なので J2 が地球の
   真の極まわりで評価される (2024 epoch で GCRS Z 軸から ~0.1°)。
-  `setup::build_orbital_system` / `build_spacecraft_dynamics` は
+  `setup::build_orbital_system` / `setup::build_spacecraft_dynamics` は
   `PointMass` + `ZonalGravity` を合成する (これらが構築する `SimpleEci` 系では
   振る舞い保存)。drag なしの J2 + 第三体 ISS クロスバリデーションでは、Orekit に
   対する `Gcrs` の最終位置誤差が 1 桁以上改善する。([#194](https://github.com/sksat/orts/pull/194), [#204](https://github.com/sksat/orts/pull/204))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ section is subdivided by package.
   `+Z`, so it is numerically identical to the classic frame-Z formula; for
   `Gcrs` it is the IAU 2006 CIP, so J2 is evaluated about Earth's true pole
   (~0.1° off the GCRS Z axis by 2024). `setup::build_orbital_system` /
-  `build_spacecraft_dynamics` compose `PointMass` + `ZonalGravity`, which is
+  `setup::build_spacecraft_dynamics` compose `PointMass` + `ZonalGravity`, which is
   behaviour-preserving for the `SimpleEci` systems they build, and in the
   drag-free J2 + third-body ISS cross-validation the `Gcrs` final-position error
   against Orekit drops by more than an order of magnitude. ([#194](https://github.com/sksat/orts/pull/194), [#204](https://github.com/sksat/orts/pull/204))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,56 @@ section is subdivided by package.
   backends): msg-io `deliver` / `take_outbound`, and stream-io `stream_deliver`
   / `stream_take` / `stream_close` for raw byte streams. ([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 - WIT v0 plugin interface extended with the msg-io and stream-io channels. ([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
+- `perturbations::ZonalGravity<F: EarthRotationPole = SimpleEci>` — zonal
+  harmonics (J2 plus optional J3 / J4) as a pole-aware perturbation `Model`
+  instead of a `GravityField`, evaluated about the central body's rotation pole
+  rather than assuming the frame's Z axis is the pole
+  (`ZonalGravity::new(mu, r_body, j2, j3, j4)`). For `SimpleEci` the pole is
+  `+Z`, so it is numerically identical to the classic frame-Z formula; for
+  `Gcrs` it is the IAU 2006 CIP, so J2 is evaluated about Earth's true pole
+  (~0.1° off the GCRS Z axis by 2024). `setup::build_orbital_system` /
+  `build_spacecraft_dynamics` compose `PointMass` + `ZonalGravity`, which is
+  behaviour-preserving for the `SimpleEci` systems they build, and in the
+  drag-free J2 + third-body ISS cross-validation the `Gcrs` final-position error
+  against Orekit drops by more than an order of magnitude. ([#194](https://github.com/sksat/orts/pull/194), [#204](https://github.com/sksat/orts/pull/204))
+- `PanelSrp` is frame-generic: its `Model` impl is bounded on
+  `F: EphemerisFrameBridge` instead of being pinned to `SimpleEci`, so
+  attitude-dependent panel SRP can be used in any frame that defines a
+  GCRS → `F` ephemeris rotation. Bit-identical for the GCRS-aligned
+  `SimpleEci` / `Gcrs`. ([#238](https://github.com/sksat/orts/pull/238))
 
 #### Changed
 - `StateEffector` is now frame-generic — `StateEffector<S, F: frame::Eci =
   SimpleEci>` returning `ExternalLoads<F>`, like `Model<S, F>` — so effectors
   produce loads already in the host inertial frame. The defaulted `F` keeps
   existing `StateEffector<S>` impls compiling unchanged. ([#148](https://github.com/sksat/orts/pull/148))
+- `ThirdBodyGravity` and `SolarRadiationPressure` are frame-correct instead of
+  blanket-implemented over every `Eci` frame: their `Model` impls are bounded on
+  `arika::earth::transform::EphemerisFrameBridge` and rotate the analytic (GCRS)
+  Sun / Moon ephemeris into the integration frame before differencing it with the
+  satellite state. Numbers are unchanged for `SimpleEci` / `Gcrs` (identity
+  rotation), `Cirs` now applies the precession / nutation rotation, and a frame
+  with no `EphemerisFrameBridge` impl (e.g. `Teme`) is a compile error rather
+  than a silent wrong-frame mix. ([#193](https://github.com/sksat/orts/pull/193), [#237](https://github.com/sksat/orts/pull/237), [#191](https://github.com/sksat/orts/issues/191))
+- Atmospheric drag takes the co-rotation velocity `Ω × r` about the central
+  body's true spin axis rather than the frame's `+Z`: for Earth the axis comes
+  from `EarthRotationPole::earth_pole` in the integration frame — `+Z` for
+  `SimpleEci` (bit-identical to the old `[0, 0, ω] × r`) and the IAU 2006 CIP
+  for `Gcrs`, removing the ~0.1–0.3° misalignment a `+Z` assumption incurred
+  there. LOD variation in `|Ω|` is still omitted, and for a non-Earth central
+  body the frame Z axis is kept with that body's `omega_body` — that body's real
+  spin-axis orientation is not modelled, a documented limitation. ([#209](https://github.com/sksat/orts/pull/209), [#210](https://github.com/sksat/orts/issues/210))
+- **BREAKING**: `perturbations::BodyPositionFn` — and therefore
+  `ThirdBodyGravity::custom` — takes `&Epoch<Tdb>` instead of `&Epoch`
+  (`Epoch<Utc>`), because a celestial-body ephemeris is a dynamical-time
+  quantity; the force-model call boundary converts with `.to_tdb()`. Custom
+  ephemeris closures must be re-typed. ([#222](https://github.com/sksat/orts/pull/222))
+- **BREAKING**: the frame-capability bound on `magnetic::field_inertial`,
+  `visibility::VisibilityMonitor` and `perturbations::AtmosphericDrag` is now
+  `arika::earth::EarthFixedTransform`, previously
+  `orts::environment::EarthFrameBridge`. The associated items are unchanged
+  (`Fixed`, `EopStorage`, `to_geodetic`, `fixed_to_inertial`), so downstream code
+  only needs the new import path. ([#213](https://github.com/sksat/orts/pull/213))
 
 #### Fixed
 - Removed an unsound frame re-tag in `SpacecraftDynamics`: effector loads tagged
@@ -44,11 +88,32 @@ section is subdivided by package.
   conversion, silently mislabeling coordinates for any `F != SimpleEci`. Latent
   (the only shipped effector is torque-only) but wrong for a translational
   effector. ([#148](https://github.com/sksat/orts/pull/148), [#103](https://github.com/sksat/orts/issues/103))
+- The absolute epoch handed to force models is `epoch_0 + t` on the uniform SI
+  timeline (`Epoch::add_si_seconds`) in `OrbitalSystem`, `SpacecraftDynamics`,
+  `AttitudeSystem`, `DecoupledAttitudeSystem`, `AugmentedAttitudeSystem` and
+  `VisibilityMonitor::update`. The previous leap-naive `add_seconds` advanced `t`
+  on the UTC calendar, so any step spanning a leap second advanced physical time
+  by one extra second — evaluating ephemerides, Earth rotation and contact-window
+  geometry at the wrong instant. ([#215](https://github.com/sksat/orts/pull/215))
 
 #### Removed
 - **BREAKING**: the `orts::tle` module is removed; TLE parsing moved to
   `arika::tle` (decoding into the shared `arika::elements::Sgp4Elements`).
   Downstream code using `orts::tle` must migrate to `arika`. ([#87](https://github.com/sksat/orts/pull/87))
+- **BREAKING**: the `orts::environment` module is removed. Its contents moved to
+  `arika` and were renamed: `EarthFrameBridge` →
+  `arika::earth::EarthFixedTransform`, `EarthPoleBridge` →
+  `arika::earth::EarthRotationPole`, and `PositionEop` / `GcrsEopStorage` →
+  `arika::earth::eop::{PositionEop, GcrsEopStorage}` (also re-exported from
+  `arika::earth`). No compatibility re-export is kept in `orts`. Note that
+  `arika`'s `PositionEop` no longer requires `Send + Sync` — thread-safety is
+  carried by the boxed `GcrsEopStorage` instead. ([#213](https://github.com/sksat/orts/pull/213))
+- **BREAKING**: `orbital::gravity::ZonalHarmonics` is removed; `GravityField` is
+  now only the genuinely frame-invariant `PointMass`. Oblateness is a
+  perturbation `Model` — replace
+  `OrbitalSystem::new(mu, Box::new(ZonalHarmonics { r_body, j2, j3, j4 }))` with
+  `OrbitalSystem::new(mu, Box::new(PointMass)).with_model(ZonalGravity::new(mu, r_body, j2, j3, j4))`
+  (note that `mu` is now passed to the perturbation explicitly). ([#204](https://github.com/sksat/orts/pull/204))
 
 ### `orts-cli` (Rust, crates.io, binary)
 
@@ -109,6 +174,49 @@ section is subdivided by package.
   `--tle-line2`; and `--tle-line1` / `--tle-line2` must be given together. ([#87](https://github.com/sksat/orts/pull/87))
 - TLE epoch day-of-year is validated against the (leap-aware) year length, so a
   malformed field is rejected rather than rolling into another year. ([#87](https://github.com/sksat/orts/pull/87))
+- **BREAKING**: config-key aliases are collapsed to one canonical spelling per
+  key. `[[command]]`, `[[ground_station]]`, `[satellites.magnetorquers]` and
+  `[satellites.thruster]` are the only accepted forms; the former
+  `[[commands]]`, `[[ground_stations]]`, `[satellites.mtq]` and
+  `[satellites.thrusters]` are gone — and `mtq` / `thrusters` were the canonical
+  spellings in released 0.2.0 configs. Unknown keys are ignored rather than
+  rejected, so a config still using an old spelling loses that section
+  *silently*; rename the keys. ([#200](https://github.com/sksat/orts/pull/200))
+- **BREAKING**: a TLE / OMM orbit's initial state is seeded by real SGP4
+  propagation instead of being read as osculating Keplerian elements. The element
+  set is propagated with `arika`'s SGP4 to the evaluation epoch and the resulting
+  TEME state is rotated into the integration frame
+  (`FrameTransform<Teme, SimpleEci>`). The old two-body conversion was wrong by
+  tens of km at epoch, so trajectories from `--tle` / `--omm` / `--norad-id` /
+  `[satellites.orbit] type = "tle"|"norad"` change. Relatedly, when `--epoch` (or
+  config `epoch`) is omitted and the first satellite has a TLE / OMM orbit, the
+  simulation epoch now defaults to *that element set's epoch* (tsince = 0)
+  instead of "now"; with several element sets only the first is at tsince = 0 and
+  the rest are extrapolated from the shared epoch. Circular orbits are
+  unaffected. ([#241](https://github.com/sksat/orts/pull/241))
+- **BREAKING**: a TLE / OMM orbit combined with a non-Earth central body is
+  rejected up front (SGP4 / TEME is Earth-centered, WGS72) on all three paths:
+  `orts run` / `orts serve` startup, the WebSocket `StartSimulation` config
+  (an error to the client instead of a panic), and a dynamic `add_satellite`.
+  Previously an Earth-relative SGP4 state was integrated under the other body's
+  μ, radius and perturbation set. ([#241](https://github.com/sksat/orts/pull/241))
+- `orts serve`'s per-model acceleration breakdown (the `accelerations` map in the
+  WebSocket `State` message) carries a `zonal_gravity` entry, and `gravity` is
+  the point-mass term only — oblateness moved from the gravity field into a
+  separate perturbation model. The total acceleration is unchanged. ([#194](https://github.com/sksat/orts/pull/194))
+- A satellite added to a running `orts serve` session has its initial state
+  evaluated at `epoch + current_t`, so a TLE / OMM is propagated to the moment it
+  enters the simulation rather than to `t = 0`; a malformed element set is
+  reported as an error instead of crashing the server. ([#241](https://github.com/sksat/orts/pull/241))
+- Config validation is stricter and runs before the simulation starts, on every
+  path that loads a config (`orts run`, `orts serve --config`, and
+  `orts config validate`): an unknown `body`, a malformed `epoch` and a malformed
+  inline `[satellites.orbit] type = "tle"` are clean errors instead of a later
+  panic. ([#216](https://github.com/sksat/orts/pull/216))
+- `orts run` rejects contradictory stdout requests before running the (possibly
+  long) simulation, and exits with status 2 for these usage errors — including
+  `--format rrd` to stdout, which previously exited 1 after the whole simulation
+  had already run. ([#214](https://github.com/sksat/orts/pull/214))
 
 #### Fixed
 - `orts run --format csv --output <path>` now writes the CSV to `<path>`.
@@ -117,6 +225,9 @@ section is subdivided by package.
 - `orts serve` started with a `--config` file now rejects a `[[command]]`
   timeline with a clear error (command timelines run only under `orts run`)
   instead of silently dropping it. ([#58](https://github.com/sksat/orts/pull/58))
+- Simulation time is advanced on the uniform SI timeline
+  (`Epoch::add_si_seconds`), so a run spanning a leap second no longer shifts the
+  epoch handed to force models, sensors and plugin ticks by an extra second. ([#215](https://github.com/sksat/orts/pull/215))
 
 ### `orts-plugin-sdk` (Rust, crates.io)
 
@@ -145,7 +256,7 @@ section is subdivided by package.
 ### `arika` (Rust, crates.io)
 
 #### Added
-- Element-set parsing ([#87](https://github.com/sksat/orts/pull/87)). A shared
+- Element-set parsing ([#87](https://github.com/sksat/orts/pull/87), [#230](https://github.com/sksat/orts/pull/230), [#245](https://github.com/sksat/orts/pull/245)). A shared
   no-alloc `elements::Sgp4Elements` — a *validated* mean-element set (catalog
   number, UTC epoch, six SGP4 mean elements, B\* drag; angles in radians, mean
   motion in rad/s). Built with `Sgp4Elements::try_new` /
@@ -164,9 +275,10 @@ section is subdivided by package.
     unified, BOM-tolerant entry point that auto-detects and dispatches
     TLE / OMM-JSON / OMM-KVN / OMM-XML.
 - SGP4 / SDP4 propagation behind the optional `sgp4` feature
-  (`sgp4::Sgp4Propagator`): builds from an `Sgp4Elements`, reuses the
-  epoch `Constants`, and propagates to a `(Vec3<Teme>, Vec3<Teme>)` state in km /
-  km·s. Wraps the `sgp4` crate in AFSPC compatibility mode (WGS72). The
+  (`sgp4::Sgp4Propagator`): `from_elements` reuses the epoch `Constants`
+  across calls, and `propagate_minutes_since_epoch` / `propagate(Epoch<Utc>)`
+  return a `(Vec3<Teme>, Vec3<Teme>)` state in km / km·s or an `Sgp4Error`
+  (`Initialization` / `Diverged`, which also covers non-finite request times). Wraps the `sgp4` crate in AFSPC compatibility mode (WGS72). The
   dependency is pulled with only `libm`, so propagation works in `no_std`
   builds without `alloc`. Validated against the Vallado verification vectors for
   near-earth (SGP4) and deep-space (SDP4) satellites. ([#235](https://github.com/sksat/orts/pull/235))
@@ -189,11 +301,100 @@ section is subdivided by package.
 - `earth::topocentric` — ground-site look angles: `TopocentricSite<F: Ecef>`
   (from a WGS-84 `Geodetic`, precomputing the local ENU basis) and `LookAngles`
   (azimuth / elevation / slant range), via `look_angles(target)`. ([#112](https://github.com/sksat/orts/pull/112))
+- GPS Time as a first-class scale: the `epoch::Gps` marker with `Epoch<Gps>`
+  (`from_jd_gps`) and its conversion edges (`Epoch::<Utc>::to_gps`,
+  `Epoch::<Tai>::to_gps`, `Epoch::<Gps>::to_tai` / `to_utc`) — a fixed
+  TAI − 19 s with no leap seconds. GNSS week / seconds-of-week are types rather
+  than bare integers: `GpsWeek` (the continuous count, no 1024-week rollover)
+  with `GpsWeek::from_broadcast(raw10, reference)` to resolve a 10-bit
+  navigation-message week, the range-checked `SecondsOfWeek`,
+  `Epoch::<Gps>::from_week_seconds` / `to_week_seconds`, and `GPS_EPOCH_JD`. ([#192](https://github.com/sksat/orts/pull/192))
+- `epoch::FixedOffsetFromTai` — the capability trait for scales whose offset
+  from TAI is a fixed number of SI seconds (`Tai` 0, `Tt` +32.184, `Gps` −19),
+  with `SECONDS_AFTER_TAI` as the single source of truth for the matching
+  conversion edge. UTC (leap-second piecewise), TDB (periodic series) and UT1
+  (EOP-dependent) deliberately do not implement it, so "the offset from TAI is
+  constant" is a type-level fact instead of a convention. ([#192](https://github.com/sksat/orts/pull/192))
+- `Epoch::duration_since(&earlier)` — the exact SI-second interval measured on
+  the shared TAI timeline, correct across leap seconds and across scales
+  (`earlier` may carry a different scale). ([#205](https://github.com/sksat/orts/pull/205))
+- `epoch::TwoPartJd` and the sealed `epoch::JdRepr` — a Julian Date carried as
+  `hi + lo` (SOFA-style two-part date), keeping the full mantissa available for
+  the sub-day fraction; `Epoch::jd_parts()` hands the pair to two-part consumers
+  without the single-`f64` collapse. ([#205](https://github.com/sksat/orts/pull/205), [#208](https://github.com/sksat/orts/pull/208))
+- Precision tier in the type: `Epoch<S, P: Precision>` with the sealed tiers
+  `Precise` (default; two-part JD, 16 bytes, sub-nanosecond) and `Coarse`
+  (single `f64`, 8 bytes, tens of microseconds — for wasm / `no_std` targets
+  where RAM and cycles are scarce), converted with `Epoch::to_precision::<Q>()`
+  and reported by `precision_name()`. The tier is monomorphized, mixing tiers
+  needs an explicit conversion, and `Epoch` / `Epoch<S>` still mean
+  `Epoch<Utc, Precise>`. ([#208](https://github.com/sksat/orts/pull/208))
+- `earth::transform` — the per-frame Earth-orientation capability traits, moved
+  in from `orts::environment` and renamed: `EarthRotationPole` (`earth_pole`,
+  the minimal capability zonal gravity and atmospheric co-rotation need) and
+  `EarthFixedTransform` (the paired `Fixed: Ecef` frame plus `to_geodetic`,
+  `fixed_to_inertial` and the state-transform factories). Both are implemented
+  for `SimpleEci` (ERA-only Z rotation, pole `+Z`) and `Gcrs` (IAU 2006 CIO
+  chain, pole = model CIP). The supporting `earth::eop::PositionEop` bound and
+  the owned, type-erased `earth::eop::GcrsEopStorage` moved with them. ([#213](https://github.com/sksat/orts/pull/213))
+- `frame::FrameTransform<From, To>` — `Rotation`'s kinematic companion, carrying
+  the orientation plus the angular velocity of `To` relative to `From`, so it
+  transforms velocities and full states through the transport theorem
+  (`transform_position`, `transform_velocity`, `transform_state`, `inverse`,
+  `angular_velocity_in_from`). Earth ECI↔ECEF instances come from
+  `EarthFixedTransform::inertial_to_fixed_transform` /
+  `fixed_to_inertial_transform`, whose ω is `OMEGA · earth_pole` — Earth spin
+  transport only, with the IAU 2006 precession / nutation / polar-motion rates
+  and the LOD correction omitted. ([#219](https://github.com/sksat/orts/pull/219))
+- `earth::transform::EphemerisFrameBridge` — the `GCRS → F` rotation that lets
+  third-body / SRP force models express an analytic (Meeus) ephemeris in their
+  integration frame instead of consuming a raw vector that is only valid for
+  GCRS-aligned frames. Identity for `Gcrs` and `SimpleEci`, and the EOP-free
+  IAU 2006 model rotation for `Cirs` (`Rotation::<Gcrs, Cirs>::iau2006_model`);
+  a frame without the impl cannot be used with those forces, so a new
+  of-date frame has to state its `GCRS → F` rotation. ([#237](https://github.com/sksat/orts/pull/237))
 
 #### Changed
 - `Epoch::from_iso8601` also accepts the ordinal / day-of-year form
   (`YYYY-DDDTHH:MM:SS`, used by CCSDS OMM), and the trailing `Z` is now optional.
   A strict relaxation — previously-accepted inputs still parse. ([#87](https://github.com/sksat/orts/pull/87))
+- **BREAKING**: `Epoch<S>` stores a canonical TAI instant internally instead of
+  the scale's own Julian Date. Scale conversions (`to_tai`, `to_tt`, `to_tdb`,
+  `to_gps`, …) are non-destructive re-tags of one instant, and the leap-second
+  table, the fixed TAI offsets and the TDB periodic term are applied only at
+  construction and read-out, keeping full precision in between.
+  `from_jd_*(x).jd() == x` still round-trips and `TimeScale` stays sealed, but
+  `Epoch` is no longer a transparent JD wrapper — `jd()` is a per-scale read-out
+  rather than the stored field, and identical instants built through different
+  paths now compare equal. ([#205](https://github.com/sksat/orts/pull/205))
+- **BREAKING**: the analytic ephemerides take `&Epoch<Tdb>` instead of
+  `&Epoch<Utc>` and no longer convert internally — `sun::sun_direction_eci`,
+  `sun_position_eci`, `sun_distance_km`, `equation_of_time`,
+  `sun_direction_from_body`, `sun_distance_from_body`, `moon::moon_position_eci`,
+  `planets::obliquity` and `planets::heliocentric_position_ecliptic`. The
+  dynamical time these Meeus models are defined against is now stated in the
+  type, and a caller that converts at the boundary with `.to_tdb()` gets
+  numerically identical results. The UTC-indexed `MoonEphemeris` trait
+  deliberately keeps `&Epoch<Utc>`. ([#222](https://github.com/sksat/orts/pull/222))
+
+#### Fixed
+- `Epoch::<Utc>::add_si_seconds` is an exact SI add on the uniform TAI
+  timeline. The previous UTC-iterating implementation drifted by up to a second
+  when the result landed inside an inserted leap second; a regression test pins
+  that `add_si_seconds(dt)` followed by `duration_since` recovers `dt` across
+  the 2017-01-01 leap. ([#205](https://github.com/sksat/orts/pull/205))
+
+#### Removed
+- **BREAKING**: the `epoch::Ut1` scale marker is gone. UT1 is realized by
+  Earth's rotation — a measured EOP quantity, not a data-free offset from TAI —
+  so it cannot share the canonical TAI timeline `Epoch<S>` now stores. It lives
+  in its own `epoch::Ut1Epoch` (`from_jd_ut1`, `jd`, `era`), reachable through
+  `Epoch::<Utc>::to_ut1(eop)` / `to_ut1_naive()`. Signatures that took
+  `&Epoch<Ut1>` now take `&Ut1Epoch`:
+  `Rotation::<SimpleEci, SimpleEcef>::from_ut1`,
+  `Rotation::<SimpleEcef, SimpleEci>::from_ut1`,
+  `Rotation::<Cirs, Tirs>::from_era` and
+  `Rotation::<Gcrs, Itrs>::iau2006_full`. ([#205](https://github.com/sksat/orts/pull/205))
 
 ### `utsuroi` (Rust, crates.io)
 
@@ -210,6 +411,19 @@ section is subdivided by package.
   `fetch-horizons`). `fetch` is retained as an umbrella feature that enables
   every `fetch-*` source, so `features = ["fetch"]` keeps building (and now
   also pulls in `fetch-igrf`). ([#150](https://github.com/sksat/orts/pull/150))
+- **BREAKING**: `HarrisPriester::with_sun_direction_fn` takes
+  `fn(&Epoch<Tdb>) -> Vec3<Gcrs>` instead of `fn(&Epoch) -> Vec3<Gcrs>`
+  (i.e. `Epoch<Utc>`), following `arika`'s analytic ephemerides which now require
+  a TDB epoch. The model keeps its UTC input and converts with `.to_tdb()` at the
+  call boundary; callers overriding the Sun-direction hook must retype their
+  function. ([#222](https://github.com/sksat/orts/pull/222))
+
+#### Fixed
+- Solar-ephemeris quantities are evaluated on the correct time scale: the
+  Harris-Priester density-bulge apex converts its UTC epoch to TDB before asking
+  for the Sun direction, and `nrlmsise00::geo::local_solar_time` does the same
+  for the Equation of Time. Previously a UTC epoch was passed straight into a
+  TDB-argument ephemeris (~69 s of scale error). ([#222](https://github.com/sksat/orts/pull/222))
 
 ### `viewer`
 
@@ -273,6 +487,12 @@ section is subdivided by package.
   pay no init cost (fixed Sun direction, no body rotation). ([#89](https://github.com/sksat/orts/pull/89))
 - WS protocol types are now the `ts-rs`-generated bindings (see `orts-cli`),
   replacing the hand-written wire types and adding the `satellite_added` variant. ([#95](https://github.com/sksat/orts/pull/95))
+- **BREAKING**: the `ts-rs` wire bindings track the canonicalised config keys —
+  `SatelliteConfig.mtq` → `magnetorquers` (both in the `start_simulation`
+  `SimConfig` payload and the flattened `add_satellite` message),
+  `SimConfig.commands` → `command`, and `SimConfig.ground_stations` →
+  `ground_station`. Old keys are ignored rather than rejected, so a WS client
+  still sending `mtq` loses its magnetorquer configuration without an error. ([#200](https://github.com/sksat/orts/pull/200))
 
 #### Fixed
 - Default WebSocket URL on static deploys falls back to `ws://localhost:9001/ws`
@@ -324,17 +544,40 @@ section is subdivided by package.
   corpus; `llms-small.txt` is a condensed overview that excludes the
   autogenerated rustdoc/typedoc API reference. ([#225](https://github.com/sksat/orts/pull/225))
 
+#### Changed
+- The documentation site runs on Astro 7 with Starlight 0.40 (and
+  `@astrojs/react` 6). Sidebar `autogenerate` groups moved to Starlight 0.40's
+  nested schema, which the upgrade otherwise rejected; the autogenerated rustdoc
+  / typedoc API sections stay collapsed as before. ([#126](https://github.com/sksat/orts/pull/126), [#180](https://github.com/sksat/orts/pull/180), [#250](https://github.com/sksat/orts/pull/250))
+- The docs site is gated in CI: the full Astro / Starlight build runs on
+  documentation-affecting PRs (previously only on push to main, so a build
+  regression surfaced after merge), and the site's `.astro` / `.ts` sources are
+  type-checked with `astro check`, which `astro build` never did. ([#180](https://github.com/sksat/orts/pull/180), [#233](https://github.com/sksat/orts/pull/233))
+
 ### Dependencies
 
-- Rust toolchain → 1.96.0.
+- Rust toolchain → 1.96.1.
+- New Rust dependency: `sgp4` 2.4, behind `arika`'s optional `sgp4` feature
+  (pulled with only `libm`, so the `no_std` / no-`alloc` tiers still build) and
+  enabled by `orts-cli`.
 - Rust: `wasmtime` / `wasmtime-wasi` 44 (security), `rerun` 0.33,
-  `tokio-tungstenite` 0.29, `nalgebra` 0.35, `tokio` 1.52, `axum` 0.8.9.
+  `tokio-tungstenite` 0.29, `nalgebra` 0.35, `tokio` 1.52, `axum` 0.8.9,
+  `kble-socket` 0.5 (with the `kble` CLI 0.5 in the E2E job), `rand` 0.10 /
+  `rand_distr` 0.6, `wit-bindgen` 0.58 (`orts-plugin-sdk` binding generation),
+  `clap` 4.6, `thiserror` 2.0, `toml` 1.1.
 - `notalawyer` 0.3 — the embedded third-party license NOTICE is generated
   through the cargo-about *library* (an `orts-cli` build-dependency) instead
   of the `cargo about` binary, so no binary is installed in CI or baked into
   the cross build image.
 - npm: `vite` 8, `@vitejs/plugin-react` 6, the React monorepo, `ws` 8.21
-  (security), `mermaid` 11.15 (security).
+  (security), `mermaid` 11.16 (security), Astro 7 with `@astrojs/starlight` 0.40
+  and `@astrojs/react` 6 (Astro 7.1.0 was a security release), TypeScript 6,
+  Biome 2.5, `vite-plugin-dts` 5, `three` 0.184, and the new `starlight-llms-txt`
+  0.10 behind the docs `llms.txt` generation.
+- Tooling: pnpm 11 — the workspace declares `allowBuilds` explicitly (pnpm 11
+  refuses to install otherwise) and the `minimumReleaseAge` supply-chain floor is
+  enforced on `--frozen-lockfile` installs — plus Node.js 24 and wasi-sdk 33 for
+  the `nos3-adcs` example build.
 
 ## [0.2.0](https://github.com/sksat/orts/releases/tag/v0.2.0) - 2026-04-20
 


### PR DESCRIPTION
0.3.0 のリリース準備。`[Unreleased]` が **PR #240 で止まっていた**一方で main には
その後 124 PR（非 Renovate 43件）がマージされており、**BREAKING を含む変更が
changelog に載っていなかった**。それを現在の main まで追従させる。

## 追加した主な内容

**`arika`**（今サイクル最大）
- 時刻スケール再設計: GPS Time (`epoch::Gps` / `GpsWeek` / `SecondsOfWeek`)、
  `FixedOffsetFromTai`、`duration_since`、`TwoPartJd` と精度 tier `Epoch<S, P>`
- `earth::transform` capability trait 群（`orts::environment` から移設）、
  `FrameTransform`（速度・状態変換）、`EphemerisFrameBridge`
- **BREAKING**: 正準 TAI 内部表現、`Epoch<Tdb>` 必須の解析エフェメリス、
  `Ut1` marker 削除（→ `Ut1Epoch`）

**`orts`**
- `ZonalGravity<F>`（極を意識した J2/J3/J4）、frame-generic `PanelSrp`、
  frame-correct な third-body / SRP、真の自転軸まわりの drag co-rotation、
  SI タイムラインのエポック
- **BREAKING**: `orts::environment` 削除、`ZonalHarmonics` 削除（移行手順つき）

**`orts-cli`**
- **BREAKING**: config キーの正準化（`mtq` / `thrusters` はリリース済み 0.2.0 の
  綴りで、いまは黙って無視される）、SGP4 で初期状態を求める TLE/OMM 取り込みと
  要素セットエポックの既定化、非地球天体との組み合わせ拒否
- 検証の厳格化、使用法エラーの exit code 2、`accelerations` の `zonal_gravity`

**その他**: `tobari` の `Epoch<Tdb>` hook（BREAKING）と時刻スケール修正、
`viewer` の wire キー正準化（BREAKING）、Docs の Astro 7 / Starlight 0.40 と
CI gate、Dependencies 全面更新。

## 陳腐化していた既存エントリの修正

- 要素セットのパース: `Sgp4Elements` への分割と検証型化を反映し、PR 帰属に
  #230 / #245 を追加（#87 だけでは実際に出荷された形と一致しなかった）
- SGP4 伝播: 実際のエントリポイント（`from_elements` /
  `propagate_minutes_since_epoch` / `propagate`）と `Sgp4Error` を明記

## 検証

- パッケージ別に 4 つの調査を並行実施し、**コミットメッセージではなく
  origin/main の実コードで** symbol / 挙動を裏取り（`ZonalHarmonics` の不在、
  `epoch/gps.rs` の存在、`environment.rs` の消滅、tobari の
  `fn(&Epoch<Tdb>)`、config の `rename` 等を個別に確認）
- PR 番号は推測せず、定義コミットのマージ ancestry を辿って確定
- EN / JA は **102 項目・123 リンクで一致**、セクション見出しも完全一致
- 差分は `[Unreleased]` 内のみ（0.2.0 / 0.1.1 / 0.1.0 は無改変）
- `codex review` 実施 → 指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
