### PR TITLE
perf(orts): gate rerun behind an opt-in feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,14 +285,22 @@ jobs:
         run: cargo test --locked --workspace --exclude orts
 
       # orts's `rerun` feature is opt-in, so rust-test-orts (which builds orts
-      # with no features) does not run the .rrd round-trip tests. Select them
-      # via --workspace rather than `-p orts --features rerun`: the workspace
-      # feature union already enables orts/rerun through orts-cli, so the lib
-      # test binary is the one rust-build compiled and cached. Using `-p orts`
-      # would narrow the package set, change arika/tobari's features, and
-      # rebuild the whole graph.
+      # with no features) does not run the .rrd round-trip tests. Run them here
+      # instead.
+      #
+      # Keep the `--workspace` package selection: the resulting feature union
+      # for orts is {plugin-wasm, plugin-wasm-async, rerun}, identical to the
+      # `cargo test --workspace --no-run` that rust-build already cached, so
+      # this reuses that lib test binary. Narrowing to `-p orts` would drop
+      # arika/sgp4 and tobari/fetch-cssi from the union and rebuild the graph.
+      #
+      # `--features orts/rerun` is redundant with orts-cli's dependency edge
+      # (verified: `cargo test --workspace --lib --unit-graph` already resolves
+      # the orts lib test unit with `rerun` on) but stated explicitly so the
+      # step cannot silently degrade into matching zero tests if orts-cli ever
+      # stops enabling the feature.
       - name: Test (orts rerun export)
-        run: cargo test --locked --workspace --lib record::rerun_export::
+        run: cargo test --locked --workspace --features orts/rerun --lib record::rerun_export::
 
       # The SGP4 propagation tests (Vallado verification vectors) live behind
       # arika's optional `sgp4` feature; run them explicitly so they execute

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,16 @@ jobs:
       - name: Test (all except orts)
         run: cargo test --locked --workspace --exclude orts
 
+      # orts's `rerun` feature is opt-in, so rust-test-orts (which builds orts
+      # with no features) does not run the .rrd round-trip tests. Select them
+      # via --workspace rather than `-p orts --features rerun`: the workspace
+      # feature union already enables orts/rerun through orts-cli, so the lib
+      # test binary is the one rust-build compiled and cached. Using `-p orts`
+      # would narrow the package set, change arika/tobari's features, and
+      # rebuild the whole graph.
+      - name: Test (orts rerun export)
+        run: cargo test --locked --workspace --lib record::rerun_export::
+
       # The SGP4 propagation tests (Vallado verification vectors) live behind
       # arika's optional `sgp4` feature; run them explicitly so they execute
       # regardless of which workspace members enable the feature.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,8 +299,11 @@ jobs:
       # the orts lib test unit with `rerun` on) but stated explicitly so the
       # step cannot silently degrade into matching zero tests if orts-cli ever
       # stops enabling the feature.
+      # Quoted: the trailing `::` of the test filter would otherwise be read
+      # as a YAML mapping separator (a `:` at end-of-line closes a key), which
+      # makes the whole workflow file fail to parse.
       - name: Test (orts rerun export)
-        run: cargo test --locked --workspace --features orts/rerun --lib record::rerun_export::
+        run: "cargo test --locked --workspace --features orts/rerun --lib record::rerun_export::"
 
       # The SGP4 propagation tests (Vallado verification vectors) live behind
       # arika's optional `sgp4` feature; run them explicitly so they execute

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -30,6 +30,14 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - WIT v0 plugin interface に msg-io / stream-io チャネルを追加。([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
+- **破壊的変更:** `record::rerun_export` (`.rrd` の export/import) が新しい opt-in
+  feature `rerun` を必要とするようになった。
+  `orts = { version = "…", features = ["rerun"] }` で有効化する。
+  `orts` は default feature を持たないので、他の機能への影響はない。
+  `.rrd` を書き出さないビルドでは、`orts` の依存グラフ 355 crates のうち 323 crates が
+  不要になる。`cargo test -p orts` の依存解決は 382 crates から 94 crates になり、
+  lib test 651 本のうち 643 本と `orts/tests/` の統合テスト 23 本は `rerun` を必要としない。
+  ([#314](https://github.com/sksat/orts/pull/314))
 - `StateEffector` を frame-generic 化 — `StateEffector<S, F: frame::Eci =
   SimpleEci>` で `ExternalLoads<F>` を返す (`Model<S, F>` と同様)。effector は
   host の慣性 frame で荷重を生成するようになった。既定の `F` により既存の

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -34,9 +34,9 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   feature `rerun` を必要とするようになった。
   `orts = { version = "…", features = ["rerun"] }` で有効化する。
   `orts` は default feature を持たないので、他の機能への影響はない。
-  `.rrd` を書き出さないビルドでは、`orts` の依存グラフ 355 crates のうち 323 crates が
-  不要になる。`cargo test -p orts` の依存解決は 382 crates から 94 crates になり、
-  lib test 651 本のうち 643 本と `orts/tests/` の統合テスト 23 本は `rerun` を必要としない。
+  `.rrd` を書き出さないビルドでは、`orts` の依存グラフ 271 crates のうち 230 crates が
+  不要になる。`cargo test -p orts` の依存解決は 303 crates から 94 crates になり、
+  lib test 653 本のうち 645 本と `orts/tests/` の統合テスト 23 本は `rerun` を必要としない。
   ([#314](https://github.com/sksat/orts/pull/314))
 - `StateEffector` を frame-generic 化 — `StateEffector<S, F: frame::Eci =
   SimpleEci>` で `ExternalLoads<F>` を返す (`Model<S, F>` と同様)。effector は

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ section is subdivided by package.
 - WIT v0 plugin interface extended with the msg-io and stream-io channels. ([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
+- **Breaking:** `record::rerun_export` (`.rrd` export/import) now requires the
+  new opt-in `rerun` feature. Enable it with
+  `orts = { version = "…", features = ["rerun"] }`. `orts` has no default
+  features, so nothing else in the crate is affected. This drops 323 of the 355
+  crates in `orts`'s dependency graph for builds that do not write `.rrd`:
+  `cargo test -p orts` resolves 94 crates instead of 382, and 643 of the 651 lib
+  tests plus all 23 integration tests under `orts/tests/` need no part of it.
+  ([#314](https://github.com/sksat/orts/pull/314))
 - `StateEffector` is now frame-generic — `StateEffector<S, F: frame::Eci =
   SimpleEci>` returning `ExternalLoads<F>`, like `Model<S, F>` — so effectors
   produce loads already in the host inertial frame. The defaulted `F` keeps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@ section is subdivided by package.
 - **Breaking:** `record::rerun_export` (`.rrd` export/import) now requires the
   new opt-in `rerun` feature. Enable it with
   `orts = { version = "…", features = ["rerun"] }`. `orts` has no default
-  features, so nothing else in the crate is affected. This drops 323 of the 355
+  features, so nothing else in the crate is affected. This drops 230 of the 271
   crates in `orts`'s dependency graph for builds that do not write `.rrd`:
-  `cargo test -p orts` resolves 94 crates instead of 382, and 643 of the 651 lib
+  `cargo test -p orts` resolves 94 crates instead of 303, and 645 of the 653 lib
   tests plus all 23 integration tests under `orts/tests/` need no part of it.
   ([#314](https://github.com/sksat/orts/pull/314))
 - `StateEffector` is now frame-generic — `StateEffector<S, F: frame::Eci =

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -271,7 +271,7 @@ orts (orts/)
     attitude/         # AttitudeState, AttitudeSystem, GravityGradientTorque
     spacecraft/       # SpacecraftState, SpacecraftDynamics
     group/            # PropGroup, GroupState, InterSatelliteForce
-    record/           # Recording, Rerun export (default feature)
+    record/           # Recording, Rerun export (opt-in feature `rerun`)
     setup.rs          # build_orbital_system(), build_spacecraft_dynamics() ヘルパー
     lib.rs
 ```
@@ -339,8 +339,20 @@ trait PropGroup {
 
 ECS データモデルとデータ記録を担当:
 - Recording, Component, Archetype trait
-- Rerun (.rrd) エクスポート（default feature `rerun`; `default-features = false` で除外可能）
+- Rerun (.rrd) エクスポート（opt-in feature `rerun`)
 - Recorder trait（CLI/WS からの記録インターフェース）
+
+`rerun` を opt-in にしているのは、`orts` の依存グラフ 355 crates のうち 323 crates が
+`rerun` 経由でしか到達しないためである。
+接触点は `record::rerun_export` だけで、`record` の他の module と simulation core は
+`rerun` を参照しない。
+lib test 650 本のうち `rerun` を必要とするのは `rerun_export` の 7 本であり、
+`orts/tests/` の統合テストは全て `rerun` 非依存である。
+`orts` は他の feature (`plugin-wasm`, `fetch-*`) も含めて default feature を持たないので、
+`rerun` もそれに揃える。
+.rrd を書き出す `orts-cli` は `features = ["rerun"]` で明示的に有効化する。
+
+format 自体を維持するかどうかの検討は #311。
 
 #### 状態ベクトル 3層設計
 
@@ -716,7 +728,7 @@ SOI 切り替え時の注意点:
 - **Model の純関数性**: `Model<S>::eval(&self, ...)` は副作用を持たない純関数的評価。内部状態の変更は行わない
 - **Context パターン**: `DynamicalSystem::derivatives()` に渡す環境情報 (暦元、天体暦、大気モデル) は将来的に Context 構造体に統合する可能性がある。現状は各 system のフィールドで保持
 - **trait object ポリシー**: モデルは `Box<dyn Model<ConcreteState>>` で実行時差し替え可能。`GravityField`, `AtmosphereModel` 等の環境 trait も `Box<dyn Trait>` で差し替え可能。`impl GravityField for Box<dyn GravityField>` はビルダーヘルパー用の便利 impl であり、性能クリティカルなパスでは `SpacecraftDynamics<G>` のモノモーフィゼーションを使用する
-- **feature gate**: 重いモデル (NRLMSISE-00, Rerun, WebSocket, CSSI HTTP) は feature flag で分離。Rerun は orts の default feature
+- **feature gate**: 重いモデル (NRLMSISE-00, Rerun, WebSocket, CSSI HTTP) は feature flag で分離。`orts` は default feature を持たず、全て opt-in
 
 ## Viewer データフローアーキテクチャ
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -339,14 +339,14 @@ trait PropGroup {
 
 ECS データモデルとデータ記録を担当:
 - Recording, Component, Archetype trait
-- Rerun (.rrd) エクスポート（opt-in feature `rerun`)
+- Rerun (.rrd) エクスポート（opt-in feature `rerun`）
 - Recorder trait（CLI/WS からの記録インターフェース）
 
 `rerun` を opt-in にしているのは、`orts` の依存グラフ 355 crates のうち 323 crates が
 `rerun` 経由でしか到達しないためである。
 接触点は `record::rerun_export` だけで、`record` の他の module と simulation core は
 `rerun` を参照しない。
-lib test 650 本のうち `rerun` を必要とするのは `rerun_export` の 7 本であり、
+lib test 651 本のうち `rerun` を必要とするのは `rerun_export` の 8 本であり、
 `orts/tests/` の統合テストは全て `rerun` 非依存である。
 `orts` は他の feature (`plugin-wasm`, `fetch-*`) も含めて default feature を持たないので、
 `rerun` もそれに揃える。

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -342,11 +342,11 @@ ECS データモデルとデータ記録を担当:
 - Rerun (.rrd) エクスポート（opt-in feature `rerun`）
 - Recorder trait（CLI/WS からの記録インターフェース）
 
-`rerun` を opt-in にしているのは、`orts` の依存グラフ 355 crates のうち 323 crates が
-`rerun` 経由でしか到達しないためである。
+`rerun` を opt-in にしているのは、`orts` の依存グラフ 271 crates のうち 230 crates が
+rerun の subcrate 経由でしか到達しないためである。
 接触点は `record::rerun_export` だけで、`record` の他の module と simulation core は
 `rerun` を参照しない。
-lib test 651 本のうち `rerun` を必要とするのは `rerun_export` の 8 本であり、
+lib test 653 本のうち `rerun` を必要とするのは `rerun_export` の 8 本であり、
 `orts/tests/` の統合テストは全て `rerun` 非依存である。
 `orts` は他の feature (`plugin-wasm`, `fetch-*`) も含めて default feature を持たないので、
 `rerun` もそれに揃える。

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -32,7 +32,9 @@ nalgebra.workspace = true
 utsuroi.workspace = true
 tobari = { workspace = true, features = ["fetch-cssi"] }
 arika = { workspace = true, features = ["sgp4"] }
-orts.workspace = true
+# `rerun` is not optional here: .rrd is the default `--format` and the
+# `replay` / `convert` subcommands exist only to read it.
+orts = { workspace = true, features = ["rerun"] }
 log = "0.4.29"
 clap.workspace = true
 tokio.workspace = true

--- a/orts/Cargo.toml
+++ b/orts/Cargo.toml
@@ -23,11 +23,11 @@ include = [
 
 [dependencies]
 nalgebra.workspace = true
-re_sdk.workspace = true
-re_sdk_types.workspace = true
-re_log_encoding.workspace = true
-re_chunk.workspace = true
-re_log_types.workspace = true
+re_sdk = { workspace = true, optional = true }
+re_sdk_types = { workspace = true, optional = true }
+re_log_encoding = { workspace = true, optional = true }
+re_chunk = { workspace = true, optional = true }
+re_log_types = { workspace = true, optional = true }
 arika.workspace = true
 utsuroi.workspace = true
 tobari.workspace = true
@@ -47,6 +47,20 @@ tokio = { version = "1", default-features = false, features = [
 ], optional = true }
 
 [features]
+# Rerun (.rrd) export/import via `record::rerun_export`.
+#
+# Opt-in because the rerun subcrates are 230 of this crate's 271
+# dependencies, while `record`'s other modules and the whole simulation
+# core never touch them. Of the 651 lib tests only the 8 in
+# `record::rerun_export` need them, and all 23 integration tests under
+# `orts/tests/` build without them.
+rerun = [
+    "dep:re_sdk",
+    "dep:re_sdk_types",
+    "dep:re_log_encoding",
+    "dep:re_chunk",
+    "dep:re_log_types",
+]
 fetch-weather = ["tobari/fetch-cssi"]
 fetch-horizons = ["arika/fetch-horizons"]
 # Phase P1: load WASM Component guest controllers at runtime via

--- a/orts/examples/apollo11/README.md
+++ b/orts/examples/apollo11/README.md
@@ -30,9 +30,12 @@ https://github.com/sksat/orts/releases/download/v0.1.1/apollo11_combined.mp4
 
 ```sh
 # シミュレーション実行（RRD 出力）
-cargo run --example apollo11 -p orts
+# `rerun` feature が必要。これがないと apollo11.rrd を書き出さず、
+# 下の可視化セクションが入力を得られない。
+cargo run --example apollo11 -p orts --features rerun
 
 # テスト（タイミング・精度の assertion）
+# assertion は RRD 出力に依存しないので feature は不要。
 cargo test --example apollo11 -p orts
 ```
 

--- a/orts/examples/apollo11/main.rs
+++ b/orts/examples/apollo11/main.rs
@@ -1236,7 +1236,6 @@ fn main() {
         rec.log_orbital_state(&moon_path, &tp, &os);
     }
 
-    let rrd_path = "orts/examples/apollo11/apollo11.rrd";
     rec.metadata = orts::record::recording::SimMetadata {
         epoch_jd: Some(parking_epoch.jd()),
         mu: Some(MU_EARTH),
@@ -1246,9 +1245,16 @@ fn main() {
         period: None,
         ..Default::default()
     };
-    orts::record::rerun_export::save_as_rrd(&rec, "orts-apollo11", rrd_path).unwrap();
-    println!();
-    println!("Saved to {rrd_path} (open with: rerun {rrd_path})");
+    // The trajectory validation above is the point of this example; the
+    // .rrd dump is just for eyeballing it in the Rerun viewer, so it is
+    // gated rather than making the example require the `rerun` feature.
+    #[cfg(feature = "rerun")]
+    {
+        let rrd_path = "orts/examples/apollo11/apollo11.rrd";
+        orts::record::rerun_export::save_as_rrd(&rec, "orts-apollo11", rrd_path).unwrap();
+        println!();
+        println!("Saved to {rrd_path} (open with: rerun {rrd_path})");
+    }
 }
 
 // Tests — validate against NASA Postflight Trajectory AS-506

--- a/orts/examples/artemis1/README.md
+++ b/orts/examples/artemis1/README.md
@@ -36,6 +36,11 @@ apollo11 example が離散イベント (LOI/TEI/EI) の時刻一致を検証す�
 
 ```sh
 # シミュレーション実行 (Horizons fetch → propagate → verify → RRD 出力)
+# RRD 出力には `rerun` feature も必要。これがないと verify までで終了し、
+# RRD 用の dense Orion テーブル fetch (~5 MB) と再伝播はスキップされる。
+cargo run --release --example artemis1 -p orts --features fetch-horizons,rerun
+
+# verify だけ実行する場合 (RRD 用の fetch と再伝播を省く)
 cargo run --release --example artemis1 -p orts --features fetch-horizons
 
 # 初回実行時: Moon + Sun + Orion を Horizons から fetch (~数十秒)
@@ -46,7 +51,8 @@ cargo run --release --example artemis1 -p orts --features fetch-horizons
 
 ### Rerun RRD
 
-`cargo run` 末尾で `orts/examples/artemis1/artemis1.rrd` (~40 MB) を出力する。
+`rerun` feature 付きの `cargo run` 末尾で `orts/examples/artemis1/artemis1.rrd`
+(~40 MB) を出力する。
 
 ```sh
 rerun orts/examples/artemis1/artemis1.rrd

--- a/orts/examples/artemis1/main.rs
+++ b/orts/examples/artemis1/main.rs
@@ -370,7 +370,7 @@ const ORION_REF_STEP: &str = "1m";
 ///
 /// Matches the `apollo11.rrd` convention alongside the companion
 /// example and is `.gitignore`d via the top-level ignore list.
-#[cfg(feature = "fetch-horizons")]
+#[cfg(all(feature = "fetch-horizons", feature = "rerun"))]
 const RRD_OUTPUT_PATH: &str = "orts/examples/artemis1/artemis1.rrd";
 
 /// Mission epoch used as the `sim_time = 0` reference for the RRD
@@ -1059,10 +1059,13 @@ fn main() {
     // before the save call below takes `&rec`.
     drop(chain_recording);
 
-    println!("  saving RRD to {RRD_OUTPUT_PATH}");
-    orts::record::rerun_export::save_as_rrd(&rec, "orts-artemis1", RRD_OUTPUT_PATH)
-        .expect("save artemis1 RRD");
-    println!();
+    #[cfg(feature = "rerun")]
+    {
+        println!("  saving RRD to {RRD_OUTPUT_PATH}");
+        orts::record::rerun_export::save_as_rrd(&rec, "orts-artemis1", RRD_OUTPUT_PATH)
+            .expect("save artemis1 RRD");
+        println!();
+    }
 
     // Summary tables
     print_summary(&results);

--- a/orts/examples/artemis1/main.rs
+++ b/orts/examples/artemis1/main.rs
@@ -269,15 +269,15 @@ use orts::orbital::OrbitalSystem;
 use orts::orbital::gravity::PointMass;
 #[cfg(feature = "fetch-horizons")]
 use orts::perturbations::{ConstantThrust, ThirdBodyGravity, ZonalGravity};
-#[cfg(feature = "fetch-horizons")]
+#[cfg(all(feature = "fetch-horizons", feature = "rerun"))]
 use orts::record::archetypes::OrbitalState as RecordOrbitalState;
-#[cfg(feature = "fetch-horizons")]
+#[cfg(all(feature = "fetch-horizons", feature = "rerun"))]
 use orts::record::components::{BodyRadius, GravitationalParameter, Position3D};
-#[cfg(feature = "fetch-horizons")]
+#[cfg(all(feature = "fetch-horizons", feature = "rerun"))]
 use orts::record::entity_path::EntityPath;
-#[cfg(feature = "fetch-horizons")]
+#[cfg(all(feature = "fetch-horizons", feature = "rerun"))]
 use orts::record::recording::Recording;
-#[cfg(feature = "fetch-horizons")]
+#[cfg(all(feature = "fetch-horizons", feature = "rerun"))]
 use orts::record::timeline::TimePoint;
 #[cfg(feature = "fetch-horizons")]
 use utsuroi::{Dop853, Integrator};
@@ -349,7 +349,7 @@ const DT_SECONDS: f64 = 10.0;
 /// `OUTPUT_INTERVAL` and gives ~8,600 samples for the chain window
 /// (smooth trajectory visible in Rerun's 3D view, fine enough to
 /// resolve burn onset / DRO loop shape).
-#[cfg(feature = "fetch-horizons")]
+#[cfg(all(feature = "fetch-horizons", feature = "rerun"))]
 const OUTPUT_INTERVAL: f64 = 60.0;
 
 /// Dense Orion reference step for the chain-window Horizons fetch.
@@ -363,7 +363,7 @@ const OUTPUT_INTERVAL: f64 = 60.0;
 /// cubic Hermite error at 60 s sample spacing is O(h^4) ≈ sub-metre for
 /// Orion's smooth trajectory near the DRI/DRDI burns — below the
 /// display resolution of any imaginable plot.
-#[cfg(feature = "fetch-horizons")]
+#[cfg(all(feature = "fetch-horizons", feature = "rerun"))]
 const ORION_REF_STEP: &str = "1m";
 
 /// Output path for the Rerun RRD file produced at the end of `main`.
@@ -381,7 +381,7 @@ const RRD_OUTPUT_PATH: &str = "orts/examples/artemis1/artemis1.rrd";
 /// sample. Using `COAST_PHASES[0]`'s start keeps the `sim_time` axis
 /// readable (first sample at t = 0 days, last sample at ~22.96 days)
 /// and matches the "outbound coast" phase the reader sees first.
-#[cfg(feature = "fetch-horizons")]
+#[cfg(all(feature = "fetch-horizons", feature = "rerun"))]
 const MISSION_EPOCH_ISO: &str = "2022-11-17T00:00:00Z";
 
 /// Moon ephemeris window covering all three coast phases, padded ±1 h for
@@ -905,162 +905,166 @@ fn main() {
     // have their own stdout summaries for those gaps, and rendering
     // the omitted ~5-day coasts would triple the RRD size for no
     // visual benefit).
-    println!("── Building Rerun RRD visualization ──");
-    let mission_epoch = Epoch::from_iso8601(MISSION_EPOCH_ISO).expect("valid mission epoch");
+    // Skipped wholesale without the `rerun` feature: everything below
+    // exists only to produce the .rrd, and the dense Horizons fetch
+    // (~5 MB) plus the second propagation would otherwise run with
+    // nowhere to write the result.
+    #[cfg(feature = "rerun")]
+    {
+        println!("── Building Rerun RRD visualization ──");
+        let mission_epoch = Epoch::from_iso8601(MISSION_EPOCH_ISO).expect("valid mission epoch");
 
-    // Fetch one dense Orion reference table covering the **whole**
-    // recorded span (outbound start → return end). A single fetch
-    // lets `HorizonsTable::interpolate` handle every recorded phase
-    // from memory with no per-step HTTP calls, and the cached CSV
-    // (~5 MB for ~23 days × 1 min) is reused on subsequent runs.
-    let ref_start_iso = COAST_PHASES[0].1; // outbound start
-    let ref_stop_iso = COAST_PHASES[COAST_PHASES.len() - 1].2; // return end
-    let ref_start = Epoch::from_iso8601(ref_start_iso)
-        .expect("valid outbound start")
-        .add_seconds(-60.0);
-    let ref_stop = Epoch::from_iso8601(ref_stop_iso)
-        .expect("valid return end")
-        .add_seconds(60.0);
-    println!("  fetching dense Orion reference table ({ORION_REF_STEP} spacing)…");
-    let orion_ref_table = HorizonsTable::fetch_vector_table(
-        ORION_TARGET,
-        EARTH_GEOCENTER,
-        &ref_start,
-        &ref_stop,
-        ORION_REF_STEP,
-        None,
-    )
-    .expect("fetch Orion reference table");
-    println!(
-        "  {} Orion reference samples over {} → {}",
-        orion_ref_table.samples().len(),
-        iso_short(&ref_start),
-        iso_short(&ref_stop),
-    );
-
-    // Build the recording skeleton. Earth and Moon mu / radius come
-    // from `KnownBody::properties()` so the two entities use the same
-    // source of truth; any future correction (e.g. switching to DE441
-    // GM_EARTH) lands in both places at once.
-    let mut rec = Recording::new();
-    let earth_props = arika::body::KnownBody::Earth.properties();
-    let earth_path = EntityPath::parse("/world/earth");
-    rec.log_static(&earth_path, &GravitationalParameter(earth_props.mu));
-    rec.log_static(&earth_path, &BodyRadius(earth_props.radius));
-    let moon_path = EntityPath::parse("/world/moon");
-    let moon_props = arika::body::KnownBody::Moon.properties();
-    rec.log_static(&moon_path, &GravitationalParameter(moon_props.mu));
-    rec.log_static(&moon_path, &BodyRadius(moon_props.radius));
-
-    let mut chain_recording = ChainRecording::new(&mut rec, &orion_ref_table);
-
-    // Helper closure: record a pure-coast phase into a phase-specific
-    // slot of the entity tree. The `phase_key` becomes the final
-    // path segment (`/world/sat/artemis1/<phase_key>`) so downstream
-    // per-phase slicing in plot_trajectory.py can filter by entity
-    // path, avoiding the sim_time-boundary collision problem.
-    let record_fill = |phase_key: &'static str,
-                       label: &'static str,
-                       start_iso: &'static str,
-                       end_iso: &'static str,
-                       chain_recording: &mut ChainRecording| {
-        let phase_start = Epoch::from_iso8601(start_iso).expect("valid fill start");
-        let met = (phase_start.jd() - mission_epoch.jd()) * 86_400.0;
-        chain_recording.reset_for_phase(met, phase_key);
-        record_coast_phase(
-            label,
-            start_iso,
-            end_iso,
-            &moon_ephem,
-            &sun_table_arc,
-            chain_recording,
+        // Fetch one dense Orion reference table covering the **whole**
+        // recorded span (outbound start → return end). A single fetch
+        // lets `HorizonsTable::interpolate` handle every recorded phase
+        // from memory with no per-step HTTP calls, and the cached CSV
+        // (~5 MB for ~23 days × 1 min) is reused on subsequent runs.
+        let ref_start_iso = COAST_PHASES[0].1; // outbound start
+        let ref_stop_iso = COAST_PHASES[COAST_PHASES.len() - 1].2; // return end
+        let ref_start = Epoch::from_iso8601(ref_start_iso)
+            .expect("valid outbound start")
+            .add_seconds(-60.0);
+        let ref_stop = Epoch::from_iso8601(ref_stop_iso)
+            .expect("valid return end")
+            .add_seconds(60.0);
+        println!("  fetching dense Orion reference table ({ORION_REF_STEP} spacing)…");
+        let orion_ref_table = HorizonsTable::fetch_vector_table(
+            ORION_TARGET,
+            EARTH_GEOCENTER,
+            &ref_start,
+            &ref_stop,
+            ORION_REF_STEP,
+            None,
+        )
+        .expect("fetch Orion reference table");
+        println!(
+            "  {} Orion reference samples over {} → {}",
+            orion_ref_table.samples().len(),
+            iso_short(&ref_start),
+            iso_short(&ref_stop),
         );
-    };
 
-    // --- Phase sequence (covering the whole 2022-11-17 → 2022-12-10
-    //     recorded mission window with no gaps) ---
-    //
-    // 1. Outbound coast (verified)          2022-11-17 → 2022-11-20
-    // 2. Outbound-to-chain fill (unmodelled OPF on 2022-11-21 inside)
-    //                                       2022-11-20 → 2022-11-25T21:40
-    // 3. DRI → DRDI chain (verified)        2022-11-25T21:40 → 2022-12-01T22:06
-    // 4. Chain-to-return fill (unmodelled RPF on 2022-12-05 inside)
-    //                                       2022-12-01T22:06 → 2022-12-06
-    // 5. Return coast (verified)            2022-12-06 → 2022-12-10
-    //
-    // Each phase starts fresh from the Horizons reference state at
-    // its own start epoch so upstream errors do not accumulate into
-    // the next phase; the fills 2 and 4 will visibly diverge from
-    // the Horizons reference at ~1 day past their start because the
-    // powered flyby Δv is missing from the force model.
-    record_fill(
-        "outbound",
-        COAST_PHASES[0].0,
-        COAST_PHASES[0].1,
-        COAST_PHASES[0].2,
-        &mut chain_recording,
-    );
+        // Build the recording skeleton. Earth and Moon mu / radius come
+        // from `KnownBody::properties()` so the two entities use the same
+        // source of truth; any future correction (e.g. switching to DE441
+        // GM_EARTH) lands in both places at once.
+        let mut rec = Recording::new();
+        let earth_props = arika::body::KnownBody::Earth.properties();
+        let earth_path = EntityPath::parse("/world/earth");
+        rec.log_static(&earth_path, &GravitationalParameter(earth_props.mu));
+        rec.log_static(&earth_path, &BodyRadius(earth_props.radius));
+        let moon_path = EntityPath::parse("/world/moon");
+        let moon_props = arika::body::KnownBody::Moon.properties();
+        rec.log_static(&moon_path, &GravitationalParameter(moon_props.mu));
+        rec.log_static(&moon_path, &BodyRadius(moon_props.radius));
 
-    if BURN_CHAIN_INDICES.len() >= 2 {
-        let chain_burns: Vec<&Maneuver> =
-            BURN_CHAIN_INDICES.iter().map(|&i| &MANEUVERS[i]).collect();
-        let chain_pre_iso = chain_burns[0].pre_epoch_iso;
-        let chain_post_iso = chain_burns[chain_burns.len() - 1].post_epoch_iso;
+        let mut chain_recording = ChainRecording::new(&mut rec, &orion_ref_table);
 
-        // Fill between outbound end and chain pre. Contains the OPF
-        // (Outbound Powered Flyby, 2022-11-21, ~210 m/s) which the
-        // force model does not carry — the plot will show divergence
-        // starting around MET ~5 days.
+        // Helper closure: record a pure-coast phase into a phase-specific
+        // slot of the entity tree. The `phase_key` becomes the final
+        // path segment (`/world/sat/artemis1/<phase_key>`) so downstream
+        // per-phase slicing in plot_trajectory.py can filter by entity
+        // path, avoiding the sim_time-boundary collision problem.
+        let record_fill = |phase_key: &'static str,
+                           label: &'static str,
+                           start_iso: &'static str,
+                           end_iso: &'static str,
+                           chain_recording: &mut ChainRecording| {
+            let phase_start = Epoch::from_iso8601(start_iso).expect("valid fill start");
+            let met = (phase_start.jd() - mission_epoch.jd()) * 86_400.0;
+            chain_recording.reset_for_phase(met, phase_key);
+            record_coast_phase(
+                label,
+                start_iso,
+                end_iso,
+                &moon_ephem,
+                &sun_table_arc,
+                chain_recording,
+            );
+        };
+
+        // --- Phase sequence (covering the whole 2022-11-17 → 2022-12-10
+        //     recorded mission window with no gaps) ---
+        //
+        // 1. Outbound coast (verified)          2022-11-17 → 2022-11-20
+        // 2. Outbound-to-chain fill (unmodelled OPF on 2022-11-21 inside)
+        //                                       2022-11-20 → 2022-11-25T21:40
+        // 3. DRI → DRDI chain (verified)        2022-11-25T21:40 → 2022-12-01T22:06
+        // 4. Chain-to-return fill (unmodelled RPF on 2022-12-05 inside)
+        //                                       2022-12-01T22:06 → 2022-12-06
+        // 5. Return coast (verified)            2022-12-06 → 2022-12-10
+        //
+        // Each phase starts fresh from the Horizons reference state at
+        // its own start epoch so upstream errors do not accumulate into
+        // the next phase; the fills 2 and 4 will visibly diverge from
+        // the Horizons reference at ~1 day past their start because the
+        // powered flyby Δv is missing from the force model.
         record_fill(
-            "opf_fill",
-            "Outbound → chain fill (contains OPF 2022-11-21)",
-            COAST_PHASES[0].2, // outbound end
-            chain_pre_iso,
+            "outbound",
+            COAST_PHASES[0].0,
+            COAST_PHASES[0].1,
+            COAST_PHASES[0].2,
             &mut chain_recording,
         );
 
-        let chain_pre = Epoch::from_iso8601(chain_pre_iso).expect("valid chain pre epoch");
-        let met = (chain_pre.jd() - mission_epoch.jd()) * 86_400.0;
-        chain_recording.reset_for_phase(met, "chain");
-        println!("  recording DRI → DRDI chain ({chain_pre_iso} → {chain_post_iso})");
-        record_chain_trajectory(
-            &chain_burns,
-            &moon_ephem,
-            &sun_table_arc,
-            &mut chain_recording,
-        );
+        if BURN_CHAIN_INDICES.len() >= 2 {
+            let chain_burns: Vec<&Maneuver> =
+                BURN_CHAIN_INDICES.iter().map(|&i| &MANEUVERS[i]).collect();
+            let chain_pre_iso = chain_burns[0].pre_epoch_iso;
+            let chain_post_iso = chain_burns[chain_burns.len() - 1].post_epoch_iso;
 
-        // Fill between chain post and return start. Contains the RPF
-        // (Return Powered Flyby, 2022-12-05, ~328 m/s) which the
-        // force model also does not carry — divergence starts ~4
-        // days after the fill begins.
+            // Fill between outbound end and chain pre. Contains the OPF
+            // (Outbound Powered Flyby, 2022-11-21, ~210 m/s) which the
+            // force model does not carry — the plot will show divergence
+            // starting around MET ~5 days.
+            record_fill(
+                "opf_fill",
+                "Outbound → chain fill (contains OPF 2022-11-21)",
+                COAST_PHASES[0].2, // outbound end
+                chain_pre_iso,
+                &mut chain_recording,
+            );
+
+            let chain_pre = Epoch::from_iso8601(chain_pre_iso).expect("valid chain pre epoch");
+            let met = (chain_pre.jd() - mission_epoch.jd()) * 86_400.0;
+            chain_recording.reset_for_phase(met, "chain");
+            println!("  recording DRI → DRDI chain ({chain_pre_iso} → {chain_post_iso})");
+            record_chain_trajectory(
+                &chain_burns,
+                &moon_ephem,
+                &sun_table_arc,
+                &mut chain_recording,
+            );
+
+            // Fill between chain post and return start. Contains the RPF
+            // (Return Powered Flyby, 2022-12-05, ~328 m/s) which the
+            // force model also does not carry — divergence starts ~4
+            // days after the fill begins.
+            if COAST_PHASES.len() >= 3 {
+                record_fill(
+                    "rpf_fill",
+                    "Chain → return fill (contains RPF 2022-12-05)",
+                    chain_post_iso,
+                    COAST_PHASES[2].1, // return start
+                    &mut chain_recording,
+                );
+            }
+        }
+
         if COAST_PHASES.len() >= 3 {
             record_fill(
-                "rpf_fill",
-                "Chain → return fill (contains RPF 2022-12-05)",
-                chain_post_iso,
-                COAST_PHASES[2].1, // return start
+                "return",
+                COAST_PHASES[2].0,
+                COAST_PHASES[2].1,
+                COAST_PHASES[2].2,
                 &mut chain_recording,
             );
         }
-    }
 
-    if COAST_PHASES.len() >= 3 {
-        record_fill(
-            "return",
-            COAST_PHASES[2].0,
-            COAST_PHASES[2].1,
-            COAST_PHASES[2].2,
-            &mut chain_recording,
-        );
-    }
+        // Drop the ChainRecording so its mutable borrow of `rec` ends
+        // before the save call below takes `&rec`.
+        drop(chain_recording);
 
-    // Drop the ChainRecording so its mutable borrow of `rec` ends
-    // before the save call below takes `&rec`.
-    drop(chain_recording);
-
-    #[cfg(feature = "rerun")]
-    {
         println!("  saving RRD to {RRD_OUTPUT_PATH}");
         orts::record::rerun_export::save_as_rrd(&rec, "orts-artemis1", RRD_OUTPUT_PATH)
             .expect("save artemis1 RRD");
@@ -2039,7 +2043,7 @@ fn verify_burn_chain_continuous(
 /// without losing visible trajectory resolution — at DRO distances the
 /// spacecraft moves < 60 m per integrator step, which is below the
 /// screen pixel even in a close-up Earth view.
-#[cfg(feature = "fetch-horizons")]
+#[cfg(all(feature = "fetch-horizons", feature = "rerun"))]
 struct ChainRecording<'a> {
     rec: &'a mut Recording,
     orion_ref: &'a HorizonsTable,
@@ -2067,7 +2071,7 @@ struct ChainRecording<'a> {
     sim_t_offset: f64,
 }
 
-#[cfg(feature = "fetch-horizons")]
+#[cfg(all(feature = "fetch-horizons", feature = "rerun"))]
 impl<'a> ChainRecording<'a> {
     fn new(rec: &'a mut Recording, orion_ref: &'a HorizonsTable) -> Self {
         Self {
@@ -2224,7 +2228,7 @@ impl<'a> ChainRecording<'a> {
 ///
 /// Earth is logged as static in `main` (body radius + µ) outside this
 /// function because it never moves in the ECI frame.
-#[cfg(feature = "fetch-horizons")]
+#[cfg(all(feature = "fetch-horizons", feature = "rerun"))]
 fn record_chain_trajectory(
     burns: &[&Maneuver],
     moon_ephem: &Arc<dyn MoonEphemeris>,
@@ -2348,7 +2352,7 @@ fn record_chain_trajectory(
 /// verify_coast would leak visualization concerns into the
 /// verification code, and the extra ~few hundred millisecond CPU cost
 /// is negligible next to the Horizons fetches.
-#[cfg(feature = "fetch-horizons")]
+#[cfg(all(feature = "fetch-horizons", feature = "rerun"))]
 fn record_coast_phase(
     label: &str,
     start_iso: &str,

--- a/orts/examples/artemis1/plot_trajectory.py
+++ b/orts/examples/artemis1/plot_trajectory.py
@@ -8,7 +8,7 @@ Usage:
     uv run orts/examples/artemis1/plot_trajectory.py
 
 Reads `artemis1.rrd` (emitted by `cargo run --example artemis1 -p orts
---features fetch-horizons`) via the `orts convert` CLI and produces
+--features fetch-horizons,rerun`) via the `orts convert` CLI and produces
 four PNGs alongside this script:
 
 - `artemis1_full_mission.png` — all three recorded phases (outbound
@@ -133,7 +133,9 @@ def load_entities() -> dict[str, np.ndarray]:
         sys.exit(
             f"error: {RRD_PATH} does not exist.\n"
             f"       run `cargo run --release --example artemis1 -p orts \\\n"
-            f"              --features fetch-horizons` first to generate it."
+            f"              --features fetch-horizons,rerun` first to generate it.\n"
+            f"       (without the `rerun` feature the example verifies the\n"
+            f"        trajectory but writes no .rrd)"
         )
 
     result = subprocess.run(

--- a/orts/examples/orbital_lifetime/README.md
+++ b/orts/examples/orbital_lifetime/README.md
@@ -92,6 +92,11 @@ cargo run --example orbital_lifetime -p orts
 # All groups (requires network for CSSI fetch)
 cargo run --example orbital_lifetime -p orts --features fetch-weather
 
+# Either command above also writes orbital_lifetime.rrd once the `rerun`
+# feature is on; without it the run still prints its results and asserts,
+# but produces no .rrd for the plotting step below.
+cargo run --example orbital_lifetime -p orts --features rerun,fetch-weather
+
 # Generate plot
 cargo run --bin orts -- convert --format csv \
     orts/examples/orbital_lifetime/orbital_lifetime.rrd \

--- a/orts/examples/orbital_lifetime/main.rs
+++ b/orts/examples/orbital_lifetime/main.rs
@@ -529,7 +529,6 @@ fn main() {
     println!();
 
     // Save RRD
-    let rrd_path = "orts/examples/orbital_lifetime/orbital_lifetime.rrd";
     rec.metadata = orts::record::recording::SimMetadata {
         epoch_jd: Some(epoch.jd()),
         mu: Some(MU_EARTH),
@@ -539,8 +538,12 @@ fn main() {
         period: None,
         ..Default::default()
     };
-    orts::record::rerun_export::save_as_rrd(&rec, "orts-orbital-lifetime", rrd_path).unwrap();
-    println!("Saved to {rrd_path} (open with: rerun {rrd_path})");
+    #[cfg(feature = "rerun")]
+    {
+        let rrd_path = "orts/examples/orbital_lifetime/orbital_lifetime.rrd";
+        orts::record::rerun_export::save_as_rrd(&rec, "orts-orbital-lifetime", rrd_path).unwrap();
+        println!("Saved to {rrd_path} (open with: rerun {rrd_path})");
+    }
 
     // Assertions (active during `cargo test --example`)
     // Group 1: all scenarios must terminate with reentry

--- a/orts/examples/orbital_lifetime/plot_altitude.py
+++ b/orts/examples/orbital_lifetime/plot_altitude.py
@@ -6,8 +6,8 @@
 """Plot altitude history for each scenario from orbital_lifetime CSV.
 
 Usage:
-    # Generate CSV first:
-    cargo run --example orbital_lifetime -p orts --features fetch-weather
+    # Generate CSV first (`rerun` is what writes the .rrd):
+    cargo run --example orbital_lifetime -p orts --features rerun,fetch-weather
     cargo run --bin orts -- convert --format csv \
         orts/examples/orbital_lifetime/orbital_lifetime.rrd \
         --output orts/examples/orbital_lifetime/orbital_lifetime.csv

--- a/orts/src/record/mod.rs
+++ b/orts/src/record/mod.rs
@@ -4,5 +4,7 @@ pub mod component;
 pub mod components;
 pub mod entity_path;
 pub mod recording;
+/// Rerun (.rrd) export/import. Requires the `rerun` feature.
+#[cfg(feature = "rerun")]
 pub mod rerun_export;
 pub mod timeline;

--- a/plugin-sdk/examples/Cargo.lock
+++ b/plugin-sdk/examples/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "glam"
@@ -205,18 +205,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -237,7 +231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown",
  "serde",
  "serde_core",
 ]
@@ -555,9 +549,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.244.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
 dependencies = [
  "leb128fmt",
  "wasmparser",
@@ -565,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.244.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+checksum = "5f998ccc6e012f7b86865eb2a106c8a0422017a1a88977ce01a69f2244be2e57"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -577,30 +571,30 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.244.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
 dependencies = [
  "bitflags",
- "hashbrown 0.15.5",
+ "hashbrown",
  "indexmap",
  "semver",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "a43552cfa071f246cfd99e5dbb23710dfe7336b3259e09339818483359470749"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.51.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+checksum = "4738d1c9a78e97bc7f664bfafd5d8e67d7bb26faa5c41e6d628e8bbdad3ec351"
 dependencies = [
  "anyhow",
  "heck",
@@ -609,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.51.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+checksum = "1130ce1f531bc9f9a75922244aa773bf5e2117fda1ef4a86b9f98d6b8135eb46"
 dependencies = [
  "anyhow",
  "heck",
@@ -625,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.51.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+checksum = "07296369e4d598e7e79b64eef66f724d83324ea671bcf677d78fc5cf92604ae5"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -640,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.244.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+checksum = "83a5e60173c413659c689f0581b0cf5d1a2404077568f9ffdce748a9eb2fc913"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -659,11 +653,12 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.244.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+checksum = "e960732e824fab95099971a09e638979347c94ca48568d3c854c945729196947"
 dependencies = [
  "anyhow",
+ "hashbrown",
  "id-arena",
  "indexmap",
  "log",


### PR DESCRIPTION
## 変更

`orts` の .rrd export を opt-in feature `rerun` の後ろに置く。

- `orts/Cargo.toml`: rerun の 5 subcrate を `optional = true` にし、feature `rerun` でまとめる
- `orts/src/record/mod.rs`: `pub mod rerun_export` に `#[cfg(feature = "rerun")]`
- `cli/Cargo.toml`: `orts = { workspace = true, features = ["rerun"] }`
- examples 3 本: 末尾の `save_as_rrd` 呼び出しを `#[cfg]` で囲む
- `ci.yml`: `rust-test` に .rrd round-trip テストの実行 step を追加

## 根拠

`rerun` に触るのは `record::rerun_export` の 1 ファイルだけで、公開シグネチャに rerun の型は現れない。
`record` は leaf module であり、simulation core から参照されていない。

| 指標 | before | after |
|---|---|---|
| `cargo test -p orts` の依存 crate 数 | 303 | **94** |
| `orts` の依存 crate 数（230 が feature の後ろ） | 271 | **41** |

lib test 653 本のうち feature が必要なのは `record::rerun_export` の **8 本**で、残り 645 本は feature off で pass する。
`orts/tests/` の統合テスト 23 本はすべて feature 非依存。

CI では `rust-test-orts` と `rust-test-orts-integration` が command line 無変更で rerun を積まなくなる（どちらも `-p orts` で feature を渡していない）。

## 設計判断

### default feature にはしていない

`orts` は `plugin-wasm` も `fetch-weather` も `fetch-horizons` も opt-in で、default feature 集合を持たない。
`rerun` もそれに揃えた。
これにより上記 2 ジョブが CI 側の変更なしで恩恵を受ける。

DESIGN.md は 2 箇所で「Rerun は orts の default feature」と書いていたので、根拠付きで opt-in に改めた。

`orts-cli` は `arika/sgp4` や `tobari/fetch-cssi` と同じように明示的に有効化する。
.rrd は `--format` の default で、`replay` と `convert` はそれを読むためのサブコマンドなので、CLI 側は常時有効でよい。
`orts-cli` の依存グラフは変更前と**バイト単位で同一**（398 crates）であることを確認済み。

### examples は `required-features` ではなく `#[cfg]`

`apollo11` / `artemis1` / `orbital_lifetime` の価値は軌道計算の検証にあるので、feature なしでもコンパイルと assertion が走るようにした。
`artemis1` は save 呼び出しだけでなく RRD 構築ブロック全体を gate している（dense Orion テーブルの HTTP fetch ~5 MB と 3 フェーズの再伝播を含むため）。

### CI に実行 step を足した理由

feature が off になると `record::rerun_export` の 8 本がどのジョブからも実行されなくなる。
`rust-test` に次を追加した。

```
cargo test --locked --workspace --features orts/rerun --lib record::rerun_export::
```

`--workspace` の package 選択を保っているのは、これで得られる `orts` の feature union が
`{plugin-wasm, plugin-wasm-async, rerun}` となり、`rust-build` が `cargo test --workspace --no-run` で
すでに `rust-native` cache に保存した lib test binary をそのまま再利用できるから。
`-p orts` に絞ると `arika/sgp4` と `tobari/fetch-cssi` が union から外れてグラフ全体を再ビルドする。

実測で 11.5 秒、8 tests passed / 645 filtered out。

`--features orts/rerun` は `orts-cli` の依存 edge と重複するが明示している。
`--unit-graph` で確認したところ指定の有無で unit graph は 690 units のまま同一で、キャッシュへの影響はない。
明示しておけば、将来 `orts-cli` が feature を有効にしなくなったときに step が 0 件テストで通る事態を防げる。

## #330 との関係

#330（umbrella → subcrate 直依存、マージ済み）の上に乗っている。
効く範囲は重ならない。

- #330: .rrd を書くビルド（`orts-cli`、`--workspace`）。460 → 398 crates
- この PR: .rrd を書かないビルド（`-p orts` 系の CI 2 ジョブ）。303 → 94 crates

feature を off にすると subcrate 群ごと落ちる。

## 検証したこと

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p orts -- -D warnings`（feature off、CI と同じ呼び出し）
- `cargo test --locked -p orts --lib`（feature off）645 passed
- `cargo test --locked -p orts --features rerun --lib record::rerun_export::` 8 passed
- `cargo test --locked -p orts --lib --examples --no-run`（feature off）example 3 本すべてリンク
- `cargo build -p orts --features fetch-horizons --example artemis1` と `--features fetch-horizons,rerun` の両方が警告ゼロ
- `cargo tree -p orts-cli` が #330 後の状態と同一

`orts/examples/apollo11/main.rs` の `REF_TLI_GET` 未使用と `earth_perigee` の `epoch` 引数未使用の警告は main から変わらず既存のもの。

関連: #316（ビルド時間の tracking issue）、#311（.rrd を native format として使い続けるかの判断）、#315（criterion の切り出し）
