### PR TITLE
ci(renovate): close the unattended-merge paths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -72,17 +72,20 @@
       "matchPackageNames": ["notalawyer", "notalawyer-clap", "notalawyer-build"]
     },
     {
-      "description": "Auto-merge patch-level updates once required CI checks pass",
+      "description": "Auto-merge patch-level updates once required CI checks pass. These land on main unattended, so they wait twice the repo-wide cooldown before Renovate even opens them — a hijacked patch release is the classic supply-chain vector, and the extra week is the only review a merged-without-a-human update gets",
       "matchUpdateTypes": ["patch"],
-      "automerge": true
+      "automerge": true,
+      "minimumReleaseAge": "14 days"
     }
   ],
   "lockFileMaintenance": {
+    "description": "Lockfile refreshes re-resolve the whole tree, so they pull transitive updates wholesale. pnpm enforces minimumReleaseAge on the npm side even for --frozen-lockfile installs, but cargo has no release-age gate at all, so these are reviewed by a human instead of auto-merged",
     "enabled": true,
-    "automerge": true
+    "automerge": false
   },
   "vulnerabilityAlerts": {
-    "automerge": true,
+    "description": "Security fixes skip the release-age cooldown so the fix is available immediately, but they are deliberately NOT auto-merged: a compromised release dressed up as a security fix would otherwise reach main unattended and same-day. A human merges these. `automerge` is set explicitly to false because most security fixes are patch-level, and the patch rule above would otherwise still auto-merge them",
+    "automerge": false,
     "minimumReleaseAge": "0 days"
   }
 }


### PR DESCRIPTION
依存更新を「誰も見ないまま main に入れる」経路を 3 つ閉じる。`renovate.json` のみの変更。

## 背景

supply-chain 対策として release-age cooldown は既に入っている（Renovate の `minimumReleaseAge: 7 days`、pnpm 側の `minimumReleaseAge: 10080`）。これは「公開直後の版を lockfile に入れない」仕組みで、**誰かがその更新を見る**ことを前提にしている。

ところが実際には、見ずに main へ入る経路が 3 つあった。

## 変更

| 経路 | 変更前 | 変更後 | なぜ |
|---|---|---|---|
| `vulnerabilityAlerts` | `automerge: true` + `minimumReleaseAge: "0 days"` | **`automerge: false`**（0 日 cooldown は維持） | 公開数分後のリリースが同日・無人で main に入る経路だった。「security fix を騙る」タイプの攻撃に対して無防備。修正の**入手**は即時のままにし、**マージ**は人が見る |
| patch の automerge | 7 日（リポジトリ既定） | **14 日** | 誰もレビューしない更新にとって、経過時間が唯一のチェックになる。hijack された patch リリースは典型的な攻撃ベクタ |
| `lockFileMaintenance` | `automerge: true` | **`automerge: false`** | ツリー全体を再解決して推移的更新をまとめて引く。npm 側は pnpm が `--frozen-lockfile` install でも release-age を強制するが、**cargo 側には age ゲートが無い** |

`vulnerabilityAlerts` は `automerge: false` を**明示**する必要がある。セキュリティ修正の多くは patch レベルなので、`automerge: true` を消すだけでは上の patch ルールが適用され、無人マージが続いてしまう（`codex review` の指摘で気づいた）。

各ルールには理由を `description` に書いた（既存の書き方に合わせている）。

## トレードオフ

セキュリティ修正と lockfile 更新に**人手のマージが必要になる**。Renovate PR が溜まりやすくなる代わりに、main に入るものを必ず一度は人が見ることになる。patch の 14 日も、更新が遅くなる分だけ安全側に振っている。

「セキュリティ修正だけは即マージしたい」なら `vulnerabilityAlerts` の `automerge` を戻せば元の挙動になる（そのぶん上記のリスクを取る）。

## 検証

公式の `renovate-config-validator` を通過。

## 関連

供給網対策のもう半分（lockfile に既に入っている依存の advisory を CI で検出する cargo-deny の追加）は #313 で別に出している。元は 1 つの PR だったが、レビュー単位として独立しているので分割した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
