### PR TITLE
fix: 地磁気モデルの符号と Schmidt 準正規化を修正

### DIFF
--- a/plugin-sdk/examples/detumble-nadir/src/lib.rs
+++ b/plugin-sdk/examples/detumble-nadir/src/lib.rs
@@ -86,7 +86,11 @@ impl Plugin<TickInput, Command> for Controller {
                     return Ok(None);
                 }
 
-                let m = -gain * omega.cross(&b);
+                // B-dot law: m = -k dB/dt, and in the body frame
+                // dB/dt ~ -omega x B, so m = +k (omega x B). The negated form
+                // commands the opposite moment and *spins the satellite up*.
+                // Matches `orts::attitude::control::BdotCross`.
+                let m = *gain * omega.cross(&b);
                 let max = *max_moment;
 
                 Ok(Some(Command {

--- a/plugin-sdk/examples/nos3-adcs/test.sh
+++ b/plugin-sdk/examples/nos3-adcs/test.sh
@@ -145,7 +145,24 @@ test_bdot() {
     gen_config 1 11100.0 0.1 1.0 "bdot_kb = 1e4
 bdot_b_range = 1e-9"
     read -r initial final elapsed < <(run_sim "$TMPTOML" bdot)
-    check_reduction "B-dot" 0.05 "$initial" "$final" "$elapsed"
+    # 0.10 (90% reduction) from measurement, not from a control requirement:
+    # with a correct IGRF field this run reaches 93.1% in 2 orbits.
+    #
+    # It used to be 0.05 (95%), which passed at 97.7% only because the field
+    # model was wrong — the eastward component was inverted and the
+    # intermediate-order Legendre terms were mis-scaled, which together
+    # overstated the achievable damping. B-dot torque is quadratic in B and
+    # only damps the omega component perpendicular to it, so a field that is
+    # off by ~8.6 deg in direction changes the reachable reduction, not just
+    # its magnitude.
+    #
+    # This is an integration check ("the NOS3 C FSW loads as a WASM component,
+    # reads the magnetometer, drives the MTQ, and omega comes down"), so the
+    # bound is deliberately looser than the measured value. Pinning the
+    # measured number would make every future field- or ephemeris-model
+    # improvement fail here. Validating the damping *rate* against NOS3's own
+    # simulator is separate work.
+    check_reduction "B-dot" 0.10 "$initial" "$final" "$elapsed"
 }
 
 test_sunsafe() {
@@ -156,6 +173,10 @@ sunsafe_sside = [1.0, 0.0, 0.0]
 sunsafe_vmax = 0.01
 momentum_management = true" "0.01, -0.005, 0.008"
     read -r initial final elapsed < <(run_sim "$TMPTOML" sunsafe)
+    # Integration check, as for B-dot: the bound is looser than the measured
+    # value (94.2%) so that field- and ephemeris-model improvements do not
+    # fail it. Sun-Safe uses reaction wheels, so it depends on the magnetic
+    # field only through momentum management.
     check_reduction "Sun-Safe" 0.2 "$initial" "$final" "$elapsed"
 }
 
@@ -166,6 +187,8 @@ inertial_kr = [2.0, 2.0, 2.0]
 inertial_phi_err_max = 1.0
 momentum_management = true" "0.01, -0.005, 0.008"
     read -r initial final elapsed < <(run_sim "$TMPTOML" inertial)
+    # Reaction-wheel quaternion PID, so essentially independent of the
+    # magnetic field; measured 100.0%. Tight bound is safe here.
     check_reduction "Inertial" 0.01 "$initial" "$final" "$elapsed"
 }
 

--- a/tobari/src/magnetic/dipole.rs
+++ b/tobari/src/magnetic/dipole.rs
@@ -44,15 +44,30 @@ impl TiltedDipole {
     /// Earth's tilted dipole (IGRF approximate).
     ///
     /// - Dipole strength: ~7.94e15 T*m^3 (= mu_0/(4*pi) * 7.94e22 A*m^2)
-    /// - Axis tilted ~11.5 deg from geographic north (simplified: tilt in x-z plane in ECEF)
+    /// - Geomagnetic pole tilted ~11.5 deg from geographic north (simplified:
+    ///   tilt in the x-z plane in ECEF)
+    ///
+    /// The dipole **moment** points roughly geographic *south*, i.e. opposite
+    /// the geomagnetic north pole — that is what makes field lines enter the
+    /// Earth in the northern hemisphere. IGRF says the same thing through
+    /// `g_1^0 < 0`. Concretely, with `m_hat` pointing south:
+    ///
+    /// - at the equator `m_hat . r_hat = 0`, so `B ~ -m_hat` points north;
+    /// - at the north pole `r_hat = +Z` and `m_hat . r_hat = -1`, so
+    ///   `3(m_hat . r_hat) r_hat - m_hat = +2 m_hat`, which points into the
+    ///   Earth.
+    ///
+    /// Both match the real field; using `+Z` here inverts the whole vector.
     ///
     /// The axis is stored in ECEF coordinates and will be rotated to ECI
     /// using the epoch's GMST when computing the field.
     pub fn earth() -> Self {
         let tilt = 11.5_f64.to_radians();
+        // Geomagnetic north pole direction, then negated to get the moment.
+        let pole = Vector3::new(tilt.sin(), 0.0, tilt.cos());
         Self {
             dipole_strength: EARTH_DIPOLE_STRENGTH,
-            axis_ecef: Vector3::new(tilt.sin(), 0.0, tilt.cos()).normalize(),
+            axis_ecef: -pole.normalize(),
         }
     }
 
@@ -279,6 +294,58 @@ mod tests {
         assert!(
             (mag_ratio - 1.0).abs() < 0.5,
             "Magnitudes should be similar, ratio={mag_ratio:.3}"
+        );
+    }
+
+    // Sign / direction. Every other test here compares magnitudes, which are
+    // invariant under a full inversion of the field — so these pin the actual
+    // vector against the real Earth's field.
+
+    /// At the geographic equator the field points geographic *north*: the
+    /// dipole moment is southward, `m_hat . r_hat = 0` there, so `B ~ -m_hat`.
+    #[test]
+    fn equatorial_field_points_north() {
+        let dipole = TiltedDipole::new(EARTH_DIPOLE_STRENGTH, Vector3::new(0.0, 0.0, -1.0));
+        let b = dipole.compute_field_ecef(&Vector3::new(7000.0, 0.0, 0.0));
+        assert!(
+            b.z > 0.0,
+            "equatorial field should point north (+Z), got {b:?}"
+        );
+        // Purely northward for an untilted dipole on the equator.
+        assert!(
+            b.x.abs() < 1e-12 * b.z.abs(),
+            "unexpected radial part: {b:?}"
+        );
+    }
+
+    /// At the north pole the field points *into* the Earth (radially inward),
+    /// which is why a compass needle dips downward there.
+    #[test]
+    fn north_polar_field_points_into_earth() {
+        let dipole = TiltedDipole::new(EARTH_DIPOLE_STRENGTH, Vector3::new(0.0, 0.0, -1.0));
+        let b = dipole.compute_field_ecef(&Vector3::new(0.0, 0.0, 7000.0));
+        assert!(
+            b.z < 0.0,
+            "field at the north pole should point into the Earth (-Z), got {b:?}"
+        );
+    }
+
+    /// `TiltedDipole::earth()` must use the southward moment, not the
+    /// geomagnetic pole direction. A sign slip here inverts every magnetometer
+    /// reading and every `m x B` torque in the simulator.
+    #[test]
+    fn earth_dipole_moment_points_south() {
+        let dipole = TiltedDipole::earth();
+        assert!(
+            dipole.axis_ecef.z < 0.0,
+            "Earth's dipole moment points geographic south, got axis {:?}",
+            dipole.axis_ecef
+        );
+        // Equatorial field is northward, as for the untilted case above.
+        let b = dipole.compute_field_ecef(&Vector3::new(0.0, 7000.0, 0.0));
+        assert!(
+            b.z > 0.0,
+            "equatorial field should point north (+Z), got {b:?}"
         );
     }
 }

--- a/tobari/src/magnetic/igrf/mod.rs
+++ b/tobari/src/magnetic/igrf/mod.rs
@@ -279,28 +279,27 @@ fn interpolate_custom(
 
 // Spherical harmonic evaluation
 
-/// Evaluate the IGRF spherical harmonic expansion.
+/// Number of rows/columns in the fixed-size Legendre tables.
+const ND: usize = IGRF_MAX_DEGREE + 1;
+
+/// Schmidt semi-normalized associated Legendre functions `P[n][m]` and their
+/// colatitude derivatives `dP/dtheta`, for `n, m <= max_degree`.
 ///
-/// Returns (B_r, B_theta, B_phi) in nT, where:
-/// - B_r: radial (outward)
-/// - B_theta: southward (colatitude direction)
-/// - B_phi: eastward (longitude direction)
-fn evaluate_sh(
-    g: &[f64],
-    h: &[f64],
-    r_km: f64,
+/// Fixed-size `[IGRF_MAX_DEGREE+1][IGRF_MAX_DEGREE+1]` = `[14][14]`; only
+/// indices `0..=max_degree` are populated. ~3 KiB on the stack.
+///
+/// Schmidt semi-normalization means
+/// `P^m_n = sqrt(2 (n-m)! / (n+m)!) * P_{n,m}` for `m > 0` (and the plain
+/// Legendre function for `m = 0`), which is the convention the IGRF Gauss
+/// coefficients are defined in. It is characterised by
+/// `∫_{-1}^{1} [P^m_n(x)]^2 dx = 2/(2n+1)` for `m = 0` and `4/(2n+1)` for
+/// `m >= 1` — see `schmidt_normalization_holds`, which pins every recursion
+/// branch below without needing external reference values.
+fn schmidt_legendre(
     cos_theta: f64,
     sin_theta: f64,
-    phi: f64,
     max_degree: usize,
-) -> (f64, f64, f64) {
-    let a = IGRF_REFERENCE_RADIUS;
-    let ratio = a / r_km;
-
-    // Schmidt semi-normalized associated Legendre polynomials P[n][m] and dP/dtheta.
-    // Fixed-size [IGRF_MAX_DEGREE+1][IGRF_MAX_DEGREE+1] = [14][14]; only
-    // indices 0..=max_degree are used. ~3 KiB on stack.
-    const ND: usize = IGRF_MAX_DEGREE + 1;
+) -> ([[f64; ND]; ND], [[f64; ND]; ND]) {
     let nd = max_degree + 1;
     let mut p = [[0.0; ND]; ND];
     let mut dp = [[0.0; ND]; ND];
@@ -321,10 +320,18 @@ fn evaluate_sh(
     }
 
     // Sub-diagonal: P[n][n-1]
+    //
+    // The coefficient is `sqrt(2n-1)`, not `2n-1`: substituting `m = n-1` into
+    // the general recursion below gives `denom = sqrt(n^2 - (n-1)^2) =
+    // sqrt(2n-1)` and `k = 0`, so
+    //   P[n][n-1] = (2n-1) cos(theta) P[n-1][n-1] / sqrt(2n-1)
+    //             = sqrt(2n-1) cos(theta) P[n-1][n-1].
+    // Using `2n-1` broke Schmidt semi-normalization for every intermediate
+    // order (0 < m < n), since these values also seed the general recursion.
     for n in 1..nd {
-        p[n][n - 1] = cos_theta * (2 * n - 1) as f64 * p[n - 1][n - 1];
-        dp[n][n - 1] =
-            (2 * n - 1) as f64 * (cos_theta * dp[n - 1][n - 1] - sin_theta * p[n - 1][n - 1]);
+        let c = ((2 * n - 1) as f64).sqrt();
+        p[n][n - 1] = cos_theta * c * p[n - 1][n - 1];
+        dp[n][n - 1] = c * (cos_theta * dp[n - 1][n - 1] - sin_theta * p[n - 1][n - 1]);
     }
 
     // General recursion: P[n][m] for m < n-1
@@ -340,6 +347,30 @@ fn evaluate_sh(
                 / denom;
         }
     }
+
+    (p, dp)
+}
+
+/// Evaluate the IGRF spherical harmonic expansion.
+///
+/// Returns (B_r, B_theta, B_phi) in nT, where:
+/// - B_r: radial (outward)
+/// - B_theta: southward (colatitude direction)
+/// - B_phi: eastward (longitude direction)
+fn evaluate_sh(
+    g: &[f64],
+    h: &[f64],
+    r_km: f64,
+    cos_theta: f64,
+    sin_theta: f64,
+    phi: f64,
+    max_degree: usize,
+) -> (f64, f64, f64) {
+    let a = IGRF_REFERENCE_RADIUS;
+    let ratio = a / r_km;
+
+    let (p, dp) = schmidt_legendre(cos_theta, sin_theta, max_degree);
+    let nd = max_degree + 1;
 
     // Accumulate field components
     let mut b_r = 0.0;
@@ -370,9 +401,14 @@ fn evaluate_sh(
             b_theta -= r_power * gh_cos_sin * dp[n][m];
 
             // B_phi = -(1/(r sin theta)) dV/dphi
-            //       = sum (a/r)^(n+2) * m * (-g sin + h cos) * P / sin(theta)
+            //       = sum (a/r)^(n+2) * m * (g sin - h cos) * P / sin(theta)
+            //
+            // Note the outer minus sign: d/dphi (g cos m.phi + h sin m.phi) is
+            // m(-g sin + h cos), and B_phi negates it. Dropping that negation
+            // inverts the whole eastward component. This is the standard
+            // `Y = m (g sin m.phi - h cos m.phi) P / sin(theta)`.
             if m > 0 {
-                let gh_sin_cos = -g_nm * sin_m_phi + h_nm * cos_m_phi;
+                let gh_sin_cos = g_nm * sin_m_phi - h_nm * cos_m_phi;
                 if sin_theta.abs() > 1e-10 {
                     b_phi += r_power * m_f * gh_sin_cos * p[n][m] / sin_theta;
                 } else if m == 1 {
@@ -557,11 +593,31 @@ mod tests {
         };
         let input = make_input(geo, &epoch);
 
-        let b_igrf = b_magnitude(&igrf.field_ecef(&input));
-        let b_dipole = b_magnitude(&dipole.field_ecef(&input));
+        let v_igrf = igrf.field_ecef(&input);
+        let v_dipole = dipole.field_ecef(&input);
 
-        // At GEO the dipole dominates; expect <10% difference
+        // Compare the *vector direction*, not just the magnitude: a
+        // magnitude-only check is invariant under a full sign inversion of
+        // either model, which is exactly the kind of bug that hid here before.
+        //
+        // The tolerance is loose on purpose. `TiltedDipole` places its 11.5°
+        // tilt at longitude 0, while the real geomagnetic pole sits near
+        // 80.6°N 72.6°W — the two axes are 12.4° apart, which shows up here as
+        // roughly 21° between the field vectors (measured cos ≈ 0.933). So this
+        // guards against inversion, not against that tilt-longitude
+        // simplification. An inverted model gives cos ≈ -0.93.
+        let dot: f64 = (0..3).map(|i| v_igrf[i] * v_dipole[i]).sum();
+        let cos_angle = dot / (b_magnitude(&v_igrf) * b_magnitude(&v_dipole));
+        assert!(
+            cos_angle > 0.85,
+            "IGRF and dipole should point the same way at GEO, \
+             got cos(angle) = {cos_angle:.4} (IGRF {v_igrf:?}, dipole {v_dipole:?})"
+        );
+
+        // At GEO the dipole dominates; expect <15% difference
         // (TiltedDipole uses approximate parameters, so some difference is expected)
+        let b_igrf = b_magnitude(&v_igrf);
+        let b_dipole = b_magnitude(&v_dipole);
         let diff_pct = ((b_igrf - b_dipole) / b_dipole).abs() * 100.0;
         assert!(
             diff_pct < 15.0,
@@ -652,5 +708,201 @@ mod tests {
             diff_pct < 25.0,
             "Degree-1 truncation should be within 25% of full model, got {diff_pct:.1}%"
         );
+    }
+
+    /// Pin every branch of [`schmidt_legendre`] without external reference
+    /// values, via the orthogonality relation that *defines* Schmidt
+    /// semi-normalization:
+    ///
+    /// ```text
+    /// ∫_{-1}^{1} [P^m_n(x)]^2 dx = 2/(2n+1)   (m = 0)
+    ///                            = 4/(2n+1)   (m >= 1)
+    /// ```
+    ///
+    /// This is what catches a wrong recursion coefficient: using `2n-1`
+    /// instead of `sqrt(2n-1)` on the sub-diagonal leaves `m = 0` and `m = n`
+    /// correct but breaks every intermediate order, because those values also
+    /// seed the general recursion. So the test must cover `0 < m < n`, not just
+    /// the extremes.
+    #[test]
+    fn schmidt_normalization_holds() {
+        // Midpoint rule over x = cos(theta). Smooth integrand, so this is
+        // plenty for the 1e-3 relative tolerance below.
+        const STEPS: usize = 20_000;
+        const MAX_N: usize = 6;
+
+        let mut integrals = [[0.0_f64; ND]; ND];
+        for i in 0..STEPS {
+            let x = -1.0 + (i as f64 + 0.5) * 2.0 / STEPS as f64;
+            let sin_theta = (1.0 - x * x).max(0.0).sqrt();
+            let (p, _) = schmidt_legendre(x, sin_theta, MAX_N);
+            for n in 0..=MAX_N {
+                for m in 0..=n {
+                    integrals[n][m] += p[n][m] * p[n][m];
+                }
+            }
+        }
+
+        for n in 1..=MAX_N {
+            for m in 0..=n {
+                let got = integrals[n][m] * 2.0 / STEPS as f64;
+                let expected = if m == 0 { 2.0 } else { 4.0 } / (2 * n + 1) as f64;
+                let rel = (got - expected).abs() / expected;
+                assert!(
+                    rel < 1e-3,
+                    "P^{m}_{n} is not Schmidt semi-normalized: \
+                     ∫P² = {got:.6}, expected {expected:.6} (relative error {rel:.3e})"
+                );
+            }
+        }
+    }
+
+    /// The pole branch of `B_phi` uses the closed form
+    /// `lim_{θ→0} P^1_n(cos θ)/sin θ = sqrt(n(n+1)/2)`, derived straight from
+    /// the Schmidt definition. Check the recursion agrees with it, so the two
+    /// code paths cannot drift apart again.
+    #[test]
+    fn near_pole_p_n1_matches_closed_form_limit() {
+        let theta = 1e-7_f64;
+        let (p, _) = schmidt_legendre(theta.cos(), theta.sin(), 6);
+        for n in 1..=6 {
+            let n_f = n as f64;
+            let expected = (n_f * (n_f + 1.0) / 2.0).sqrt();
+            let got = p[n][1] / theta.sin();
+            assert!(
+                (got - expected).abs() < 1e-6 * expected,
+                "P^1_{n}/sin(theta) near the pole = {got:.9}, \
+                 closed form sqrt(n(n+1)/2) = {expected:.9}"
+            );
+        }
+    }
+
+    /// `dP/dtheta` must be the analytic derivative of `P`, for every recursion
+    /// branch. Compared against a central difference rather than a table, so
+    /// this needs no external reference values either.
+    #[test]
+    fn schmidt_legendre_derivative_matches_central_difference() {
+        const EPS: f64 = 1e-6;
+        for theta_deg in [7.0_f64, 31.0, 45.0, 88.0, 124.0, 170.0] {
+            let theta = theta_deg.to_radians();
+            let (_, dp) = schmidt_legendre(theta.cos(), theta.sin(), IGRF_MAX_DEGREE);
+            let (p_plus, _) =
+                schmidt_legendre((theta + EPS).cos(), (theta + EPS).sin(), IGRF_MAX_DEGREE);
+            let (p_minus, _) =
+                schmidt_legendre((theta - EPS).cos(), (theta - EPS).sin(), IGRF_MAX_DEGREE);
+            for n in 0..=IGRF_MAX_DEGREE {
+                for m in 0..=n {
+                    let numeric = (p_plus[n][m] - p_minus[n][m]) / (2.0 * EPS);
+                    // Scale the tolerance by the local magnitude; these grow
+                    // with degree.
+                    let scale = dp[n][m].abs().max(1.0);
+                    assert!(
+                        (dp[n][m] - numeric).abs() < 1e-5 * scale,
+                        "dP^{m}_{n}/dtheta at {theta_deg} deg: analytic {:.9}, \
+                         central difference {numeric:.9}",
+                        dp[n][m]
+                    );
+                }
+            }
+        }
+    }
+
+    /// Exercise the real `evaluate_sh` path with a single non-zero coefficient,
+    /// so the *eastward* sign convention is pinned end to end rather than only
+    /// the Legendre recursion.
+    ///
+    /// With only `h_1^1 > 0` the potential is `V ~ h sin(phi) sin(theta)`, so
+    /// `B_phi = -(1/(r sin theta)) dV/dphi < 0` at `phi = 0` on the equator.
+    /// The standard form is `Y = m (g sin m.phi - h cos m.phi) P / sin(theta)`;
+    /// dropping its outer minus sign inverts the whole component.
+    #[test]
+    fn b_phi_sign_matches_potential_derivative() {
+        let mut g = [0.0; N_COEFFS];
+        let mut h = [0.0; N_COEFFS];
+        h[coeff_index(1, 1)] = 1000.0;
+
+        // Equator, phi = 0.
+        let (_, _, b_phi) = evaluate_sh(&g, &h, IGRF_REFERENCE_RADIUS, 0.0, 1.0, 0.0, 1);
+        assert!(
+            b_phi < 0.0,
+            "with h_1^1 > 0 at phi = 0 on the equator, B_phi must be negative, got {b_phi}"
+        );
+
+        // A quarter turn east puts h_1^1 into the radial/southward terms
+        // instead, so B_phi passes through zero.
+        let (_, _, b_phi_quarter) = evaluate_sh(
+            &g,
+            &h,
+            IGRF_REFERENCE_RADIUS,
+            0.0,
+            1.0,
+            core::f64::consts::FRAC_PI_2,
+            1,
+        );
+        assert!(
+            b_phi_quarter.abs() < 1e-9,
+            "B_phi should vanish at phi = 90 deg for a pure h_1^1, got {b_phi_quarter}"
+        );
+
+        // Same check for a pure g_1^1: V ~ g cos(phi) sin(theta), so
+        // dV/dphi = -g sin(phi) sin(theta), which is zero at phi = 0 and
+        // positive-B_phi at phi = 90 deg.
+        g[coeff_index(1, 1)] = 1000.0;
+        h[coeff_index(1, 1)] = 0.0;
+        let (_, _, b_phi_g) = evaluate_sh(
+            &g,
+            &h,
+            IGRF_REFERENCE_RADIUS,
+            0.0,
+            1.0,
+            core::f64::consts::FRAC_PI_2,
+            1,
+        );
+        assert!(
+            b_phi_g > 0.0,
+            "with g_1^1 > 0 at phi = 90 deg, B_phi must be positive, got {b_phi_g}"
+        );
+    }
+
+    /// The `sin_theta <= 1e-10` pole branch must agree with the ordinary path
+    /// just off the pole — otherwise `B_phi` jumps discontinuously there. This
+    /// covers the closed-form limit, its south-pole parity, and the eastward
+    /// sign all at once, which the recursion-only test cannot.
+    #[test]
+    fn b_phi_pole_branch_is_continuous() {
+        let mut g = [0.0; N_COEFFS];
+        let mut h = [0.0; N_COEFFS];
+        // Both m=1 coefficients, so neither term is accidentally cancelled.
+        g[coeff_index(1, 1)] = 1000.0;
+        h[coeff_index(1, 1)] = -2000.0;
+        g[coeff_index(2, 1)] = 500.0;
+        h[coeff_index(2, 1)] = 300.0;
+        let phi = 0.7_f64;
+
+        for (name, cos_theta) in [("north", 1.0_f64), ("south", -1.0_f64)] {
+            // Exactly on the axis: takes the limit branch.
+            let (_, _, at_pole) =
+                evaluate_sh(&g, &h, IGRF_REFERENCE_RADIUS, cos_theta, 0.0, phi, 2);
+            // A hair off the axis: takes the ordinary `P / sin(theta)` path.
+            let theta = if cos_theta > 0.0 {
+                1e-8
+            } else {
+                core::f64::consts::PI - 1e-8
+            };
+            let (_, _, near_pole) = evaluate_sh(
+                &g,
+                &h,
+                IGRF_REFERENCE_RADIUS,
+                theta.cos(),
+                theta.sin(),
+                phi,
+                2,
+            );
+            assert!(
+                (at_pole - near_pole).abs() < 1e-6 * at_pole.abs().max(1.0),
+                "B_phi is discontinuous at the {name} pole: limit branch {at_pole:.9}, \
+                 ordinary path just off-axis {near_pole:.9}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## 背景

地磁気モデルに符号・正規化の誤りが 4 件あり、いずれも**既存テストが検出できない**状態でした。既存テストが磁場の `magnitude` しか比較していないためです。magnitude はベクトルの完全反転に対して不変で、しかも正規化誤差は一定バイアスにならないので、緩い範囲チェックはどちらの実装でも通ってしまいます。

### 1. IGRF: Schmidt 準正規化の sub-diagonal 係数

`(2n-1)` としていた箇所が `sqrt(2n-1)` でなければなりません。一般漸化式に `m = n-1` を代入すると `denom = sqrt(n² - (n-1)²) = sqrt(2n-1)`、`k = 0` となり `P[n][n-1] = sqrt(2n-1)·cosθ·P[n-1][n-1]` が出ます。

壊れる範囲は `m = n-1` だけではなく **`0 < m < n` の全ての中間 order** です。sub-diagonal の値が一般漸化式の入力にもなるためです。正しかったのは `m = 0` と `m = n` のみで、degree 1（支配的な双極子項）が無傷だったために気づきにくくなっていました。

リポジトリ自身の IGRF-14 係数（2025 epoch）で両方の漸化式を評価した誤差:

| 位置 | 現行 \|B\| | 修正後 \|B\| | ベクトル差 (2 修正込み) |
|---|---|---|---|
| LEO 赤道 (r=6871 km) | 21,491 nT | 24,259 nT | 4,626 nT (19.1%) |
| LEO 中緯度 (45°N, 135°E) | 46,269 nT | 41,719 nT | 11,997 nT (28.8%) |
| 地表 赤道 (0°, 0°) | 28,604 nT | 31,966 nT | 5,546 nT (17.4%) |
| GEO | 97.7 nT | 99.8 nT | 29.8 nT (29.8%) |

ベクトル差は正規化と `B_phi` の両方の修正を含みます（`B_phi` の符号は `|B|` を変えないので、\|B\| の列は正規化修正のみの効果です）。

地表赤道の実際の全磁力は約 32 µT で、修正後の 31,966 nT が一致します。現行の 28,604 nT は 11% 低い値でした。誤差が一定バイアスでない点（赤道では過小、中緯度では過大）が、緩い magnitude テストを通していた理由です。

なお **同じ `(2n-1)` は unnormalized 規約では正しい**係数です。おそらくこれが混入経路で、`nrlmsise00::compute_legendre` は unnormalized 規約を明示して使っており影響を受けません（検算済み）。

### 2. IGRF: `B_phi`（東西成分）の符号

`B_φ = -(1/(r sinθ)) ∂V/∂φ` で、`∂/∂φ (g cos mφ + h sin mφ) = m(-g sin mφ + h cos mφ)` なので

```
B_φ ∝ -m(-g sin mφ + h cos mφ)/sinθ = +m(g sin mφ - h cos mφ)/sinθ
```

実装は微分結果 `(-g sin + h cos)` をそのまま加算しており、**外側のマイナスが落ちて**東西成分が全体的に反転していました。文献の標準形 `Y(east) = m(g sin mφ - h cos mφ)·P/sinθ` と一致しません。

物理検算: `h_1^1 > 0` のみを与え φ=0・赤道上を見ると `V ∝ h sinφ sinθ` なので `∂V/∂φ ∝ h > 0`、したがって `B_φ < 0` が正しいところ、実装は `B_φ > 0` を返していました。

`B_r` と `B_θ` は検算した結果**正しい**ので、東西成分だけの問題です。同じ関数内に種類の違う符号バグ（正規化係数と `B_phi`）が 2 つ入っていたことになります。

### 3. TiltedDipole: 軸の向き

地球の磁気双極子**モーメント**はおおよそ地理的**南**向きです（IGRF の `g_1^0` が負であることに対応）。`earth()` は北向きにしていたため、磁場ベクトル全体が反転していました。

検算: 赤道では `m_hat · r_hat = 0` なので `B ~ -m_hat` が北を向く必要があります。北極では `r_hat = +Z`、`m_hat · r_hat = -1` なので `3(m_hat·r_hat)r_hat - m_hat = +2 m_hat` となり、これが地球内部を向きます。どちらも南向きモーメントでのみ成立します。

### 4. plugin-sdk `detumble-nadir` example: B-dot 則の符号

`m = -k dB/dt` で、機体系では `dB/dt ≈ -ω×B` なので `m = +k(ω×B)` です。example はマイナスを二重に掛けており、**角速度を増大させる**モーメントを指令していました。

`orts::attitude::control::BdotCross`（native 参照実装）と `bdot-finite-diff` example はどちらも正しい符号です。解析近似形を書くときの孤立した取り違えでした。

## 2 つの符号バグが相殺しない理由

detumble のトルクは

```
τ = m × B = -k(ω×B) × B
```

で **B について 2 次**なので、`B → -B` としても τ は変わりません。2 つは独立したバグで、既存の「ω が減る」系テストは磁場の符号に対して完全に盲目です（実際、双極子が反転したままでも `discrete_bdot_reduces_angular_velocity_*` は通っていました）。

## テスト

- **`schmidt_normalization_holds`**: Schmidt 準正規化を*定義する*直交性関係（`∫P² dx = 2/(2n+1)` for `m=0`、`4/(2n+1)` for `m≥1`）で全ての漸化式分岐を固定します。**外部リファレンス値が不要**なのが利点です。バグが潜んでいた `0 < m < n` を必ず含めています。
- **`near_pole_p_n1_matches_closed_form_limit`**: `B_phi` の極処理が既に前提としていた閉形式 `lim P^1_n/sinθ = sqrt(n(n+1)/2)` と漸化式を結びます。この 2 つのコード経路は黙って食い違っていました（n=2 で 1.732 対 3.000）。
- 双極子の方向テスト 3 件（赤道で北向き / 北極で地球内部向き / `earth()` の軸が南向き）。
- **`igrf_converges_to_dipole_at_geo` を magnitude 比較からベクトル方向比較へ強化**。閾値は意図的に緩く（cos > 0.85、実測 0.933）しています。モデルは 11.5° の傾斜を経度 0° に置いていますが実際の地磁気北極は 80.6°N 72.6°W で、**軸方向が 12.4° ずれている**ためです。このアサーションは反転（cos ≈ −0.93 になる）を捕まえる目的で、傾斜経度の簡略化を検証するものではありません。

- **`b_phi_sign_matches_potential_derivative`**: 単一係数（`h_1^1` のみ / `g_1^1` のみ）を注入して `evaluate_sh()` を直接叩き、東西成分の符号規約を端から端まで固定します。正規化 property テストは `schmidt_legendre()` しか通らないので、この経路は別途押さえる必要がありました。
- **`b_phi_pole_branch_is_continuous`**: `sin_theta <= 1e-10` の極分岐と、軸をわずかに外した通常経路の連続性を北極・南極の両方で確認します。閉形式の極限・南極の parity・極での連続性をまとめて固定します。
- **`schmidt_legendre_derivative_matches_central_difference`**: `dP/dθ` が `P` の解析微分であることを中心差分と比較して degree 13 まで検証します（これも外部データ不要）。

新規テストはいずれも**旧コードで失敗し新コードで通ること**を実測で確認しました。一方、既存の IGRF テスト 11 件はどちらでも通ります。

なお `b_phi_pole_branch_is_continuous` は `B_phi` の符号反転に対しては不変です（比較する 2 経路が同じ `gh_sin_cos` を使うため）。符号を固定するのは `b_phi_sign_matches_potential_derivative` の役割です。

## `nos3-adcs-e2e` の閾値

磁場の値が変わるので、磁気トルカを使う姿勢制御の数値結果も変わります。NOS3 ADCS の B-dot デタンブル E2E で実測した結果:

| | 2 軌道後の \|ω\| | 減衰率 |
|---|---|---|
| 修正前 | 0.0050334 rad/s | 97.7% |
| 修正後 | 0.0150106 rad/s | 93.1% |

正しい磁場では 2 軌道で 95% に届かない、というのが実態です。減衰の指数は 29% 低下しています（`ln`: −3.76 → −2.67）。ω は単調に減っており、発散はしていません。

支配的な要因は `B_phi` の**方向**修正です。B-dot のトルクは `τ = k(ω×B)×B` で ω の B に垂直な成分だけを減衰させるため、磁場の向きが約 8.6°（中緯度）ずれていると、どの ω 成分をどれだけ減衰できるかが変わります。大きさ（`<B²>`）の変化は軌道平均で 4.5〜8.4% しかなく、これだけでは説明できません。

つまり閾値 95% は、**向きが 8.6° ずれ大きさが数%過大な磁場**を前提に、しかも余裕 2.7 ポイントで通っていた値でした。

この E2E の目的は制御性能の仕様ではなく統合確認です（CI のコメント: 「builds the NOS3 generic_adcs WASM plugin (C FFI via wasi-sdk) and verifies B-dot detumbling reduces angular velocity」、README: 「既存の AOCS フライトソフトウェアの C コードを変更なしで WASM 化し、SILS のコンセプトを実証する」）。そこで閾値を **0.10 (90%)** にし、実測 93.1% に対して意図的に余裕を持たせました。実測値そのものを固定すると、今後の磁場モデル・暦モデルの精度改善で毎回落ちます。

Sun-Safe (0.2) と Inertial (0.01) は実測 94.2% / 100.0% で余裕があるため閾値は変えず、同じ理由をコメントとして残しました。Inertial は RW のクォータニオン PID なので磁場にほぼ依存せず、厳しい閾値のままで問題ありません。

減衰の**速度**を NOS3 公式シミュレータと比較して検証するのは、この PR とは別の作業です。

## 対象外

- **傾斜経度の是正**: `TiltedDipole` の 11.5° 傾斜を実際の地磁気極経度（約 72.6°W）に合わせる変更。モデル精度の改善であってバグ修正ではないため分離します。
- **plugin-sdk example のテスト整備**: 10 個の example crate はどれもテストを 1 つも持たず、全て workspace 外の `cdylib` です。制御則が反転したまま生き残れたのは本質的にこれが理由ですが、10 crate の再構成はこの PR の主題ではないため別途提案します。

