### PR TITLE
docs: CLAUDE.md を最新の Anthropic ベストプラクティスに合わせて書き直す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 orts is a numerical computation and optimization platform for spacecraft simulation — orbital and attitude dynamics.
 
 - Design doc (why): [DESIGN.md](DESIGN.md) / architecture map (what): [ARCHITECTURE.md](ARCHITECTURE.md)
-- Crate / package inventory and roles: see the Project Structure tables in [README.md](README.md)
+- crate / package inventory and roles: see the Project Structure tables in [README.md](README.md)
 
 ## Development Policy
 
@@ -40,7 +40,7 @@ orts is a numerical computation and optimization platform for spacecraft simulat
 
 - Verify technical claims (CHANGELOG, docs, etc.) against the implementation and tests before writing them down
 - In Japanese documents, keep technical terms in English (crate, workspace, commit) — no katakana transliteration
-- Crate and package names stay lowercase even at the start of a sentence (orts, arika — never Orts)
+- Technical terms and crate / package names stay lowercase even at the start of a sentence (crate, orts, arika — never Crate or Orts)
 - Use a negation ("not A, but B") only where it records a rejected alternative or an actual failure mode; decorative contrasts read as filler
 
 ## Languages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,12 +36,6 @@ orts is a numerical computation and optimization platform for spacecraft simulat
 - Define magic numbers as constants, or comment their rationale
 - Python helper scripts (under examples/ and tools/) are managed with uv
 
-## Footguns
-
-- `cargo test -p orts-cli` regenerates the TypeScript bindings in `viewer/src/protocol/generated/` (`TS_RS_EXPORT_DIR` in `.cargo/config.toml`), and CI enforces a clean diff — after changing protocol types, regenerate and commit
-- `.cargo/config.toml` configures the mold + clang linker; a non-empty global `RUSTFLAGS` silently disables it
-- Release process: see [RELEASING.md](RELEASING.md)
-
 ## Documentation
 
 - Verify technical claims (CHANGELOG, docs, etc.) against the implementation and tests before writing them down
@@ -56,3 +50,9 @@ orts is a numerical computation and optimization platform for spacecraft simulat
 ## Dependencies
 
 - When adding a new library, look up the latest stable version first; don't pin an old version
+
+## Footguns
+
+- `cargo test -p orts-cli` regenerates the TypeScript bindings in `viewer/src/protocol/generated/` (`TS_RS_EXPORT_DIR` in `.cargo/config.toml`), and CI enforces a clean diff — after changing protocol types, regenerate and commit
+- `.cargo/config.toml` configures the mold + clang linker; a non-empty global `RUSTFLAGS` silently disables it
+- Release process: see [RELEASING.md](RELEASING.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 orts is a numerical computation and optimization platform for spacecraft simulation — orbital and attitude dynamics.
 
-- Design doc (why): [DESIGN.md](DESIGN.md) / architecture map (what): [ARCHITECTURE.md](ARCHITECTURE.md)
+- Design doc (why): [DESIGN.md](DESIGN.md)
+- Architecture map (what): [ARCHITECTURE.md](ARCHITECTURE.md)
 - crate / package inventory and roles: see the Project Structure tables in [README.md](README.md)
 
 ## Development Policy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,6 @@ orts is a numerical computation and optimization platform for spacecraft simulat
 
 - Verify technical claims (CHANGELOG, docs, etc.) against the implementation and tests before writing them down
 - In Japanese documents, keep technical terms in English (crate, workspace, commit) — no katakana transliteration
-- Technical terms and crate / package names stay lowercase even at the start of a sentence (crate, orts, arika — never Crate or Orts)
 - Use a negation ("not A, but B") only where it records a rejected alternative or an actual failure mode; decorative contrasts read as filler
 
 ## Languages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,14 +6,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 orts is a numerical computation and optimization platform for spacecraft simulation — orbital and attitude dynamics.
 
-- Design doc: [DESIGN.md](DESIGN.md) (Japanese) / top-level structure: [ARCHITECTURE.md](ARCHITECTURE.md)
+- Design doc (why): [DESIGN.md](DESIGN.md) / architecture map (what): [ARCHITECTURE.md](ARCHITECTURE.md)
 - Crate / package inventory and roles: see the Project Structure tables in [README.md](README.md)
 
 ## Development Policy
 
 - For architecture-level changes, update DESIGN.md first, then implement
 - Before starting implementation, get a smart-friend review of the plan
-- TDD-first: verify behavior with unit tests before integrating. Validate E2E against GMAT / Orekit as reference implementations (fixture generators live in tools/)
+- TDD-first: verify behavior with unit tests before integrating. Validate E2E against GMAT / Orekit as reference implementations (fixture generators live in tools/), using canonical problems (SSO, constellations, Lagrange points, swing-bys) as test cases
+- Keep responsibilities strictly separated across crates and modules — that separation is what enables parallel development and independent testing
 - Before committing, run `cargo fmt` / `cargo clippy --workspace -- -D warnings` / the relevant tests / `pnpm lint`
 - Changes touching logic, APIs, or design get an external review via the code-review skill before commit (typo fixes and mechanical replacements may skip it); after addressing findings, re-review until it passes
 - After pushing, checking the CI result is part of the task
@@ -39,6 +40,8 @@ orts is a numerical computation and optimization platform for spacecraft simulat
 
 - Verify technical claims (CHANGELOG, docs, etc.) against the implementation and tests before writing them down
 - In Japanese documents, keep technical terms in English (crate, workspace, commit) — no katakana transliteration
+- Crate and package names stay lowercase even at the start of a sentence (orts, arika — never Orts)
+- Use a negation ("not A, but B") only where it records a rejected alternative or an actual failure mode; decorative contrasts read as filler
 
 ## Languages
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,59 +4,59 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-orts is a numerical computation and optimization platform primarily for orbital mechanics.
+orts is a numerical computation and optimization platform for spacecraft simulation — orbital and attitude dynamics.
 
-- 設計意図: [DESIGN.md](DESIGN.md)(日本語)/ 全体構造: [ARCHITECTURE.md](ARCHITECTURE.md)
-- crate / package の一覧と役割: [README.md](README.md) の Project Structure の表を参照
+- Design doc: [DESIGN.md](DESIGN.md) (Japanese) / top-level structure: [ARCHITECTURE.md](ARCHITECTURE.md)
+- Crate / package inventory and roles: see the Project Structure tables in [README.md](README.md)
 
 ## Languages
 
-- **Rust**: コアシミュレーションプラットフォーム(Cargo workspace)
-- **TypeScript/React**: リアルタイムビューアなど(pnpm workspace)
-- **Python**: examples/ や tools/ の補助スクリプト。環境は uv で管理する
+- **Rust**: core simulation platform (Cargo workspace)
+- **TypeScript/React**: real-time viewer and related packages (pnpm workspace)
+- **Python**: helper scripts under examples/ and tools/, managed with uv
 
 ## Build & Test
 
-- `plugin-sdk/examples/` は独立した workspace(`cargo component build`, target は `wasm32-wasip1`)。`cargo test --workspace` には含まれない
-- 一部の crate は no_std / wasm 向けの check が CI にある(no_std の feature 構成ごとの clippy は lint job、wasm32 は viewer-build など wasm-pack を使う job)。何をどう check するかは `.github/workflows/ci.yml` が正。該当 crate を変更したら同じ check をローカルでも回す
+- `plugin-sdk/examples/` is a standalone workspace (`cargo component build`, target `wasm32-wasip1`); `cargo test --workspace` does not cover it
+- Some crates have no_std / wasm checks in CI (per-feature clippy in the lint job for no_std; wasm32 via the wasm-pack jobs such as viewer-build). `.github/workflows/ci.yml` is the source of truth — when changing such a crate, run the same checks locally
 
 ## Footguns
 
-- `cargo test -p orts-cli` は `viewer/src/protocol/generated/` の TypeScript bindings を再生成する(`TS_RS_EXPORT_DIR` @ `.cargo/config.toml`)。CI が diff を enforce するので、protocol 型を変更したら再生成して commit する
-- `.cargo/config.toml` が mold + clang linker を設定している。グローバルな `RUSTFLAGS` が非空だとこの設定は黙って無効化される
-- リリース手順は [RELEASING.md](RELEASING.md) を参照
+- `cargo test -p orts-cli` regenerates the TypeScript bindings in `viewer/src/protocol/generated/` (`TS_RS_EXPORT_DIR` in `.cargo/config.toml`), and CI enforces a clean diff — after changing protocol types, regenerate and commit
+- `.cargo/config.toml` configures the mold + clang linker; a non-empty global `RUSTFLAGS` silently disables it
+- Release process: see [RELEASING.md](RELEASING.md)
 
 ## Development Workflow
 
-- アーキテクチャレベルの変更は DESIGN.md を先に更新してから実装する
-- 設計判断を伴う実装(新しい module 構成、trait / public API の設計、設計の選択肢が複数あるとき)は、着手前に smart-friend で独立レビューにかけ、レビューが通るまで設計を見直す
-- TDD-first: 統合の前にユニットテストで挙動を検証する。GMAT / Orekit を参照実装とした E2E 検証(fixture 生成は tools/)
-- commit 前に `cargo fmt` / `cargo clippy --workspace -- -D warnings` / 関連テスト / `pnpm lint` を通す
-- ロジック・API・設計に触れる変更は commit 前に code-review skill で外部レビューを受ける(typo 修正や機械的な置換だけの commit は省略してよい)。指摘対応後は re-review し、通ってから commit する
-- push 後は CI 結果の確認までを一連の作業とする
-- WebSocket 通信・データフロー・UI 統合など mock しにくい部分を変更したら Playwright E2E も実行する(Playwright は CLI を使う。MCP ツールではない)
+- For architecture-level changes, update DESIGN.md first, then implement
+- Before starting implementation, get a smart-friend review of the plan
+- TDD-first: verify behavior with unit tests before integrating. Validate E2E against GMAT / Orekit as reference implementations (fixture generators live in tools/)
+- Before committing, run `cargo fmt` / `cargo clippy --workspace -- -D warnings` / the relevant tests / `pnpm lint`
+- Changes touching logic, APIs, or design get an external review via the code-review skill before commit (typo fixes and mechanical replacements may skip it); after addressing findings, re-review until it passes
+- After pushing, checking the CI result is part of the task
+- When changing parts that are hard to mock (WebSocket communication, data flow, UI integration), also run the Playwright E2E tests (use the Playwright CLI, not MCP tools)
 
 ## Testing Rules
 
-- テストは「何を検証したいか」を明確にする。トートロジーになっているテストは書かない
-- 不具合を見つけたら、まず再現テストを書いてから修正する(regression 防止)
-- テスト失敗やバグを「既存の問題」「flaky」と判断する場合は、再現確認などの根拠を示す
-- テストやテストモジュールの削除は、事前に対象・理由・カバー状況を列挙して user のレビューを受ける。依存関係の問題は削除ではなく依存の追加で解決する
-- 挙動を保存するリファクタでは characterization test で既存挙動を固定する。境界値と非有限値(`NaN`, `±∞`)も含める
+- Make every test state what it verifies; don't write tautological tests
+- When you find a bug, write a reproducing test first, then fix it (regression prevention)
+- Before attributing a failure to a "pre-existing issue" or "flakiness", show evidence such as a reproduction
+- To delete tests or test modules, first enumerate the targets, reasons, and coverage status for user review. Solve dependency problems by adding dependencies, not by deleting tests
+- For behavior-preserving refactors, pin the existing behavior with characterization tests, including boundary and non-finite inputs (`NaN`, `±∞`)
 
 ## Working Rules
 
-- 重いコマンド(`cargo test --workspace` など)はフルログをファイルに保存してから必要箇所を抽出する。最初から `| tail` で切り詰めない
-- サイズの大きいバイナリ生成物(gif、画像など)は Claude 自身で Read せず、人間の目視確認に委ねる。大きいバイナリファイルは commit しない
-- 命名は実態・意味に忠実にする(真値かノイズ入りか、暗黙のデフォルトの有無などが名前から読み取れるように)
-- 対応を先送りする判断をしたら TODO コメントを残す
-- マジックナンバーは定数として定義するか、根拠をコメントで書く
+- For heavy commands (e.g. `cargo test --workspace`), save the full log to a file and extract what you need from it; don't truncate with `| tail` from the start
+- Don't Read large binary artifacts (gifs, images, etc.) yourself — leave judging them to human eyes. Don't commit large binary files
+- Name things after what they actually are (e.g. whether a value is ground truth or noisy, whether an implicit default exists — make it readable from the name)
+- Leave a TODO comment when deferring work
+- Define magic numbers as constants, or comment their rationale
 
 ## Documentation
 
-- 技術的な主張(CHANGELOG、docs など)は実装・テストと照合して裏取りしてから書く
-- 日本語文書でも技術用語は英語表記のまま使う(crate, workspace, commit)。カタカナ化しない
+- Verify technical claims (CHANGELOG, docs, etc.) against the implementation and tests before writing them down
+- In Japanese documents, keep technical terms in English (crate, workspace, commit) — no katakana transliteration
 
 ## Dependencies
 
-- 新しいライブラリを追加する際は、最新の安定バージョンを調べてから指定する。古いバージョンを指定しない
+- When adding a new library, look up the latest stable version first; don't pin an old version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ orts is a numerical computation and optimization platform primarily for orbital 
 ## Development Workflow
 
 - アーキテクチャレベルの変更は DESIGN.md を先に更新してから実装する
-- 設計判断を伴う実装(新しい module 構成、trait / public API の設計、設計の選択肢が複数あるとき)は、着手前に smart-friend skill で独立レビューにかけ、レビューが通るまで設計を見直す
+- 設計判断を伴う実装(新しい module 構成、trait / public API の設計、設計の選択肢が複数あるとき)は、着手前に smart-friend で独立レビューにかけ、レビューが通るまで設計を見直す
 - TDD-first: 統合の前にユニットテストで挙動を検証する。GMAT / Orekit を参照実装とした E2E 検証(fixture 生成は tools/)
 - commit 前に `cargo fmt` / `cargo clippy --workspace -- -D warnings` / 関連テスト / `pnpm lint` を通す
 - ロジック・API・設計に触れる変更は commit 前に code-review skill で外部レビューを受ける(typo 修正や機械的な置換だけの commit は省略してよい)。指摘対応後は re-review し、通ってから commit する

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,5 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## Project Overview
 
 orts is a numerical computation and optimization platform for spacecraft simulation — orbital and attitude dynamics.
@@ -12,9 +10,9 @@ orts is a numerical computation and optimization platform for spacecraft simulat
 
 ## Development Policy
 
-- For architecture-level changes, update DESIGN.md first, then implement
+- For architecture-level changes, update DESIGN.md first, then implement; keep ARCHITECTURE.md (en/ja) in sync when the structure changes
 - Before starting implementation, get a smart-friend review of the plan
-- TDD-first: verify behavior with unit tests before integrating. Validate E2E against GMAT / Orekit as reference implementations (fixture generators live in tools/), using canonical problems (SSO, constellations, Lagrange points, swing-bys) as test cases
+- TDD-first: verify behavior with unit tests before integrating. For numerical-dynamics changes, validate against reference implementations such as Orekit (fixture generators live in tools/)
 - Keep responsibilities strictly separated across crates and modules — that separation is what enables parallel development and independent testing
 - Before committing, run `cargo fmt` / `cargo clippy --workspace -- -D warnings` / the relevant tests / `pnpm lint`
 - Changes touching logic, APIs, or design get an external review via the code-review skill before commit (typo fixes and mechanical replacements may skip it); after addressing findings, re-review until it passes
@@ -26,39 +24,34 @@ orts is a numerical computation and optimization platform for spacecraft simulat
 - Make every test state what it verifies; don't write tautological tests
 - When you find a bug, write a reproducing test first, then fix it (regression prevention)
 - Before attributing a failure to a "pre-existing issue" or "flakiness", show evidence such as a reproduction
-- To delete tests or test modules, first enumerate the targets, reasons, and coverage status for user review. Solve dependency problems by adding dependencies, not by deleting tests
-- For behavior-preserving refactors, pin the existing behavior with characterization tests, including boundary and non-finite inputs (`NaN`, `±∞`)
+- To delete tests or test modules, first enumerate the targets, reasons, and coverage status for user review
+- For behavior-preserving refactors, pin the existing behavior with characterization tests, including boundary inputs; for floating-point code, also non-finite inputs (`NaN`, `±∞`)
 
 ## Working Rules
 
-- For heavy commands (e.g. `cargo test --workspace`), save the full log to a file and extract what you need from it; don't truncate with `| tail` from the start
-- Don't Read large binary artifacts (gifs, images, etc.) yourself — leave judging them to human eyes. Don't commit large binary files
+- For heavy commands (e.g. `cargo test --workspace`), save the full log to a file outside the worktree and extract what you need from it; don't truncate with `| tail` from the start
+- Don't Read large binary artifacts (gifs, images, etc.) yourself — leave judging them to human eyes. Don't commit newly generated large binaries without user approval
 - Name things after what they actually are (e.g. whether a value is ground truth or noisy, whether an implicit default exists — make it readable from the name)
 - Leave a TODO comment when deferring work
 - Define magic numbers as constants, or comment their rationale
-
-## Documentation
-
-- Verify technical claims (CHANGELOG, docs, etc.) against the implementation and tests before writing them down
-- In Japanese documents, keep technical terms in English (crate, workspace, commit) — no katakana transliteration
-- Use a negation ("not A, but B") only where it records a rejected alternative or an actual failure mode; decorative contrasts read as filler
-
-## Languages
-
-- **Rust**: core simulation platform (Cargo workspace)
-- **TypeScript/React**: real-time viewer and related packages (pnpm workspace)
-- **Python**: helper scripts under examples/ and tools/, managed with uv
-
-## Build & Test
-
-- `plugin-sdk/examples/` is a standalone workspace (`cargo component build`, target `wasm32-wasip1`); `cargo test --workspace` does not cover it
-- Some crates have no_std / wasm checks in CI (per-feature clippy in the lint job for no_std; wasm32 via the wasm-pack jobs such as viewer-build). `.github/workflows/ci.yml` is the source of truth — when changing such a crate, run the same checks locally
+- Python helper scripts (under examples/ and tools/) are managed with uv
 
 ## Footguns
 
 - `cargo test -p orts-cli` regenerates the TypeScript bindings in `viewer/src/protocol/generated/` (`TS_RS_EXPORT_DIR` in `.cargo/config.toml`), and CI enforces a clean diff — after changing protocol types, regenerate and commit
 - `.cargo/config.toml` configures the mold + clang linker; a non-empty global `RUSTFLAGS` silently disables it
 - Release process: see [RELEASING.md](RELEASING.md)
+
+## Documentation
+
+- Verify technical claims (CHANGELOG, docs, etc.) against the implementation and tests before writing them down
+- In Japanese documents, don't transliterate English technical terms into katakana (crate, not クレート)
+- Use a negation ("not A, but B") only where it records a rejected alternative or an actual failure mode; decorative contrasts read as filler
+
+## Build & Test
+
+- `plugin-sdk/examples/` is a standalone workspace (`cargo component build`, target `wasm32-wasip1`); `cargo test --workspace` does not cover it
+- Some crates have no_std / wasm checks in CI (per-feature clippy in the lint job for no_std; wasm32 via the wasm-pack jobs such as viewer-build). `.github/workflows/ci.yml` is the source of truth — when changing such a crate, run the same checks locally
 
 ## Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,66 +4,59 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-orts is a numerical computation and optimization platform primarily for orbital mechanics. The design document is [DESIGN.md](DESIGN.md) (written in Japanese).
+orts is a numerical computation and optimization platform primarily for orbital mechanics.
 
-## Languages and Structure
+- 設計意図: [DESIGN.md](DESIGN.md)(日本語)/ 全体構造: [ARCHITECTURE.md](ARCHITECTURE.md)
+- crate / package の一覧と役割: [README.md](README.md) の Project Structure の表を参照
 
-- **Rust**: Core simulation platform — coordinate transformations, numerical integration, orbital mechanics solvers, CLI interface
-- **TypeScript/React**: Web-based real-time viewer for simulation visualization (React + @react-three/fiber + Vite)
+## Languages
 
-Rust libraries are split by responsibility (e.g., coordinate transforms, numerical integration) with independent test suites per module.
+- **Rust**: コアシミュレーションプラットフォーム(Cargo workspace)
+- **TypeScript/React**: リアルタイムビューアなど(pnpm workspace)
+- **Python**: examples/ や tools/ の補助スクリプト。環境は uv で管理する
 
-## Build Commands
+## Build & Test
 
-### Rust (Cargo workspace)
-- `cargo run --bin orts -- run` — run a simulation (auto-detects orts.toml in CWD)
-- `cargo run --bin orts -- serve` — start WebSocket server (port 9001)
-- `cargo run --bin orts -- serve --sat "altitude=800" --dt 5` — custom parameters
-- `cargo run --bin orts -- serve --dt 1 --output-interval 10` — fine dt with decimated output
-- `cargo test -p utsuroi` — test only the utsuroi (integrator) crate
-- `cargo test -p arika` — test only the arika crate
-- `cargo test -p tobari` — test only the tobari (Earth environment models) crate
-- `cargo test -p orts` — test the simulation library (orts crate)
-- `cargo test -p orts-cli` — run CLI E2E tests
+- `plugin-sdk/examples/` は独立した workspace(`cargo component build`, target は `wasm32-wasip1`)。`cargo test --workspace` には含まれない
+- 一部の crate は no_std / wasm 向けの check が CI にある(no_std の feature 構成ごとの clippy は lint job、wasm32 は viewer-build など wasm-pack を使う job)。何をどう check するかは `.github/workflows/ci.yml` が正。該当 crate を変更したら同じ check をローカルでも回す
 
-## Development Methodology
+## Footguns
 
-- **TDD-first**: Write unit tests before integration. Every module (numerical integration, coordinate transforms, etc.) must have unit tests verifying behavior before being integrated.
-- **Reference validation**: Use GMAT and Orekit as reference implementations for E2E black-box testing.
-- **Playwright** for viewer E2E tests.
-- **CLI execution** enables simple E2E testing of the simulator independently from the viewer.
-- **Validate the design before implementing**: an issue or spec is a starting point, not a fixed prescription. For non-trivial designs or refactors, sanity-check the approach with an independent design review (the `smart-friend` skill / Codex) before writing code — the stated plan is not always the cleanest one (a proposed "shared utility" may already exist in `std`; a literal file split may be the wrong granularity).
-- **External review before merge**: get a code review (Codex / Copilot) on non-trivial PRs. Independent reviewers catch complementary issues — design/whole-program vs. line-level edge cases.
-- **Behavior-preserving refactors**: pin the existing behavior with a characterization test, and include boundary *and* non-finite inputs (`NaN`, `±∞`) — float predicate rewrites can match for finite values yet diverge at `NaN`.
+- `cargo test -p orts-cli` は `viewer/src/protocol/generated/` の TypeScript bindings を再生成する(`TS_RS_EXPORT_DIR` @ `.cargo/config.toml`)。CI が diff を enforce するので、protocol 型を変更したら再生成して commit する
+- `.cargo/config.toml` が mold + clang linker を設定している。グローバルな `RUSTFLAGS` が非空だとこの設定は黙って無効化される
+- リリース手順は [RELEASING.md](RELEASING.md) を参照
 
-## Pre-commit Checklist
+## Development Workflow
 
-Before committing, always run the relevant checks and confirm they pass.
+- アーキテクチャレベルの変更は DESIGN.md を先に更新してから実装する
+- 設計判断を伴う実装(新しい module 構成、trait / public API の設計、設計の選択肢が複数あるとき)は、着手前に smart-friend skill で独立レビューにかけ、レビューが通るまで設計を見直す
+- TDD-first: 統合の前にユニットテストで挙動を検証する。GMAT / Orekit を参照実装とした E2E 検証(fixture 生成は tools/)
+- commit 前に `cargo fmt` / `cargo clippy --workspace -- -D warnings` / 関連テスト / `pnpm lint` を通す
+- ロジック・API・設計に触れる変更は commit 前に code-review skill で外部レビューを受ける(typo 修正や機械的な置換だけの commit は省略してよい)。指摘対応後は re-review し、通ってから commit する
+- push 後は CI 結果の確認までを一連の作業とする
+- WebSocket 通信・データフロー・UI 統合など mock しにくい部分を変更したら Playwright E2E も実行する(Playwright は CLI を使う。MCP ツールではない)
 
-### Rust
-- `cargo fmt --all` — format all crates (CI enforces `--check`)
-- `cargo clippy --workspace -- -D warnings` — lint with warnings as errors
-- `cargo test --workspace` — run all tests
-- Some crates are `no_std` and/or built for `wasm` beyond the default std build, and CI checks each applicable tier per crate. When changing a crate, run the tiers that apply to it — not just the std `--workspace` checks above.
+## Testing Rules
 
-### TypeScript (viewer + uneri)
-- `pnpm lint` — lint & format check (Biome, CI enforces)
-- `pnpm lint:fix` — auto-fix lint & format issues
-- `pnpm --filter uneri build` — build uneri library
-- `pnpm --filter orts-viewer build` — build viewer (includes wasm-pack + tsc)
-- `pnpm --filter uneri test` — run uneri unit tests
-- `pnpm --filter orts-viewer test` — run viewer unit tests
+- テストは「何を検証したいか」を明確にする。トートロジーになっているテストは書かない
+- 不具合を見つけたら、まず再現テストを書いてから修正する(regression 防止)
+- テスト失敗やバグを「既存の問題」「flaky」と判断する場合は、再現確認などの根拠を示す
+- テストやテストモジュールの削除は、事前に対象・理由・カバー状況を列挙して user のレビューを受ける。依存関係の問題は削除ではなく依存の追加で解決する
+- 挙動を保存するリファクタでは characterization test で既存挙動を固定する。境界値と非有限値(`NaN`, `±∞`)も含める
 
-### E2E tests (Playwright)
-WebSocket 通信、データフロー、UI 統合など mock しにくい部分を変更した場合は E2E テストも実行する:
-- `cd uneri && pnpm test:e2e` — uneri E2E (DuckDB + charting)
-- `cd viewer && npx playwright test` — viewer E2E (requires orts serve + vite dev)
+## Working Rules
+
+- 重いコマンド(`cargo test --workspace` など)はフルログをファイルに保存してから必要箇所を抽出する。最初から `| tail` で切り詰めない
+- サイズの大きいバイナリ生成物(gif、画像など)は Claude 自身で Read せず、人間の目視確認に委ねる。大きいバイナリファイルは commit しない
+- 命名は実態・意味に忠実にする(真値かノイズ入りか、暗黙のデフォルトの有無などが名前から読み取れるように)
+- 対応を先送りする判断をしたら TODO コメントを残す
+- マジックナンバーは定数として定義するか、根拠をコメントで書く
+
+## Documentation
+
+- 技術的な主張(CHANGELOG、docs など)は実装・テストと照合して裏取りしてから書く
+- 日本語文書でも技術用語は英語表記のまま使う(crate, workspace, commit)。カタカナ化しない
 
 ## Dependencies
 
-- 新しいライブラリを追加する際は、最新の安定バージョンを調べてから指定する。古いバージョンを指定しない。
-
-## Architecture Notes
-
-- Systems and precision are configurable — e.g., Earth-Moon-Sun for SSO vs. full N-body for solar system simulations; detailed atmospheric drag vs. simple drag coefficients.
-- Strict separation of concerns across modules to enable parallel development.
+- 新しいライブラリを追加する際は、最新の安定バージョンを調べてから指定する。古いバージョンを指定しない

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ orts is a numerical computation and optimization platform for spacecraft simulat
 - Keep responsibilities strictly separated across crates and modules — that separation is what enables parallel development and independent testing
 - For architecture-level changes, update DESIGN.md first, then implement; keep ARCHITECTURE.md (en/ja) in sync when the structure changes
 - Before committing, run `cargo fmt` / `cargo clippy --workspace -- -D warnings` / the relevant tests / `pnpm lint`
-- Changes touching logic, APIs, or design get an external review via the code-review skill before commit (typo fixes and mechanical replacements may skip it); after addressing findings, re-review until it passes
+- Changes touching logic, APIs, or design get an external review via the code-review-gpt skill before commit (typo fixes and mechanical replacements may skip it); after addressing findings, re-review until it passes
 - After pushing, checking the CI result is part of the task
 - When changing parts that are hard to mock (WebSocket communication, data flow, UI integration), also run the Playwright E2E tests (use the Playwright CLI, not MCP tools)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,10 @@ orts is a numerical computation and optimization platform for spacecraft simulat
 
 ## Development Policy
 
-- For architecture-level changes, update DESIGN.md first, then implement; keep ARCHITECTURE.md (en/ja) in sync when the structure changes
 - Before starting implementation, get a smart-friend review of the plan
 - TDD-first: verify behavior with unit tests before integrating. For numerical-dynamics changes, validate against reference implementations such as Orekit (fixture generators live in tools/)
 - Keep responsibilities strictly separated across crates and modules — that separation is what enables parallel development and independent testing
+- For architecture-level changes, update DESIGN.md first, then implement; keep ARCHITECTURE.md (en/ja) in sync when the structure changes
 - Before committing, run `cargo fmt` / `cargo clippy --workspace -- -D warnings` / the relevant tests / `pnpm lint`
 - Changes touching logic, APIs, or design get an external review via the code-review skill before commit (typo fixes and mechanical replacements may skip it); after addressing findings, re-review until it passes
 - After pushing, checking the CI result is part of the task

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,24 +9,7 @@ orts is a numerical computation and optimization platform for spacecraft simulat
 - Design doc: [DESIGN.md](DESIGN.md) (Japanese) / top-level structure: [ARCHITECTURE.md](ARCHITECTURE.md)
 - Crate / package inventory and roles: see the Project Structure tables in [README.md](README.md)
 
-## Languages
-
-- **Rust**: core simulation platform (Cargo workspace)
-- **TypeScript/React**: real-time viewer and related packages (pnpm workspace)
-- **Python**: helper scripts under examples/ and tools/, managed with uv
-
-## Build & Test
-
-- `plugin-sdk/examples/` is a standalone workspace (`cargo component build`, target `wasm32-wasip1`); `cargo test --workspace` does not cover it
-- Some crates have no_std / wasm checks in CI (per-feature clippy in the lint job for no_std; wasm32 via the wasm-pack jobs such as viewer-build). `.github/workflows/ci.yml` is the source of truth — when changing such a crate, run the same checks locally
-
-## Footguns
-
-- `cargo test -p orts-cli` regenerates the TypeScript bindings in `viewer/src/protocol/generated/` (`TS_RS_EXPORT_DIR` in `.cargo/config.toml`), and CI enforces a clean diff — after changing protocol types, regenerate and commit
-- `.cargo/config.toml` configures the mold + clang linker; a non-empty global `RUSTFLAGS` silently disables it
-- Release process: see [RELEASING.md](RELEASING.md)
-
-## Development Workflow
+## Development Policy
 
 - For architecture-level changes, update DESIGN.md first, then implement
 - Before starting implementation, get a smart-friend review of the plan
@@ -56,6 +39,23 @@ orts is a numerical computation and optimization platform for spacecraft simulat
 
 - Verify technical claims (CHANGELOG, docs, etc.) against the implementation and tests before writing them down
 - In Japanese documents, keep technical terms in English (crate, workspace, commit) — no katakana transliteration
+
+## Languages
+
+- **Rust**: core simulation platform (Cargo workspace)
+- **TypeScript/React**: real-time viewer and related packages (pnpm workspace)
+- **Python**: helper scripts under examples/ and tools/, managed with uv
+
+## Build & Test
+
+- `plugin-sdk/examples/` is a standalone workspace (`cargo component build`, target `wasm32-wasip1`); `cargo test --workspace` does not cover it
+- Some crates have no_std / wasm checks in CI (per-feature clippy in the lint job for no_std; wasm32 via the wasm-pack jobs such as viewer-build). `.github/workflows/ci.yml` is the source of truth — when changing such a crate, run the same checks locally
+
+## Footguns
+
+- `cargo test -p orts-cli` regenerates the TypeScript bindings in `viewer/src/protocol/generated/` (`TS_RS_EXPORT_DIR` in `.cargo/config.toml`), and CI enforces a clean diff — after changing protocol types, regenerate and commit
+- `.cargo/config.toml` configures the mold + clang linker; a non-empty global `RUSTFLAGS` silently disables it
+- Release process: see [RELEASING.md](RELEASING.md)
 
 ## Dependencies
 


### PR DESCRIPTION
## 概要

最近の Anthropic 公式ガイダンスに合わせて CLAUDE.md を書き直す。

方針: **コード・README・ci.yml から導出できる情報は書かず、導出不能な事実と規範だけを残す**。

- Footguns セクションを新設: `cargo test -p orts-cli` による TS protocol bindings 再生成 (CI が diff を enforce)、グローバル `RUSTFLAGS` による mold linker 設定の黙殺、`plugin-sdk/examples/` が独立 workspace で `--workspace` に含まれない件
- 過去セッション (2026-03〜04、65 セッション) のトランスクリプトから「user が繰り返し言っていたこと」を採掘し、恒久ルールに昇格: テスト規律 (トートロジー禁止、再現テスト先行、「既存/flaky」断定に根拠、テスト削除の事前列挙)、重いコマンドのフルログ保存、大きいバイナリの扱い、命名の忠実性、TODO/根拠コメント、技術的主張の裏取り、Python の uv 管理
- Claude 5 世代で不要になったルールは入れない (進捗報告スキャフォールディング、commit 毎の必須レビュー)
- serve のコマンド例・`cargo test -p <crate>` の列挙・E2E コマンドの列挙・Architecture Notes を削除 (導出可能)

## 参照したベストプラクティス

- [Manage Claude's memory](https://code.claude.com/docs/en/memory) — 「200 行未満を目標。長いファイルはコンテキストを消費し遵守率を下げる」「各行に『消したら Claude がミスするか?』を問い、No なら削る」。全体の取捨基準と Footguns (gotchas) 重視の根拠
- [Claude Code best practices](https://code.claude.com/docs/en/best-practices) — 含める/含めないの対照表。「導出可能な情報 (ディレクトリ構成、依存リスト、アーキテクチャ概要) は書かない」「検証可能な具体性で書く」。コマンド列挙と Architecture Notes を削った根拠
- [Model migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide) — 「Claude 5 世代では検証・セルフチェックの催促と進捗報告スキャフォールディングを削除せよ (over-verification の原因)」。done/remaining 自発提示ルールを見送り、commit 毎の必須レビューを『ロジック・API・設計に触れる変更』に限定した根拠
- [Prompting best practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices) — 「Tell the model what TO do rather than what NOT to do」「禁止は理由 (motivation) 付きで書く」。ルールの肯定形への言い換えと、Documentation の negation ルールの根拠
- (参考、二次ソース) Boris Cherny の公開 tips — 「Claude の誤りを観測したときに CLAUDE.md へ追記する (先回りの禁止事項を並べない)」。トランスクリプト採掘によるルール昇格の進め方と一致

## レビュー

Codex による code review 2 巡 + smart-friend による変更レビュー 1 巡を実施し、指摘を反映済み (wasm check の所在、ja/en ペアルールの過剰適用、GMAT/典型問題の過大な記述、NaN ルールの限定、バイナリルールと既存 asset の矛盾など)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)