### PR TITLE
chore(skills): codex skill のモデル指定を環境デフォルトに委譲し、code-review-gpt に rename する

### DIFF
--- a/.claude/skills/code-review-gpt/SKILL.md
+++ b/.claude/skills/code-review-gpt/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: code-review
+name: code-review-gpt
 description: |
-  Run an external AI code review to get independent feedback on code changes.
+  Run an external AI code review (Codex) to get independent feedback on code changes.
   Use this skill when the user asks for a code review, says "コードレビューして", "レビュー", "変更を見て",
   "code review", or wants external feedback on their recent commits or uncommitted changes.
 ---
 
-# code-review: External AI Code Reviewer
+# code-review-gpt: External AI Code Reviewer
 
 Codex CLI (`codex review`) を使って、コード変更に対する独立したレビューを得る。
 diff の取得は codex が自動で行う。

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -15,18 +15,18 @@ diff の取得は codex が自動で行う。
 
 ```bash
 # 未コミットの変更をレビュー
-codex review -c model=gpt-5.5 --uncommitted
+codex review --uncommitted
 
 # 特定ブランチとの差分をレビュー
-codex review -c model=gpt-5.5 --base main
+codex review --base main
 
 # 特定コミットをレビュー
-codex review -c model=gpt-5.5 --commit <SHA>
+codex review --commit <SHA>
 ```
 
 カスタムプロンプトで追加のレビュー指示を渡すこともできる（対象指定なしの自由プロンプトモード）:
 ```bash
-codex review -c model=gpt-5.5 "TDD-first の方針に沿っているかも確認してください"
+codex review "TDD-first の方針に沿っているかも確認してください"
 ```
 
 **制約: `[PROMPT]` と対象指定オプション (`--uncommitted`/`--base`/`--commit`) は排他。同時に使うとエラーになる。**
@@ -50,6 +50,5 @@ Codex の回答を鵜呑みにせず、自分の視点も持った上で建設�
 
 ## 注意事項
 
-- モデル指定は `-m` ではなく `-c model=gpt-5.5` を使う（`codex review` の制約）
+- モデルは環境デフォルト (`~/.codex/config.toml` の `model`) を使う。明示指定する場合は `-c model=<model>` (`codex review` に `-m` は無い)
 - codex の実行には時間がかかることがある。Bash の timeout は 300000 (5分) を設定する
-- ユーザーが別のモデルを指定した場合はそれに従う

--- a/.claude/skills/smart-friend/SKILL.md
+++ b/.claude/skills/smart-friend/SKILL.md
@@ -14,12 +14,12 @@ Claude 単独では得られない「別の視点」を提供することが目�
 ## 使い方
 
 ```bash
-codex exec --sandbox read-only -m gpt-5.5 "<prompt>"
+codex exec --sandbox read-only "<prompt>"
 ```
 
 プロンプトが長い場合や `$` やバッククォートを含む場合は、heredoc で stdin から渡す:
 ```bash
-cat <<'EOF' | codex exec --sandbox read-only -m gpt-5.5 -
+cat <<'EOF' | codex exec --sandbox read-only -
 <prompt>
 EOF
 ```
@@ -65,4 +65,4 @@ Codex のレビュー結果を受けて、状況に応じた対応を取る:
 
 - 必ず `--sandbox read-only` を付けてファイル変更を防ぐ
 - codex の実行には時間がかかることがある。Bash の timeout は 300000 (5分) を設定する
-- ユーザーが別のモデルを指定した場合はそれに従う
+- モデルは環境デフォルト (`~/.codex/config.toml` の `model`) を使う


### PR DESCRIPTION
## 概要

smart-friend / code-review skill (Codex CLI ベース) の 2 つの整理。

### モデル指定の除去

ハードコードされていたモデル指定 (`-m gpt-5.5` / `-c model=gpt-5.5`) を除去し、環境デフォルト (`~/.codex/config.toml` の `model`) に委譲する。
チェックインされるファイルにモデル名を書くと腐る (gpt-5.4 → 5.5 → 5.6-sol の変遷が実例)。

`codex review` には `-m` フラグが存在しない (明示指定は `-c model=<model>` のみ) という実在の制約は、code-review 側に 1 行残している。

### code-review → code-review-gpt に rename

Claude Code が official の `code-review` skill を同梱するようになり、skill listing 上で名前が衝突していたため rename。CLAUDE.md 側の参照更新は #324 に含まれる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)