### PR TITLE
fix(viewer): 姿勢と trail を位置と同じ基底・epoch から導出する

### DIFF
--- a/viewer/registry.json
+++ b/viewer/registry.json
@@ -88,6 +88,11 @@
           "target": "@components/orbit-viewer/debug/satWorldQuat.ts"
         },
         {
+          "path": "src/displayFrame.ts",
+          "type": "registry:lib",
+          "target": "@components/orbit-viewer/displayFrame.ts"
+        },
+        {
           "path": "src/displayScale.ts",
           "type": "registry:lib",
           "target": "@components/orbit-viewer/displayScale.ts"

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -8,7 +8,7 @@ import {
   entityPathToBodyId,
   getBodyRadius,
 } from "../bodies.js";
-import { transformToLvlh } from "../coordTransform.js";
+import { displayPosition, displayRotation, resolveDisplayFrame } from "../displayFrame.js";
 import {
   computeSceneAmplification,
   type DisplayScaleProfile,
@@ -22,7 +22,7 @@ import { getSatelliteModelConfig } from "../satelliteModels.js";
 import { type MarkerShape, resolveMarkerShape } from "../satelliteShapes.js";
 import { computeCameraUp, computeLvlhAxes, type LvlhAxes, SCENE_UP } from "../sceneFrame.js";
 import type { TrailBufferLike } from "../utils/TrailBuffer.js";
-import { body_orientation, earth_rotation_angle, eci_to_ecef } from "../wasm/arikaInit.js";
+import { body_orientation, earth_rotation_angle } from "../wasm/arikaInit.js";
 import { CelestialBody } from "./CelestialBody.js";
 import { OrbitTrail } from "./OrbitTrail.js";
 import { buildRenderEntries } from "./renderEntries.js";
@@ -261,51 +261,28 @@ function SecondaryBody({
   const bodyRadiusKm = getBodyRadius(bodyId, bodyDefinitions);
   const radius = bodyRadiusKm != null ? bodyRadiusKm / scaleRadius : 0.01;
 
-  // Position transform: same pipeline as Satellite (ECI → ECEF → LVLH)
-  let scenePos: [number, number, number];
-  if (isLegacyEcef(referenceFrame) && epochJd != null) {
-    const ecef = eci_to_ecef(position.x, position.y, position.z, epochJd, position.t);
-    scenePos = [ecef[0] / scaleRadius, ecef[1] / scaleRadius, ecef[2] / scaleRadius];
-  } else if (originPosition != null && lvlhAxes != null) {
-    scenePos = transformToLvlh(
-      position.x,
-      position.y,
-      position.z,
-      originPosition,
-      lvlhAxes,
-      scaleRadius,
-    );
-  } else if (originPosition != null) {
-    scenePos = [
-      (position.x - originPosition[0]) / scaleRadius,
-      (position.y - originPosition[1]) / scaleRadius,
-      (position.z - originPosition[2]) / scaleRadius,
-    ];
-  } else {
-    scenePos = [position.x / scaleRadius, position.y / scaleRadius, position.z / scaleRadius];
-  }
+  // Position and orientation share one display frame (see displayFrame.ts), so
+  // the mesh can never be placed in one basis and oriented in another.
+  const era =
+    isLegacyEcef(referenceFrame) && epochJd != null
+      ? earth_rotation_angle(epochJd, position.t)
+      : null;
+  const frame = resolveDisplayFrame(referenceFrame, { era, originPosition, lvlhAxes });
+  const scenePos = displayPosition(frame, position.x, position.y, position.z, scaleRadius);
 
-  // Body orientation via IAU rotation model (arika WASM).
-  // IAU quaternion is body-fixed → ECI. For non-inertial display frames
-  // (ECEF, LVLH), we must apply the same frame rotation as positions get.
-  const orientation = useMemo(() => {
+  // Body-fixed → inertial orientation via the IAU rotation model (arika WASM),
+  // including the Three.js +Y-pole → IAU +Z-pole alignment.
+  const bodyToInertial = useMemo(() => {
     if (epochJd == null) return undefined;
     const q = body_orientation(bodyId, epochJd, position.t);
     if (!q) return undefined;
-    // IAU body-fixed → ECI: q = [w, x, y, z]
-    const iauQuat = new THREE.Quaternion(q[1], q[2], q[3], q[0]); // THREE uses (x,y,z,w)
-    // Pole alignment: rotate +Y (Three.js pole) → +Z (IAU pole)
+    // IAU body-fixed → ECI: q = [w, x, y, z]; THREE uses (x, y, z, w)
+    const iauQuat = new THREE.Quaternion(q[1], q[2], q[3], q[0]);
     const poleAlign = new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0));
-    // body-fixed → ECI → (optional frame rotation)
-    let combined = iauQuat.multiply(poleAlign);
-    // ECEF: apply inverse Earth rotation (same as position transform)
-    if (isLegacyEcef(referenceFrame) && epochJd != null) {
-      const era = earth_rotation_angle(epochJd, position.t);
-      const ecefRot = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, 0, -era));
-      combined = ecefRot.multiply(combined);
-    }
-    return combined;
-  }, [bodyId, epochJd, position.t, referenceFrame]);
+    return iauQuat.multiply(poleAlign);
+  }, [bodyId, epochJd, position.t]);
+
+  const orientation = bodyToInertial ? displayRotation(frame).multiply(bodyToInertial) : undefined;
 
   return (
     <group position={scenePos} quaternion={orientation ?? undefined}>
@@ -501,18 +478,17 @@ export function OrbitSceneContents({
   // Central body position and orientation in LVLH frame
   const bodyLvlhPosition = useMemo<[number, number, number] | null>(() => {
     if (!lvlhActive || originPosition == null || lvlhAxes == null) return null;
-    return transformToLvlh(0, 0, 0, originPosition, lvlhAxes, effectiveScaleRadius);
+    return displayPosition(
+      { kind: "localOrbital", origin: originPosition, axes: lvlhAxes },
+      0,
+      0,
+      0,
+      effectiveScaleRadius,
+    );
   }, [lvlhActive, originPosition, lvlhAxes, effectiveScaleRadius]);
 
   const bodyLvlhQuaternion = useMemo<[number, number, number, number] | null>(() => {
-    if (!lvlhActive || lvlhAxes == null) return null;
-    // R_lvlh: basis matrix [inTrack, crossTrack, radial] maps LVLH→ECI
-    const lvlhMat = new THREE.Matrix4().makeBasis(
-      new THREE.Vector3(...lvlhAxes.inTrack),
-      new THREE.Vector3(...lvlhAxes.crossTrack),
-      new THREE.Vector3(...lvlhAxes.radial),
-    );
-    const lvlhQuat = new THREE.Quaternion().setFromRotationMatrix(lvlhMat);
+    if (!lvlhActive || lvlhAxes == null || originPosition == null) return null;
     let bodyToInertialQuat: THREE.Quaternion;
     if (centralBody === "earth") {
       // Keep Earth in the same simple ERA frame as position/geodetic transforms.
@@ -531,10 +507,15 @@ export function OrbitSceneContents({
       );
     }
 
-    // Body orientation in LVLH: R_lvlh^T * R_body_to_inertial.
-    const bodyQuat = lvlhQuat.clone().conjugate().multiply(bodyToInertialQuat);
+    // Body orientation in the display frame: R_inertial→lvlh * R_body→inertial,
+    // with the rotation taken from the same basis the positions use.
+    const bodyQuat = displayRotation({
+      kind: "localOrbital",
+      origin: originPosition,
+      axes: lvlhAxes,
+    }).multiply(bodyToInertialQuat);
     return [bodyQuat.x, bodyQuat.y, bodyQuat.z, bodyQuat.w];
-  }, [lvlhActive, lvlhAxes, epochJd, centralBody, simTime, era]);
+  }, [lvlhActive, lvlhAxes, originPosition, epochJd, centralBody, simTime, era]);
 
   // Target offset for SmoothOriginGroup (non-LVLH satellite-centered fallback)
   const originOffset = useMemo<[number, number, number]>(() => {

--- a/viewer/src/components/OrbitTrail.tsx
+++ b/viewer/src/components/OrbitTrail.tsx
@@ -6,8 +6,13 @@ import {
   batchEncodeEciHighLow,
   encodeFloat64ToHighLow,
 } from "../coordTransform.js";
+import {
+  type TrailTransformKey,
+  needsFullRewrite as trailTransformChanged,
+  trailTransformKey,
+} from "../displayFrame.js";
 import type { OrbitPoint } from "../orbit.js";
-import { frameCenterEquals, isLegacyEcef, type ReferenceFrame } from "../referenceFrame.js";
+import type { ReferenceFrame } from "../referenceFrame.js";
 import type { LvlhAxes } from "../sceneFrame.js";
 import { orbitTrailFrag, orbitTrailVert } from "../shaders/orbitTrail.js";
 import type { TrailBufferLike } from "../utils/TrailBuffer.js";
@@ -70,7 +75,7 @@ export function OrbitTrail({
   const positionHighRef = useRef(new Float32Array(INITIAL_CAPACITY * 3));
   const positionLowRef = useRef(new Float32Array(INITIAL_CAPACITY * 3));
   const generationRef = useRef(-1);
-  const prevFrameRef = useRef<ReferenceFrame>(referenceFrame);
+  const prevTransformRef = useRef<TrailTransformKey>(trailTransformKey(referenceFrame, epochJd));
 
   // Geometry with dual high/low attributes
   const geometry = useMemo(() => {
@@ -145,14 +150,22 @@ export function OrbitTrail({
   const lvlhAxesRef = useRef(lvlhAxes);
   lvlhAxesRef.current = lvlhAxes;
 
-  // Unified writePoints: encode source coordinates into high/low buffers
-  function writePoints(src: readonly OrbitPoint[], from: number, to: number): void {
-    if (isLegacyEcef(referenceFrame) && epochJd != null) {
+  // Unified writePoints: encode source coordinates into high/low buffers.
+  // The branch is taken from the same transform key that drives invalidation
+  // below, so vertices can never be baked with a transform the key does not
+  // record (a late-arriving epoch used to switch the branch mid-buffer).
+  function writePoints(
+    key: TrailTransformKey,
+    src: readonly OrbitPoint[],
+    from: number,
+    to: number,
+  ): void {
+    if (key.ecefEpochJd != null) {
       batchEncodeEcefHighLow(
         src,
         from,
         to,
-        epochJd,
+        key.ecefEpochJd,
         positionHighRef.current,
         positionLowRef.current,
         from,
@@ -163,10 +176,15 @@ export function OrbitTrail({
   }
 
   useFrame(() => {
+    // One key decides everything about the transform: which branch bakes the
+    // vertices, whether the per-frame uniforms apply, and when already-written
+    // vertices must be re-encoded.
+    const transformKey = trailTransformKey(referenceFrame, epochJd);
+    const isEcef = transformKey.ecefEpochJd != null;
+
     // Update per-frame uniforms (origin + rotation) before rendering.
     // In ECEF mode, vertices are in body-fixed frame — origin/rotation uniforms
     // must be identity to avoid mixing coordinate frames.
-    const isEcef = isLegacyEcef(referenceFrame);
     const curOrigin = !isEcef ? originPositionRef.current : null;
     if (curOrigin != null) {
       const [xh, xl] = encodeFloat64ToHighLow(curOrigin[0]);
@@ -197,12 +215,10 @@ export function OrbitTrail({
       (material.uniforms.uFrameRotation.value as THREE.Matrix3).copy(IDENTITY_MAT3);
     }
 
-    // Detect reference frame change (ECI ↔ ECEF) → force full rewrite
-    const frameChanged =
-      referenceFrame.orientation !== prevFrameRef.current.orientation ||
-      !frameCenterEquals(referenceFrame.center, prevFrameRef.current.center);
-    if (frameChanged) {
-      prevFrameRef.current = referenceFrame;
+    // Detect a change in the transform the vertices were baked with (frame
+    // centre/orientation, or the ECEF epoch) → force a full rewrite.
+    if (trailTransformChanged(prevTransformRef.current, transformKey)) {
+      prevTransformRef.current = transformKey;
       writtenCountRef.current = 0;
     }
 
@@ -227,11 +243,11 @@ export function OrbitTrail({
     if (needsFullRewrite) {
       generationRef.current = currentGen;
       ensureCapacity(totalPoints);
-      writePoints(allPoints, 0, totalPoints);
+      writePoints(transformKey, allPoints, 0, totalPoints);
       writtenCountRef.current = totalPoints;
       markAttrsNeedUpdate();
     } else if (totalPoints > writtenCountRef.current) {
-      appendPoints(allPoints, writtenCountRef.current, totalPoints);
+      appendPoints(transformKey, allPoints, writtenCountRef.current, totalPoints);
     }
 
     const vc = visibleCount != null ? Math.min(visibleCount, totalPoints) : totalPoints;
@@ -264,9 +280,14 @@ export function OrbitTrail({
   }
 
   /** Append points[from..to) to the GPU buffers. */
-  function appendPoints(src: readonly OrbitPoint[], from: number, to: number): void {
+  function appendPoints(
+    key: TrailTransformKey,
+    src: readonly OrbitPoint[],
+    from: number,
+    to: number,
+  ): void {
     ensureCapacity(to);
-    writePoints(src, from, to);
+    writePoints(key, src, from, to);
     writtenCountRef.current = to;
     markAttrsNeedUpdate();
   }

--- a/viewer/src/components/Satellite.tsx
+++ b/viewer/src/components/Satellite.tsx
@@ -1,11 +1,16 @@
 import { Suspense } from "react";
-import { transformToLvlh } from "../coordTransform.js";
+import {
+  displayPosition,
+  displayQuaternion,
+  type Quat,
+  resolveDisplayFrame,
+} from "../displayFrame.js";
 import type { OrbitPoint } from "../orbit.js";
 import { isLegacyEcef, type ReferenceFrame } from "../referenceFrame.js";
 import { getSatelliteModelConfig } from "../satelliteModels.js";
 import { type MarkerShape, resolveMarkerShape } from "../satelliteShapes.js";
 import type { LvlhAxes } from "../sceneFrame.js";
-import { body_quat_to_rsw, eci_to_ecef } from "../wasm/arikaInit.js";
+import { earth_rotation_angle } from "../wasm/arikaInit.js";
 import { BodyAxes } from "./BodyAxes.js";
 import { PrimitiveMarker } from "./PrimitiveMarker.js";
 import { SatelliteModel } from "./SatelliteModel.js";
@@ -81,67 +86,31 @@ export function Satellite({
   hideSphereFallback = false,
   markerShape,
 }: SatelliteProps) {
-  let scenePos: [number, number, number];
+  // One display frame drives both the position and the attitude, so they can
+  // never end up in different bases (the LVLH axis order and the ECEF rotation
+  // used to be derived independently, and disagreed).
+  const era =
+    isLegacyEcef(referenceFrame) && epochJd != null
+      ? earth_rotation_angle(epochJd, position.t)
+      : null;
+  const frame = resolveDisplayFrame(referenceFrame, { era, originPosition, lvlhAxes });
 
-  if (isLegacyEcef(referenceFrame) && epochJd != null) {
-    // WASM fast path for ECEF
-    const ecef = eci_to_ecef(position.x, position.y, position.z, epochJd, position.t);
-    scenePos = [ecef[0] / scaleRadius, ecef[1] / scaleRadius, ecef[2] / scaleRadius];
-  } else if (originPosition != null && lvlhAxes != null) {
-    // LVLH body-frame transform (f64 precision)
-    scenePos = transformToLvlh(
-      position.x,
-      position.y,
-      position.z,
-      originPosition,
-      lvlhAxes,
-      scaleRadius,
-    );
-  } else if (originPosition != null) {
-    // Simple offset subtraction fallback
-    scenePos = [
-      (position.x - originPosition[0]) / scaleRadius,
-      (position.y - originPosition[1]) / scaleRadius,
-      (position.z - originPosition[2]) / scaleRadius,
-    ];
-  } else {
-    scenePos = [position.x / scaleRadius, position.y / scaleRadius, position.z / scaleRadius];
-  }
+  const scenePos = displayPosition(frame, position.x, position.y, position.z, scaleRadius);
 
-  // Extract attitude quaternion (body-to-ECI) and transform to display frame
-  const rawQuaternion: [number, number, number, number] | undefined =
+  // Attitude quaternion as delivered: body-to-inertial, Hamilton [w, x, y, z].
+  const rawQuaternion: Quat | undefined =
     position.qw != null
       ? [position.qw, position.qx ?? 0, position.qy ?? 0, position.qz ?? 0]
       : undefined;
 
-  let displayQuaternion: [number, number, number, number] | undefined;
-  if (rawQuaternion && lvlhAxes != null) {
-    // Local-orbital view: transform body-to-ECI → body-to-RSW via arika WASM.
-    // (The historical viewer label "lvlhAxes" refers to the local orbital
-    // frame; the arika API now uses standard RSW convention.)
-    displayQuaternion = body_quat_to_rsw(
-      position.x,
-      position.y,
-      position.z,
-      position.vx,
-      position.vy,
-      position.vz,
-      rawQuaternion[0],
-      rawQuaternion[1],
-      rawQuaternion[2],
-      rawQuaternion[3],
-    );
-  } else {
-    // ECI view: use body-to-ECI as-is
-    displayQuaternion = rawQuaternion;
-  }
+  const displayQuat = displayQuaternion(frame, rawQuaternion);
 
   const modelConfig = satId ? getSatelliteModelConfig(satId, satName) : null;
 
-  const bodyAxes = displayQuaternion ? (
+  const bodyAxes = displayQuat ? (
     <BodyAxes
       position={scenePos}
-      quaternion={displayQuaternion}
+      quaternion={displayQuat}
       axisLength={modelConfig ? modelConfig.scale * 5 : DEFAULT_SPHERE_RADIUS * 6}
       debugId={satId}
     />
@@ -151,7 +120,7 @@ export function Satellite({
     return (
       <>
         <Suspense fallback={<SphereMarker position={scenePos} color={color} />}>
-          <SatelliteModel position={scenePos} config={modelConfig} quaternion={displayQuaternion} />
+          <SatelliteModel position={scenePos} config={modelConfig} quaternion={displayQuat} />
         </Suspense>
         {bodyAxes}
       </>
@@ -165,13 +134,13 @@ export function Satellite({
   // at every orientation — sphere otherwise).
   const shape = resolveMarkerShape({
     override: markerShape,
-    hasAttitude: displayQuaternion != null,
+    hasAttitude: displayQuat != null,
   });
   const fallbackMarker =
     shape === "sphere" ? (
       <SphereMarker position={scenePos} color={color} />
     ) : (
-      <PrimitiveMarker position={scenePos} quaternion={displayQuaternion} />
+      <PrimitiveMarker position={scenePos} quaternion={displayQuat} />
     );
   return (
     <>

--- a/viewer/src/displayFrame.test.ts
+++ b/viewer/src/displayFrame.test.ts
@@ -1,0 +1,383 @@
+import * as THREE from "three";
+import { describe, expect, it } from "vitest";
+import {
+  type DisplayFrame,
+  displayPosition,
+  displayQuaternion,
+  displayRotation,
+  needsFullRewrite,
+  type Quat,
+  resolveDisplayFrame,
+  trailTransformKey,
+  type Vec3,
+} from "./displayFrame.js";
+import type { ReferenceFrame } from "./referenceFrame.js";
+import { computeLvlhAxes } from "./sceneFrame.js";
+import { sunDirectionInDisplayFrame } from "./sunLighting.js";
+import { isArikaReady } from "./wasm/arikaInit.js";
+
+const EARTH_RADIUS = 6378.137;
+const MU = 398600.4418;
+
+const ECEF_FRAME: ReferenceFrame = { center: { type: "central_body" }, orientation: "body_fixed" };
+const ECI_FRAME: ReferenceFrame = { center: { type: "central_body" }, orientation: "inertial" };
+const SAT_LVLH_FRAME: ReferenceFrame = {
+  center: { type: "satellite", id: "sat" },
+  orientation: "local_orbital",
+};
+
+/** Circular orbit state [km, km/s] at true anomaly `phase` with inclination `inc`. */
+function orbitState(radius: number, phase: number, inc: number): { r: Vec3; v: Vec3 } {
+  const speed = Math.sqrt(MU / radius);
+  const inPlane = new THREE.Vector3(Math.cos(phase), Math.sin(phase), 0);
+  const inPlaneVel = new THREE.Vector3(-Math.sin(phase), Math.cos(phase), 0);
+  const tilt = new THREE.Matrix4().makeRotationX(inc);
+  const r = inPlane.clone().multiplyScalar(radius).applyMatrix4(tilt);
+  const v = inPlaneVel.clone().multiplyScalar(speed).applyMatrix4(tilt);
+  return { r: [r.x, r.y, r.z], v: [v.x, v.y, v.z] };
+}
+
+function quatFromEuler(x: number, y: number, z: number): Quat {
+  const q = new THREE.Quaternion().setFromEuler(new THREE.Euler(x, y, z));
+  return [q.w, q.x, q.y, q.z];
+}
+
+/** Rotate `b` by the Hamilton [w,x,y,z] quaternion `q`. */
+function rotate(q: Quat, b: Vec3): Vec3 {
+  const v = new THREE.Vector3(...b).applyQuaternion(new THREE.Quaternion(q[1], q[2], q[3], q[0]));
+  return [v.x, v.y, v.z];
+}
+
+/**
+ * Cross-path invariant: a body axis drawn by the attitude path must point where
+ * the *position* path puts a point offset along that same axis.
+ *
+ * Take a body unit axis `b` and a small offset ε [km]. The point
+ * `r + ε·(R(q_body→inertial)·b)` is a physical position, so pushing it through
+ * `displayPosition` gives where the tip of the body axis really is in the scene.
+ * The attitude path draws that tip at `scenePos + (ε/scale)·R(q_display)·b`.
+ * `displayPosition` is affine in the offset, so for an exact frame the two agree
+ * to floating-point noise; a mismatched basis (or a missing ERA rotation) leaves
+ * an O(1) residual relative to the offset length.
+ *
+ * Returns the residual normalised by the scene-space offset length.
+ */
+function axisResidual(
+  frame: DisplayFrame,
+  r: Vec3,
+  bodyToInertial: Quat,
+  b: Vec3,
+  scaleRadius: number,
+): number {
+  const eps = 1e-3; // km
+  const inertialAxis = rotate(bodyToInertial, b);
+  const tip = displayPosition(
+    frame,
+    r[0] + eps * inertialAxis[0],
+    r[1] + eps * inertialAxis[1],
+    r[2] + eps * inertialAxis[2],
+    scaleRadius,
+  );
+
+  const base = displayPosition(frame, r[0], r[1], r[2], scaleRadius);
+  const displayed = displayQuaternion(frame, bodyToInertial);
+  if (displayed == null) throw new Error("attitude path returned no quaternion");
+  const sceneAxis = rotate(displayed, b);
+  const sceneEps = eps / scaleRadius;
+
+  return (
+    Math.hypot(
+      base[0] + sceneEps * sceneAxis[0] - tip[0],
+      base[1] + sceneEps * sceneAxis[1] - tip[1],
+      base[2] + sceneEps * sceneAxis[2] - tip[2],
+    ) / sceneEps
+  );
+}
+
+const BODY_AXES: Vec3[] = [
+  [1, 0, 0],
+  [0, 1, 0],
+  [0, 0, 1],
+];
+
+const ATTITUDES: Quat[] = [
+  [1, 0, 0, 0],
+  quatFromEuler(0.3, -0.5, 1.1),
+  quatFromEuler(-1.7, 0.9, 0.2),
+];
+
+describe("position/attitude cross-path invariant", () => {
+  it("holds in the local-orbital (LVLH) frame across orbit phases and inclinations", () => {
+    for (const phase of [0, 0.7, 2.1, 4.9]) {
+      for (const inc of [0, 0.6, Math.PI / 2]) {
+        const { r, v } = orbitState(7378, phase, inc);
+        const axes = computeLvlhAxes(r, v);
+        expect(axes).not.toBeNull();
+        if (axes == null) return;
+        const frame = resolveDisplayFrame(SAT_LVLH_FRAME, {
+          originPosition: r,
+          lvlhAxes: axes,
+        });
+        expect(frame.kind).toBe("localOrbital");
+
+        for (const attitude of ATTITUDES) {
+          for (const b of BODY_AXES) {
+            expect(axisResidual(frame, r, attitude, b, EARTH_RADIUS)).toBeLessThan(1e-6);
+          }
+        }
+      }
+    }
+  });
+
+  it("holds in the body-fixed (ECEF) frame, including ERA = 90°", () => {
+    for (const era of [0, Math.PI / 2, 2.4, -1.1]) {
+      const { r } = orbitState(7378, 0.9, 0.4);
+      const frame = resolveDisplayFrame(ECEF_FRAME, { era });
+      expect(frame.kind).toBe("bodyFixed");
+
+      for (const attitude of ATTITUDES) {
+        for (const b of BODY_AXES) {
+          expect(axisResidual(frame, r, attitude, b, EARTH_RADIUS)).toBeLessThan(1e-6);
+        }
+      }
+    }
+  });
+
+  it("holds in the satellite-centred inertial frame (origin offset only)", () => {
+    const { r } = orbitState(7000, 1.3, 0.2);
+    const frame = resolveDisplayFrame(
+      { center: { type: "satellite", id: "sat" }, orientation: "inertial" },
+      { originPosition: [r[0] - 30, r[1] + 12, r[2] - 4] },
+    );
+    expect(frame.kind).toBe("inertial");
+    for (const attitude of ATTITUDES) {
+      for (const b of BODY_AXES) {
+        expect(axisResidual(frame, r, attitude, b, EARTH_RADIUS)).toBeLessThan(1e-6);
+      }
+    }
+  });
+});
+
+describe("displayPosition", () => {
+  it("applies R_z(-ERA) in the body-fixed frame", () => {
+    // Pins the arika convention ECEF = R_z(−ERA)·ECI: at ERA = 90°,
+    // +X_ECI → −Y_ECEF (arika/src/frame.rs::from_era_90deg).
+    const frame: DisplayFrame = { kind: "bodyFixed", era: Math.PI / 2 };
+    const p = displayPosition(frame, 1, 0, 0, 1);
+    expect(p[0]).toBeCloseTo(0, 12);
+    expect(p[1]).toBeCloseTo(-1, 12);
+    expect(p[2]).toBeCloseTo(0, 12);
+  });
+
+  it("leaves the polar axis untouched in the body-fixed frame", () => {
+    const p = displayPosition({ kind: "bodyFixed", era: 1.234 }, 0, 0, 500, 100);
+    expect(p[0]).toBeCloseTo(0, 12);
+    expect(p[1]).toBeCloseTo(0, 12);
+    expect(p[2]).toBeCloseTo(5, 12);
+  });
+});
+
+describe("displayQuaternion", () => {
+  it("passes the body-to-inertial attitude through unchanged in the inertial frame", () => {
+    // The inertial view is what tests/attitude-rendering.spec.ts pins: scene
+    // axes coincide with ECI, so the delivered quaternion must reach the mesh
+    // untouched.
+    const attitude = quatFromEuler(0.3, -0.5, 1.1);
+    const expected: Quat = [...attitude];
+    expect(displayQuaternion({ kind: "inertial", origin: null }, attitude)).toEqual(expected);
+    expect(displayQuaternion({ kind: "inertial", origin: [1, 2, 3] }, attitude)).toEqual(expected);
+  });
+
+  it("returns undefined when there is no attitude", () => {
+    expect(displayQuaternion({ kind: "bodyFixed", era: 1 }, undefined)).toBeUndefined();
+  });
+
+  it("maps the body axes onto the LVLH scene axes [in-track, cross-track, radial]", () => {
+    // Equatorial orbit at +X: radial = +X, in-track = +Y, cross-track = +Z.
+    // A body aligned with the orbit frame in *RSW* order (body X = radial) must
+    // render along the scene's radial axis, which is +Z — not +X. Using arika's
+    // [R,S,W] quaternion here instead of this basis rotates every axis by a
+    // 120° cyclic permutation.
+    const { r, v } = orbitState(7378, 0, 0);
+    const axes = computeLvlhAxes(r, v);
+    if (axes == null) throw new Error("degenerate orbit");
+    const frame: DisplayFrame = { kind: "localOrbital", origin: r, axes };
+
+    const radialInScene = rotate(displayQuaternion(frame, [1, 0, 0, 0]) as Quat, [1, 0, 0]);
+    expect(radialInScene[0]).toBeCloseTo(0, 12);
+    expect(radialInScene[1]).toBeCloseTo(0, 12);
+    expect(radialInScene[2]).toBeCloseTo(1, 12);
+  });
+
+  it("builds the local-orbital attitude without the arika WASM module", () => {
+    // The LVLH attitude used to come from arika's `body_quat_to_rsw`, which an
+    // embedder's first render reaches before `initArika()` resolves — throwing
+    // "not a function" and taking down the React subtree. Deriving it from the
+    // LVLH basis removes the dependency entirely.
+    expect(isArikaReady(), "this test is only meaningful with the WASM unloaded").toBe(false);
+    const { r, v } = orbitState(7378, 1.1, 0.3);
+    const axes = computeLvlhAxes(r, v);
+    if (axes == null) throw new Error("degenerate orbit");
+    const frame = resolveDisplayFrame(SAT_LVLH_FRAME, { originPosition: r, lvlhAxes: axes });
+    expect(displayQuaternion(frame, quatFromEuler(0.1, 0.2, 0.3))).toBeDefined();
+  });
+
+  it("does not mutate the input quaternion", () => {
+    const { r, v } = orbitState(6900, 0.5, 0.2);
+    const axes = computeLvlhAxes(r, v);
+    if (axes == null) throw new Error("degenerate orbit");
+    const frames: DisplayFrame[] = [
+      { kind: "bodyFixed", era: 0.7 },
+      { kind: "localOrbital", origin: r, axes },
+      { kind: "inertial", origin: null },
+    ];
+    for (const frame of frames) {
+      const attitude: Quat = quatFromEuler(0.2, 0.4, 0.6);
+      const copy: Quat = [...attitude];
+      displayQuaternion(frame, attitude);
+      expect(attitude).toEqual(copy);
+    }
+  });
+});
+
+describe("displayRotation", () => {
+  it("rotates inertial coordinates exactly like displayPosition", () => {
+    const { r, v } = orbitState(7100, 2.2, 0.5);
+    const axes = computeLvlhAxes(r, v);
+    if (axes == null) throw new Error("degenerate orbit");
+    const frames: DisplayFrame[] = [
+      { kind: "bodyFixed", era: 1.9 },
+      { kind: "localOrbital", origin: [0, 0, 0], axes },
+      { kind: "inertial", origin: null },
+    ];
+    for (const frame of frames) {
+      const viaPosition = displayPosition(frame, r[0], r[1], r[2], 1);
+      const viaRotation = new THREE.Vector3(...r).applyQuaternion(displayRotation(frame));
+      expect(viaRotation.x).toBeCloseTo(viaPosition[0], 6);
+      expect(viaRotation.y).toBeCloseTo(viaPosition[1], 6);
+      expect(viaRotation.z).toBeCloseTo(viaPosition[2], 6);
+    }
+  });
+
+  it("writes into the provided output quaternion", () => {
+    const out = new THREE.Quaternion();
+    expect(displayRotation({ kind: "bodyFixed", era: 0.5 }, out)).toBe(out);
+  });
+
+  it("agrees with the sun-direction display transform", () => {
+    // sunDirectionInDisplayFrame rotates a direction into the same display
+    // frame through its own implementation. Pin the two against each other so
+    // the lighting and the geometry cannot drift apart.
+    const { r, v } = orbitState(7200, 3.3, 0.8);
+    const axes = computeLvlhAxes(r, v);
+    if (axes == null) throw new Error("degenerate orbit");
+    const dir: Vec3 = [0.4, -0.7, 0.59];
+    const cases: [DisplayFrame, Vec3][] = [
+      [
+        { kind: "bodyFixed", era: 1.4 },
+        sunDirectionInDisplayFrame(dir, {
+          isEcef: true,
+          era: 1.4,
+          lvlhActive: false,
+          lvlhAxes: null,
+        }),
+      ],
+      [
+        { kind: "localOrbital", origin: [0, 0, 0], axes },
+        sunDirectionInDisplayFrame(dir, {
+          isEcef: false,
+          era: null,
+          lvlhActive: true,
+          lvlhAxes: axes,
+        }),
+      ],
+    ];
+    for (const [frame, expected] of cases) {
+      const got = new THREE.Vector3(...dir).applyQuaternion(displayRotation(frame));
+      expect(got.x).toBeCloseTo(expected[0], 12);
+      expect(got.y).toBeCloseTo(expected[1], 12);
+      expect(got.z).toBeCloseTo(expected[2], 12);
+    }
+  });
+});
+
+describe("resolveDisplayFrame", () => {
+  it("needs an ERA to rotate: an ECEF frame without one stays inertial", () => {
+    // The epoch (hence ERA) can arrive after the first points do; falling back
+    // to inertial keeps position and attitude in one basis either way.
+    expect(resolveDisplayFrame(ECEF_FRAME, {}).kind).toBe("inertial");
+    expect(resolveDisplayFrame(ECEF_FRAME, { era: null }).kind).toBe("inertial");
+  });
+
+  it("ignores an ERA in frames that are not body-fixed", () => {
+    expect(resolveDisplayFrame(ECI_FRAME, { era: 1.2 }).kind).toBe("inertial");
+  });
+
+  it("requires both an origin and axes for the local-orbital frame", () => {
+    const { r, v } = orbitState(7000, 0.4, 0.1);
+    const axes = computeLvlhAxes(r, v);
+    if (axes == null) throw new Error("degenerate orbit");
+    expect(resolveDisplayFrame(SAT_LVLH_FRAME, { lvlhAxes: axes }).kind).toBe("inertial");
+    expect(resolveDisplayFrame(SAT_LVLH_FRAME, { originPosition: r }).kind).toBe("inertial");
+    expect(resolveDisplayFrame(SAT_LVLH_FRAME, { originPosition: r, lvlhAxes: axes }).kind).toBe(
+      "localOrbital",
+    );
+  });
+});
+
+describe("trail transform key", () => {
+  it("requires a rewrite when the ECEF epoch arrives late (null → value)", () => {
+    // A CSV load streams every point before the `info` event that carries the
+    // epoch, so vertices baked in ECI must be re-encoded once it lands.
+    const before = trailTransformKey(ECEF_FRAME, undefined);
+    const after = trailTransformKey(ECEF_FRAME, 2451545.0);
+    expect(before.ecefEpochJd).toBeNull();
+    expect(needsFullRewrite(before, after)).toBe(true);
+    expect(needsFullRewrite(after, before)).toBe(true);
+  });
+
+  it("requires a rewrite when the ECEF epoch changes", () => {
+    expect(
+      needsFullRewrite(
+        trailTransformKey(ECEF_FRAME, 2451545.0),
+        trailTransformKey(ECEF_FRAME, 2460000.5),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not rewrite as time advances with the same frame and epoch", () => {
+    const key = trailTransformKey(ECEF_FRAME, 2451545.0);
+    expect(needsFullRewrite(key, trailTransformKey(ECEF_FRAME, 2451545.0))).toBe(false);
+    expect(needsFullRewrite(key, key)).toBe(false);
+  });
+
+  it("ignores the epoch outside the body-fixed frame (inertial vertices are epoch-free)", () => {
+    expect(
+      needsFullRewrite(
+        trailTransformKey(ECI_FRAME, undefined),
+        trailTransformKey(ECI_FRAME, 2451545.0),
+      ),
+    ).toBe(false);
+  });
+
+  it("requires a rewrite when the frame orientation or centre changes", () => {
+    expect(
+      needsFullRewrite(
+        trailTransformKey(ECI_FRAME, 2451545.0),
+        trailTransformKey(ECEF_FRAME, 2451545.0),
+      ),
+    ).toBe(true);
+    expect(
+      needsFullRewrite(
+        trailTransformKey(
+          { center: { type: "satellite", id: "a" }, orientation: "inertial" },
+          null,
+        ),
+        trailTransformKey(
+          { center: { type: "satellite", id: "b" }, orientation: "inertial" },
+          null,
+        ),
+      ),
+    ).toBe(true);
+  });
+});

--- a/viewer/src/displayFrame.ts
+++ b/viewer/src/displayFrame.ts
@@ -1,0 +1,209 @@
+/**
+ * Display-frame kernel: one definition of how the scene axes relate to the
+ * central-body inertial frame, shared by positions *and* attitudes.
+ *
+ * A display frame is a rotation (inertial → scene axes) plus an origin. Both
+ * halves of a rendered object are derived from the same {@link DisplayFrame}
+ * value here, so a position and the attitude drawn at that position can never
+ * follow different conventions:
+ *
+ * - `inertial` — scene axes are the central-body inertial axes; only the origin
+ *   may be shifted (satellite-centred inertial view).
+ * - `bodyFixed` — scene axes co-rotate with the central body: `R_z(−ERA)`,
+ *   matching `arika`'s `SimpleEci → SimpleEcef` (`ECEF = R_z(−ERA)·ECI`).
+ * - `localOrbital` — scene axes are the centred satellite's orbit frame in the
+ *   viewer's [in-track, cross-track, radial] order, i.e. the basis
+ *   `[Ŝ, Ŵ, R̂]`. Note this is *not* the [R̂, Ŝ, Ŵ] column order of the RSW
+ *   convention used by `arika::rsw_quaternion`; the two differ by a cyclic axis
+ *   permutation (a 120° rotation about (1,1,1)), which is exactly why the
+ *   attitude must be built from this basis and not from an RSW quaternion.
+ */
+
+import * as THREE from "three";
+import { transformToLvlh } from "./coordTransform.js";
+import {
+  type FrameCenter,
+  type FrameOrientation,
+  frameCenterEquals,
+  isLegacyEcef,
+  type ReferenceFrame,
+} from "./referenceFrame.js";
+import type { LvlhAxes } from "./sceneFrame.js";
+
+/** Cartesian triple [x, y, z]. */
+export type Vec3 = [number, number, number];
+
+/** Hamilton scalar-first quaternion [w, x, y, z] — the viewer-wide convention. */
+export type Quat = [number, number, number, number];
+
+/** How the scene axes and origin relate to the central-body inertial frame. */
+export type DisplayFrame =
+  | { kind: "inertial"; origin: Vec3 | null }
+  | { kind: "bodyFixed"; era: number }
+  | { kind: "localOrbital"; origin: Vec3; axes: LvlhAxes };
+
+/** Frame geometry a caller has already resolved for the current sample. */
+export interface DisplayFrameInputs {
+  /**
+   * Earth Rotation Angle [rad] at the sample's own time, or null when unknown.
+   * Required for (and only used by) the body-fixed frame; pass the value from
+   * `earth_rotation_angle(epochJd, t)` so the same angle drives both halves.
+   */
+  era?: number | null;
+  /** ECI position [km] of the frame centre, or null for the central body. */
+  originPosition?: Vec3 | null;
+  /**
+   * Orbit-frame axes of the centred entity, as resolved by `resolveSceneFrame`.
+   * Non-null means the local-orbital transform is active — that decision belongs
+   * to the frame-resolution kernel and is not re-derived here.
+   */
+  lvlhAxes?: LvlhAxes | null;
+}
+
+/**
+ * Resolve the display frame for one sample. The branch order matches the
+ * frame semantics: a body-fixed central-body view rotates, a satellite-centred
+ * local-orbital view re-bases, anything else only shifts the origin.
+ */
+export function resolveDisplayFrame(
+  referenceFrame: ReferenceFrame,
+  { era = null, originPosition = null, lvlhAxes = null }: DisplayFrameInputs,
+): DisplayFrame {
+  if (isLegacyEcef(referenceFrame) && era != null) {
+    return { kind: "bodyFixed", era };
+  }
+  if (originPosition != null && lvlhAxes != null) {
+    return { kind: "localOrbital", origin: originPosition, axes: lvlhAxes };
+  }
+  return { kind: "inertial", origin: originPosition };
+}
+
+/**
+ * Express an inertial position [km] in the display frame, scaled to scene units.
+ */
+export function displayPosition(
+  frame: DisplayFrame,
+  x: number,
+  y: number,
+  z: number,
+  scaleRadius: number,
+): Vec3 {
+  const invScale = 1 / scaleRadius;
+  switch (frame.kind) {
+    case "bodyFixed": {
+      // ECEF = R_z(−ERA) · ECI (arika: Rotation<SimpleEci, SimpleEcef>::from_era)
+      const c = Math.cos(frame.era);
+      const s = Math.sin(frame.era);
+      return [(c * x + s * y) * invScale, (-s * x + c * y) * invScale, z * invScale];
+    }
+    case "localOrbital":
+      return transformToLvlh(x, y, z, frame.origin, frame.axes, scaleRadius);
+    case "inertial": {
+      const o = frame.origin;
+      if (o == null) return [x * invScale, y * invScale, z * invScale];
+      return [(x - o[0]) * invScale, (y - o[1]) * invScale, (z - o[2]) * invScale];
+    }
+  }
+}
+
+// Scratch objects: the display rotation is recomputed for every satellite on
+// every rendered frame, and none of them escapes (callers get a fresh
+// quaternion or a fresh tuple), so reusing them keeps the intermediates off the
+// per-frame allocation path.
+const scratchBasis = new THREE.Matrix4();
+const scratchAxisA = new THREE.Vector3();
+const scratchAxisB = new THREE.Vector3();
+const scratchAxisC = new THREE.Vector3();
+const scratchRotation = new THREE.Quaternion();
+const scratchAttitude = new THREE.Quaternion();
+
+/**
+ * Rotation taking inertial vector components to display-frame components.
+ *
+ * Writes into `out` when given (avoiding an allocation) and returns it.
+ * Applying this to a position is equivalent to {@link displayPosition} with a
+ * null origin.
+ */
+export function displayRotation(frame: DisplayFrame, out?: THREE.Quaternion): THREE.Quaternion {
+  const q = out ?? new THREE.Quaternion();
+  switch (frame.kind) {
+    case "bodyFixed":
+      // R_z(−ERA), the rotation displayPosition applies to the coordinates.
+      return q.setFromAxisAngle(scratchAxisA.set(0, 0, 1), -frame.era);
+    case "localOrbital": {
+      const { inTrack, crossTrack, radial } = frame.axes;
+      // Basis columns [in-track, cross-track, radial] map scene → inertial, so
+      // its conjugate maps inertial → scene, exactly as the dot products in
+      // transformToLvlh do for positions.
+      scratchBasis.makeBasis(
+        scratchAxisA.set(...inTrack),
+        scratchAxisB.set(...crossTrack),
+        scratchAxisC.set(...radial),
+      );
+      return q.setFromRotationMatrix(scratchBasis).conjugate();
+    }
+    case "inertial":
+      return q.identity();
+  }
+}
+
+/**
+ * Express a body-to-inertial attitude quaternion in the display frame.
+ *
+ * `q_display = R_inertial→display ⊗ q_body→inertial`, with the rotation taken
+ * from the same {@link DisplayFrame} the position uses. Returns undefined for an
+ * undefined input so callers can pass an optional attitude straight through.
+ *
+ * The inertial frame returns the input array itself — the scene axes are the
+ * inertial axes, and keeping the reference lets React skip re-applying an
+ * unchanged quaternion. Never mutates the input.
+ */
+export function displayQuaternion(
+  frame: DisplayFrame,
+  bodyToInertial: Quat | undefined,
+): Quat | undefined {
+  if (bodyToInertial == null) return undefined;
+  if (frame.kind === "inertial") return bodyToInertial;
+  const [w, x, y, z] = bodyToInertial;
+  const q = displayRotation(frame, scratchRotation).multiply(scratchAttitude.set(x, y, z, w));
+  return [q.w, q.x, q.y, q.z];
+}
+
+/**
+ * Identity of the transform a trail's vertices were *baked* with.
+ *
+ * The trail stores encoded vertices, so a change here invalidates everything
+ * already written — unlike the origin/rotation uniforms, which are per-frame.
+ */
+export interface TrailTransformKey {
+  orientation: FrameOrientation;
+  center: FrameCenter;
+  /**
+   * Epoch the ECEF encoding was baked with, or null when the vertices are in
+   * inertial axes. Carrying the epoch (not just a boolean) also catches an
+   * epoch that arrives late or changes — a CSV load streams its points before
+   * the `info` event that reveals the epoch.
+   */
+  ecefEpochJd: number | null;
+}
+
+/** Resolve the trail transform key for the current frame + epoch. */
+export function trailTransformKey(
+  referenceFrame: ReferenceFrame,
+  epochJd: number | null | undefined,
+): TrailTransformKey {
+  return {
+    orientation: referenceFrame.orientation,
+    center: referenceFrame.center,
+    ecefEpochJd: isLegacyEcef(referenceFrame) && epochJd != null ? epochJd : null,
+  };
+}
+
+/** Whether the baked vertices must be re-encoded because the transform changed. */
+export function needsFullRewrite(prev: TrailTransformKey, next: TrailTransformKey): boolean {
+  return (
+    prev.orientation !== next.orientation ||
+    !frameCenterEquals(prev.center, next.center) ||
+    prev.ecefEpochJd !== next.ecefEpochJd
+  );
+}

--- a/viewer/src/wasm/arikaInit.ts
+++ b/viewer/src/wasm/arikaInit.ts
@@ -12,18 +12,6 @@ type SunDirectionFromBody = (body: string, epoch_jd: number, t: number) => Float
 type SunDistanceFromBody = (body: string, epoch_jd: number, t: number) => number;
 type JdToUtcString = (epoch_jd: number, t: number) => string;
 type BodyOrientation = (body: string, epoch_jd: number, t: number) => Float64Array;
-type BodyQuatToRsw = (
-  pos_x: number,
-  pos_y: number,
-  pos_z: number,
-  vel_x: number,
-  vel_y: number,
-  vel_z: number,
-  qw: number,
-  qx: number,
-  qy: number,
-  qz: number,
-) => Float64Array;
 
 let initialized = false;
 let initPromise: Promise<void> | undefined;
@@ -35,7 +23,6 @@ let wasmSunDirFromBody: SunDirectionFromBody | undefined;
 let wasmSunDistFromBody: SunDistanceFromBody | undefined;
 let wasmJdToUtc: JdToUtcString | undefined;
 let wasmBodyOrientation: BodyOrientation | undefined;
-let wasmBodyQuatToRsw: BodyQuatToRsw | undefined;
 
 /** Options for {@link initArika}. */
 export interface InitArikaOptions {
@@ -70,7 +57,6 @@ export function initArika(options?: InitArikaOptions): Promise<void> {
     wasmSunDistFromBody = mod.sun_distance_from_body;
     wasmJdToUtc = mod.jd_to_utc_string;
     wasmBodyOrientation = mod.body_orientation;
-    wasmBodyQuatToRsw = mod.body_quat_to_rsw;
     initialized = true;
   });
   initPromise = p;
@@ -138,30 +124,6 @@ export function body_orientation(
   t: number,
 ): [number, number, number, number] | undefined {
   const result = wasmBodyOrientation!(body, epoch_jd, t);
-  if (result.length === 0) return undefined;
-  return [result[0], result[1], result[2], result[3]];
-}
-
-/**
- * Transform body-to-ECI quaternion to body-to-RSW frame via WASM.
- *
- * RSW axis order: [Radial, Along-track, Cross-track] (standard Vallado).
- *
- * Returns [w, x, y, z] (Hamilton scalar-first) or undefined if degenerate.
- */
-export function body_quat_to_rsw(
-  pos_x: number,
-  pos_y: number,
-  pos_z: number,
-  vel_x: number,
-  vel_y: number,
-  vel_z: number,
-  qw: number,
-  qx: number,
-  qy: number,
-  qz: number,
-): [number, number, number, number] | undefined {
-  const result = wasmBodyQuatToRsw!(pos_x, pos_y, pos_z, vel_x, vel_y, vel_z, qw, qx, qy, qz);
   if (result.length === 0) return undefined;
   return [result[0], result[1], result[2], result[3]];
 }

--- a/viewer/tests/attitude-rendering.spec.ts
+++ b/viewer/tests/attitude-rendering.spec.ts
@@ -27,6 +27,10 @@
  * Zero angular velocity keeps the attitude ≈ constant over the short window: from
  * rest the gravity-gradient torque produces only sub-degree drift before the seek
  * time, far inside the tolerance below.
+ *
+ * A second test switches to the satellite-centred local-orbital (LVLH) view,
+ * where the scene axes are the orbit frame rather than ECI, and asserts the
+ * matching invariant there.
  */
 import { type ChildProcess, spawn } from "node:child_process";
 import fs from "node:fs";
@@ -191,6 +195,86 @@ test("rendered satellite adopts the delivered body-to-inertial attitude", async 
   ).toBeGreaterThan(0.9);
   expect(Math.abs(bodyXinWorld[0]), "body +X should have no scene-X component").toBeLessThan(0.1);
   expect(Math.abs(bodyXinWorld[2]), "body +X should have no scene-Z component").toBeLessThan(0.1);
+});
+
+test("LVLH view renders the attitude in the same basis as the positions", async ({ page }) => {
+  // The LVLH scene basis is [in-track, cross-track, radial] = scene [X, Y, Z]
+  // (coordTransform.ts), so the attitude must be expressed in that basis too.
+  // The orbit is equatorial (inclination defaults to 0), hence its normal — the
+  // cross-track axis — is inertial +Z. The satellite's attitude is a rotation
+  // *about* inertial Z, so it leaves the body +Z axis on inertial +Z: the
+  // rendered body +Z must point along scene +Y, at every orbital phase and for
+  // any Earth rotation angle.
+  //
+  // Deriving the attitude from an RSW-ordered ([radial, along-track,
+  // cross-track]) quaternion instead puts body +Z on scene +Z — the axes are
+  // cyclically permuted, which looks like a plausible attitude.
+  //
+  // Its own server, deliberately: this satellite's minimum-inertia axis (Izz)
+  // points along the orbit normal, which is a gravity-gradient *unstable*
+  // equilibrium, so the attitude only stays near its initial value for the
+  // first minutes of a run (measured: body +Z had swung ~78° off inertial Z by
+  // the time the shared server had served the test above). The inertial test
+  // relies on the same freshness implicitly; here it is explicit.
+  const { child, port } = await spawnServer(configPath);
+  const freshWsUrl = `ws://localhost:${port}/ws`;
+  try {
+    await page.goto("/?noAutoConnect=1");
+    await page.locator('[data-testid="ws-url-input"]').fill(freshWsUrl);
+    await page.locator('[data-testid="ws-connect-btn"]').click();
+    await expect(page.locator('[data-testid="ws-status-text"]')).toContainText("Connected", {
+      timeout: 15000,
+    });
+    await expect(page.locator("canvas").first()).toBeVisible();
+    await page.waitForFunction(
+      () =>
+        typeof (window as unknown as Record<string, unknown>).__debug_get_sat_world_quat ===
+        "function",
+      { timeout: 15000 },
+    );
+
+    // Deterministic state: pause playback so the captured frame is stable.
+    const playPause = page.locator('[data-testid="play-pause-btn"]');
+    if ((await playPause.textContent())?.includes("Pause")) {
+      await playPause.click();
+    }
+
+    // Centre on the satellite → the frame selector switches to LVLH.
+    await page
+      .locator('[data-testid="frame-selector-select"]')
+      .selectOption(`satellite:${SAT_ENTITY_PATH}`);
+
+    // Poll: the LVLH transform only activates once the scene has both a position
+    // and a velocity for the centred satellite, and the first frame after the
+    // switch can still be composited from the previous frame's basis.
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate((id) => {
+            const w = window as unknown as Record<string, unknown>;
+            const scene = w.__debug_scene_frame as { lvlhActive?: boolean } | undefined;
+            if (!scene?.lvlhActive) return null;
+            const get = w.__debug_get_sat_world_quat as
+              | ((id: string) => [number, number, number, number] | null)
+              | undefined;
+            const q = get?.(id);
+            if (!q) return null;
+            const [qx, qy, qz, qw] = q; // Three.js order (x, y, z, w)
+            // Scene-Y component of the rendered body +Z axis (third column of R).
+            return 2 * (qy * qz - qx * qw);
+          }, SAT_ENTITY_PATH),
+        {
+          timeout: 20000,
+          message:
+            "rendered body +Z should point along the LVLH cross-track axis (scene +Y). " +
+            "A value near 0 means the attitude is expressed in RSW axis order while the " +
+            "scene uses [in-track, cross-track, radial].",
+        },
+      )
+      .toBeGreaterThan(0.9);
+  } finally {
+    child.kill("SIGTERM");
+  }
 });
 
 test("marker shape: global default persists to URL and per-satellite override is offered", async ({


### PR DESCRIPTION
viewer が衛星を描画するとき、その位置と、その位置に描く姿勢クォータニオンが別々の経路で作られていた。同じ表示フレームの中で位置と姿勢が違う規約に従っていたため、姿勢の表示が黙って誤る。位置と姿勢を一つのフレーム値から導出するように直した。表示専用の修正で、出力されるデータや保存される数値は変わらない。

## 背景

`viewer/src/components/Satellite.tsx` は位置をフレームごとに変換していたが、姿勢は別経路で作っていた。

1. **local-orbital (LVLH) ビューの軸順序が 120° ずれる**
   位置は `[in-track, cross-track, radial]` 基底（`coordTransform.ts` の `transformToLvlh`、scene の X/Y/Z）に射影されるのに、姿勢は arika WASM の `body_quat_to_rsw` から来ていた。arika の RSW は `[radial, along-track, cross-track]` 列順（`arika/src/lib.rs` の `rsw_quaternion`）で、両者は (1,1,1) 軸まわり 120° の巡回置換ぶん違う。実測すると body 軸の向きが最大 1.7ε ずれる（ε は軸長）―― つまり軸が 120° 別方向を指す。位置と trail は正しいので絵として破綻せず、「もっともらしい姿勢」に見える。

2. **body-fixed (ECEF) ビューで姿勢だけ慣性系に残る**
   位置は `R_z(-ERA)` で回すが、姿勢は body→ECI のまま描かれていた。ECEF ビューでは地球メッシュを静止させる（`earthRotation = isEcef ? 0 : era`）ので、姿勢の誤差は ERA(t) そのもの ―― 約 15°/h で増え、一周して 360° まで達する。静止した地球に対する誤差なので目で気づけない。

3. **LVLH の初回描画で未初期化 WASM を呼ぶ**
   `body_quat_to_rsw` の呼び出しは WASM の準備状態を見ていなかった。`OrbitScene` は `initArika()` を effect で開始するため、最初の render は必ずモジュール未読み込みで到達する。satellite-centred + local_orbital + attitude ありの embedder は `TypeError` で React subtree ごと落ちる。orts アプリ本体は `App.tsx` が読み込み完了まで `null` を返すので影響を受けない。

4. **trail の全書き換えキーに epoch が入っていない**
   `OrbitTrail` は ECEF/ECI のどちらで頂点を焼くかを `epochJd != null` で決めるのに、無効化キーには frame の centre/orientation しか入っていなかった。CSV 読み込みは全チャンクを流し終えてから epoch を載せた `info` を出すので、ECEF を選んだ状態でファイルを読むと trail 全体が ECI で焼かれたまま残り、マーカーだけが ECEF 位置に移る。

## 変更内容

`viewer/src/displayFrame.ts` を追加した。「scene の軸が中心天体慣性系とどう関係するか」を一つの `DisplayFrame` 値（`inertial` / `bodyFixed` / `localOrbital`）で表し、位置 (`displayPosition`)・姿勢 (`displayQuaternion`)・方向ベクトル用の回転 (`displayRotation`)・trail の焼き付けキー (`trailTransformKey` / `needsFullRewrite`) をすべてそこから導出する。位置と姿勢が別の規約を持つ状態が構造的に作れなくなる。

- `Satellite` と `SecondaryBody`（Moon 等）、LVLH ビューの中心天体の向き、`OrbitTrail` をこのカーネル経由にした。
- ECEF の姿勢は `earth_rotation_angle` から取った ERA で `R_z(-ERA)` を前から掛ける。位置も同じ ERA から f64 で回すので、両者が同じ角度を使うことが構造で保証される。副作用として、マーカー位置が f32 の `eci_to_ecef` WASM 呼び出しを経由しなくなり精度が上がる（trail の batch 経路は f32 のまま。両者の差は LEO で 0.5 m 程度、scene 単位で 8e-8）。
- LVLH の姿勢は LVLH 基底から TS で組むので WASM を触らない。これで 3 が消える。`body_quat_to_rsw` の TS バインディングは呼び出し元が無くなったので削除した（Rust 側の `arika::body_quat_to_rsw` は残す）。
- trail のキーに「頂点を焼いたときの ECEF epoch」を持たせ、焼き付け分岐・per-frame uniform・無効化判定をすべて同じキーから引く。null→値、値の変更で全書き換えが走り、時刻の進行では走らない。
- `SecondaryBody` は ECEF では ERA 回転を掛けていたが LVLH では掛けていなかった（コメントには「ECEF, LVLH の両方で位置と同じ回転が必要」と書かれていた）。カーネル経由にしたので LVLH ビューでも Moon の IAU 向きが正しく回る。

## テスト

`viewer/src/displayFrame.test.ts`（21 件）。中心は位置経路と姿勢経路の cross-path 不変量で、外部データに依存しない。

body 単位軸 `b`、微小量 ε について、`r + ε·(M_body→ECI·b)` を**位置経路**で変換した点と、`scenePos + (ε/scale)·R(displayQuaternion)·b` が一致すること（`displayPosition` はオフセットについてアフィンなので、正しいフレームなら浮動小数点誤差まで一致する）。LVLH は 4 つの軌道位相 × 3 つの傾斜角、ECEF は ERA = 0 / 90° / 2.4 / -1.1 rad で回す。

修正を戻すと落ちることを実測で確認した:

| 戻した内容 | 落ちるテスト |
| --- | --- |
| LVLH 基底を RSW 列順 `[R,S,W]` に | 3 件（相対誤差 1e-10 → 5e-1〜1.7） |
| ECEF の姿勢回転を恒等に | 2 件 |
| trail キーから epoch を外す | 2 件 |

不変量は符号対称（位置と姿勢の両方の ERA 符号を反転しても通る）なので、`ECEF = R_z(-ERA)·ECI` を ERA = 90° で `+X_ECI → -Y_ECEF` として明示的に固定するテストを別に置いた（`arika/src/frame.rs` の `from_era_90deg` と対応）。あわせて、同じ表示回転を独自実装している `sunDirectionInDisplayFrame` とカーネルが一致することも固定した。

E2E は `viewer/tests/attitude-rendering.spec.ts` に LVLH ビューの 1 件を追加した。赤道円軌道 + 慣性 Z 軸まわり 90° の姿勢では body +Z が慣性 +Z（= cross-track）に残るので、描画された body +Z は軌道位相と ERA に関係なく scene +Y を向く。RSW 順だと scene +Z を向くので落ちる（実測 0.9 超 → -0.0004）。

この衛星は最小慣性主軸 (Izz) が軌道法線を向いており重力傾斜的に不安定な平衡なので、姿勢が初期値の近くにあるのは run の最初の数分だけ（共有サーバーが先行テストを処理し終えた時点では body +Z が慣性 Z から約 78° 振れていた）。そのため専用の `orts serve` を立てて実行する。既存の慣性系テストも暗黙に同じ前提に依っている。

`viewer/registry.json` は `displayFrame.ts` が public library の import closure に入ったので再生成した。

### 実行結果

- `pnpm --filter orts-viewer test`: 39 files / 455 passed
- `npx tsc --noEmit`: エラーなし
- `pnpm lint`: エラーなし（既存の warning のみ）
- Playwright: `attitude-rendering.spec.ts`（3 件）、`lvlh-orientation.spec.ts`（1 件）、`csv-file-load.spec.ts`（1 件）すべて green。シーンの規約を pin している既存 2 件（LVLH の地球極 = scene +Y、慣性系の姿勢）は期待値のまま通る。

## 対象外

- `OrbitTrail` の ECEF 頂点は `eci_to_ecef_batch`（f32 の位置・時刻）を通り続ける。f32 の入力型は WASM 側の API 変更を伴うため別途。
- `earth_rotation_angle` は render 中に呼ぶので、ECEF フレームの embedder が `initArika()` 解決前に epoch 付きで描画すると依然 throw する。`OrbitScene` が WASM 準備完了まで epoch を渡さない契約で守られており、置き換えた `eci_to_ecef` 呼び出しと同じ露出範囲。
- 中心天体と太陽方向は最初の衛星のタイムスタンプ由来の scene 全体の `era` を使い続ける（マーカーは各サンプルの `position.t`）。衛星ごとにサンプル時刻が違うと両者の ERA がずれるが、これは既存の別課題。
