### PR TITLE
ci: summarise the cargo-deny output instead of dumping it

### DIFF
--- a/.github/workflows/advisories.yml
+++ b/.github/workflows/advisories.yml
@@ -61,7 +61,7 @@ jobs:
         id: report
         run: |
           set +e
-          cargo deny -L info check advisories > advisories.txt 2>&1
+          cargo deny --color never -L info check advisories > advisories.txt 2>&1
           deny_status=$?
           set -e
           live=$(grep -cE '^error\[(vulnerability|unmaintained|unsound|notice|yanked)\]' advisories.txt || true)
@@ -76,16 +76,39 @@ jobs:
           echo "state=$state" >> "$GITHUB_OUTPUT"
           echo "cargo-deny exit $deny_status, $live live advisories, state $state"
 
+          # `note[advisory-ignored]` is one per accepted exception; the RUSTSEC id
+          # sits on the deny.toml line the diagnostic points at.
+          accepted=$(grep -c '^note\[advisory-ignored\]' advisories.txt || true)
+
           {
             echo "### cargo-deny advisories — $state"
             echo
-            if [ "$state" = "error" ]; then
-              echo "cargo-deny exited $deny_status without reporting an advisory, so the state is **unknown** for this run. The tracking issue was left untouched."
+            case "$state" in
+              live)
+                echo "Live findings needing attention: $live"
+                ;;
+              clean)
+                echo "No live advisories."
+                ;;
+              error)
+                echo "cargo-deny exited $deny_status without reporting an advisory, so the state is **unknown** for this run. The tracking issue was left untouched."
+                ;;
+            esac
+            echo
+            echo "Accepted exceptions (see \`deny.toml\` for why each one is there): $accepted"
+            if [ "$accepted" -gt 0 ]; then
               echo
+              grep -oE 'id = "RUSTSEC-[0-9-]+"' advisories.txt \
+                | sed -E 's/id = "(.+)"/- [\1](https:\/\/rustsec.org\/advisories\/\1)/'
             fi
+            echo
+            echo '<details><summary>full cargo-deny output</summary>'
+            echo
             echo '```'
             cat advisories.txt
             echo '```'
+            echo
+            echo '</details>'
           } | tee report.md >> "$GITHUB_STEP_SUMMARY"
 
       # Skipped when the state is unknown — a run that checked nothing must not

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,13 +150,19 @@ jobs:
           # `note[advisory-ignored]` is one per accepted exception; the RUSTSEC id
           # sits on the deny.toml line the diagnostic points at.
           accepted=$(grep -c '^note\[advisory-ignored\]' advisories.txt || true)
-          errors=$(grep -cE '^error\[' advisories.txt || true)
+          # Count advisory categories only. A non-zero exit with none of these
+          # means cargo-deny itself failed (advisory-db fetch, bad config) and
+          # checked nothing — reporting that as "0 advisory errors" would read
+          # like a clean security result.
+          live=$(grep -cE '^error\[(vulnerability|unmaintained|unsound|notice|yanked)\]' advisories.txt || true)
 
           {
             if [ "$status" -eq 0 ]; then
               echo "### cargo-deny: advisories ok"
+            elif [ "$live" -gt 0 ]; then
+              echo "### cargo-deny: $live advisory finding(s)"
             else
-              echo "### cargo-deny: $errors advisory error(s)"
+              echo "### cargo-deny: check did not complete (exit $status, no advisory reported)"
             fi
             echo
             echo "Accepted exceptions (see \`deny.toml\` for why each one is there): $accepted"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,15 +143,36 @@ jobs:
       - name: cargo-deny (advisories)
         run: |
           set +e
-          cargo deny -L info check advisories 2>&1 | tee advisories.txt
+          cargo deny --color never -L info check advisories 2>&1 | tee advisories.txt
           status=${PIPESTATUS[0]}
           set -e
+
+          # `note[advisory-ignored]` is one per accepted exception; the RUSTSEC id
+          # sits on the deny.toml line the diagnostic points at.
+          accepted=$(grep -c '^note\[advisory-ignored\]' advisories.txt || true)
+          errors=$(grep -cE '^error\[' advisories.txt || true)
+
           {
-            echo '### cargo-deny advisories'
+            if [ "$status" -eq 0 ]; then
+              echo "### cargo-deny: advisories ok"
+            else
+              echo "### cargo-deny: $errors advisory error(s)"
+            fi
+            echo
+            echo "Accepted exceptions (see \`deny.toml\` for why each one is there): $accepted"
+            if [ "$accepted" -gt 0 ]; then
+              echo
+              grep -oE 'id = "RUSTSEC-[0-9-]+"' advisories.txt \
+                | sed -E 's/id = "(.+)"/- [\1](https:\/\/rustsec.org\/advisories\/\1)/'
+            fi
+            echo
+            echo '<details><summary>full cargo-deny output</summary>'
             echo
             echo '```'
             cat advisories.txt
             echo '```'
+            echo
+            echo '</details>'
           } >> "$GITHUB_STEP_SUMMARY"
           exit $status
 


### PR DESCRIPTION
cargo-deny の run summary が生ログの貼り付けになっていて読みにくかったので、要約を主にする。

## 変更前の問題

summary に cargo-deny の診断出力をそのまま code block で流していた。実行結果として知りたいのは「advisory があるか」と「承知の例外を何件抱えているか」の2点だが、それが約 110 行の罫線と依存グラフに埋もれていた。step summary は色を解釈しないので、cargo-deny が付ける装飾も活きない。

## 変更後

```
### cargo-deny: advisories ok

Accepted exceptions (see `deny.toml` for why each one is there): 3

- RUSTSEC-2024-0436
- RUSTSEC-2026-0222
- RUSTSEC-2026-0188

<details>full cargo-deny output</details>
```

- 見出しで可否、次の行で例外の件数
- 各例外の RUSTSEC id を rustsec.org へリンク（`ignore` に書いた理由は `deny.toml` を見る、と案内）
- 生の出力は `<details>` に格納
- `--color never` を明示（runner を端末と判定してエスケープが混ざる可能性を消す）

定期実行の `Advisories` workflow も同じ形にした。あわせて、状態ごとの一行が3状態で同じ文だったのを、それぞれ具体的な内容に変えた。

## 検証

ci.yml と同じシェルロジックをローカルで実行し、レンダリング結果を確認した（上記の出力そのもの。生ログ 110 行は `<details>` 側）。両 workflow は YAML パースを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
