### PR TITLE
fix: 不正な時間パラメータでハング・panic せずエラーにする

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -3,3 +3,78 @@ pub mod convert;
 pub mod replay;
 pub mod run;
 pub mod serve;
+
+/// A command failure, carrying the process exit code it should produce.
+///
+/// Commands return this instead of calling `std::process::exit` themselves, so
+/// `main` is the only place that decides how the process ends. That keeps the
+/// failure paths unit-testable: the message can be asserted without spawning a
+/// subprocess.
+///
+/// The code distinguishes a usage error (2) from a runtime failure (1); both
+/// were previously spelled as direct `exit` calls at the point of detection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CmdError {
+    pub message: String,
+    pub code: i32,
+}
+
+impl CmdError {
+    /// A runtime failure: valid invocation, but the work could not complete
+    /// (bad config values, I/O error, integration failure).
+    pub fn failure(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            code: 1,
+        }
+    }
+
+    /// A usage error: the flags themselves are contradictory, so no amount of
+    /// retrying the same invocation can succeed.
+    pub fn usage(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            code: 2,
+        }
+    }
+}
+
+impl std::fmt::Display for CmdError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for CmdError {}
+
+impl From<String> for CmdError {
+    fn from(message: String) -> Self {
+        Self::failure(message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failure_and_usage_carry_distinct_codes() {
+        assert_eq!(CmdError::failure("x").code, 1);
+        assert_eq!(CmdError::usage("x").code, 2);
+    }
+
+    #[test]
+    fn display_is_the_bare_message() {
+        // `main` prefixes "Error: ", so the message must not repeat it.
+        assert_eq!(
+            CmdError::failure("dt must be positive").to_string(),
+            "dt must be positive"
+        );
+    }
+
+    #[test]
+    fn string_converts_to_a_runtime_failure() {
+        let e: CmdError = "bad config".to_string().into();
+        assert_eq!(e, CmdError::failure("bad config"));
+    }
+}

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -19,6 +19,26 @@ use crate::cli::{IntegratorChoice, OutputFormat, SimArgs};
 use crate::satellite::OrbitSpec;
 use crate::sim::params::SimParams;
 
+/// Apply the config-file validation rules to the direct-CLI argument path.
+///
+/// `SimParams::from_sim_args` builds the same `SimParams` as
+/// `SimParams::from_config` but skips `SimConfig::validate`, so without this
+/// `--dt 0` hangs, `--dt nan` panics in step-size control, and
+/// `--dt 10 --output-interval 1` panics inside `clamp`.
+pub(crate) fn validate_sim_args(sim: &SimArgs) {
+    let checks = crate::config::validate_time_params(
+        sim.dt,
+        sim.output_interval,
+        sim.stream_interval,
+        sim.duration,
+    )
+    .and_then(|()| crate::config::validate_tolerances(sim.integrator, sim.atol, sim.rtol));
+    if let Err(e) = checks {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+}
+
 pub fn run_simulation_cmd(sim: &SimArgs, output: Option<&str>, format: OutputFormat, json: bool) {
     let mut params = if let Some(config_path) = &sim.config {
         let config = crate::config::SimConfig::load(std::path::Path::new(config_path))
@@ -28,6 +48,10 @@ pub fn run_simulation_cmd(sim: &SimArgs, output: Option<&str>, format: OutputFor
             });
         SimParams::from_config(&config)
     } else if sim.has_orbit_args() {
+        // The direct-CLI path bypasses `SimConfig::validate`, so apply the
+        // same time/tolerance checks here rather than letting a bad `--dt`
+        // hang the propagation loop or panic inside step-size control.
+        validate_sim_args(sim);
         SimParams::from_sim_args(sim, false)
     } else {
         // Auto-detect orts.toml in the current directory
@@ -994,6 +1018,12 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
         .iter()
         .map(|sat| sat.controller.sample_period())
         .fold(f64::INFINITY, f64::min);
+    // `fold` also yields `INFINITY` for an empty fleet, which the loop below
+    // cannot step with either.
+    if let Err(e) = crate::config::validate_sample_period(dt_ctrl) {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
     let dt_ode = params.dt.min(dt_ctrl);
 
     let mut t = 0.0;

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -16,6 +16,7 @@ use orts::record::timeline::TimePoint;
 use orts::visibility::{StationContact, VisibilityMonitor};
 
 use crate::cli::{IntegratorChoice, OutputFormat, SimArgs};
+use crate::commands::CmdError;
 use crate::satellite::OrbitSpec;
 use crate::sim::params::SimParams;
 
@@ -25,54 +26,49 @@ use crate::sim::params::SimParams;
 /// `SimParams::from_config` but skips `SimConfig::validate`, so without this
 /// `--dt 0` hangs, `--dt nan` panics in step-size control, and
 /// `--dt 10 --output-interval 1` panics inside `clamp`.
-pub(crate) fn validate_sim_args(sim: &SimArgs) {
-    let checks = crate::config::validate_time_params(
+pub(crate) fn validate_sim_args(sim: &SimArgs) -> Result<(), String> {
+    crate::config::validate_time_params(
         sim.dt,
         sim.output_interval,
         sim.stream_interval,
         sim.duration,
-    )
-    .and_then(|()| crate::config::validate_tolerances(sim.integrator, sim.atol, sim.rtol));
-    if let Err(e) = checks {
-        eprintln!("Error: {e}");
-        std::process::exit(1);
-    }
+    )?;
+    crate::config::validate_tolerances(sim.integrator, sim.atol, sim.rtol)
 }
 
-pub fn run_simulation_cmd(sim: &SimArgs, output: Option<&str>, format: OutputFormat, json: bool) {
+pub fn run_simulation_cmd(
+    sim: &SimArgs,
+    output: Option<&str>,
+    format: OutputFormat,
+    json: bool,
+) -> Result<(), CmdError> {
     let mut params = if let Some(config_path) = &sim.config {
-        let config = crate::config::SimConfig::load(std::path::Path::new(config_path))
-            .unwrap_or_else(|e| {
-                eprintln!("Error: {e}");
-                std::process::exit(1);
-            });
+        let config = crate::config::SimConfig::load(std::path::Path::new(config_path))?;
         SimParams::from_config(&config)
     } else if sim.has_orbit_args() {
         // The direct-CLI path bypasses `SimConfig::validate`, so apply the
         // same time/tolerance checks here rather than letting a bad `--dt`
         // hang the propagation loop or panic inside step-size control.
-        validate_sim_args(sim);
+        validate_sim_args(sim)?;
         SimParams::from_sim_args(sim, false)
     } else {
         // Auto-detect orts.toml in the current directory
         let config_path = std::path::Path::new("orts.toml");
         if config_path.exists() {
-            let config = crate::config::SimConfig::load(config_path).unwrap_or_else(|e| {
-                eprintln!("Error: {e}");
-                std::process::exit(1);
-            });
+            let config = crate::config::SimConfig::load(config_path)?;
             SimParams::from_config(&config)
         } else {
-            eprintln!("Error: no simulation configuration found.");
-            eprintln!("Provide --config <path>, place orts.toml in the current directory,");
-            eprintln!("or specify an orbit with --sat / --tle / --norad-id.");
-            std::process::exit(1);
+            return Err(CmdError::usage(
+                "no simulation configuration found.\n\
+                 Provide --config <path>, place orts.toml in the current directory,\n\
+                 or specify an orbit with --sat / --tle / --norad-id.",
+            ));
         }
     };
     // Resolve and validate the stdout/output contract before running the
     // (potentially long) simulation, so usage errors fail fast.
     let sink = resolve_data_sink(output, format);
-    validate_output_contract(&sink, format, json);
+    validate_output_contract(&sink, format, json)?;
 
     // CLI backend flags always override config-file defaults so
     // `orts run --config … --plugin-backend=sync|async` works.
@@ -87,22 +83,27 @@ pub fn run_simulation_cmd(sim: &SimArgs, output: Option<&str>, format: OutputFor
             .iter()
             .all(|s| s.controller_config.is_some());
     let rec = if has_controller {
-        run_controlled_simulation(&params, sim)
+        run_controlled_simulation(&params, sim)?
     } else {
-        run_simulation(&params)
+        run_simulation(&params)?
     };
 
-    let artifact = write_simulation_output(&rec, &params, &sink, format);
+    let artifact = write_simulation_output(&rec, &params, &sink, format)?;
 
     if json {
         let summary = build_run_summary(&params, &rec, artifact);
-        serde_json::to_writer_pretty(std::io::stdout(), &summary).unwrap_or_else(|e| {
-            eprintln!("Error serializing run summary: {e}");
-            std::process::exit(1);
-        });
+        use std::io::Write;
+        let mut stdout = std::io::stdout().lock();
+        serde_json::to_writer_pretty(&mut stdout, &summary)
+            .map_err(|e| CmdError::failure(format!("serializing run summary: {e}")))?;
         // Trailing newline so the JSON document is its own line on stdout.
-        println!();
+        // Written through the same locked writer so a failure is reported
+        // instead of being swallowed by `println!`.
+        stdout
+            .write_all(b"\n")
+            .map_err(|e| CmdError::failure(format!("writing run summary: {e}")))?;
     }
+    Ok(())
 }
 
 /// stdout/output contract for `orts run`: stdout carries exactly one of the
@@ -133,20 +134,23 @@ fn resolve_data_sink(output: Option<&str>, format: OutputFormat) -> DataSink<'_>
 }
 
 /// Reject contradictory stdout requests before the simulation runs.
-fn validate_output_contract(sink: &DataSink, format: OutputFormat, json: bool) {
+fn validate_output_contract(
+    sink: &DataSink,
+    format: OutputFormat,
+    json: bool,
+) -> Result<(), CmdError> {
     if matches!(sink, DataSink::Stdout) && matches!(format, OutputFormat::Rrd) {
-        eprintln!(
-            "Error: cannot write .rrd data to stdout. Use --format csv or pass --output <path>."
-        );
-        std::process::exit(2);
+        return Err(CmdError::usage(
+            "cannot write .rrd data to stdout. Use --format csv or pass --output <path>.",
+        ));
     }
     if json && matches!(sink, DataSink::Stdout) {
-        eprintln!(
-            "Error: --json writes the run summary to stdout, so simulation data cannot also go \
-             to stdout. Pass --output <path> for the data (e.g. --output result.csv)."
-        );
-        std::process::exit(2);
+        return Err(CmdError::usage(
+            "--json writes the run summary to stdout, so simulation data cannot also go \
+             to stdout. Pass --output <path> for the data (e.g. --output result.csv).",
+        ));
     }
+    Ok(())
 }
 
 /// Write the recording to the resolved sink and return the file artifact (if
@@ -156,43 +160,40 @@ fn write_simulation_output(
     params: &SimParams,
     sink: &DataSink,
     format: OutputFormat,
-) -> Option<Artifact> {
+) -> Result<Option<Artifact>, CmdError> {
     match (sink, format) {
         (DataSink::Stdout, OutputFormat::Csv) => {
-            print_recording_as_csv(rec, params);
-            None
+            // A reader that closes the pipe early (`orts run | head`) is an
+            // I/O error, not a reason to panic out of the writer.
+            print_recording_as_csv(rec, params)
+                .map_err(|e| CmdError::failure(format!("writing CSV to stdout: {e}")))?;
+            Ok(None)
         }
         // Rejected earlier by validate_output_contract.
         (DataSink::Stdout, OutputFormat::Rrd) => {
             unreachable!("rrd-to-stdout is rejected by validate_output_contract")
         }
         (DataSink::File(path), OutputFormat::Csv) => {
-            let mut file = std::fs::File::create(path).unwrap_or_else(|e| {
-                eprintln!("Error creating {path}: {e}");
-                std::process::exit(1);
-            });
-            write_recording_as_csv(&mut file, rec, Some(params)).unwrap_or_else(|e| {
-                eprintln!("Error writing {path}: {e}");
-                std::process::exit(1);
-            });
+            let mut file = std::fs::File::create(path)
+                .map_err(|e| CmdError::failure(format!("creating {path}: {e}")))?;
+            write_recording_as_csv(&mut file, rec, Some(params))
+                .map_err(|e| CmdError::failure(format!("writing {path}: {e}")))?;
             eprintln!("Saved to {path}");
-            Some(Artifact {
+            Ok(Some(Artifact {
                 kind: "recording",
                 format: "csv",
                 path: (*path).to_string(),
-            })
+            }))
         }
         (DataSink::File(path), OutputFormat::Rrd) => {
-            orts::record::rerun_export::save_as_rrd(rec, "orts", path).unwrap_or_else(|e| {
-                eprintln!("Error saving .rrd: {e}");
-                std::process::exit(1);
-            });
+            orts::record::rerun_export::save_as_rrd(rec, "orts", path)
+                .map_err(|e| CmdError::failure(format!("saving .rrd: {e}")))?;
             eprintln!("Saved to {path}");
-            Some(Artifact {
+            Ok(Some(Artifact {
                 kind: "recording",
                 format: "rrd",
                 path: (*path).to_string(),
-            })
+            }))
         }
     }
 }
@@ -446,7 +447,7 @@ fn report_contact_windows(params: &SimParams, monitors: Vec<VisibilityMonitor<Si
 }
 
 /// Run the simulation and return a Recording.
-pub fn run_simulation(params: &SimParams) -> Recording {
+pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
     use crate::sim::core::sat_params;
     use orts::setup::{build_orbital_system, default_third_bodies};
 
@@ -509,7 +510,7 @@ pub fn run_simulation(params: &SimParams) -> Recording {
         );
         let initial = sat
             .initial_state(params.mu, params.epoch)
-            .unwrap_or_else(|e| panic!("satellite '{}': {e}", sat.id));
+            .map_err(|e| CmdError::failure(format!("satellite '{}': {e}", sat.id)))?;
 
         group = group.add_satellite_until(sat.id.as_str(), initial, sat.period, system);
     }
@@ -558,6 +559,9 @@ pub fn run_simulation(params: &SimParams) -> Recording {
             t = max_period;
         }
 
+        // Propagation errors are reported, not unwrapped: an invalid step size
+        // or a stalled clock is a diagnosable condition, and panicking here
+        // discards the `IntegrationError` that says which.
         let outcome = if let Some(monitors) = visibility.as_mut() {
             group
                 .propagate_to_with(t, |id, ts, state| {
@@ -569,9 +573,11 @@ pub fn run_simulation(params: &SimParams) -> Recording {
                         vis_last_t[i] = ts;
                     }
                 })
-                .unwrap()
+                .map_err(|e| format!("integration failed while advancing to t={t:.3}: {e}"))?
         } else {
-            group.propagate_to(t).unwrap()
+            group
+                .propagate_to(t)
+                .map_err(|e| format!("integration failed while advancing to t={t:.3}: {e}"))?
         };
 
         // Record states for satellites that reached this output time
@@ -649,13 +655,13 @@ pub fn run_simulation(params: &SimParams) -> Recording {
         orbit_description: orbit_desc,
     };
 
-    rec
+    Ok(rec)
 }
 
 /// Print a Recording as CSV to stdout.
-pub fn print_recording_as_csv(rec: &Recording, params: &SimParams) {
+pub fn print_recording_as_csv(rec: &Recording, params: &SimParams) -> std::io::Result<()> {
     let mut stdout = std::io::stdout().lock();
-    write_recording_as_csv(&mut stdout, rec, Some(params)).unwrap();
+    write_recording_as_csv(&mut stdout, rec, Some(params))
 }
 
 /// Write a Recording as CSV to any writer.
@@ -880,7 +886,7 @@ fn lookup_field_names(component_name: &str, n: usize) -> Vec<String> {
 }
 
 /// 制御付きシミュレーション（プラグインコントローラ + RW + センサ）。
-fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
+fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Result<Recording, CmdError> {
     use crate::sim::controlled::{
         ControlledBuildContext, build_controlled_satellite, step_controlled,
     };
@@ -911,19 +917,13 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
     let mut wasm_cache = {
         #[cfg(feature = "plugin-wasm-async")]
         {
-            orts::plugin::wasm::WasmPluginCache::new_with_async_mode(async_mode).unwrap_or_else(
-                |e| {
-                    eprintln!("Error initializing WASM plugin cache: {e}");
-                    std::process::exit(1);
-                },
-            )
+            orts::plugin::wasm::WasmPluginCache::new_with_async_mode(async_mode)
+                .map_err(|e| CmdError::failure(format!("initializing WASM plugin cache: {e}")))?
         }
         #[cfg(not(feature = "plugin-wasm-async"))]
         {
-            orts::plugin::wasm::WasmPluginCache::new().unwrap_or_else(|e| {
-                eprintln!("Error initializing WASM plugin cache: {e}");
-                std::process::exit(1);
-            })
+            orts::plugin::wasm::WasmPluginCache::new()
+                .map_err(|e| CmdError::failure(format!("initializing WASM plugin cache: {e}")))?
         }
     };
     // Only use rayon parallelism for the sim loop when the user
@@ -949,11 +949,9 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
             plugin_backend,
         };
         for spec in &params.satellites {
-            let sat =
-                build_controlled_satellite(spec, params.epoch, &mut ctx).unwrap_or_else(|e| {
-                    eprintln!("Error building controlled satellite '{}': {e}", spec.id);
-                    std::process::exit(1);
-                });
+            let sat = build_controlled_satellite(spec, params.epoch, &mut ctx).map_err(|e| {
+                CmdError::failure(format!("building controlled satellite '{}': {e}", spec.id))
+            })?;
             satellites.push(sat);
         }
     }
@@ -978,13 +976,14 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
         let mut scheduled = Vec::new();
         for cmd in &params.commands {
             let Some(&idx) = id_to_index.get(cmd.sat.as_str()) else {
-                eprintln!("command targets unknown satellite '{}'", cmd.sat);
-                std::process::exit(1);
+                return Err(CmdError::usage(format!(
+                    "command targets unknown satellite '{}'",
+                    cmd.sat
+                )));
             };
-            let message = cmd.to_message(idx).unwrap_or_else(|e| {
-                eprintln!("invalid command: {e}");
-                std::process::exit(1);
-            });
+            let message = cmd
+                .to_message(idx)
+                .map_err(|e| CmdError::usage(format!("invalid command: {e}")))?;
             scheduled.push(crate::sim::command_schedule::ScheduledCommand {
                 t: cmd.t,
                 sat_index: idx,
@@ -1019,10 +1018,8 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
     // argument when one side is NaN, so a NaN period would be silently
     // discarded by the fold and never rejected.
     for (i, sat) in satellites.iter().enumerate() {
-        if let Err(e) = crate::config::validate_sample_period(sat.controller.sample_period()) {
-            eprintln!("Error: satellites[{i}]: {e}");
-            std::process::exit(1);
-        }
+        crate::config::validate_sample_period(sat.controller.sample_period())
+            .map_err(|e| CmdError::failure(format!("satellites[{i}]: {e}")))?;
     }
     let dt_ctrl = satellites
         .iter()
@@ -1030,10 +1027,7 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
         .fold(f64::INFINITY, f64::min);
     // `fold` also yields `INFINITY` for an empty fleet, which the loop below
     // cannot step with either.
-    if let Err(e) = crate::config::validate_sample_period(dt_ctrl) {
-        eprintln!("Error: {e}");
-        std::process::exit(1);
-    }
+    crate::config::validate_sample_period(dt_ctrl).map_err(CmdError::failure)?;
     let dt_ode = params.dt.min(dt_ctrl);
 
     let mut t = 0.0;
@@ -1052,20 +1046,19 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
                 .deliver(sc.message.clone());
         }
 
+        // `try_for_each` rather than `for_each` + exit: a rayon worker calling
+        // `std::process::exit` tears the process down from inside the pool,
+        // skipping every caller's cleanup. Collect the first error instead.
         if parallel_step {
             use rayon::prelude::*;
-            satellites.par_iter_mut().for_each(|sat| {
-                step_controlled(sat, t, dt, dt_ode, params.epoch.as_ref()).unwrap_or_else(|e| {
-                    eprintln!("Simulation error at t={t:.3}: {e}");
-                    std::process::exit(1);
-                });
-            });
+            satellites
+                .par_iter_mut()
+                .try_for_each(|sat| step_controlled(sat, t, dt, dt_ode, params.epoch.as_ref()))
+                .map_err(|e| CmdError::failure(format!("simulation error at t={t:.3}: {e}")))?;
         } else {
             for sat in &mut satellites {
-                step_controlled(sat, t, dt, dt_ode, params.epoch.as_ref()).unwrap_or_else(|e| {
-                    eprintln!("Simulation error at t={t:.3}: {e}");
-                    std::process::exit(1);
-                });
+                step_controlled(sat, t, dt, dt_ode, params.epoch.as_ref())
+                    .map_err(|e| CmdError::failure(format!("simulation error at t={t:.3}: {e}")))?;
             }
         }
 
@@ -1155,7 +1148,7 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
         orbit_description: orbit_desc,
     };
 
-    rec
+    Ok(rec)
 }
 
 /// Log controlled satellite state: orbit + attitude + commands + actuator telemetry.
@@ -1250,5 +1243,99 @@ fn log_controlled_state(
                 )),
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    /// Build `SimArgs` the way the CLI does, so clap's defaults are exercised
+    /// too. `validate_sim_args` returning `Result` is what makes this testable
+    /// at all — it used to `process::exit(1)` at the point of detection.
+    fn args(extra: &[&str]) -> SimArgs {
+        let mut argv = vec!["orts", "--sat", "altitude=500"];
+        argv.extend_from_slice(extra);
+        SimArgs::try_parse_from(argv).expect("test argv should parse")
+    }
+
+    #[test]
+    fn default_args_are_valid() {
+        assert!(validate_sim_args(&args(&[])).is_ok());
+    }
+
+    #[test]
+    fn rejects_non_positive_dt() {
+        // `--dt=-1` rather than `--dt -1`: clap treats a bare `-1` as an
+        // unknown flag, so the negative value only reaches us through the
+        // `=` form (or a config file).
+        for dt in ["--dt=0", "--dt=-1", "--dt=nan", "--dt=inf"] {
+            let e = validate_sim_args(&args(&[dt])).expect_err(&format!("{dt} should be rejected"));
+            assert!(e.contains("dt"), "{dt} gave {e:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_output_interval_below_dt() {
+        let e = validate_sim_args(&args(&["--dt", "10", "--output-interval", "1"]))
+            .expect_err("output_interval < dt");
+        assert!(e.contains("output_interval"), "{e:?}");
+    }
+
+    #[test]
+    fn rejects_unusable_tolerances_for_adaptive_integrators() {
+        let e = validate_sim_args(&args(&[
+            "--integrator",
+            "dp45",
+            "--atol",
+            "0",
+            "--rtol",
+            "0",
+        ]))
+        .expect_err("both-zero tolerances with dp45");
+        assert!(e.contains("atol") && e.contains("rtol"), "{e:?}");
+    }
+
+    #[test]
+    fn accepts_unused_tolerances_for_rk4() {
+        // RK4 never reads them, so zeros must not fail the run.
+        assert!(
+            validate_sim_args(&args(&[
+                "--integrator",
+                "rk4",
+                "--atol",
+                "0",
+                "--rtol",
+                "0"
+            ]))
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn rrd_to_stdout_is_a_usage_error() {
+        let err = validate_output_contract(&DataSink::Stdout, OutputFormat::Rrd, false)
+            .expect_err("rrd to stdout");
+        assert_eq!(err.code, 2, "contradictory flags are a usage error");
+        assert!(err.message.contains("stdout"), "{err:?}");
+    }
+
+    #[test]
+    fn json_plus_stdout_data_is_a_usage_error() {
+        let err = validate_output_contract(&DataSink::Stdout, OutputFormat::Csv, true)
+            .expect_err("json + csv-to-stdout");
+        assert_eq!(err.code, 2);
+    }
+
+    #[test]
+    fn compatible_output_contracts_are_accepted() {
+        assert!(validate_output_contract(&DataSink::Stdout, OutputFormat::Csv, false).is_ok());
+        assert!(
+            validate_output_contract(&DataSink::File("out.csv"), OutputFormat::Csv, true).is_ok()
+        );
+        assert!(
+            validate_output_contract(&DataSink::File("out.rrd"), OutputFormat::Rrd, false).is_ok()
+        );
     }
 }

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -1014,6 +1014,16 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Recording {
     }
 
     // 全衛星の sample_period の最小値をグローバル tick に使う。
+    //
+    // Validate per satellite *before* folding: `f64::min` returns the other
+    // argument when one side is NaN, so a NaN period would be silently
+    // discarded by the fold and never rejected.
+    for (i, sat) in satellites.iter().enumerate() {
+        if let Err(e) = crate::config::validate_sample_period(sat.controller.sample_period()) {
+            eprintln!("Error: satellites[{i}]: {e}");
+            std::process::exit(1);
+        }
+    }
     let dt_ctrl = satellites
         .iter()
         .map(|sat| sat.controller.sample_period())

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -111,6 +111,7 @@ impl SimGroup {
         };
         for sat in sats.iter_mut() {
             let dt_ctrl = sat.controller.sample_period();
+            crate::config::validate_sample_period(dt_ctrl)?;
             let dt_ode = params.dt.min(dt_ctrl);
             let mut t = current_t;
             while t < target_t - 1e-12 {

--- a/cli/src/commands/serve/mod.rs
+++ b/cli/src/commands/serve/mod.rs
@@ -21,6 +21,7 @@ use tokio::net::TcpListener;
 use tokio::sync::{broadcast, mpsc};
 
 use crate::cli::SimArgs;
+use crate::commands::CmdError;
 use crate::sim::params::SimParams;
 
 use manager::SimCommand;
@@ -39,14 +40,19 @@ struct AppState {
     reserved_stdio: Option<stream_bridge::StreamKey>,
 }
 
-pub fn run_server(sim: &SimArgs, port: u16, stream_stdio: Option<&str>) {
+pub fn run_server(sim: &SimArgs, port: u16, stream_stdio: Option<&str>) -> Result<(), CmdError> {
     // Parse + reject malformed flags before starting the runtime so a typo
     // fails fast instead of surfacing as a dead endpoint later.
-    let stdio_key = stream_stdio.map(|s| {
-        parse_stream_stdio(s).unwrap_or_else(|e| panic!("Error: --stream-stdio {s}: {e}"))
-    });
-    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
-    rt.block_on(async_server(sim, port, stdio_key));
+    let stdio_key = match stream_stdio {
+        Some(s) => Some(
+            parse_stream_stdio(s)
+                .map_err(|e| CmdError::usage(format!("--stream-stdio {s}: {e}")))?,
+        ),
+        None => None,
+    };
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| CmdError::failure(format!("creating the tokio runtime: {e}")))?;
+    rt.block_on(async_server(sim, port, stdio_key))
 }
 
 /// Parse a `--stream-stdio` value of the form `sat/stream` (both halves
@@ -104,11 +110,15 @@ async fn stream_ws_handler(
         .into_response()
 }
 
-async fn async_server(sim: &SimArgs, port: u16, stdio_key: Option<stream_bridge::StreamKey>) {
+async fn async_server(
+    sim: &SimArgs,
+    port: u16,
+    stdio_key: Option<stream_bridge::StreamKey>,
+) -> Result<(), CmdError> {
     let addr = format!("0.0.0.0:{port}");
     let listener = TcpListener::bind(&addr)
         .await
-        .unwrap_or_else(|e| panic!("failed to bind to {addr}: {e}"));
+        .map_err(|e| CmdError::failure(format!("binding to {addr}: {e}")))?;
 
     let actual_port = listener.local_addr().unwrap().port();
     eprintln!("Server listening on http://localhost:{actual_port}");
@@ -121,10 +131,12 @@ async fn async_server(sim: &SimArgs, port: u16, stdio_key: Option<stream_bridge:
 
     // Determine initial config: if CLI args specify simulation, auto-start.
     let initial_config = if has_explicit_sim_args(sim) {
-        sim.config.as_ref().map(|config_path| {
-            crate::config::SimConfig::load(std::path::Path::new(config_path))
-                .unwrap_or_else(|e| panic!("Error: {e}"))
-        })
+        match sim.config.as_ref() {
+            Some(config_path) => Some(crate::config::SimConfig::load(std::path::Path::new(
+                config_path,
+            ))?),
+            None => None,
+        }
     } else {
         None
     };
@@ -132,8 +144,7 @@ async fn async_server(sim: &SimArgs, port: u16, stdio_key: Option<stream_bridge:
     // `orts serve` does not drive config `[[command]]` timelines (run-only);
     // reject loudly instead of silently dropping scheduled uplinks.
     if let Some(cfg) = &initial_config {
-        cfg.ensure_serve_supported()
-            .unwrap_or_else(|e| panic!("Error: {e}"));
+        cfg.ensure_serve_supported().map_err(CmdError::usage)?;
     }
 
     // With an explicit config, a `--stream-stdio` typo would otherwise be a
@@ -146,9 +157,9 @@ async fn async_server(sim: &SimArgs, port: u16, stdio_key: Option<stream_bridge:
             spec.id == *sat && spec.streams.iter().any(|n| n == stream)
         });
         if !declared {
-            panic!(
-                "Error: --stream-stdio {sat}/{stream} is not declared in the config (streams = [...])"
-            );
+            return Err(CmdError::usage(format!(
+                "--stream-stdio {sat}/{stream} is not declared in the config (streams = [...])"
+            )));
         }
     }
 
@@ -167,7 +178,7 @@ async fn async_server(sim: &SimArgs, port: u16, stdio_key: Option<stream_bridge:
         // later delegate to simulation_manager (after a terminate +
         // restart) honors them too.
         // Same reason as in `run`: this path skips `SimConfig::validate`.
-        crate::commands::run::validate_sim_args(sim);
+        crate::commands::run::validate_sim_args(sim)?;
         let params = Arc::new(SimParams::from_sim_args(sim, true));
         tokio::spawn(manager::simulation_manager_with_params(
             params,
@@ -231,10 +242,10 @@ async fn async_server(sim: &SimArgs, port: u16, stdio_key: Option<stream_bridge:
                     eprintln!("stdio plug closed; shutting down");
                 })
                 .await
-                .expect("server error");
         }
-        None => axum::serve(listener, app).await.expect("server error"),
+        None => axum::serve(listener, app).await,
     }
+    .map_err(|e| CmdError::failure(format!("server error: {e}")))
 }
 
 #[cfg(test)]

--- a/cli/src/commands/serve/mod.rs
+++ b/cli/src/commands/serve/mod.rs
@@ -166,6 +166,8 @@ async fn async_server(sim: &SimArgs, port: u16, stdio_key: Option<stream_bridge:
         // threshold, but we still pass the overrides so that any
         // later delegate to simulation_manager (after a terminate +
         // restart) honors them too.
+        // Same reason as in `run`: this path skips `SimConfig::validate`.
+        crate::commands::run::validate_sim_args(sim);
         let params = Arc::new(SimParams::from_sim_args(sim, true));
         tokio::spawn(manager::simulation_manager_with_params(
             params,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -610,8 +610,151 @@ impl SatelliteConfig {
         if let Some(thruster) = &self.thruster {
             thruster.validate().map_err(|e| format!("thruster: {e}"))?;
         }
+        // A non-finite orbit number propagates into the derived orbital
+        // period. `run` then loops on `while !group.all_finished()` with a NaN
+        // end time that no comparison can ever satisfy, so the simulation
+        // never terminates. Reject the input instead.
+        if let OrbitConfig::Circular {
+            altitude,
+            inclination,
+            raan,
+        } = &self.orbit
+        {
+            for (name, value) in [
+                ("altitude", *altitude),
+                ("inclination", *inclination),
+                ("raan", *raan),
+            ] {
+                if !value.is_finite() {
+                    return Err(format!("orbit.{name} must be finite (got {value})"));
+                }
+            }
+        }
         Ok(())
     }
+
+    /// Reject a circular orbit whose semi-major axis is not positive.
+    ///
+    /// Split from [`validate`](Self::validate) because `a = R_body + altitude`
+    /// needs the central body, which lives on [`SimConfig`].
+    fn validate_against_body(&self, body: KnownBody) -> Result<(), String> {
+        if let OrbitConfig::Circular { altitude, .. } = &self.orbit {
+            let r0 = body.properties().radius + altitude;
+            if r0 <= 0.0 {
+                return Err(format!(
+                    "orbit.altitude ({altitude}) puts the semi-major axis at or below zero \
+                     for body '{}' (radius {} km)",
+                    body.properties().name,
+                    body.properties().radius
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Reject time knobs the integrator cannot make progress with.
+///
+/// Shared by the config-file path ([`SimConfig::validate`]) and the direct-CLI
+/// path (`orts run --sat ...`, `orts serve --dt ...`), which reach
+/// `SimParams` through different constructors and would otherwise disagree
+/// about what is accepted.
+///
+/// Each value is load-bearing:
+/// - `dt` drives `while t < t_end`, so zero never advances.
+/// - `output_interval` drives `t += output_interval` in `run`, so zero never
+///   reaches `max_period`.
+/// - `stream_interval` is a divisor in the serve loop's pacing, where zero
+///   yields `0 * inf = NaN` and panics `Duration::from_secs_f64`.
+/// - `duration` becomes each satellite's propagation period.
+///
+/// `output_interval < dt` is rejected too: `SimParams` clamps
+/// `stream_interval` into `[dt, output_interval]`, which panics outright on
+/// inverted bounds.
+pub fn validate_time_params(
+    dt: f64,
+    output_interval: Option<f64>,
+    stream_interval: Option<f64>,
+    duration: Option<f64>,
+) -> Result<(), String> {
+    if !dt.is_finite() || dt <= 0.0 {
+        return Err(format!("dt must be positive and finite (got {dt})"));
+    }
+    for (name, value) in [
+        ("output_interval", output_interval),
+        ("stream_interval", stream_interval),
+        ("duration", duration),
+    ] {
+        if let Some(v) = value
+            && (!v.is_finite() || v <= 0.0)
+        {
+            return Err(format!("{name} must be positive and finite (got {v})"));
+        }
+    }
+    if let Some(output_interval) = output_interval
+        && output_interval < dt
+    {
+        return Err(format!(
+            "output_interval ({output_interval}) must be >= dt ({dt}): the simulation \
+             cannot emit output more often than it steps"
+        ));
+    }
+    Ok(())
+}
+
+/// Reject a controller tick that cannot advance the control loop.
+///
+/// Both controlled-run loops step with `dt = sample_period.min(remaining)`, so
+/// a zero period leaves `t += 0` spinning and a negative one walks backwards.
+/// The period comes from the plugin/controller rather than from user config,
+/// so it has to be checked where it is first used.
+pub fn validate_sample_period(dt_ctrl: f64) -> Result<(), String> {
+    if dt_ctrl.is_finite() && dt_ctrl > 0.0 {
+        Ok(())
+    } else {
+        Err(format!(
+            "controller sample period must be positive and finite (got {dt_ctrl})"
+        ))
+    }
+}
+
+/// Reject tolerances that cannot drive adaptive error control.
+///
+/// `sc = atol + rtol * |y|` is the adaptive error scale. With both zero, an
+/// exactly-zero state component gives `0 / 0 = NaN`, which the stepper can
+/// neither accept nor shrink away from.
+///
+/// Skipped for RK4, which ignores the tolerances entirely — rejecting them
+/// there would fail configs that carry unused `atol`/`rtol`.
+pub fn validate_tolerances(
+    integrator: IntegratorChoice,
+    atol: f64,
+    rtol: f64,
+) -> Result<(), String> {
+    if !matches!(
+        integrator,
+        IntegratorChoice::Dp45 | IntegratorChoice::Dop853
+    ) {
+        return Ok(());
+    }
+    if !atol.is_finite() || atol < 0.0 {
+        return Err(format!(
+            "integrator.atol must be non-negative and finite (got {atol})"
+        ));
+    }
+    if !rtol.is_finite() || rtol < 0.0 {
+        return Err(format!(
+            "integrator.rtol must be non-negative and finite (got {rtol})"
+        ));
+    }
+    if atol == 0.0 && rtol == 0.0 {
+        return Err(
+            "integrator.atol and integrator.rtol must not both be zero: adaptive \
+             error control needs at least one positive tolerance"
+                .to_string(),
+        );
+    }
+    Ok(())
 }
 
 impl SimConfig {
@@ -624,6 +767,17 @@ impl SimConfig {
     /// not resolve `norad` orbits — that requires a network fetch and is left
     /// to run time.
     pub fn validate(&self) -> Result<(), String> {
+        validate_time_params(
+            self.dt,
+            self.output_interval,
+            self.stream_interval,
+            self.duration,
+        )?;
+        validate_tolerances(
+            self.integrator_choice(),
+            self.integrator.atol,
+            self.integrator.rtol,
+        )?;
         if crate::satellite::try_parse_body(&self.body).is_none() {
             return Err(format!(
                 "unknown body '{}' (expected one of: sun, mercury, venus, earth, \
@@ -638,8 +792,12 @@ impl SimConfig {
                 "invalid epoch '{epoch}': expected ISO 8601 (e.g. 2026-01-01T00:00:00Z)"
             ));
         }
+        let body = crate::satellite::try_parse_body(&self.body)
+            .expect("body was validated as parseable above");
         for (i, sat) in self.satellites.iter().enumerate() {
             sat.validate()
+                .map_err(|e| format!("satellites[{i}]: {e}"))?;
+            sat.validate_against_body(body)
                 .map_err(|e| format!("satellites[{i}]: {e}"))?;
             // Parse inline TLE lines with the same parser `from_config` uses, so
             // a malformed element set is rejected here rather than panicking.
@@ -1453,6 +1611,200 @@ altitude = 500
             args: serde_json::json!({ "big": 9_223_372_036_854_775_808u64 }),
         };
         assert!(cmd.to_message(0).is_err());
+    }
+
+    fn config_with(extra: &str) -> SimConfig {
+        let toml = format!(
+            r#"
+{extra}
+
+[[satellites]]
+[satellites.orbit]
+type = "circular"
+altitude = 500
+"#
+        );
+        toml::from_str(&toml).expect("test config should deserialize")
+    }
+
+    /// `dt <= 0` (and NaN) used to reach the integrator, where
+    /// `while t < t_end` never advances, so `orts run` hung instead of
+    /// reporting the bad config.
+    #[test]
+    fn validate_rejects_non_positive_dt() {
+        for dt in ["0.0", "-1.0", "nan", "inf"] {
+            let config = config_with(&format!("dt = {dt}"));
+            let err = config
+                .validate()
+                .expect_err(&format!("dt = {dt} should be rejected"));
+            assert!(err.contains("dt"), "dt = {dt} gave {err:?}");
+        }
+    }
+
+    #[test]
+    fn validate_accepts_positive_dt() {
+        assert!(config_with("dt = 5.0").validate().is_ok());
+    }
+
+    /// A non-finite orbit number reaches the derived orbital period, and a NaN
+    /// end time makes `while !group.all_finished()` loop forever.
+    #[test]
+    fn validate_rejects_non_finite_orbit_numbers() {
+        for field in ["altitude", "inclination", "raan"] {
+            // `altitude` is required, so only add the 500 km default when the
+            // field under test is one of the optional ones.
+            let base = if field == "altitude" {
+                String::new()
+            } else {
+                "altitude = 500\n".to_string()
+            };
+            let toml = format!(
+                r#"
+dt = 10.0
+
+[[satellites]]
+[satellites.orbit]
+type = "circular"
+{base}{field} = nan
+"#
+            );
+            let config: SimConfig = toml::from_str(&toml).expect("deserializes");
+            let err = config
+                .validate()
+                .expect_err(&format!("{field} = nan should be rejected"));
+            assert!(err.contains(field), "{field} gave {err:?}");
+        }
+    }
+
+    /// `a = R_body + altitude`, so a large negative altitude has no orbit.
+    #[test]
+    fn validate_rejects_altitude_below_body_centre() {
+        let toml = r#"
+dt = 10.0
+body = "earth"
+
+[[satellites]]
+[satellites.orbit]
+type = "circular"
+altitude = -7000.0
+"#;
+        let config: SimConfig = toml::from_str(toml).expect("deserializes");
+        let err = config.validate().expect_err("altitude below body centre");
+        assert!(err.contains("semi-major axis"), "{err:?}");
+    }
+
+    #[test]
+    fn validate_accepts_negative_altitude_above_body_centre() {
+        // Physically underground but numerically a valid orbit; not this
+        // check's job to reject.
+        let toml = r#"
+dt = 10.0
+body = "earth"
+
+[[satellites]]
+[satellites.orbit]
+type = "circular"
+altitude = -100.0
+"#;
+        let config: SimConfig = toml::from_str(toml).expect("deserializes");
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn sample_period_validator() {
+        assert!(validate_sample_period(0.1).is_ok());
+        for dt in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            assert!(validate_sample_period(dt).is_err(), "dt_ctrl = {dt}");
+        }
+    }
+
+    #[test]
+    fn tolerance_validator_skips_rk4() {
+        // RK4 never reads the tolerances, so unused zeros must stay valid.
+        assert!(validate_tolerances(IntegratorChoice::Rk4, 0.0, 0.0).is_ok());
+        assert!(validate_tolerances(IntegratorChoice::Dp45, 0.0, 0.0).is_err());
+        assert!(validate_tolerances(IntegratorChoice::Dop853, 0.0, 0.0).is_err());
+    }
+
+    #[test]
+    fn validate_accepts_rk4_with_zero_tolerances() {
+        let config =
+            config_with("dt = 10.0\n\n[integrator]\ntype = \"rk4\"\natol = 0.0\nrtol = 0.0");
+        assert!(config.validate().is_ok(), "RK4 ignores tolerances");
+    }
+
+    /// `output_interval = 0` never reaches `max_period` in `run`;
+    /// `stream_interval = 0` is a divisor in the serve loop's pacing, where it
+    /// produces `NaN` and panics `Duration::from_secs_f64`.
+    #[test]
+    fn validate_rejects_non_positive_intervals() {
+        for key in ["output_interval", "stream_interval", "duration"] {
+            for value in ["0.0", "-1.0", "nan", "inf"] {
+                let config = config_with(&format!("dt = 1.0\n{key} = {value}"));
+                let err = config
+                    .validate()
+                    .expect_err(&format!("{key} = {value} should be rejected"));
+                assert!(err.contains(key), "{key} = {value} gave {err:?}");
+            }
+        }
+    }
+
+    /// `SimParams::from_config` clamps `stream_interval` into
+    /// `[dt, output_interval]`; inverted bounds used to panic inside `clamp`.
+    #[test]
+    fn validate_rejects_output_interval_below_dt() {
+        let config = config_with("dt = 10.0\noutput_interval = 1.0");
+        let err = config.validate().expect_err("output_interval < dt");
+        assert!(
+            err.contains("output_interval") && err.contains("dt"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_output_interval_at_or_above_dt() {
+        assert!(
+            config_with("dt = 10.0\noutput_interval = 10.0")
+                .validate()
+                .is_ok()
+        );
+        assert!(
+            config_with("dt = 10.0\noutput_interval = 60.0")
+                .validate()
+                .is_ok()
+        );
+    }
+
+    /// With `atol == rtol == 0` the adaptive error scale is zero, so an
+    /// exactly-zero state component makes the error norm `0 / 0`.
+    #[test]
+    fn validate_rejects_both_zero_tolerances() {
+        let config = config_with("[integrator]\ntype = \"dp45\"\natol = 0.0\nrtol = 0.0");
+        let err = config.validate().expect_err("both-zero tolerances");
+        assert!(err.contains("atol") && err.contains("rtol"), "{err:?}");
+    }
+
+    #[test]
+    fn validate_rejects_non_finite_tolerances() {
+        for (atol, rtol) in [("nan", "1e-8"), ("1e-10", "-1.0"), ("1e-10", "inf")] {
+            let config = config_with(&format!(
+                "[integrator]\ntype = \"dp45\"\natol = {atol}\nrtol = {rtol}"
+            ));
+            assert!(
+                config.validate().is_err(),
+                "atol = {atol}, rtol = {rtol} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_accepts_one_zero_tolerance() {
+        // Only one of the two needs to be positive.
+        let config = config_with("[integrator]\ntype = \"dp45\"\natol = 0.0\nrtol = 1e-8");
+        assert!(
+            config.validate().is_ok(),
+            "atol = 0 with rtol > 0 is usable"
+        );
     }
 
     #[test]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1718,6 +1718,30 @@ altitude = -100.0
         }
     }
 
+    /// Why the controlled-run loops validate each satellite's period rather
+    /// than only the folded minimum: `f64::min` returns the *other* argument
+    /// when one side is NaN, so a NaN period vanishes in the fold.
+    #[test]
+    fn fold_min_hides_a_nan_sample_period() {
+        let periods = [f64::NAN, 0.1];
+        let folded = periods.iter().copied().fold(f64::INFINITY, f64::min);
+        assert_eq!(
+            folded, 0.1,
+            "f64::min drops the NaN instead of propagating it"
+        );
+        assert!(
+            validate_sample_period(folded).is_ok(),
+            "so validating only the fold result accepts a fleet containing a NaN period"
+        );
+        assert!(
+            periods
+                .iter()
+                .copied()
+                .any(|p| validate_sample_period(p).is_err()),
+            "validating per satellite catches it"
+        );
+    }
+
     #[test]
     fn tolerance_validator_skips_rk4() {
         // RK4 never reads the tolerances, so unused zeros must stay valid.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,7 +7,18 @@ mod sim;
 mod tle;
 
 use cli::{Cli, Commands};
+use commands::CmdError;
 use notalawyer_clap::ParseExt;
+
+/// `main` is the only place that ends the process: commands return `CmdError`
+/// (which carries the exit code) rather than calling `std::process::exit` from
+/// wherever the failure happened to be detected.
+fn exit_on_error(result: Result<(), CmdError>) {
+    if let Err(e) = result {
+        eprintln!("Error: {e}");
+        std::process::exit(e.code);
+    }
+}
 
 fn main() {
     // Concatenate the Rust and viewer (npm) NOTICE strings so a single
@@ -22,12 +33,21 @@ fn main() {
             output,
             format,
             json,
-        } => commands::run::run_simulation_cmd(&sim, output.as_deref(), format, json),
+        } => exit_on_error(commands::run::run_simulation_cmd(
+            &sim,
+            output.as_deref(),
+            format,
+            json,
+        )),
         Commands::Serve {
             sim,
             port,
             stream_stdio,
-        } => commands::serve::run_server(&sim, port, stream_stdio.as_deref()),
+        } => exit_on_error(commands::serve::run_server(
+            &sim,
+            port,
+            stream_stdio.as_deref(),
+        )),
         Commands::Replay { input, port } => commands::replay::run_replay(&input, port),
         Commands::Convert {
             input,

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -286,14 +286,20 @@ pub fn step_controlled(
     }
 
     // 結合伝播（軌道 + 姿勢 + RW）。
-    sat.state = Rk4.integrate(
-        &sat.dynamics,
-        sat.state.clone(),
-        t,
-        t_next,
-        dt_ode,
-        |_, _| {},
-    );
+    //
+    // `try_integrate` を使うのは、`integrate` が不正な刻み幅や停滞した時刻を
+    // panic にしてしまうため。この関数は `Result` を返すので、serve は
+    // graceful-halt 経路でクライアントへ Error を送れる。
+    sat.state = Rk4
+        .try_integrate(
+            &sat.dynamics,
+            sat.state.clone(),
+            t,
+            t_next,
+            dt_ode,
+            |_, _| {},
+        )
+        .map_err(|e| format!("integration failed on [{t:.3}, {t_next:.3}]: {e}"))?;
 
     // センサ評価 + プラグイン呼び出し。
     let current_epoch = epoch.map(|e| e.add_si_seconds(t_next));

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -286,10 +286,12 @@ impl SimParams {
         };
 
         let output_interval = args.output_interval.unwrap_or(args.dt);
+        // `min` keeps the clamp bounds ordered so an unvalidated arg set
+        // cannot panic here; see the matching note in `from_config`.
         let stream_interval = args
             .stream_interval
             .unwrap_or(output_interval)
-            .clamp(args.dt, output_interval);
+            .clamp(args.dt.min(output_interval), output_interval);
 
         // Apply --duration override: replace each satellite's period with the user-specified duration
         let satellites = if let Some(dur) = args.duration {
@@ -361,10 +363,14 @@ impl SimParams {
             .collect();
 
         let output_interval = config.output_interval.unwrap_or(config.dt);
+        // `SimConfig::validate` rejects `output_interval < dt`, but this
+        // constructor is also reachable without it; `min` keeps the clamp
+        // bounds ordered so a bad config cannot panic here. For validated
+        // configs `dt <= output_interval`, so this is the plain `dt`.
         let stream_interval = config
             .stream_interval
             .unwrap_or(output_interval)
-            .clamp(config.dt, output_interval);
+            .clamp(config.dt.min(output_interval), output_interval);
 
         let satellites = if let Some(dur) = config.duration {
             satellites

--- a/orts/src/group/coupled.rs
+++ b/orts/src/group/coupled.rs
@@ -327,6 +327,11 @@ where
             });
         }
 
+        // Reject a step size that cannot advance time before stepping: the
+        // fixed-step RK4 branch below would otherwise spin on `h = 0` (or walk
+        // backwards for `dt < 0`) forever.
+        self.integrator.validate()?;
+
         match &self.integrator {
             IntegratorConfig::Dp45 { dt, tolerances } => {
                 let mut stepper = DormandPrince.stepper(
@@ -392,10 +397,10 @@ where
                     }
                     Err(e) => {
                         self.terminated = true;
-                        let t = match &e {
-                            IntegrationError::NonFiniteState { t } => *t,
-                            IntegrationError::StepSizeTooSmall { t, .. } => *t,
-                        };
+                        // Pre-flight rejections (bad dt/tolerances) carry no
+                        // time of their own; attribute them to where the
+                        // stepper was asked to start.
+                        let t = e.time().unwrap_or(self.t);
                         let term = SatelliteTermination {
                             satellite_id: self
                                 .ids
@@ -475,10 +480,10 @@ where
                     }
                     Err(e) => {
                         self.terminated = true;
-                        let t = match &e {
-                            IntegrationError::NonFiniteState { t } => *t,
-                            IntegrationError::StepSizeTooSmall { t, .. } => *t,
-                        };
+                        // Pre-flight rejections (bad dt/tolerances) carry no
+                        // time of their own; attribute them to where the
+                        // stepper was asked to start.
+                        let t = e.time().unwrap_or(self.t);
                         let term = SatelliteTermination {
                             satellite_id: self
                                 .ids
@@ -502,6 +507,14 @@ where
 
                 while current_t < t_target - 1e-12 {
                     let h = dt.min(t_target - current_t);
+                    // `h > 0` after the validate() above, but for large
+                    // `|current_t|` it can still be below the f64 spacing there.
+                    if current_t + h == current_t {
+                        return Err(IntegrationError::TimeStagnated {
+                            t: current_t,
+                            dt: h,
+                        });
+                    }
                     current_state = Rk4.step(&self.dynamics, current_t, &current_state, h);
                     current_t += h;
 

--- a/orts/src/group/independent.rs
+++ b/orts/src/group/independent.rs
@@ -2,7 +2,7 @@ use std::ops::ControlFlow;
 
 use utsuroi::{
     AdvanceOutcome, AdvanceOutcome853, Dop853, DormandPrince, DynamicalSystem, IntegrationError,
-    Integrator, OdeState, Rk4, Tolerances,
+    Integrator, OdeState, Rk4, Tolerances, validate_step_size,
 };
 
 use super::HasPosition;
@@ -14,6 +14,24 @@ pub enum IntegratorConfig {
     Rk4 { dt: f64 },
     Dp45 { dt: f64, tolerances: Tolerances },
     Dop853 { dt: f64, tolerances: Tolerances },
+}
+
+impl IntegratorConfig {
+    /// Reject a configuration that cannot make progress.
+    ///
+    /// The variants carry public fields, so this cannot be enforced at
+    /// construction; group propagation calls it before stepping instead. The
+    /// adaptive steppers repeat these checks internally — this is what stops
+    /// the fixed-step RK4 loop, which has no such guard of its own.
+    pub fn validate(&self) -> Result<(), IntegrationError> {
+        match self {
+            Self::Rk4 { dt } => validate_step_size(*dt),
+            Self::Dp45 { dt, tolerances } | Self::Dop853 { dt, tolerances } => {
+                validate_step_size(*dt)?;
+                tolerances.validate()
+            }
+        }
+    }
 }
 
 /// Entry tracking an individual satellite's state and status.
@@ -256,6 +274,11 @@ where
         t_target: f64,
         mut observer: impl FnMut(&SatId, f64, &D::State),
     ) -> Result<PropGroupOutcome, IntegrationError> {
+        // Reject a step size that cannot advance time before touching any
+        // satellite: the fixed-step RK4 branch below would otherwise spin on
+        // `h = 0` (or walk backwards for `dt < 0`) forever.
+        self.integrator.validate()?;
+
         let mut terminations = Vec::new();
         let integrator = self.integrator.clone();
         let event_checker = &self.event_checker;
@@ -312,10 +335,10 @@ where
                         }
                         Err(e) => {
                             entry.terminated = true;
-                            let t = match &e {
-                                IntegrationError::NonFiniteState { t } => *t,
-                                IntegrationError::StepSizeTooSmall { t, .. } => *t,
-                            };
+                            // Pre-flight rejections (bad dt/tolerances) carry
+                            // no time of their own; attribute them to where
+                            // the stepper was asked to start.
+                            let t = e.time().unwrap_or(entry.t);
                             terminations.push(SatelliteTermination {
                                 satellite_id: entry.id.clone(),
                                 t,
@@ -360,10 +383,10 @@ where
                         }
                         Err(e) => {
                             entry.terminated = true;
-                            let t = match &e {
-                                IntegrationError::NonFiniteState { t } => *t,
-                                IntegrationError::StepSizeTooSmall { t, .. } => *t,
-                            };
+                            // Pre-flight rejections (bad dt/tolerances) carry
+                            // no time of their own; attribute them to where
+                            // the stepper was asked to start.
+                            let t = e.time().unwrap_or(entry.t);
                             terminations.push(SatelliteTermination {
                                 satellite_id: entry.id.clone(),
                                 t,
@@ -380,6 +403,15 @@ where
                     let mut terminated = false;
                     while current_t < effective_target - 1e-12 {
                         let h = dt.min(effective_target - current_t);
+                        // `h > 0` after the validate() above, but for large
+                        // `|current_t|` it can still be below the f64 spacing
+                        // there.
+                        if current_t + h == current_t {
+                            return Err(IntegrationError::TimeStagnated {
+                                t: current_t,
+                                dt: h,
+                            });
+                        }
                         current_state = Rk4.step(dynamics, current_t, &current_state, h);
                         current_t += h;
 
@@ -880,6 +912,48 @@ mod tests {
         let entry = group.satellites().next().unwrap();
         assert!((entry.t - 100.0).abs() < 1e-9);
         assert!(!entry.terminated);
+    }
+
+    /// The fixed-step RK4 branch has no internal step-size guard (unlike the
+    /// adaptive steppers), so `dt <= 0` used to spin on `h = 0` forever.
+    #[test]
+    fn rk4_rejects_non_advancing_step() {
+        for dt in [0.0, -1.0, f64::NAN] {
+            let mut group: IndependentGroup<TwoBodySystem> = IndependentGroup::rk4(dt)
+                .add_satellite("iss", iss_state(), TwoBodySystem { mu: MU_EARTH });
+            let err = group
+                .propagate_to(10.0)
+                .expect_err(&format!("dt = {dt} should be rejected"));
+            assert!(
+                matches!(err, IntegrationError::InvalidStepSize { .. }),
+                "dt = {dt} gave {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn integrator_config_validate_accepts_usable_settings() {
+        assert!(IntegratorConfig::Rk4 { dt: 10.0 }.validate().is_ok());
+        assert!(
+            IntegratorConfig::Dp45 {
+                dt: 10.0,
+                tolerances: Tolerances::default(),
+            }
+            .validate()
+            .is_ok()
+        );
+        // Unusable tolerances are rejected alongside the step size.
+        assert!(
+            IntegratorConfig::Dp45 {
+                dt: 10.0,
+                tolerances: Tolerances {
+                    atol: 0.0,
+                    rtol: 0.0,
+                },
+            }
+            .validate()
+            .is_err()
+        );
     }
 
     #[test]

--- a/utsuroi/src/error.rs
+++ b/utsuroi/src/error.rs
@@ -43,7 +43,12 @@ impl Tolerances {
 }
 
 /// Reason the integration was stopped by the integrator itself.
+///
+/// `#[non_exhaustive]`: adding a variant here previously broke every downstream
+/// exhaustive `match`. Consumers should use a wildcard arm, or
+/// [`IntegrationError::time()`] when all they need is the failure time.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum IntegrationError {
     /// A NaN or Inf was detected in the state after a step.
     NonFiniteState { t: f64 },

--- a/utsuroi/src/error.rs
+++ b/utsuroi/src/error.rs
@@ -18,6 +18,30 @@ impl Default for Tolerances {
     }
 }
 
+impl Tolerances {
+    /// Reject tolerances that would make adaptive error control meaningless.
+    ///
+    /// `atol == 0 && rtol == 0` makes the scale factor `sc` zero, so a
+    /// component whose error is also zero yields `0 / 0 == NaN`. A NaN error
+    /// norm compares false against both the accept threshold and the
+    /// `dt_min` floor, so the stepper would retry the same step forever.
+    pub fn validate(&self) -> Result<(), IntegrationError> {
+        let usable = self.atol.is_finite()
+            && self.rtol.is_finite()
+            && self.atol >= 0.0
+            && self.rtol >= 0.0
+            && (self.atol > 0.0 || self.rtol > 0.0);
+        if usable {
+            Ok(())
+        } else {
+            Err(IntegrationError::InvalidTolerances {
+                atol: self.atol,
+                rtol: self.rtol,
+            })
+        }
+    }
+}
+
 /// Reason the integration was stopped by the integrator itself.
 #[derive(Debug, Clone, PartialEq)]
 pub enum IntegrationError {
@@ -25,6 +49,71 @@ pub enum IntegrationError {
     NonFiniteState { t: f64 },
     /// Step size became smaller than minimum threshold.
     StepSizeTooSmall { t: f64, dt: f64 },
+    /// The requested step size is zero, negative, or non-finite, so the
+    /// integration could never reach `t_end`.
+    InvalidStepSize { dt: f64 },
+    /// `t_end` lies before `t0`. Backward integration is not supported; the
+    /// loops advance time monotonically upward.
+    InvalidTimeSpan { t0: f64, t_end: f64 },
+    /// Tolerances cannot drive adaptive error control (see
+    /// [`Tolerances::validate`]).
+    InvalidTolerances { atol: f64, rtol: f64 },
+    /// The error norm evaluated to NaN (an indeterminate `0 / 0`), so the step
+    /// could neither be accepted nor usefully retried. `+Inf` is not an error:
+    /// it shrinks the step and recovers or ends in [`Self::StepSizeTooSmall`].
+    IndeterminateErrorNorm { t: f64 },
+    /// `t + dt` rounded back to `t` in f64, so time stopped advancing even
+    /// though `dt` itself is positive.
+    TimeStagnated { t: f64, dt: f64 },
+}
+
+impl IntegrationError {
+    /// The simulation time the failure is attributed to, when the variant
+    /// carries one.
+    ///
+    /// `None` for the pre-flight argument checks ([`Self::InvalidStepSize`],
+    /// [`Self::InvalidTolerances`]), which reject before any step runs — the
+    /// caller's start time is the meaningful timestamp there. Callers that
+    /// need a `f64` unconditionally should use
+    /// `err.time().unwrap_or(start_t)`, which also keeps them compiling as
+    /// new variants are added.
+    pub fn time(&self) -> Option<f64> {
+        match self {
+            Self::NonFiniteState { t }
+            | Self::StepSizeTooSmall { t, .. }
+            | Self::IndeterminateErrorNorm { t }
+            | Self::TimeStagnated { t, .. } => Some(*t),
+            Self::InvalidTimeSpan { t0, .. } => Some(*t0),
+            Self::InvalidStepSize { .. } | Self::InvalidTolerances { .. } => None,
+        }
+    }
+}
+
+/// Reject step sizes that cannot advance time toward `t_end`.
+///
+/// `dt == 0` (or negative, or NaN) leaves `t` unchanged in the fixed-step
+/// loops, which spin forever instead of terminating.
+///
+/// Public so downstream fixed-step loops built on [`Integrator::step`]
+/// (rather than on `integrate`/`advance_to`, which check internally) can
+/// apply the same precondition and report the same error.
+///
+/// [`Integrator::step`]: crate::Integrator::step
+pub fn validate_step_size(dt: f64) -> Result<(), IntegrationError> {
+    if dt.is_finite() && dt > 0.0 {
+        Ok(())
+    } else {
+        Err(IntegrationError::InvalidStepSize { dt })
+    }
+}
+
+/// Reject a time span the monotonically-increasing loops cannot cover.
+pub(crate) fn validate_time_span(t0: f64, t_end: f64) -> Result<(), IntegrationError> {
+    if t0.is_finite() && t_end.is_finite() && t_end >= t0 {
+        Ok(())
+    } else {
+        Err(IntegrationError::InvalidTimeSpan { t0, t_end })
+    }
 }
 
 impl core::fmt::Display for IntegrationError {
@@ -37,6 +126,36 @@ impl core::fmt::Display for IntegrationError {
                 write!(
                     f,
                     "step size {dt} fell below the minimum threshold at t = {t}"
+                )
+            }
+            Self::InvalidStepSize { dt } => {
+                write!(f, "step size must be positive and finite, got dt = {dt}")
+            }
+            Self::InvalidTimeSpan { t0, t_end } => {
+                write!(
+                    f,
+                    "t_end ({t_end}) must be finite and not before t0 ({t0}); \
+                     backward integration is not supported"
+                )
+            }
+            Self::InvalidTolerances { atol, rtol } => {
+                write!(
+                    f,
+                    "tolerances must be finite and non-negative with at least one \
+                     positive, got atol = {atol}, rtol = {rtol}"
+                )
+            }
+            Self::IndeterminateErrorNorm { t } => {
+                write!(
+                    f,
+                    "error norm was NaN at t = {t} (check for atol = 0 with an \
+                     exactly zero state component, which gives 0 / 0)"
+                )
+            }
+            Self::TimeStagnated { t, dt } => {
+                write!(
+                    f,
+                    "time stopped advancing at t = {t}: t + {dt} rounds back to t"
                 )
             }
         }
@@ -107,5 +226,113 @@ mod tests {
             Ok(())
         }
         assert!(fallible().is_err());
+    }
+
+    #[test]
+    fn default_tolerances_are_valid() {
+        assert!(Tolerances::default().validate().is_ok());
+    }
+
+    #[test]
+    fn one_positive_tolerance_is_enough() {
+        assert!(
+            Tolerances {
+                atol: 0.0,
+                rtol: 1e-8,
+            }
+            .validate()
+            .is_ok()
+        );
+        assert!(
+            Tolerances {
+                atol: 1e-10,
+                rtol: 0.0,
+            }
+            .validate()
+            .is_ok()
+        );
+    }
+
+    /// Both zero makes `sc == 0`, so a zero-error component yields `0 / 0`.
+    #[test]
+    fn both_zero_tolerances_rejected() {
+        assert_eq!(
+            Tolerances {
+                atol: 0.0,
+                rtol: 0.0,
+            }
+            .validate(),
+            Err(IntegrationError::InvalidTolerances {
+                atol: 0.0,
+                rtol: 0.0
+            })
+        );
+    }
+
+    #[test]
+    fn negative_and_non_finite_tolerances_rejected() {
+        for (atol, rtol) in [
+            (-1e-10, 1e-8),
+            (1e-10, -1e-8),
+            (f64::NAN, 1e-8),
+            (1e-10, f64::INFINITY),
+        ] {
+            assert!(
+                Tolerances { atol, rtol }.validate().is_err(),
+                "atol = {atol}, rtol = {rtol} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn step_size_validator() {
+        assert!(validate_step_size(1e-3).is_ok());
+        for dt in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            assert!(validate_step_size(dt).is_err(), "dt = {dt}");
+        }
+    }
+
+    #[test]
+    fn time_span_validator() {
+        assert!(validate_time_span(0.0, 1.0).is_ok());
+        assert!(
+            validate_time_span(1.0, 1.0).is_ok(),
+            "empty span is a no-op"
+        );
+        assert!(validate_time_span(1.0, 0.0).is_err(), "backward span");
+        assert!(validate_time_span(f64::NAN, 1.0).is_err());
+        assert!(validate_time_span(0.0, f64::INFINITY).is_err());
+    }
+
+    #[test]
+    fn new_variants_have_informative_display() {
+        for (err, needle) in [
+            (IntegrationError::InvalidStepSize { dt: 0.0 }, "positive"),
+            (
+                IntegrationError::InvalidTimeSpan {
+                    t0: 1.0,
+                    t_end: 0.0,
+                },
+                "backward",
+            ),
+            (
+                IntegrationError::InvalidTolerances {
+                    atol: 0.0,
+                    rtol: 0.0,
+                },
+                "tolerances",
+            ),
+            (
+                IntegrationError::IndeterminateErrorNorm { t: 3.0 },
+                "error norm",
+            ),
+            (
+                IntegrationError::TimeStagnated { t: 4.0, dt: 1e-9 },
+                "stopped advancing",
+            ),
+        ] {
+            let msg = err.to_string();
+            assert!(msg.contains(needle), "{err:?} display was {msg:?}");
+        }
     }
 }

--- a/utsuroi/src/integrator.rs
+++ b/utsuroi/src/integrator.rs
@@ -1,5 +1,6 @@
 use core::ops::ControlFlow;
 
+use crate::error::{validate_step_size, validate_time_span};
 use crate::{DynamicalSystem, IntegrationError, IntegrationOutcome, OdeState};
 
 /// Common interface for fixed-step numerical integrators.
@@ -18,6 +19,14 @@ pub trait Integrator {
     /// record intermediate states (e.g., for energy monitoring or trajectory output).
     ///
     /// Returns the final state at `t_end`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the arguments cannot produce a terminating integration —
+    /// `dt <= 0`, a non-finite `dt`, `t_end < t0`, or a `dt` so small relative
+    /// to `t` that `t + dt` rounds back to `t`. Use
+    /// [`try_integrate`](Integrator::try_integrate) to handle those cases
+    /// without panicking. Previously these inputs spun forever instead.
     fn integrate<S, F>(
         &self,
         system: &S,
@@ -25,23 +34,54 @@ pub trait Integrator {
         t0: f64,
         t_end: f64,
         dt: f64,
-        mut callback: F,
+        callback: F,
     ) -> S::State
     where
         S: DynamicalSystem,
         F: FnMut(f64, &S::State),
     {
+        match self.try_integrate(system, initial, t0, t_end, dt, callback) {
+            Ok(state) => state,
+            Err(e) => panic!("utsuroi: integrate() cannot run: {e}"),
+        }
+    }
+
+    /// Fallible variant of [`integrate`](Integrator::integrate).
+    ///
+    /// Returns `Err` instead of panicking when the step size or time span
+    /// cannot produce a terminating integration.
+    fn try_integrate<S, F>(
+        &self,
+        system: &S,
+        initial: S::State,
+        t0: f64,
+        t_end: f64,
+        dt: f64,
+        mut callback: F,
+    ) -> Result<S::State, IntegrationError>
+    where
+        S: DynamicalSystem,
+        F: FnMut(f64, &S::State),
+    {
+        validate_step_size(dt)?;
+        validate_time_span(t0, t_end)?;
+
         let mut state = initial;
         let mut t = t0;
 
         while t < t_end {
             let h = dt.min(t_end - t);
+            // `h > 0` holds, but for large `|t|` it can still be below the
+            // spacing of representable f64 values around `t`.
+            if t + h == t {
+                return Err(IntegrationError::TimeStagnated { t, dt: h });
+            }
             state = self.step(system, t, &state, h);
             t += h;
             callback(t, &state);
         }
 
-        state
+        Ok(state)
     }
 
     /// Integrate a dynamical system with event detection and NaN/Inf checking.
@@ -66,11 +106,18 @@ pub trait Integrator {
         F: FnMut(f64, &S::State),
         E: Fn(f64, &S::State) -> ControlFlow<B>,
     {
+        if let Err(e) = validate_step_size(dt).and_then(|()| validate_time_span(t0, t_end)) {
+            return IntegrationOutcome::Error(e);
+        }
+
         let mut state = initial;
         let mut t = t0;
 
         while t < t_end {
             let h = dt.min(t_end - t);
+            if t + h == t {
+                return IntegrationOutcome::Error(IntegrationError::TimeStagnated { t, dt: h });
+            }
             state = self.step(system, t, &state, h);
             t += h;
 
@@ -86,5 +133,138 @@ pub trait Integrator {
         }
 
         IntegrationOutcome::Completed(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::ops::ControlFlow;
+
+    use nalgebra::vector;
+
+    use crate::test_systems::UniformMotion;
+    use crate::{IntegrationError, IntegrationOutcome, Rk4, State};
+
+    use super::*;
+
+    fn system() -> UniformMotion {
+        UniformMotion {
+            constant_velocity: vector![1.0, 0.0, 0.0],
+        }
+    }
+
+    fn initial() -> State<3, 2> {
+        State::<3, 2>::new(vector![0.0, 0.0, 0.0], vector![1.0, 0.0, 0.0])
+    }
+
+    // Each of these inputs used to spin the `while t < t_end` loop forever
+    // instead of terminating.
+
+    #[test]
+    fn try_integrate_rejects_zero_step() {
+        let err = Rk4
+            .try_integrate(&system(), initial(), 0.0, 1.0, 0.0, |_, _| {})
+            .unwrap_err();
+        assert_eq!(err, IntegrationError::InvalidStepSize { dt: 0.0 });
+    }
+
+    #[test]
+    fn try_integrate_rejects_negative_step() {
+        let err = Rk4
+            .try_integrate(&system(), initial(), 0.0, 1.0, -0.1, |_, _| {})
+            .unwrap_err();
+        assert_eq!(err, IntegrationError::InvalidStepSize { dt: -0.1 });
+    }
+
+    #[test]
+    fn try_integrate_rejects_non_finite_step() {
+        let err = Rk4
+            .try_integrate(&system(), initial(), 0.0, 1.0, f64::NAN, |_, _| {})
+            .unwrap_err();
+        assert!(matches!(err, IntegrationError::InvalidStepSize { dt } if dt.is_nan()));
+    }
+
+    /// `t_end < t0` used to return the initial state unchanged, silently
+    /// reporting success for an integration that never ran.
+    #[test]
+    fn try_integrate_rejects_backward_span() {
+        let err = Rk4
+            .try_integrate(&system(), initial(), 1.0, 0.0, 0.1, |_, _| {})
+            .unwrap_err();
+        assert_eq!(
+            err,
+            IntegrationError::InvalidTimeSpan {
+                t0: 1.0,
+                t_end: 0.0
+            }
+        );
+    }
+
+    #[test]
+    fn try_integrate_accepts_empty_span() {
+        // t_end == t0 is a legitimate no-op, not an error.
+        let state = Rk4
+            .try_integrate(&system(), initial(), 1.0, 1.0, 0.1, |_, _| {})
+            .expect("empty span should be a no-op, not an error");
+        assert_eq!(state.y()[0], 0.0);
+    }
+
+    /// At `t = 2^53` the f64 spacing exceeds 1, so `t + 0.5 == t`: `dt` is
+    /// positive yet time cannot advance.
+    #[test]
+    fn try_integrate_detects_time_stagnation() {
+        let t0 = 9007199254740992.0_f64; // 2^53
+        let err = Rk4
+            .try_integrate(&system(), initial(), t0, t0 + 2.0, 0.5, |_, _| {})
+            .unwrap_err();
+        assert!(matches!(err, IntegrationError::TimeStagnated { t, .. } if t == t0));
+    }
+
+    #[test]
+    #[should_panic(expected = "step size must be positive and finite")]
+    fn integrate_panics_on_zero_step() {
+        Rk4.integrate(&system(), initial(), 0.0, 1.0, 0.0, |_, _| {});
+    }
+
+    #[test]
+    fn integrate_with_events_rejects_zero_step() {
+        let outcome: IntegrationOutcome<State<3, 2>, ()> = Rk4.integrate_with_events(
+            &system(),
+            initial(),
+            0.0,
+            1.0,
+            0.0,
+            |_, _| {},
+            |_, _| ControlFlow::Continue(()),
+        );
+        assert!(matches!(
+            outcome,
+            IntegrationOutcome::Error(IntegrationError::InvalidStepSize { dt }) if dt == 0.0
+        ));
+    }
+
+    #[test]
+    fn integrate_with_events_rejects_backward_span() {
+        let outcome: IntegrationOutcome<State<3, 2>, ()> = Rk4.integrate_with_events(
+            &system(),
+            initial(),
+            1.0,
+            0.0,
+            0.1,
+            |_, _| {},
+            |_, _| ControlFlow::Continue(()),
+        );
+        assert!(matches!(
+            outcome,
+            IntegrationOutcome::Error(IntegrationError::InvalidTimeSpan { .. })
+        ));
+    }
+
+    /// The guards must not change behaviour for well-formed inputs.
+    #[test]
+    fn try_integrate_matches_integrate_for_valid_input() {
+        let a = Rk4.try_integrate(&system(), initial(), 0.0, 1.0, 0.1, |_, _| {});
+        let b = Rk4.integrate(&system(), initial(), 0.0, 1.0, 0.1, |_, _| {});
+        assert_eq!(a.expect("valid input"), b);
     }
 }

--- a/utsuroi/src/lib.rs
+++ b/utsuroi/src/lib.rs
@@ -11,7 +11,7 @@ mod comparison;
 #[cfg(test)]
 pub(crate) mod test_systems;
 
-pub use error::{IntegrationError, IntegrationOutcome, Tolerances};
+pub use error::{IntegrationError, IntegrationOutcome, Tolerances, validate_step_size};
 pub use integrator::Integrator;
 pub use solver::dop853::{AdaptiveStepper853, AdvanceOutcome853, Dop853};
 pub use solver::dp45::{AdaptiveStepper, AdvanceOutcome, DormandPrince};

--- a/utsuroi/src/solver/dop853/mod.rs
+++ b/utsuroi/src/solver/dop853/mod.rs
@@ -4,6 +4,7 @@ use core::ops::ControlFlow;
 
 use coeff::*;
 
+use crate::error::{validate_step_size, validate_time_span};
 #[allow(unused_imports)]
 use crate::math::F64Ext;
 use crate::{
@@ -220,8 +221,20 @@ impl<'a, S: DynamicalSystem> AdaptiveStepper853<'a, S> {
         F: FnMut(f64, &S::State),
         E: Fn(f64, &S::State) -> ControlFlow<B>,
     {
+        self.tol.validate()?;
+        validate_step_size(self.dt)?;
+        // Without this, a NaN or backward `t_target` makes `while self.t <
+        // t_target` false on the first test and the stepper reports Reached
+        // while sitting at its old time.
+        validate_time_span(self.t, t_target)?;
+
         while self.t < t_target {
             let h = self.dt.min(t_target - self.t);
+            // `h > 0` holds, but for large `|self.t|` it can still be below
+            // the spacing of representable f64 values around `self.t`.
+            if self.t + h == self.t {
+                return Err(IntegrationError::TimeStagnated { t: self.t, dt: h });
+            }
 
             let (y8, error, k13) = dop853_step_impl(self.system, self.t, &self.state, h, &self.k1);
 
@@ -231,6 +244,15 @@ impl<'a, S: DynamicalSystem> AdaptiveStepper853<'a, S> {
             }
 
             let err = self.state.error_norm(&y8, &error, &self.tol);
+            // A NaN norm compares false against both the accept threshold and
+            // the `dt_min` floor below, so without this guard the same step is
+            // retried forever. `+Inf` is deliberately *not* rejected: it
+            // shrinks the step (`Inf.powf(-ORDER_EXP) == 0` clamps to
+            // `MIN_FACTOR`) and so either recovers or terminates via
+            // `StepSizeTooSmall`.
+            if err.is_nan() {
+                return Err(IntegrationError::IndeterminateErrorNorm { t: self.t });
+            }
 
             if err <= 1.0 {
                 // Accept step
@@ -1003,5 +1025,86 @@ mod tests {
             rk4_err > 1e-2,
             "RK4 error {rk4_err:.2e} should be noticeable after 1000 periods with dt=0.3"
         );
+    }
+
+    // Guards against non-terminating adaptive loops (mirrors the DP45 set:
+    // `advance_to` is structurally identical in both steppers).
+
+    fn advance853(
+        initial: State<3, 2>,
+        dt: f64,
+        tol: Tolerances,
+        t_target: f64,
+    ) -> Result<(), IntegrationError> {
+        let system = HarmonicOscillator;
+        let mut stepper = Dop853.stepper(&system, initial, 0.0, dt, tol);
+        stepper
+            .advance_to::<_, _, ()>(t_target, |_, _| {}, |_, _| ControlFlow::Continue(()))
+            .map(|_| ())
+    }
+
+    fn nonzero_state() -> State<3, 2> {
+        State::<3, 2>::new(vector![1.0, 0.0, 0.0], vector![0.0, 0.0, 0.0])
+    }
+
+    #[test]
+    fn advance_to_rejects_both_zero_tolerances() {
+        let err = advance853(
+            nonzero_state(),
+            0.1,
+            Tolerances {
+                atol: 0.0,
+                rtol: 0.0,
+            },
+            1.0,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            IntegrationError::InvalidTolerances {
+                atol: 0.0,
+                rtol: 0.0
+            }
+        );
+    }
+
+    #[test]
+    fn advance_to_rejects_non_positive_step() {
+        for dt in [0.0, -0.1, f64::NAN] {
+            let err = advance853(nonzero_state(), dt, Tolerances::default(), 1.0).unwrap_err();
+            assert!(
+                matches!(err, IntegrationError::InvalidStepSize { .. }),
+                "dt = {dt} gave {err:?}"
+            );
+        }
+    }
+
+    /// `atol == 0` with an all-zero state gives `0 / 0` in the error norm.
+    #[test]
+    fn advance_to_rejects_non_finite_error_norm() {
+        let zero = State::<3, 2>::new(vector![0.0, 0.0, 0.0], vector![0.0, 0.0, 0.0]);
+        let tol = Tolerances {
+            atol: 0.0,
+            rtol: 1e-8,
+        };
+        let err = advance853(zero, 0.1, tol, 1.0).unwrap_err();
+        assert_eq!(err, IntegrationError::IndeterminateErrorNorm { t: 0.0 });
+    }
+
+    #[test]
+    fn advance_to_detects_time_stagnation() {
+        let system = HarmonicOscillator;
+        let t0 = 9007199254740992.0_f64; // 2^53
+        let mut stepper = Dop853.stepper(&system, nonzero_state(), t0, 0.5, Tolerances::default());
+        let err = stepper
+            .advance_to::<_, _, ()>(t0 + 2.0, |_, _| {}, |_, _| ControlFlow::Continue(()))
+            .map(|_| ())
+            .unwrap_err();
+        assert!(matches!(err, IntegrationError::TimeStagnated { t, .. } if t == t0));
+    }
+
+    #[test]
+    fn advance_to_still_succeeds_for_valid_input() {
+        assert!(advance853(nonzero_state(), 0.1, Tolerances::default(), 1.0).is_ok());
     }
 }

--- a/utsuroi/src/solver/dp45/mod.rs
+++ b/utsuroi/src/solver/dp45/mod.rs
@@ -4,6 +4,7 @@ use core::ops::ControlFlow;
 
 use coeff::*;
 
+use crate::error::{validate_step_size, validate_time_span};
 #[allow(unused_imports)]
 use crate::math::F64Ext;
 use crate::{
@@ -137,8 +138,20 @@ impl<'a, S: DynamicalSystem> AdaptiveStepper<'a, S> {
         F: FnMut(f64, &S::State),
         E: Fn(f64, &S::State) -> ControlFlow<B>,
     {
+        self.tol.validate()?;
+        validate_step_size(self.dt)?;
+        // Without this, a NaN or backward `t_target` makes `while self.t <
+        // t_target` false on the first test and the stepper reports Reached
+        // while sitting at its old time.
+        validate_time_span(self.t, t_target)?;
+
         while self.t < t_target {
             let h = self.dt.min(t_target - self.t);
+            // `h > 0` holds, but for large `|self.t|` it can still be below
+            // the spacing of representable f64 values around `self.t`.
+            if self.t + h == self.t {
+                return Err(IntegrationError::TimeStagnated { t: self.t, dt: h });
+            }
 
             let (y5, error, k7) = dp_step_impl(self.system, self.t, &self.state, h, &self.k1);
 
@@ -148,6 +161,15 @@ impl<'a, S: DynamicalSystem> AdaptiveStepper<'a, S> {
             }
 
             let err = self.state.error_norm(&y5, &error, &self.tol);
+            // A NaN norm compares false against both the accept threshold and
+            // the `dt_min` floor below, so without this guard the same step is
+            // retried forever. `+Inf` is deliberately *not* rejected: it
+            // shrinks the step (`Inf.powf(-0.2) == 0` clamps to
+            // `DP_MIN_FACTOR`) and so either recovers or terminates via
+            // `StepSizeTooSmall`.
+            if err.is_nan() {
+                return Err(IntegrationError::IndeterminateErrorNorm { t: self.t });
+            }
 
             if err <= 1.0 {
                 // Accept step
@@ -945,5 +967,89 @@ mod tests {
             adaptive_steps < rk4_steps,
             "Adaptive should use fewer steps: adaptive={adaptive_steps}, rk4={rk4_steps}"
         );
+    }
+
+    // Guards against non-terminating adaptive loops.
+
+    fn advance(dt: f64, tol: Tolerances, t_target: f64) -> Result<(), IntegrationError> {
+        let system = HarmonicOscillator;
+        let initial = State::<3, 2>::new(vector![1.0, 0.0, 0.0], vector![0.0, 0.0, 0.0]);
+        let mut stepper = DormandPrince.stepper(&system, initial, 0.0, dt, tol);
+        stepper
+            .advance_to::<_, _, ()>(t_target, |_, _| {}, |_, _| ControlFlow::Continue(()))
+            .map(|_| ())
+    }
+
+    /// `atol == rtol == 0` makes every scale factor zero, so `error_norm`
+    /// returns NaN, which is neither accepted nor shrunk away from.
+    #[test]
+    fn advance_to_rejects_both_zero_tolerances() {
+        let err = advance(
+            0.1,
+            Tolerances {
+                atol: 0.0,
+                rtol: 0.0,
+            },
+            1.0,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            IntegrationError::InvalidTolerances {
+                atol: 0.0,
+                rtol: 0.0
+            }
+        );
+    }
+
+    #[test]
+    fn advance_to_rejects_non_positive_step() {
+        for dt in [0.0, -0.1, f64::NAN] {
+            let err = advance(dt, Tolerances::default(), 1.0).unwrap_err();
+            assert!(
+                matches!(err, IntegrationError::InvalidStepSize { .. }),
+                "dt = {dt} gave {err:?}"
+            );
+        }
+    }
+
+    /// With `atol == 0`, a state whose components are all exactly zero gives
+    /// `sc == 0` and `error == 0`, i.e. `0 / 0`. The tolerances themselves are
+    /// valid (`rtol > 0`), so only the error-norm guard catches this.
+    #[test]
+    fn advance_to_rejects_non_finite_error_norm() {
+        let system = HarmonicOscillator;
+        // Zero state stays exactly zero under dx/dt = v, dv/dt = -x.
+        let initial = State::<3, 2>::new(vector![0.0, 0.0, 0.0], vector![0.0, 0.0, 0.0]);
+        let tol = Tolerances {
+            atol: 0.0,
+            rtol: 1e-8,
+        };
+        let mut stepper = DormandPrince.stepper(&system, initial, 0.0, 0.1, tol);
+        let err = stepper
+            .advance_to::<_, _, ()>(1.0, |_, _| {}, |_, _| ControlFlow::Continue(()))
+            .map(|_| ())
+            .unwrap_err();
+        assert_eq!(err, IntegrationError::IndeterminateErrorNorm { t: 0.0 });
+    }
+
+    /// At `t = 2^53` the f64 spacing exceeds 1, so `t + 0.5 == t`.
+    #[test]
+    fn advance_to_detects_time_stagnation() {
+        let system = HarmonicOscillator;
+        let initial = State::<3, 2>::new(vector![1.0, 0.0, 0.0], vector![0.0, 0.0, 0.0]);
+        let t0 = 9007199254740992.0_f64; // 2^53
+        let mut stepper = DormandPrince.stepper(&system, initial, t0, 0.5, Tolerances::default());
+        let err = stepper
+            .advance_to::<_, _, ()>(t0 + 2.0, |_, _| {}, |_, _| ControlFlow::Continue(()))
+            .map(|_| ())
+            .unwrap_err();
+        assert!(matches!(err, IntegrationError::TimeStagnated { t, .. } if t == t0));
+    }
+
+    /// The guards must not disturb well-formed runs.
+    #[test]
+    fn advance_to_still_succeeds_for_valid_input() {
+        assert!(advance(0.1, Tolerances::default(), 1.0).is_ok());
     }
 }

--- a/utsuroi/src/solver/verlet.rs
+++ b/utsuroi/src/solver/verlet.rs
@@ -56,6 +56,11 @@ impl StormerVerlet {
     }
 
     /// Integrate from `t0` to `t_end` with fixed step size `dt`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the arguments cannot produce a terminating integration; see
+    /// [`try_integrate`](Self::try_integrate) for the fallible form.
     pub fn integrate<const DIM: usize, S, F>(
         &self,
         system: &S,
@@ -63,30 +68,51 @@ impl StormerVerlet {
         t0: f64,
         t_end: f64,
         dt: f64,
-        mut callback: F,
+        callback: F,
     ) -> State<DIM, 2>
     where
         S: DynamicalSystem<State = State<DIM, 2>>,
         F: FnMut(f64, &State<DIM, 2>),
     {
-        if let Err(e) = validate_step_size(dt).and_then(|()| validate_time_span(t0, t_end)) {
-            panic!("utsuroi: integrate() cannot run: {e}");
+        match self.try_integrate(system, initial, t0, t_end, dt, callback) {
+            Ok(state) => state,
+            Err(e) => panic!("utsuroi: integrate() cannot run: {e}"),
         }
+    }
+
+    /// Fallible variant of [`integrate`](Self::integrate).
+    ///
+    /// Mirrors [`Integrator::try_integrate`](crate::Integrator::try_integrate)
+    /// so that "use `try_integrate` to avoid the panic" holds for every
+    /// integrator in the crate, not just the trait-based ones.
+    pub fn try_integrate<const DIM: usize, S, F>(
+        &self,
+        system: &S,
+        initial: State<DIM, 2>,
+        t0: f64,
+        t_end: f64,
+        dt: f64,
+        mut callback: F,
+    ) -> Result<State<DIM, 2>, IntegrationError>
+    where
+        S: DynamicalSystem<State = State<DIM, 2>>,
+        F: FnMut(f64, &State<DIM, 2>),
+    {
+        validate_step_size(dt)?;
+        validate_time_span(t0, t_end)?;
 
         let mut state = initial;
         let mut t = t0;
         while t < t_end {
             let h = dt.min(t_end - t);
-            assert!(
-                t + h != t,
-                "utsuroi: integrate() cannot run: {}",
-                IntegrationError::TimeStagnated { t, dt: h }
-            );
+            if t + h == t {
+                return Err(IntegrationError::TimeStagnated { t, dt: h });
+            }
             state = self.step(system, t, &state, h);
             t += h;
             callback(t, &state);
         }
-        state
+        Ok(state)
     }
 
     /// Integrate with event detection and NaN/Inf checking.
@@ -608,5 +634,61 @@ mod tests {
                  x0={x0}, v0={v0}, dt={dt}, first={first_half:.2e}, second={second_half:.2e}"
             );
         }
+    }
+
+    // `try_integrate` mirrors the trait-based solvers, so the same guards apply
+    // to the inherent (`State<DIM, 2>`-only) API.
+
+    #[test]
+    fn verlet_try_integrate_rejects_non_advancing_step() {
+        let system = HarmonicOscillator;
+        let initial = State::<3, 2>::new(vector![1.0, 0.0, 0.0], vector![0.0, 0.0, 0.0]);
+        for dt in [0.0, -0.1, f64::NAN] {
+            let err = StormerVerlet
+                .try_integrate(&system, initial.clone(), 0.0, 1.0, dt, |_, _| {})
+                .unwrap_err();
+            assert!(
+                matches!(err, IntegrationError::InvalidStepSize { .. }),
+                "dt = {dt} gave {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn verlet_try_integrate_rejects_backward_span() {
+        let system = HarmonicOscillator;
+        let initial = State::<3, 2>::new(vector![1.0, 0.0, 0.0], vector![0.0, 0.0, 0.0]);
+        let err = StormerVerlet
+            .try_integrate(&system, initial, 1.0, 0.0, 0.1, |_, _| {})
+            .unwrap_err();
+        assert!(
+            matches!(err, IntegrationError::InvalidTimeSpan { .. }),
+            "{err:?}"
+        );
+    }
+
+    /// At `t = 2^53` the f64 spacing exceeds 1, so `t + 0.5 == t`.
+    #[test]
+    fn verlet_try_integrate_detects_time_stagnation() {
+        let system = HarmonicOscillator;
+        let initial = State::<3, 2>::new(vector![1.0, 0.0, 0.0], vector![0.0, 0.0, 0.0]);
+        let t0 = 9007199254740992.0_f64;
+        let err = StormerVerlet
+            .try_integrate(&system, initial, t0, t0 + 2.0, 0.5, |_, _| {})
+            .unwrap_err();
+        assert!(matches!(err, IntegrationError::TimeStagnated { t, .. } if t == t0));
+    }
+
+    /// Valid input must go through both APIs identically — `integrate` is only
+    /// a panicking wrapper over `try_integrate`.
+    #[test]
+    fn verlet_integrate_matches_try_integrate_for_valid_input() {
+        let system = HarmonicOscillator;
+        let initial = State::<3, 2>::new(vector![1.0, 0.0, 0.0], vector![0.0, 0.0, 0.0]);
+        let a = StormerVerlet
+            .try_integrate(&system, initial.clone(), 0.0, 1.0, 0.01, |_, _| {})
+            .expect("valid input");
+        let b = StormerVerlet.integrate(&system, initial, 0.0, 1.0, 0.01, |_, _| {});
+        assert_eq!(a, b);
     }
 }

--- a/utsuroi/src/solver/verlet.rs
+++ b/utsuroi/src/solver/verlet.rs
@@ -2,6 +2,7 @@ use core::ops::ControlFlow;
 
 use nalgebra::SVector;
 
+use crate::error::{validate_step_size, validate_time_span};
 use crate::{DynamicalSystem, IntegrationError, IntegrationOutcome, OdeState, State};
 
 /// Störmer-Verlet (velocity Verlet) symplectic integrator.
@@ -68,10 +69,19 @@ impl StormerVerlet {
         S: DynamicalSystem<State = State<DIM, 2>>,
         F: FnMut(f64, &State<DIM, 2>),
     {
+        if let Err(e) = validate_step_size(dt).and_then(|()| validate_time_span(t0, t_end)) {
+            panic!("utsuroi: integrate() cannot run: {e}");
+        }
+
         let mut state = initial;
         let mut t = t0;
         while t < t_end {
             let h = dt.min(t_end - t);
+            assert!(
+                t + h != t,
+                "utsuroi: integrate() cannot run: {}",
+                IntegrationError::TimeStagnated { t, dt: h }
+            );
             state = self.step(system, t, &state, h);
             t += h;
             callback(t, &state);
@@ -96,10 +106,17 @@ impl StormerVerlet {
         F: FnMut(f64, &State<DIM, 2>),
         E: Fn(f64, &State<DIM, 2>) -> ControlFlow<B>,
     {
+        if let Err(e) = validate_step_size(dt).and_then(|()| validate_time_span(t0, t_end)) {
+            return IntegrationOutcome::Error(e);
+        }
+
         let mut state = initial;
         let mut t = t0;
         while t < t_end {
             let h = dt.min(t_end - t);
+            if t + h == t {
+                return IntegrationOutcome::Error(IntegrationError::TimeStagnated { t, dt: h });
+            }
             state = self.step(system, t, &state, h);
             t += h;
             if !state.is_finite() {

--- a/utsuroi/src/solver/yoshida.rs
+++ b/utsuroi/src/solver/yoshida.rs
@@ -9,6 +9,7 @@
 
 use core::ops::ControlFlow;
 
+use crate::error::{validate_step_size, validate_time_span};
 use crate::{DynamicalSystem, IntegrationError, IntegrationOutcome, OdeState, State};
 
 use super::verlet::StormerVerlet;
@@ -118,10 +119,20 @@ macro_rules! impl_yoshida {
                 S: DynamicalSystem<State = State<DIM, 2>>,
                 F: FnMut(f64, &State<DIM, 2>),
             {
+                if let Err(e) = validate_step_size(dt).and_then(|()| validate_time_span(t0, t_end))
+                {
+                    panic!("utsuroi: integrate() cannot run: {e}");
+                }
+
                 let mut state = initial;
                 let mut t = t0;
                 while t < t_end {
                     let h = dt.min(t_end - t);
+                    assert!(
+                        t + h != t,
+                        "utsuroi: integrate() cannot run: {}",
+                        IntegrationError::TimeStagnated { t, dt: h }
+                    );
                     state = self.step(system, t, &state, h);
                     t += h;
                     callback(t, &state);
@@ -145,10 +156,21 @@ macro_rules! impl_yoshida {
                 F: FnMut(f64, &State<DIM, 2>),
                 E: Fn(f64, &State<DIM, 2>) -> ControlFlow<B>,
             {
+                if let Err(e) = validate_step_size(dt).and_then(|()| validate_time_span(t0, t_end))
+                {
+                    return IntegrationOutcome::Error(e);
+                }
+
                 let mut state = initial;
                 let mut t = t0;
                 while t < t_end {
                     let h = dt.min(t_end - t);
+                    if t + h == t {
+                        return IntegrationOutcome::Error(IntegrationError::TimeStagnated {
+                            t,
+                            dt: h,
+                        });
+                    }
                     state = self.step(system, t, &state, h);
                     t += h;
                     if !state.is_finite() {

--- a/utsuroi/src/solver/yoshida.rs
+++ b/utsuroi/src/solver/yoshida.rs
@@ -106,6 +106,10 @@ macro_rules! impl_yoshida {
                 yoshida_step(&$weights, system, t, state, dt)
             }
 
+            /// # Panics
+            ///
+            /// Panics if the arguments cannot produce a terminating
+            /// integration; see `try_integrate` for the fallible form.
             pub fn integrate<const DIM: usize, S, F>(
                 &self,
                 system: &S,
@@ -113,31 +117,48 @@ macro_rules! impl_yoshida {
                 t0: f64,
                 t_end: f64,
                 dt: f64,
-                mut callback: F,
+                callback: F,
             ) -> State<DIM, 2>
             where
                 S: DynamicalSystem<State = State<DIM, 2>>,
                 F: FnMut(f64, &State<DIM, 2>),
             {
-                if let Err(e) = validate_step_size(dt).and_then(|()| validate_time_span(t0, t_end))
-                {
-                    panic!("utsuroi: integrate() cannot run: {e}");
+                match self.try_integrate(system, initial, t0, t_end, dt, callback) {
+                    Ok(state) => state,
+                    Err(e) => panic!("utsuroi: integrate() cannot run: {e}"),
                 }
+            }
+
+            /// Fallible variant of `integrate`, mirroring
+            /// [`Integrator::try_integrate`](crate::Integrator::try_integrate).
+            pub fn try_integrate<const DIM: usize, S, F>(
+                &self,
+                system: &S,
+                initial: State<DIM, 2>,
+                t0: f64,
+                t_end: f64,
+                dt: f64,
+                mut callback: F,
+            ) -> Result<State<DIM, 2>, IntegrationError>
+            where
+                S: DynamicalSystem<State = State<DIM, 2>>,
+                F: FnMut(f64, &State<DIM, 2>),
+            {
+                validate_step_size(dt)?;
+                validate_time_span(t0, t_end)?;
 
                 let mut state = initial;
                 let mut t = t0;
                 while t < t_end {
                     let h = dt.min(t_end - t);
-                    assert!(
-                        t + h != t,
-                        "utsuroi: integrate() cannot run: {}",
-                        IntegrationError::TimeStagnated { t, dt: h }
-                    );
+                    if t + h == t {
+                        return Err(IntegrationError::TimeStagnated { t, dt: h });
+                    }
                     state = self.step(system, t, &state, h);
                     t += h;
                     callback(t, &state);
                 }
-                state
+                Ok(state)
             }
 
             #[allow(clippy::too_many_arguments)]
@@ -662,5 +683,46 @@ mod tests {
             "3D error: {:.2e}",
             (final_state.y().x - 1.0).abs()
         );
+    }
+
+    // Same guards as the trait-based solvers, on the inherent API.
+
+    #[test]
+    fn yoshida_try_integrate_rejects_non_advancing_step() {
+        let system = HarmonicOscillator1D;
+        let initial = State::<1, 2>::new(vector![1.0], vector![0.0]);
+        for dt in [0.0, -0.1, f64::NAN] {
+            let err = Yoshida4
+                .try_integrate(&system, initial.clone(), 0.0, 1.0, dt, |_, _| {})
+                .unwrap_err();
+            assert!(
+                matches!(err, IntegrationError::InvalidStepSize { .. }),
+                "dt = {dt} gave {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn yoshida_try_integrate_rejects_backward_span() {
+        let system = HarmonicOscillator1D;
+        let initial = State::<1, 2>::new(vector![1.0], vector![0.0]);
+        let err = Yoshida4
+            .try_integrate(&system, initial, 1.0, 0.0, 0.1, |_, _| {})
+            .unwrap_err();
+        assert!(
+            matches!(err, IntegrationError::InvalidTimeSpan { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn yoshida_integrate_matches_try_integrate_for_valid_input() {
+        let system = HarmonicOscillator1D;
+        let initial = State::<1, 2>::new(vector![1.0], vector![0.0]);
+        let a = Yoshida4
+            .try_integrate(&system, initial.clone(), 0.0, 1.0, 0.01, |_, _| {})
+            .expect("valid input");
+        let b = Yoshida4.integrate(&system, initial, 0.0, 1.0, 0.01, |_, _| {});
+        assert_eq!(a, b);
     }
 }


### PR DESCRIPTION
## 背景

不正な時間パラメータが検証されずに積分ループへ到達し、ハングまたは panic を起こしていました。`orts run` での実測（修正前）:

| 設定 | 修正前の挙動 |
|---|---|
| `dt = 0.0` / `dt = -1.0` | **無限ハング**（20 秒 timeout、出力なし、終了せず） |
| `dt = nan` | `f64::clamp` の奥で panic（`min > max, or either was NaN`） |
| `dt = 10, output_interval = 1` | `SimParams::from_config` の `clamp` で panic |
| `stream_interval = 0` | serve の pacing で `Duration::from_secs_f64(NaN)` が panic |
| `orts config validate` | 上記すべてを **`OK`** と報告 |

いずれもユーザが設定ファイルに 1 行書くだけで踏めます。ハングは「重いシミュレーションが進行中」と区別がつかないため、原因の特定が特に難しい壊れ方でした。

## 修正後の挙動

不正な入力を、ハング・panic ではなく**明示的なエラー**にしました。修正後（すべて `exit=1`）:

```
dt = 0.0                        → Error: dt must be positive and finite (got 0)
dt = nan                        → Error: dt must be positive and finite (got NaN)
dt = 10, output_interval = 1     → Error: output_interval (1) must be >= dt (10): the
                                   simulation cannot emit output more often than it steps
stream_interval = 0             → Error: stream_interval must be positive and finite (got 0)
config validate（dt=0）          → Error: ... dt must be positive and finite (got 0)
正常系 dt = 10                   → exit=0（挙動は変わらず）
```

CLI 引数の直接指定（設定ファイルなし）も同様に検証されます:

```
run --sat "altitude=500" --dt 0                     → exit=1
run --sat "altitude=500" --dt 10 --output-interval 1 → exit=1
run --sat "..." --integrator dp45 --atol 0 --rtol 0  → exit=1
```

## 変更内容

### utsuroi

- `IntegrationError` に `InvalidStepSize` / `InvalidTimeSpan` / `InvalidTolerances` / `IndeterminateErrorNorm` / `TimeStagnated` を追加し、`Tolerances::validate()` を新設。
- `Integrator::try_integrate` を追加（`integrate` の fallible 版）。`integrate` はその薄いラッパで、ハングの代わりに明示的に panic する。`integrate_with_events` は `IntegrationOutcome::Error` で返す。`StormerVerlet` / `Yoshida*` は trait ではなく固有メソッドを持つので、そちらにも同形の `try_integrate` を追加した。
- `AdaptiveStepper{,853}::advance_to` に入口の検証（tolerances / step size / `t_target`）とループ内の検証（`t + h == t` の停滞、NaN の error norm）を追加。
- `IntegrationError::time()` を追加。variant を増やすたびに呼び出し側の網羅 match が壊れるのを防ぐ。
- `validate_step_size` を公開。`Integrator::step` を直接使う下流の固定ステップループが同じ前提条件を適用できるようにする。

### orts

- `IntegratorConfig::validate()` を追加し、`IndependentGroup` / `CoupledGroup` がステップを踏む前に呼ぶ。固定ステップ RK4 分岐は**自前のループ**を持っているため、utsuroi 内部のガードが効いていなかった。
- 同じ `t + h == t` 停滞ガードをそれらのループにも追加。

### orts-cli

- 検証を `validate_time_params` / `validate_tolerances` / `validate_sample_period` に切り出し、**設定ファイル経路と CLI 引数直接指定経路の両方**から呼ぶ。両者は interval の算出ロジックを重複実装しており、検証は前者にしか入っていなかった。
- 軌道パラメータの有限性と、body 半径から導かれる半径の正値を検証。`altitude = nan` は NaN の軌道周期を生み、`run` がどの終了時刻とも比較が成立しないループに入っていた。
- controlled run の tick ループが読む controller sample period を検証。0 だと `t += 0` で回り続けていた。
- 逆転した境界で `clamp` が panic しないよう `min` で順序を保証。

## 併せて塞いだ経路

`advance_to` の `t_target` 検証により、**`t_target` が NaN または過去のときに一歩も進まずに `Reached` を返す**問題も塞がりました。`while self.t < t_target` の最初の比較が false になるためです。

## 設計上の判断

- **エラーの層**: ユーザ入力の検証は CLI に置き、ライブラリ側は前提条件違反として扱う二層構造にしています。
- **`+Inf` の error norm は許容**: 永久 reject を起こすのは NaN のみです（NaN は accept 条件も `dt_min` ガードも比較が false になり抜ける）。`+Inf` は `Inf.powf(-0.2) == 0` が最小係数に clamp されて刻みが縮むため、回復するか `StepSizeTooSmall` で正常終了します。有限値の二乗和が一時的に overflow するケースを即エラーにしないための区別です。
- **tolerance は adaptive のみ検証**: RK4 は tolerance を読まないため、未使用の `atol`/`rtol` を持つ設定を落とさないようにしています。
- **`output_interval < dt` は拒否**: 従来この組み合わせは必ず `clamp` で panic していたため、動作していた設定は存在せず、後方互換性の問題はありません。

## エラー伝播の整理

初版の最大の問題は、**この PR が追加した `IntegrationError` が報告されずに panic に化けていた**ことです:

```rust
// 追加したエラー型がそのまま panic になっていた
group.propagate_to(t).unwrap()
```

同じ形が `cli/src/sim/controlled.rs` にもありました。自身は `Result` を返すのに、panic する `Rk4.integrate` を呼んでいました。

`cli/src/commands/mod.rs` に `CmdError { message, code }` を新設し、usage error は 2、runtime failure は 1 を運びます（従来 `process::exit(1)` / `exit(2)` が暗黙に持っていた区別を型に移しました）。`main` が唯一プロセス終了を決める場所になり、**`std::process::exit` は crate 内で `main` の 1 箇所だけ**になりました。

`Result` 化: `validate_sim_args` / `validate_output_contract` / `write_simulation_output` / `print_recording_as_csv` / `run_simulation` / `run_controlled_simulation` / `run_simulation_cmd` / `run_server` / `async_server`。

副次的に直ったもの:

- **rayon の worker からの `exit`**: controlled ループの並列分岐が `for_each` のクロージャ内で `process::exit(1)` していました。ワーカースレッドからプロセスを落とすので呼び出し側の cleanup が全て飛びます。`try_for_each` でエラー集約に変更。
- **serve の exit code 回帰**: `validate_sim_args` を「このファイルの既存流儀」に合わせて `panic!` にしたところ、`orts serve --sat ... --dt=0` の終了コードが 1 → 101 に変わり panic の定型文が stderr に混ざる状態を作っていました。`run_server` まで `Result` を伝播して修正。`serve/mod.rs` の `panic!` は 6 → **0 件**。
- **`initial_state` の panic**: TLE/OMM の SGP4 初期化・指定 epoch への伝播は実際に失敗しうるので伝播に変更。
- **stdout I/O**: `orts run | head` のようにパイプが先に閉じた場合に panic せず `CmdError` になります。`--json` の末尾改行も summary と同じ locked writer に。

`StormerVerlet` / `Yoshida*` にも `try_integrate` を追加し、「panic を避けたければ `try_integrate`」が**全 integrator で成立**するようにしました。

### exit code

| 入力 | exit |
|---|---|
| `--format rrd --output -` | 2 (usage) |
| `--format csv --json --output -` | 2 (usage) |
| 設定ファイルも orbit 引数もなし | 2 (usage) |
| `--dt=0` | 1 (failure) |
| `--dt 10 --output-interval 1` | 1 (failure) |
| 存在しない `--config` | 1 (failure) |
| 正常系 | 0 |

### テスト可能性

`validate_sim_args` と `validate_output_contract` が**初めてユニットテスト可能**になりました。以前は検出箇所で `exit(1)` していたため、エラーメッセージを assert するにはサブプロセスを起動するしかありませんでした。

## テスト

- utsuroi: 154 件（新規 29 件 — うち `try_integrate` 系 7 件）
- orts: 653 件（新規 2 件）
- orts-cli: `commands::` 94 件（新規 23 件 — `validate_sim_args` 8 件 / `validate_output_contract` 3 件 / `CmdError` 3 件 / config 系 9 件）
- `cargo test --workspace` 65 スイート全て pass
- `cargo fmt --all --check`、`cargo clippy --workspace -- -D warnings`、`cargo test --workspace` すべて通過

新規テストは、期待する経路を実際に踏むことを確認しています。たとえば `advance_to_rejects_non_finite_error_norm` は `atol = 0` かつ `rtol > 0`（それ自体は妥当な設定）で状態成分が厳密に 0 になる経路を通り、`0 / 0` を発生させています。
