### PR TITLE
perf(orts): depend on rerun's subcrates instead of the umbrella

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,20 +4,11 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli 0.32.3",
-]
-
-[[package]]
-name = "addr2line"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
- "gimli 0.33.0",
+ "gimli",
 ]
 
 [[package]]
@@ -387,24 +378,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,21 +538,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line 0.25.1",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object 0.37.3",
- "rustc-demangle",
- "windows-link",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,7 +549,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
 
 [[package]]
@@ -599,15 +557,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bit-vec"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -625,12 +574,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitstream-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,7 +589,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
- "regex-automata",
  "serde_core",
 ]
 
@@ -696,15 +638,6 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
-
-[[package]]
-name = "bytestring"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
-dependencies = [
- "bytes",
-]
 
 [[package]]
 name = "camino"
@@ -896,12 +829,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,12 +849,6 @@ dependencies = [
  "num-traits",
  "windows-link",
 ]
-
-[[package]]
-name = "chunked_transfer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "ciborium"
@@ -1057,39 +978,6 @@ dependencies = [
  "crossterm",
  "unicode-segmentation",
  "unicode-width",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
-dependencies = [
- "encode_unicode",
- "libc",
- "unicode-width",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1239,7 +1127,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli 0.33.0",
+ "gimli",
  "hashbrown 0.16.1",
  "libm",
  "log",
@@ -1369,15 +1257,6 @@ checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools 0.13.0",
-]
-
-[[package]]
-name = "cros-codecs"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f7441b4f31c17b6b6b7f57f6c202944aad11d0ab23739a9ff88d8d34dec621"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -1521,28 +1400,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
-]
-
-[[package]]
-name = "directories"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1575,29 +1432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "econtext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18aade80d5e09429040243ce1143ddc08a92d7a22820ac512610410a4dd5214f"
-
-[[package]]
-name = "ehttp"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f1b93eb2e039aaff63ce07cca59bd1dca02f2ce30075a17b619d2c42f56efc"
-dependencies = [
- "async-channel",
- "document-features",
- "js-sys",
- "serde",
- "serde_json",
- "ureq",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,12 +1454,6 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1653,26 +1481,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "5.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
-dependencies = [
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,15 +1501,6 @@ dependencies = [
  "cfg-if",
  "rustix 1.1.4",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
 ]
 
 [[package]]
@@ -1775,12 +1574,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "four-cc"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795cbfc56d419a7ce47ccbb7504dd9a5b7c484c083c356e797de08bd988d9629"
 
 [[package]]
 name = "fs-set-times"
@@ -1898,10 +1691,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1929,12 +1720,6 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gimli"
@@ -2023,19 +1808,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h264-reader"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "036a78b2620d92f0ec57690bc792b3bb87348632ee5225302ba2e66a48021c6c"
-dependencies = [
- "bitstream-io",
- "hex-slice",
- "log",
- "memchr",
- "rfc6381-codec",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,21 +1856,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hex-slice"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5491a308e0214554f07a81d8944abe45f552871c12e3c3c6e7e5d354039a6c4c"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "http"
@@ -2403,17 +2160,10 @@ dependencies = [
  "byteorder-lite",
  "moxcms",
  "num-traits",
- "png",
  "tiff",
  "zune-core",
  "zune-jpeg",
 ]
-
-[[package]]
-name = "indent"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f1a0777d972970f204fdf8ef319f1f4f8459131636d7e3c96c5d59570d0fa6"
 
 [[package]]
 name = "indexmap"
@@ -2425,19 +2175,6 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
-dependencies = [
- "console 0.16.3",
- "portable-atomic",
- "unicode-width",
- "unit-prefix",
- "web-time",
 ]
 
 [[package]]
@@ -2620,21 +2357,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "10.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
-dependencies = [
- "base64",
- "getrandom 0.2.17",
- "js-sys",
- "serde",
- "serde_json",
- "signature",
- "zeroize",
-]
-
-[[package]]
 name = "kble-socket"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2760,15 +2482,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libredox"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2888,16 +2601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memory-stats"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c73f5c649995a115e1a0220b35e4df0a1294500477f97a91d0660fb5abeb574a"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2955,21 +2658,6 @@ dependencies = [
  "num-traits",
  "pxfm",
 ]
-
-[[package]]
-name = "mp4ra-rust"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbc3d3867085d66ac6270482e66f3dd2c5a18451a3dc9ad7269e94844a536b7"
-dependencies = [
- "four-cc",
-]
-
-[[package]]
-name = "mpeg4-audio-const"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a1fe2275b68991faded2c80aa4a33dba398b77d276038b8f50701a22e55918"
 
 [[package]]
 name = "nalgebra"
@@ -3062,15 +2750,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,7 +2806,6 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -3138,34 +2816,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
-name = "objc2-io-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
-dependencies = [
- "libc",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3219,12 +2869,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "orts"
 version = "0.2.0"
 dependencies = [
@@ -3235,7 +2879,11 @@ dependencies = [
  "proptest",
  "rand 0.10.2",
  "rand_distr",
- "rerun",
+ "re_chunk",
+ "re_log_encoding",
+ "re_log_types",
+ "re_sdk",
+ "re_sdk_types",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
@@ -3302,12 +2950,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3329,12 +2971,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peg"
@@ -3496,29 +3132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "png"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
-dependencies = [
- "bitflags 2.13.0",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
-name = "poll-promise"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6a58fecbf9da8965bcdb20ce4fd29788d1acee68ddbb64f0ba1b81bccdb7df"
-dependencies = [
- "document-features",
- "static_assertions",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3611,7 +3224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec 0.8.0",
+ "bit-vec",
  "bitflags 2.13.0",
  "num-traits",
  "rand 0.9.4",
@@ -3853,28 +3466,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "re_analytics"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a83e8c9f7cd79abe0fa6327398dba73829d2cf6ead10f218227325f420180a"
-dependencies = [
- "crossbeam",
- "directories",
- "ehttp",
- "jiff",
- "re_build_info",
- "re_log",
- "re_quota_channel",
- "serde",
- "serde_json",
- "sha2",
- "thiserror 2.0.20",
- "url",
- "uuid",
- "web-sys",
-]
-
-[[package]]
 name = "re_arrow_util"
 version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3890,58 +3481,6 @@ dependencies = [
  "re_tuid",
  "serde_json",
  "thiserror 2.0.20",
-]
-
-[[package]]
-name = "re_auth"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2550766042f37b875c1b66da84196e159d7f530aefe0d62f798e6d5c3448201c"
-dependencies = [
- "async-trait",
- "base64",
- "directories",
- "ehttp",
- "getrandom 0.2.17",
- "getrandom 0.3.4",
- "hmac",
- "http 1.4.2",
- "jiff",
- "js-sys",
- "jsonwebtoken",
- "parking_lot",
- "rand 0.9.4",
- "re_analytics",
- "re_log",
- "ring",
- "saturating_cast",
- "serde",
- "serde_json",
- "sha2",
- "signature",
- "thiserror 2.0.20",
- "tiny_http",
- "tokio",
- "tonic",
- "tower 0.5.3",
- "url",
- "uuid",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "re_backoff"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d79d7ae5e3364f41f849216203ba50393b5bc80f8d45038325042f2e3740460"
-dependencies = [
- "getrandom 0.3.4",
- "js-sys",
- "rand 0.9.4",
- "tokio",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -3983,17 +3522,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "re_capabilities"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410125b882b72ab8c9adcdfd29f25e631afdaa93c620f0bebcd43384578c72a"
-dependencies = [
- "document-features",
- "re_log",
- "static_assertions",
-]
-
-[[package]]
 name = "re_case"
 version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4031,73 +3559,6 @@ dependencies = [
  "re_tuid",
  "re_types_core",
  "thiserror 2.0.20",
-]
-
-[[package]]
-name = "re_chunk_store"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd3b9244f5e0df06a5c32f48ba89bf5f4ea0202b45116b22415b03f9d079b92"
-dependencies = [
- "ahash",
- "anyhow",
- "arrow",
- "document-features",
- "indent",
- "itertools 0.14.0",
- "nohash-hasher",
- "parking_lot",
- "re_arrow_util",
- "re_byte_size",
- "re_chunk",
- "re_format",
- "re_log",
- "re_log_encoding",
- "re_log_types",
- "re_sdk_types",
- "re_sorbet",
- "re_tracing",
- "re_types_core",
- "saturating_cast",
- "thiserror 2.0.20",
- "web-time",
-]
-
-[[package]]
-name = "re_entity_db"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf32dc4d5b7bfd28dc7a3a91c1c68970f16d8aa8cc21fb0341fec70927162672"
-dependencies = [
- "ahash",
- "arrow",
- "document-features",
- "emath",
- "indexmap",
- "itertools 0.14.0",
- "nohash-hasher",
- "poll-promise",
- "re_arrow_util",
- "re_byte_size",
- "re_chunk",
- "re_chunk_store",
- "re_format",
- "re_log",
- "re_log_channel",
- "re_log_encoding",
- "re_log_types",
- "re_mutex",
- "re_query",
- "re_sorbet",
- "re_tracing",
- "re_types_core",
- "re_uri",
- "serde",
- "static_assertions",
- "tap",
- "thiserror 2.0.20",
- "vec1",
- "web-time",
 ]
 
 [[package]]
@@ -4201,9 +3662,7 @@ dependencies = [
  "log-once",
  "parking_lot",
  "tracing",
- "tracing-log",
  "tracing-subscriber",
- "tracing-web",
 ]
 
 [[package]]
@@ -4296,56 +3755,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "re_memory"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4347d9e2eff4ae463b691c29db388f425974b42035b5b30be4f1336af28b79ae"
-dependencies = [
- "ahash",
- "backtrace",
- "crossbeam",
- "itertools 0.14.0",
- "memory-stats",
- "nohash-hasher",
- "parking_lot",
- "re_format",
- "re_log",
- "re_quota_channel",
- "re_tracing",
- "saturating_cast",
- "serde",
- "smallvec",
- "sysinfo",
- "wasm-bindgen",
- "web-time",
-]
-
-[[package]]
-name = "re_mp4"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fda65f84bc3fc10f07d2969f2146376d791406dddc357ac42f0bba4dbd33a2"
-dependencies = [
- "byteorder",
- "bytes",
- "num-rational",
- "serde",
- "serde_json",
- "thiserror 2.0.20",
-]
-
-[[package]]
-name = "re_mutex"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22c47635699c73c956359cb04e7c7ad48e9c9d73cc2bc24a9347662a21019d3d"
-dependencies = [
- "cfg-if",
- "parking_lot",
- "re_log",
-]
-
-[[package]]
 name = "re_protos"
 version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4379,33 +3788,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "re_query"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21db9bef92c1f2afb831704b790745e8a7e4c9430fd7c04bac14ac20138b08b3"
-dependencies = [
- "ahash",
- "anyhow",
- "arrow",
- "indent",
- "itertools 0.14.0",
- "nohash-hasher",
- "parking_lot",
- "paste",
- "re_byte_size",
- "re_chunk",
- "re_chunk_store",
- "re_error",
- "re_format",
- "re_log",
- "re_log_types",
- "re_tracing",
- "re_types_core",
- "seq-macro",
- "thiserror 2.0.20",
-]
-
-[[package]]
 name = "re_quota_channel"
 version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4416,45 +3798,6 @@ dependencies = [
  "re_byte_size",
  "re_format",
  "re_log",
-]
-
-[[package]]
-name = "re_redap_client"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8689ccd034f0eb82758a866e30de80d7faabc4504b3decea76bd2609c036323e"
-dependencies = [
- "ahash",
- "arrow",
- "ehttp",
- "futures",
- "itertools 0.14.0",
- "jiff",
- "opentelemetry",
- "re_arrow_util",
- "re_auth",
- "re_backoff",
- "re_byte_size",
- "re_chunk",
- "re_error",
- "re_format",
- "re_log",
- "re_log_channel",
- "re_log_encoding",
- "re_log_types",
- "re_protos",
- "re_tracing",
- "re_uri",
- "serde",
- "thiserror 2.0.20",
- "tokio",
- "tokio-stream",
- "tonic",
- "tonic-web-wasm-client",
- "tower 0.5.3",
- "tracing",
- "url",
- "web-time",
 ]
 
 [[package]]
@@ -4650,61 +3993,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "re_video"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f09754e175f1d009d2638a7b750390895d2c25ea68b02045adc73775b6a5213"
-dependencies = [
- "ahash",
- "bit-vec 0.9.1",
- "bytemuck",
- "cfg_aliases",
- "cros-codecs",
- "econtext",
- "getrandom 0.3.4",
- "h264-reader",
- "image",
- "itertools 0.14.0",
- "js-sys",
- "poll-promise",
- "re_byte_size",
- "re_log",
- "re_mp4",
- "re_mutex",
- "re_quota_channel",
- "re_rvl",
- "re_span",
- "re_tracing",
- "re_tuid",
- "saturating_cast",
- "scuffle-av1",
- "scuffle-bytes-util",
- "smallvec",
- "thiserror 2.0.20",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "web-time",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4749,63 +4043,6 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
-
-[[package]]
-name = "rerun"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffb78e3c31e4aef67d0c8b2a92dc8957b6f7fe0a0ced2878c2f5f228ad2c772"
-dependencies = [
- "ahash",
- "anyhow",
- "arrow",
- "camino",
- "cfg-if",
- "crossbeam",
- "document-features",
- "indexmap",
- "indicatif",
- "itertools 0.14.0",
- "parking_lot",
- "puffin",
- "rayon",
- "re_arrow_util",
- "re_build_info",
- "re_build_tools",
- "re_byte_size",
- "re_capabilities",
- "re_chunk",
- "re_entity_db",
- "re_error",
- "re_format",
- "re_log",
- "re_log_channel",
- "re_log_encoding",
- "re_log_types",
- "re_memory",
- "re_protos",
- "re_quota_channel",
- "re_redap_client",
- "re_sdk",
- "re_sdk_types",
- "re_sorbet",
- "re_tracing",
- "re_uri",
- "re_video",
- "similar-asserts",
- "tokio",
- "walkdir",
-]
-
-[[package]]
-name = "rfc6381-codec"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed54c20f5c3ec82eab6d998b313dc75ec5d5650d4f57675e61d72489040297fd"
-dependencies = [
- "mp4ra-rust",
- "mpeg4-audio-const",
-]
 
 [[package]]
 name = "ring"
@@ -5045,12 +4282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "saturating_cast"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc4972f129a0ea378b69fa7c186d63255606e362ad00795f00b869dea5265eb"
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5064,36 +4295,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "scuffle-av1"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028eddc8b17fe9dba817b238c56d3acf03748bdbed4c35783cfb93857ef15955"
-dependencies = [
- "byteorder",
- "bytes",
- "scuffle-bytes-util",
- "scuffle-workspace-hack",
-]
-
-[[package]]
-name = "scuffle-bytes-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0417748c2a42f4a08d4e634b68b1d64f22a8c24bef2e7ac93df33aa61202a45b"
-dependencies = [
- "byteorder",
- "bytes",
- "bytestring",
- "scuffle-workspace-hack",
-]
-
-[[package]]
-name = "scuffle-workspace-hack"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8028ded836a0d9fabdfa4d713389b76a2098b5153f50a135c8faed7e3a3d5ae2"
 
 [[package]]
 name = "security-framework"
@@ -5127,12 +4328,6 @@ dependencies = [
  "serde",
  "serde_core",
 ]
-
-[[package]]
-name = "seq-macro"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -5281,15 +4476,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "simba"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5312,26 +4498,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-dependencies = [
- "bstr",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "similar-asserts"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
-dependencies = [
- "console 0.15.11",
- "similar",
-]
 
 [[package]]
 name = "siphasher"
@@ -5469,20 +4635,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows",
-]
-
-[[package]]
 name = "system-interface"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5497,12 +4649,6 @@ dependencies = [
  "windows-sys 0.59.0",
  "winx",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -5608,18 +4754,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
-]
-
-[[package]]
-name = "tiny_http"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
-dependencies = [
- "ascii",
- "chunked_transfer",
- "httpdate",
- "log",
 ]
 
 [[package]]
@@ -5985,19 +5119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-web"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e6a141feebd51f8d91ebfd785af50fca223c570b86852166caa3b141defe7c"
-dependencies = [
- "js-sys",
- "tracing-core",
- "tracing-subscriber",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6141,12 +5262,6 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
-
-[[package]]
-name = "unit-prefix"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -6476,7 +5591,7 @@ version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d807f646bfecc1dbb4990d8c864beebccbdb3f2cd1b39b2b82957b4e294c6058"
 dependencies = [
- "addr2line 0.26.1",
+ "addr2line",
  "async-trait",
  "bitflags 2.13.0",
  "bumpalo",
@@ -6487,7 +5602,7 @@ dependencies = [
  "log",
  "mach2",
  "memfd",
- "object 0.39.1",
+ "object",
  "once_cell",
  "postcard",
  "pulley-interpreter",
@@ -6524,11 +5639,11 @@ dependencies = [
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
- "gimli 0.33.0",
+ "gimli",
  "hashbrown 0.16.1",
  "indexmap",
  "log",
- "object 0.39.1",
+ "object",
  "postcard",
  "rustc-demangle",
  "semver",
@@ -6589,10 +5704,10 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
- "gimli 0.33.0",
+ "gimli",
  "itertools 0.14.0",
  "log",
- "object 0.39.1",
+ "object",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
@@ -6650,7 +5765,7 @@ dependencies = [
  "cfg-if",
  "cranelift-codegen",
  "log",
- "object 0.39.1",
+ "object",
  "wasmtime-environ",
 ]
 
@@ -6672,9 +5787,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55481651bea5b8336fb200fa49914ccf802f5e7617ba9ab0b4691f16d4f97ff8"
 dependencies = [
  "cranelift-codegen",
- "gimli 0.33.0",
+ "gimli",
  "log",
- "object 0.39.1",
+ "object",
  "target-lexicon",
  "wasmparser 0.246.2",
  "wasmtime-environ",
@@ -6852,7 +5967,7 @@ checksum = "436a7fa4109b13b0e555d01ec615ab8b928b7834639aca7b2fdc1f55d70a1f0c"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
- "gimli 0.33.0",
+ "gimli",
  "regalloc2",
  "smallvec",
  "target-lexicon",
@@ -6861,27 +5976,6 @@ dependencies = [
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
-]
-
-[[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
-dependencies = [
- "windows-core",
 ]
 
 [[package]]
@@ -6895,17 +5989,6 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
 ]
 
 [[package]]
@@ -6935,16 +6018,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core",
- "windows-link",
-]
 
 [[package]]
 name = "windows-result"
@@ -7029,15 +6102,6 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]
@@ -7341,20 +6405,6 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,15 +1423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ecolor"
-version = "0.34.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05fbfa222ffb51989d5ccf33e5f7aebfcf96c5023413856b0c3618a7f79896e"
-dependencies = [
- "emath",
-]
-
-[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3854,7 +3845,6 @@ dependencies = [
  "arrow",
  "bytemuck",
  "document-features",
- "ecolor",
  "emath",
  "half",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,15 @@ axum = { version = "0.8", features = ["ws"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 futures-util = "0.3"
-rerun = { version = "0.33", default-features = false, features = ["sdk"] }
+# rerun subcrates instead of the `rerun` umbrella: the umbrella re-exports
+# re_entity_db / re_capabilities with no #[cfg], so even features = ["sdk"]
+# drags in re_query, re_chunk_store, re_video, image, re_analytics...
+# Same approach rrd-wasm already takes.
+re_sdk = "0.33"
+re_sdk_types = "0.33"
+re_log_encoding = { version = "0.33", features = ["encoder", "decoder"] }
+re_chunk = "0.33"
+re_log_types = "0.33"
 ureq = "3"
 image = { version = "0.25", default-features = false, features = ["jpeg", "tiff"] }
 toml = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,14 @@ futures-util = "0.3"
 # drags in re_query, re_chunk_store, re_video, image, re_analytics...
 # Same approach rrd-wasm already takes.
 re_sdk = "0.33"
-re_sdk_types = "0.33"
+# `default-features = false` drops re_sdk_types' default `ecolor` feature (and
+# with it ecolor + emath). It is the only one of these five with a non-empty
+# default, and `re_sdk` itself depends on it this way, so this matches what the
+# umbrella resolved to. orts uses only Scalars / Points3D / TextDocument /
+# Scalar / Text, none of which need a colour type.
+re_sdk_types = { version = "0.33", default-features = false }
+# `decoder` is orts' own requirement (DecoderApp); `encoder` comes from re_sdk
+# anyway but is named here because save_as_rrd depends on it directly.
 re_log_encoding = { version = "0.33", features = ["encoder", "decoder"] }
 re_chunk = "0.33"
 re_log_types = "0.33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,15 @@ futures-util = "0.3"
 # drags in re_query, re_chunk_store, re_video, image, re_analytics...
 # Same approach rrd-wasm already takes.
 re_sdk = "0.33"
-# `default-features = false` drops re_sdk_types' default `ecolor` feature (and
-# with it ecolor + emath). It is the only one of these five with a non-empty
-# default, and `re_sdk` itself depends on it this way, so this matches what the
-# umbrella resolved to. orts uses only Scalars / Points3D / TextDocument /
-# Scalar / Text, none of which need a colour type.
+# `default-features = false` drops re_sdk_types' default `ecolor` feature, and
+# with it the ecolor crate. `emath` stays either way — re_sdk_types depends on
+# it unconditionally. re_sdk_types is the only one of these five with a
+# non-empty default, and `re_sdk` itself depends on it this way, so this is what
+# the umbrella already resolved to. orts uses only Scalars / Points3D /
+# TextDocument / Scalar / Text, none of which need a colour type.
+#
+# rrd-wasm opts out too. Features unify per build, so one member leaving the
+# default on would pull ecolor back into every `--workspace` build.
 re_sdk_types = { version = "0.33", default-features = false }
 # `decoder` is orts' own requirement (DecoderApp); `encoder` comes from re_sdk
 # anyway but is named here because save_as_rrd depends on it directly.

--- a/orts/Cargo.toml
+++ b/orts/Cargo.toml
@@ -23,7 +23,11 @@ include = [
 
 [dependencies]
 nalgebra.workspace = true
-rerun.workspace = true
+re_sdk.workspace = true
+re_sdk_types.workspace = true
+re_log_encoding.workspace = true
+re_chunk.workspace = true
+re_log_types.workspace = true
 arika.workspace = true
 utsuroi.workspace = true
 tobari.workspace = true

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -19,7 +19,7 @@ pub fn save_as_rrd(
     app_id: &str,
     path: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let rec = rerun::RecordingStreamBuilder::new(app_id).save(path)?;
+    let rec = re_sdk::RecordingStreamBuilder::new(app_id).save(path)?;
 
     for entity_path in recording.entity_paths() {
         let store = recording.entity(entity_path).unwrap();
@@ -30,7 +30,10 @@ pub fn save_as_rrd(
             let fields = recording.lookup_component_fields(comp_name);
             for (k, field) in fields.iter().enumerate() {
                 if let Some(&val) = scalars.get(k) {
-                    rec.log_static(format!("{rr_path}/{field}"), &rerun::Scalars::new([val]))?;
+                    rec.log_static(
+                        format!("{rr_path}/{field}"),
+                        &re_sdk_types::archetypes::Scalars::new([val]),
+                    )?;
                 }
             }
         }
@@ -62,7 +65,10 @@ pub fn save_as_rrd(
                         let fields = recording.lookup_component_fields(comp_name);
                         for (k, field) in fields.iter().enumerate() {
                             if let Some(&val) = row.get(k) {
-                                rec.log(format!("{rr_path}/{field}"), &rerun::Scalars::new([val]))?;
+                                rec.log(
+                                    format!("{rr_path}/{field}"),
+                                    &re_sdk_types::archetypes::Scalars::new([val]),
+                                )?;
                             }
                         }
                     }
@@ -77,7 +83,7 @@ pub fn save_as_rrd(
                 {
                     rec.log(
                         rr_path.clone(),
-                        &rerun::Points3D::new([[pos[0], pos[1], pos[2]]]),
+                        &re_sdk_types::archetypes::Points3D::new([[pos[0], pos[1], pos[2]]]),
                     )?;
                 }
             }
@@ -119,7 +125,7 @@ pub fn save_as_rrd(
             let schema_json = serde_json::to_string(&schema_entries).unwrap();
             rec.log_static(
                 format!("meta/schema/{rr_path}"),
-                &rerun::TextDocument::new(schema_json),
+                &re_sdk_types::archetypes::TextDocument::new(schema_json),
             )?;
         }
     }
@@ -127,36 +133,48 @@ pub fn save_as_rrd(
     // Log simulation metadata as static data under meta/sim/
     let meta = &recording.metadata;
     if let Some(epoch_jd) = meta.epoch_jd {
-        rec.log_static("meta/sim/epoch_jd", &rerun::Scalars::new([epoch_jd]))?;
+        rec.log_static(
+            "meta/sim/epoch_jd",
+            &re_sdk_types::archetypes::Scalars::new([epoch_jd]),
+        )?;
     }
     if let Some(mu) = meta.mu {
-        rec.log_static("meta/sim/mu", &rerun::Scalars::new([mu]))?;
+        rec.log_static("meta/sim/mu", &re_sdk_types::archetypes::Scalars::new([mu]))?;
     }
     if let Some(body_radius) = meta.body_radius {
-        rec.log_static("meta/sim/body_radius", &rerun::Scalars::new([body_radius]))?;
+        rec.log_static(
+            "meta/sim/body_radius",
+            &re_sdk_types::archetypes::Scalars::new([body_radius]),
+        )?;
     }
     if let Some(altitude) = meta.altitude {
-        rec.log_static("meta/sim/altitude", &rerun::Scalars::new([altitude]))?;
+        rec.log_static(
+            "meta/sim/altitude",
+            &re_sdk_types::archetypes::Scalars::new([altitude]),
+        )?;
     }
     if let Some(period) = meta.period {
-        rec.log_static("meta/sim/period", &rerun::Scalars::new([period]))?;
+        rec.log_static(
+            "meta/sim/period",
+            &re_sdk_types::archetypes::Scalars::new([period]),
+        )?;
     }
     if let Some(ref name) = meta.body_name {
         rec.log_static(
             "meta/sim/body_name",
-            &rerun::TextDocument::new(name.as_str()),
+            &re_sdk_types::archetypes::TextDocument::new(name.as_str()),
         )?;
     }
     if let Some(ref iso) = meta.epoch_iso {
         rec.log_static(
             "meta/sim/epoch_iso",
-            &rerun::TextDocument::new(iso.as_str()),
+            &re_sdk_types::archetypes::TextDocument::new(iso.as_str()),
         )?;
     }
     if let Some(ref desc) = meta.orbit_description {
         rec.log_static(
             "meta/sim/orbit_description",
-            &rerun::TextDocument::new(desc.as_str()),
+            &re_sdk_types::archetypes::TextDocument::new(desc.as_str()),
         )?;
     }
 
@@ -191,9 +209,9 @@ pub struct RrdData {
 
 /// Load orbital data and metadata from an .rrd file.
 pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> {
-    use rerun::external::re_log_encoding::DecoderApp;
-    use rerun::external::re_log_types::LogMsg;
-    use rerun::log::Chunk;
+    use re_chunk::Chunk;
+    use re_log_encoding::DecoderApp;
+    use re_log_types::LogMsg;
 
     let file = std::fs::File::open(path)?;
     let reader = std::io::BufReader::new(file);
@@ -224,8 +242,8 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
                 let comp_name = comp_id.as_str();
                 if comp_name.contains("Scalar") || comp_name.contains("scalars") {
                     for row_idx in 0..n {
-                        let batch =
-                            chunk.component_batch::<rerun::components::Scalar>(comp_id, row_idx);
+                        let batch = chunk
+                            .component_batch::<re_sdk_types::components::Scalar>(comp_id, row_idx);
                         if let Some(Ok(scalar_vec)) = batch
                             && let Some(s) = scalar_vec.first()
                         {
@@ -235,8 +253,8 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
                 }
                 if comp_name.contains("Text") || comp_name.contains("text") {
                     for row_idx in 0..n {
-                        let batch =
-                            chunk.component_batch::<rerun::components::Text>(comp_id, row_idx);
+                        let batch = chunk
+                            .component_batch::<re_sdk_types::components::Text>(comp_id, row_idx);
                         if let Some(Ok(text_vec)) = batch
                             && let Some(t) = text_vec.first()
                         {
@@ -263,7 +281,7 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
             if comp_name.contains("Scalar") || comp_name.contains("scalars") {
                 for (row_idx, &t) in times.iter().enumerate() {
                     let batch =
-                        chunk.component_batch::<rerun::components::Scalar>(comp_id, row_idx);
+                        chunk.component_batch::<re_sdk_types::components::Scalar>(comp_id, row_idx);
                     if let Some(Ok(scalar_vec)) = batch {
                         for s in scalar_vec {
                             scalars
@@ -376,9 +394,9 @@ pub fn load_from_rrd(path: &str) -> Result<Vec<RrdRow>, Box<dyn std::error::Erro
 /// This enables `orts convert` to produce the same CSV output as `orts run`.
 pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Error>> {
     use crate::record::recording::ComponentColumn;
-    use rerun::external::re_log_encoding::DecoderApp;
-    use rerun::external::re_log_types::LogMsg;
-    use rerun::log::Chunk;
+    use re_chunk::Chunk;
+    use re_log_encoding::DecoderApp;
+    use re_log_types::LogMsg;
     use std::borrow::Cow;
     use std::collections::BTreeSet;
 
@@ -407,8 +425,8 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
                 let comp_name = comp_id.as_str();
                 if comp_name.contains("Scalar") || comp_name.contains("scalars") {
                     for row_idx in 0..n {
-                        let batch =
-                            chunk.component_batch::<rerun::components::Scalar>(comp_id, row_idx);
+                        let batch = chunk
+                            .component_batch::<re_sdk_types::components::Scalar>(comp_id, row_idx);
                         if let Some(Ok(scalar_vec)) = batch
                             && let Some(s) = scalar_vec.first()
                         {
@@ -418,8 +436,8 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
                 }
                 if comp_name.contains("Text") || comp_name.contains("text") {
                     for row_idx in 0..n {
-                        let batch =
-                            chunk.component_batch::<rerun::components::Text>(comp_id, row_idx);
+                        let batch = chunk
+                            .component_batch::<re_sdk_types::components::Text>(comp_id, row_idx);
                         if let Some(Ok(text_vec)) = batch
                             && let Some(t) = text_vec.first()
                         {
@@ -446,7 +464,7 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
             if comp_name.contains("Scalar") || comp_name.contains("scalars") {
                 for (row_idx, &t) in times.iter().enumerate() {
                     let batch =
-                        chunk.component_batch::<rerun::components::Scalar>(comp_id, row_idx);
+                        chunk.component_batch::<re_sdk_types::components::Scalar>(comp_id, row_idx);
                     if let Some(Ok(scalar_vec)) = batch {
                         for s in scalar_vec {
                             scalars

--- a/rrd-wasm/Cargo.toml
+++ b/rrd-wasm/Cargo.toml
@@ -19,7 +19,11 @@ crate-type = ["cdylib", "rlib"]
 re_log_encoding = { version = "0.33", features = ["decoder"] }
 re_chunk = "0.33"
 re_log_types = "0.33"
-re_sdk_types = "0.33"
+# `default-features = false` drops the default `ecolor` feature. This crate
+# decodes scalars and text and never touches a colour type. It matters beyond
+# this crate: features unify per build, so leaving it on here would pull ecolor
+# back into every `--workspace` build even though `orts` opts out.
+re_sdk_types = { version = "0.33", default-features = false }
 # Required for wasm32 target (getrandom needs js feature for browser)
 getrandom = { version = "0.3", features = ["wasm_js"] }
 


### PR DESCRIPTION
## 何を解決するか

`orts` のビルドが重い。バグ修正ではなく依存グラフの削減で、振る舞いは変えない。

`rerun` umbrella crate は `default-features = false, features = ["sdk"]` まで絞っても
不要な依存を大量に引く。原因は `rerun/src/lib.rs` にある `#[cfg]` の付いていない
再エクスポート 2 行である。

```rust
pub use re_capabilities::MainThreadToken;
pub use re_entity_db::external::re_chunk_store::{ ... };
```

この 2 行のために `re_entity_db`、`re_query`、`re_chunk_store` が必ず入り、
そこから `re_video`、`re_mp4`、`image`、`png`、`tiff`、`re_analytics`、`re_auth`、
`indicatif` が連鎖する。
**cargo feature ではこれを削れない。**

`orts` が実際に使うのは .rrd の書き込み（`RecordingStreamBuilder` と archetype 3 つ）と
読み込み（`DecoderApp`、`Chunk`、`LogMsg`、component 型 2 つ）だけなので、
該当する subcrate を直接参照する。
`rrd-wasm` が既に同じことをしている（"Minimal rerun subcrate dependencies for decoding only
— no rerun umbrella"）。

## 効果（実測）

| 指標 | before | after |
|---|---|---|
| `orts` の依存 crate 数 | 355 | **271** |
| `orts-cli` の依存 crate 数 | 460 | **398** |
| `cargo test -p orts` の依存 crate 数 | 382 | **303** |
| `Cargo.lock` | — | **−988 行** |

## 振る舞いを変えていない根拠

- 変更は `rerun_export.rs` の import path 9 箇所のみ。`save_as_rrd` のロジックは触っていない
- 公開シグネチャは 1 つも変わらない。もともと `rerun` の型を公開 API に露出していなかった
- **`record::rerun_export` の .rrd round-trip テスト 8 本が全て pass**。これが wire 互換性を固定している
- `cargo clippy --locked -p orts -- -D warnings` pass、`cargo fmt --all -- --check` pass
- `cargo check -p orts --all-targets` はエラーゼロ（apollo11 の警告 2 件は main から変わらず既存）

## codex review で 1 件修正

`re_sdk_types` を直接参照すると default feature の `ecolor` が有効になってしまう。
umbrella 経由では `re_sdk` が `re_sdk_types` を `default-features = false` で参照していたため
入っていなかった。`default-features = false` を明示してパリティを回復した（272 → 271 crates）。

5 つの subcrate のうち非空の default を持つのは `re_sdk_types` だけで、
他の 4 つは `default = []` なので明示していない。
`emath` は `re_sdk_types` の非 optional 依存なので残る（umbrella でも入っていた）。

## opt-in 化（#314）との関係

**独立していて、効く範囲が重ならない。**

- この PR は **.rrd を書くビルド**（`orts-cli`、`--workspace`）に効く。460 → 398 crates
- #314 の opt-in feature は **.rrd を書かないビルド**（`-p orts` 系の CI 2 ジョブ）に効く。382 → 94 crates

feature が off なら umbrella か subcrate かは無関係になるので、両方入れると
`cargo test -p orts` = 94、`orts-cli` = 398 になる。
どちらも他方を置き換えない。

こちらは非破壊なので、#314 の default-on / off の判断を待たずにマージできる。
先に入った方に合わせて、もう一方の数値（PR 本文、DESIGN.md、#316）を rebase する必要がある。

関連: #316（ビルド時間の tracking issue、項目 4）、#311（.rrd を native format として使い続けるかの判断）
