### PR TITLE
ci: gate dependencies with cargo-deny and close the unattended-merge paths

### DIFF
--- a/.github/workflows/advisories.yml
+++ b/.github/workflows/advisories.yml
@@ -1,0 +1,124 @@
+# Scheduled advisory watch.
+#
+# The cargo-deny job in ci.yml runs on pushes and PRs, which catches a change
+# that *introduces* a vulnerable dependency. It cannot catch the other half: a
+# RustSec advisory published against a dependency we already ship, where the
+# lockfile never changes and no CI run is triggered. That needs a clock.
+#
+# Deliberately not wired into the release pipeline — a known advisory should be
+# visible, not a release blocker. This workflow keeps a single tracking issue in
+# sync instead, and goes red in the Actions list while something is live.
+name: Advisories
+
+on:
+  schedule:
+    # Mondays, 03:00 UTC.
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: advisories
+  cancel-in-progress: false
+
+jobs:
+  advisories:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Parse rust-toolchain.toml
+        id: rust-toolchain
+        uses: ./.github/actions/parse-rust-toolchain
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2.82.8
+        with:
+          tool: cargo-deny@0.20.2
+
+      # Resolves one of three states so a broken run is never mistaken for a
+      # clean one. This step does not fail: the tracking issue has to be synced
+      # first, and the job is failed at the end instead.
+      #
+      #   live  — cargo-deny reported at least one advisory
+      #   clean — cargo-deny ran and reported none
+      #   error — cargo-deny exited non-zero without reporting a single advisory,
+      #           i.e. the check never actually ran (advisory-db fetch, lockfile,
+      #           config...). Treated as unknown, because calling that clean
+      #           would close the tracking issue on a run that checked nothing.
+      #
+      # `-L info` also lists the advisories deny.toml ignores, which are silent
+      # at the default log level.
+      - name: Check advisories
+        id: report
+        run: |
+          set +e
+          cargo deny -L info check advisories > advisories.txt 2>&1
+          deny_status=$?
+          set -e
+          live=$(grep -cE '^error\[(vulnerability|unmaintained|unsound|notice|yanked)\]' advisories.txt || true)
+
+          if [ "$live" -gt 0 ]; then
+            state=live
+          elif [ "$deny_status" -ne 0 ]; then
+            state=error
+          else
+            state=clean
+          fi
+          echo "state=$state" >> "$GITHUB_OUTPUT"
+          echo "cargo-deny exit $deny_status, $live live advisories, state $state"
+
+          {
+            echo "### cargo-deny advisories — $state"
+            echo
+            if [ "$state" = "error" ]; then
+              echo "cargo-deny exited $deny_status without reporting an advisory, so the state is **unknown** for this run. The tracking issue was left untouched."
+              echo
+            fi
+            echo '```'
+            cat advisories.txt
+            echo '```'
+          } | tee report.md >> "$GITHUB_STEP_SUMMARY"
+
+      # Skipped when the state is unknown — a run that checked nothing must not
+      # create, edit or close the tracking issue.
+      - name: Sync tracking issue
+        if: steps.report.outputs.state != 'error'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: Dependency advisories
+          LIVE: ${{ steps.report.outputs.state == 'live' }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          number=$(gh issue list --state open --limit 100 --json number,title --jq '.[] | select(.title == env.TITLE) | .number' | head -1)
+
+          {
+            cat report.md
+            printf '\n---\nUpdated by the [advisories workflow](%s).\n' "$RUN_URL"
+            printf 'Exceptions live in `deny.toml`; each one records what would let us drop it.\n'
+          } > issue.md
+
+          if [ "$LIVE" = "true" ]; then
+            if [ -n "$number" ]; then
+              gh issue edit "$number" --body-file issue.md
+            else
+              gh issue create --title "$TITLE" --body-file issue.md
+            fi
+          elif [ -n "$number" ]; then
+            gh issue comment "$number" --body-file issue.md
+            gh issue close "$number" --comment "No live advisories left; closing. The scheduled run opens a fresh issue if one appears."
+          fi
+
+      - name: Fail unless the advisory state is clean
+        if: steps.report.outputs.state != 'clean'
+        run: |
+          echo "advisory state: ${{ steps.report.outputs.state }} - see the job summary." >&2
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,66 @@ jobs:
       - name: Lint
         run: pnpm exec biome lint .
 
+  # Supply-chain gate for the Rust side. Renovate's `minimumReleaseAge` cooldown
+  # keeps a freshly published version out of the lockfile; this job is the
+  # complementary check on what is already in it.
+  #
+  #   advisories — RustSec vulnerabilities / unmaintained crates
+  #   bans       — wildcard version requirements (duplicate majors are warn-only)
+  #   sources    — every crate must come from crates.io
+  #
+  # Licenses are deliberately not checked here: cli/about.toml already drives the
+  # NOTICE embedded in the released binary, and one source of truth beats two.
+  # Policy and documented exceptions live in deny.toml.
+  #
+  # Only the root workspace is covered; the nested plugin-sdk/examples workspace
+  # has its own lockfile and is not checked yet.
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Parse rust-toolchain.toml
+        id: rust-toolchain
+        uses: ./.github/actions/parse-rust-toolchain
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2.82.8
+        with:
+          tool: cargo-deny@0.20.2
+
+      # One advisory evaluation, used for both the gate and the summary — the
+      # advisory-database fetch and the license matching are the expensive part,
+      # so they must not run twice. `-L info` is what makes cargo-deny mention
+      # the advisories deny.toml ignores: at the default log level they are
+      # invisible, so the exceptions we knowingly carry would vanish from view
+      # the moment they were written down. The gate is cargo-deny's exit status.
+      - name: cargo-deny (advisories)
+        run: |
+          set +e
+          cargo deny -L info check advisories 2>&1 | tee advisories.txt
+          status=${PIPESTATUS[0]}
+          set -e
+          {
+            echo '### cargo-deny advisories'
+            echo
+            echo '```'
+            cat advisories.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $status
+
+      # Cheap by comparison: no advisory database, no license matching. Runs
+      # even when the advisory check failed, so one PR shows both results.
+      - name: cargo-deny (bans, sources)
+        if: always()
+        run: cargo deny check bans sources
+
   rust-build:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1654,11 +1654,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -2006,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,52 @@
+# cargo-deny — supply-chain policy for the Rust side of the workspace.
+#
+# Scope is deliberately narrow: advisories (RustSec), sources (where a crate may
+# come from) and bans (wildcard requirements, duplicate majors). License policy
+# is NOT checked here — cli/about.toml already drives the NOTICE embedded in the
+# distributed binary, and one source of truth beats two that can drift.
+#
+# CI runs `cargo deny check advisories bans sources` (see .github/workflows/ci.yml).
+# Renovate's `minimumReleaseAge` cooldown keeps a fresh release out of the
+# lockfile; this file is the complementary gate for "what is already in it".
+
+[advisories]
+# Deny every RustSec advisory. An exception goes in `ignore` with a comment
+# saying why it does not apply here and what would let us drop it again.
+yanked = "deny"
+# `unmaintained` and `unsound` take a *scope*, not a lint level — the per-category
+# levels were removed (cargo-deny#611), so every advisory is an error and only the
+# set of crates considered is configurable. Pin both to `all` so transitive
+# dependencies are covered too, instead of inheriting whichever default the
+# installed cargo-deny happens to ship. `vulnerability` and `notice` have no knob
+# at all.
+unmaintained = "all"
+unsound = "all"
+ignore = [
+  # wasmtime / wasmtime-wasi 44 sandbox advisories. Both need a major bump
+  # (>=45.0.3 / >=46.0.1 for -0188, >=46.0.2 / >=47.0.3 for -0222) and the
+  # manifest pins `~44.0.0`, so `cargo update` cannot reach the fix — it is a
+  # deliberate upgrade, tracked by the open wasmtime v47 Renovate PR (#181).
+  # Drop both entries when that lands, and note it has to resolve to 47.0.3 or
+  # newer to actually clear -0222.
+  { id = "RUSTSEC-2026-0188", reason = "wasmtime-wasi 44: WASI hard link / rename bypasses FilePerms; fixed by the wasmtime major bump in #181" },
+  { id = "RUSTSEC-2026-0222", reason = "wasmtime 44: stores can mix up type indices between engines; needs >=47.0.3, see #181" },
+  # `paste` is unmaintained with no successor and reaches us transitively, so
+  # there is no upgrade to take. Revisit when a dependent drops it.
+  { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained, pulled in transitively, no safe upgrade available" },
+]
+
+[bans]
+# A wildcard requirement lets an unreviewed release in on the next resolve,
+# which is exactly what the release-age cooldown exists to prevent.
+wildcards = "deny"
+# Duplicate majors are a build-size / correctness smell rather than a
+# supply-chain hole, and the wasmtime / rerun trees legitimately carry a few.
+# Warn so they stay visible without blocking CI.
+multiple-versions = "warn"
+
+[sources]
+# Everything must come from crates.io. There are no git dependencies today, so
+# adding one has to be a deliberate edit here.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
依存に既知の脆弱性が入っていても、誰も気づかない状態だった。それを気づける状態にする。

実際に入れてみたところ、**現 main に RustSec advisory が 6 件**あった（うち 3 件は lockfile 更新だけで直るものだった）。

## 何が足りていなかったか

supply-chain 対策として cooldown は既に入っている（Renovate `minimumReleaseAge: 7 days`、pnpm `minimumReleaseAge: 10080`、`allowBuilds` による postinstall 制御、Actions の SHA pin）。これは「**新しく入ってくるもの**を遅らせる」仕組みなので、次が守備範囲外になる。

**既に lockfile に入っているものを誰も見ていない。** 出荷中の依存に advisory が公開されても止まらないし、Renovate を経由しない `cargo add` / `cargo update` は cooldown を素通りする（cargo に pnpm の `minimumReleaseAge` 相当は無い）。この PR はそこを埋める。

（cooldown のもう一つの穴 ——「誰も見ないまま main に入る経路」—— は #321 で別に出している）

## 変更 1: 見つかった脆弱性を直した

| ID | crate | 内容 | 対応 |
|---|---|---|---|
| RUSTSEC-2026-0258 | h2 0.4.15 | unbounded empty DATA frames | **0.4.19 に更新**（lock のみ） |
| RUSTSEC-2026-0204 | crossbeam-epoch 0.9.18 | 不正ポインタ参照（`fmt::Pointer`） | **0.9.20 に更新**（lock のみ） |
| RUSTSEC-2026-0221 | event-listener 5.4.1 | unsound: `!Send` がスレッド境界を越える | **5.4.2 に更新**（lock のみ） |
| RUSTSEC-2026-0188 | wasmtime-wasi 44 | WASI の hard link / rename が `FilePerms` を回避 | 保留（下記） |
| RUSTSEC-2026-0222 | wasmtime 44 | engine 間で store の type index が混同 | 保留（下記） |
| RUSTSEC-2024-0436 | paste | unmaintained | 保留（後継なし・transitive） |

**wasmtime の 2 件は WASM plugin のサンドボックスに関わる。** 修正には major bump が必要で、manifest が `~44.0.0` を pin しているため `cargo update` では届かない。**Renovate #181（wasmtime v47）を優先してほしい**。ただし RUSTSEC-2026-0222 の解消には **47.0.3 以上**が必要。

保留する 3 件は `deny.toml` の `ignore` に、**何があれば外せるか**を書いて登録した。

## 変更 2: cargo-deny を CI に追加した

`cargo-deny` job（cargo-deny 0.20.2 を pin）が 2 ステップ走る。

| ステップ | CI が落ちる条件 |
|---|---|
| `cargo deny -L info check advisories` | lockfile の crate に advisory がある（`ignore` 登録済みを除く） |
| `cargo deny check bans sources` | `*` のような wildcard 版指定がある / crates.io 以外（git 依存など）から来ている |

落ちないもの: 重複 major（wasmtime / rerun ツリーに元からあるので warn 止まり）、`ignore` に登録済みのもの。

**リリースは塞がない。** `release` job は `cargo-deny` に依存させていないので、既知の advisory があってもタグは打てる。

licenses は検査しない。`cli/about.toml` が配布バイナリに埋め込む NOTICE を既に駆動しており、同じ判断材料を 2 箇所に持つとドリフトするため。

### 抱えている例外が見えるようにした

cargo-deny は既定のログレベルでは **`ignore` した advisory を一切表示しない**。つまり例外は書いた瞬間に不可視になり、CI を見ても 1 件抱えているのか 5 件なのか分からない。`-L info` で実行すると `note[advisory-ignored]` として理由つきで出るので、その出力を run summary に貼っている。

cargo-deny の呼び出しは 1 回。advisory DB の取得と license 照合が重いので、CI が落ちるかの判定と summary で同じ実行結果を使う（`bans` / `sources` は DB 不要なので別ステップ）。

### 定期実行も追加した

CI job は push / PR でしか走らないので、「出荷中の依存に advisory が公開された」ケースを拾えない（lockfile が変わらないので何もトリガーされない）。weekly の `Advisories` workflow が時計で回り、`Dependency advisories` という 1 つの issue を同期する（無ければ作成 / あれば更新 / 解消したら close）。

壊れた実行を「異常なし」と誤認しないよう 3 状態を判定する。advisory DB の取得失敗などで cargo-deny が異常終了すると advisory は 1 件も報告されないため、素朴に書くと「advisory なし」と解釈して**検査が走っていないのに issue を close** してしまう。

| 状態 | 判定 | 挙動 |
|---|---|---|
| live | advisory 行がある | issue を作成 / 更新、job は fail |
| clean | exit 0 かつ advisory 行なし | issue を close |
| error | 異常終了したが advisory 行なし | **issue を触らない**、job は fail |

## 検証

- `cargo-deny` をローカルに導入し、`deny.toml` を実際に実行して確認。最終状態は `advisories ok, bans ok, sources ok`（exit 0）
- 3 状態の判定を実測: clean = exit 0 / 0 件、live = exit 1 / 3 件（`ignore` を外した場合）、error = exit 1 / 0 件（`--manifest-path` を壊した場合）
- `.github/workflows/*.yml` は YAML パースを確認。`renovate.json` は公式 `renovate-config-validator` を通過
- `codex review` を反復し、4 件の実質的な指摘を修正（壊れた実行を異常なしと誤認、cargo-deny 自身のエラーを advisory と誤認、advisory scope が暗黙）

### advisory scope を明示している理由

`[advisories]` の `unmaintained` / `unsound` は **lint level ではなく scope**（`all` / `workspace` / `transitive` / `none`）を取る。per-category の level は cargo-deny#611 で削除済みで、advisory は常に error、`notice` はキー自体が無い。残っていた暗黙の依存は scope の既定値で、**それが `all` より狭かった**。`unmaintained = "all"` / `unsound = "all"` を明示したところ RUSTSEC-2026-0221（event-listener）が出てきた。

## 判断してほしいこと

- **branch protection**: 必須チェックは現在 15 件で `cargo-deny` は含まれない。つまり今は「赤くなるが merge はできる」。実際に止めるなら ruleset への追加が必要
- **wasmtime #181 の優先度**: 上記のサンドボックス脆弱性 2 件

## 入れていないこと

- `release` job を `cargo-deny` に依存させる（既知の advisory でリリースを止めるのはやりすぎと判断）
- nested workspace（`plugin-sdk/examples` は独自 lockfile を持つが未検査）
- cargo 版 cooldown チェックの自作

🤖 Generated with [Claude Code](https://claude.com/claude-code)
