### PR TITLE
fix: orts run が姿勢設定を捨てる問題と、入口ごとに異なる config 検証を揃える

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,6 +602,9 @@ jobs:
           cargo test --locked -p orts-cli --test serve_stream_bridge_e2e
           cargo test --locked -p orts-cli --test serve_kble_e2e
           cargo test --locked -p orts-cli --test serve_kble_stdio_e2e
+          # The README quick-start and controller-config tests need the guest
+          # WASM; under `rust-test`, which does not build it, they soft-skip.
+          cargo test --locked -p orts-cli --test run_mode_e2e
 
   # Build CLI with embedded viewer SPA in release profile.
   # Runs on main push (smoke test) AND tag push (release job consumes

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -127,6 +127,23 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   追加を拒否する。`sensors` / `reaction_wheels` / `magnetorquers` / `thruster`
   が controller なしで宣言された場合は stderr と `orts run --json` の
   `warnings` に警告を出す。([#335](https://github.com/sksat/orts/pull/335))
+- config 単体から「ダイナミクスを構築できない・開始できない」と分かる姿勢設定を、
+  config を読むすべての経路で拒否するようになった。`orts config validate` も含む (従来は valid と報告した
+  設定を `run` と `serve` が拒否していた)。検査は `AttitudeConfig` に置き、
+  範囲チェックだけでは通ってしまうものを塞いだ: `NaN` はあらゆる比較が false に
+  なるので `NaN` の質量が `mass <= 0.0` をすり抜けていた。慣性テンソルは
+  「ダイナミクスが取る逆行列が存在し `I·I⁻¹ ≈ E` を満たすか」で判定する。
+  行列式の大きさによる閾値ではこれを判定できず、条件数 1 の `[1e-11; 3]` を拒否し、
+  逆行列が有限のゼロ行列になって(あらゆるトルクに角加速度ゼロで応える)
+  `[1e154; 3]` を受理していた。torque-free な t=0 の角加速度が有限で
+  あることを要求する。軌道を必要とするもの (シミュレーションが実際に
+  始める微分に含まれる gravity-gradient torque) は判定の範囲外で、そちらは最初の
+  ステップで run を止める。`orts run` はモード分岐の前にこの検査を適用する (controlled 経路は
+  別の場所で衛星を構築するため検査を通っていなかった)。([#335](https://github.com/sksat/orts/pull/335))
+- 単位四元数でない `initial_quaternion` を、積分の前に正規化するようになった。
+  したがって t=0 の出力に出るのも正規化後の値になる。config は元から非ゼロの
+  四元数を受理していたが、生の値を積分すると大きな四元数がノルムが overflow する
+  まで成長していた。([#335](https://github.com/sksat/orts/pull/335))
 - `config` テーブルのない `[satellites.controller]` が、guest 自身の既定値で
   起動するようになった。省略時は文字列 `"null"` が guest に渡り、`init` が
   失敗していた。([#335](https://github.com/sksat/orts/pull/335))
@@ -212,6 +229,13 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 #### Added
 - `IntegrationError` が `core::error::Error` を実装 (手書き、`thiserror` 不使用、
   `no_std` でも動作)。`?` 連鎖や `Box<dyn Error>` に乗るようになった。([#147](https://github.com/sksat/orts/pull/147))
+
+#### Fixed
+- `Integrator::try_integrate` が、結果が非有限になった最初のステップで
+  `IntegrationError::NonFiniteState` を返して停止するようになった
+  (`integrate_with_events` が既に行っていた検査)。従来は `NaN` 状態のまま
+  span 全体を回して `Ok` を返していたため、`orts serve` の制御ループが
+  その状態からセンサを読み、plugin controller に渡し、成功を報告していた。([#335](https://github.com/sksat/orts/pull/335))
 
 ### `tobari` (Rust, crates.io)
 

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -108,6 +108,28 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - `--config` ファイルで起動した `orts serve` は `[[command]]` タイムラインを
   含む config を明確なエラーで拒否する (コマンドタイムラインは `orts run`
   のみ)。従来は黙って破棄していた。([#58](https://github.com/sksat/orts/pull/58))
+- `orts run` が `[satellites.attitude]` を honor する。全衛星に姿勢設定がある
+  fleet は `orts serve` と同じ spacecraft dynamics (姿勢状態 + coupled gravity
+  gradient) で伝播され、CSV に四元数と機体系角速度の列が増える。従来は全衛星が
+  controller を持たない限り軌道だけを伝播し、姿勢・アクチュエータ・センサ設定を
+  警告なしに捨てていた (README のクイックスタート設定もその一つ)。モード判定
+  (orbit-only / spacecraft / controlled) は `orts run`、`ServeEngine::build`、
+  serve の WebSocket config 検証が共有する 1 箇所に集約したので、同じ config が
+  エントリポイントによって姿勢を伝播したりしなかったりすることはなくなった。
+  ([#335](https://github.com/sksat/orts/pull/335))
+- 実行モードが act できない設定は黙って捨てず報告する: `orts run` は配送先の
+  controller がない `[[command]]` タイムラインと、宣言された stream-io の
+  `streams` (run のループには pump する transport がない) を拒否する。両
+  エントリポイントは controller 設定の混在を拒否する (制御ループは fleet 全体を
+  回すか全く回さないかなので、混在させると controller が回らない)。WebSocket の
+  `start_simulation` も `orts serve --config` と同じ `[[command]]` 拒否を適用
+  する。実行中の orbit-only シミュレーションへの `controller` 付き衛星の動的
+  追加を拒否する。`sensors` / `reaction_wheels` / `magnetorquers` / `thruster`
+  が controller なしで宣言された場合は stderr と `orts run --json` の
+  `warnings` に警告を出す。([#335](https://github.com/sksat/orts/pull/335))
+- README のクイックスタート設定がパースできるようになった。
+  `[satellites.reaction_wheels]` に必須の `max_momentum` が欠けていた。
+  ([#335](https://github.com/sksat/orts/pull/335))
 
 ### `orts-plugin-sdk` (Rust, crates.io)
 

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -127,8 +127,12 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   追加を拒否する。`sensors` / `reaction_wheels` / `magnetorquers` / `thruster`
   が controller なしで宣言された場合は stderr と `orts run --json` の
   `warnings` に警告を出す。([#335](https://github.com/sksat/orts/pull/335))
-- README のクイックスタート設定がパースできるようになった。
-  `[satellites.reaction_wheels]` に必須の `max_momentum` が欠けていた。
+- `config` テーブルのない `[satellites.controller]` が、guest 自身の既定値で
+  起動するようになった。省略時は文字列 `"null"` が guest に渡り、`init` が
+  失敗していた。([#335](https://github.com/sksat/orts/pull/335))
+- README のクイックスタート設定が、書かれたとおりパースでき動くようになった。
+  `pd-rw-control` example plugin で RW を駆動する構成にし、
+  `[satellites.reaction_wheels]` に必須の `max_momentum` が欠けていたのを補った。
   ([#335](https://github.com/sksat/orts/pull/335))
 
 ### `orts-plugin-sdk` (Rust, crates.io)

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -130,10 +130,10 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - `config` テーブルのない `[satellites.controller]` が、guest 自身の既定値で
   起動するようになった。省略時は文字列 `"null"` が guest に渡り、`init` が
   失敗していた。([#335](https://github.com/sksat/orts/pull/335))
-- README のクイックスタート設定が、書かれたとおりパースでき動くようになった。
-  `pd-rw-control` example plugin で RW を駆動する構成にし、
-  `[satellites.reaction_wheels]` に必須の `max_momentum` が欠けていたのを補った。
-  ([#335](https://github.com/sksat/orts/pull/335))
+- README のクイックスタート設定が、書かれたとおり動くようになった。
+  `pd-rw-control` example plugin で RW を駆動する構成にした。従来は `sensors` と
+  `[satellites.reaction_wheels]` を controller なしで宣言しており、
+  それらを command するものが無かった。([#335](https://github.com/sksat/orts/pull/335))
 
 ### `orts-plugin-sdk` (Rust, crates.io)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,7 +137,11 @@ section is subdivided by package.
   a `controller` to a running orbit-only simulation is rejected; and `sensors` /
   `reaction_wheels` / `magnetorquers` / `thruster` declared without a controller
   warn on stderr and in `orts run --json`'s `warnings`. ([#335](https://github.com/sksat/orts/pull/335))
-- The README quick-start config parses: `[satellites.reaction_wheels]` was
+- A `[satellites.controller]` with no `config` table starts the guest on its own
+  defaults. The omitted table reached the guest as the string `"null"`, which
+  failed its `init`. ([#335](https://github.com/sksat/orts/pull/335))
+- The README quick-start config parses and runs as shown: it drives the wheels
+  with the `pd-rw-control` example plugin, and `[satellites.reaction_wheels]` was
   missing the required `max_momentum`. ([#335](https://github.com/sksat/orts/pull/335))
 
 ### `orts-plugin-sdk` (Rust, crates.io)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,26 @@ section is subdivided by package.
   a `controller` to a running orbit-only simulation is rejected; and `sensors` /
   `reaction_wheels` / `magnetorquers` / `thruster` declared without a controller
   warn on stderr and in `orts run --json`'s `warnings`. ([#335](https://github.com/sksat/orts/pull/335))
+- The attitude configs a config alone shows the dynamics cannot be built from or
+  started are rejected wherever a config is read — `orts config validate` included, which reported one
+  as valid that `run` and `serve` then refused. The checks live on
+  `AttitudeConfig` and cover what range checks alone let through: a `NaN` passes
+  every comparison, so a `NaN` mass slipped past `mass <= 0.0`; the inertia
+  tensor is judged by whether the inverse the dynamics take exists and satisfies
+  `I·I⁻¹ ≈ E`, which a magnitude threshold on the determinant cannot decide (it
+  rejected a perfectly conditioned `[1e-11; 3]` and accepted `[1e154; 3]`, whose
+  inverse comes back as a finite matrix of zeros that answers every torque with
+  no angular acceleration); and the torque-free angular acceleration at `t = 0`
+  has to be finite. What needs the orbit — the gravity-gradient torque
+  in the derivative the simulation actually starts from — is out of its reach and
+  stops the run at the first step instead. `orts run` also applies the check
+  before dispatching to any mode — the
+  controlled path built its satellites elsewhere and skipped
+  it. ([#335](https://github.com/sksat/orts/pull/335))
+- An `initial_quaternion` that is not a unit quaternion is normalized before it
+  is integrated, so it is also the normalized one that appears in the `t = 0`
+  output. The config has always accepted any non-zero quaternion; integrating
+  the raw one let a large one grow until its norm overflowed. ([#335](https://github.com/sksat/orts/pull/335))
 - A `[satellites.controller]` with no `config` table starts the guest on its own
   defaults. The omitted table reached the guest as the string `"null"`, which
   failed its `init`. ([#335](https://github.com/sksat/orts/pull/335))
@@ -228,6 +248,14 @@ section is subdivided by package.
 - `IntegrationError` now implements `core::error::Error` (by hand, no
   `thiserror`, works under `no_std`), so it participates in `?` chains and
   `Box<dyn Error>`. ([#147](https://github.com/sksat/orts/pull/147))
+
+#### Fixed
+- `Integrator::try_integrate` stops with `IntegrationError::NonFiniteState` at
+  the first step whose result is not finite, the check
+  `integrate_with_events` already made. It ran the whole span on a `NaN` state
+  and returned `Ok`, so `orts serve`'s controlled loop read sensors off that
+  state, handed it to a plugin controller, and reported
+  success. ([#335](https://github.com/sksat/orts/pull/335))
 
 ### `tobari` (Rust, crates.io)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,28 @@ section is subdivided by package.
 - `orts serve` started with a `--config` file now rejects a `[[command]]`
   timeline with a clear error (command timelines run only under `orts run`)
   instead of silently dropping it. ([#58](https://github.com/sksat/orts/pull/58))
+- `orts run` honors `[satellites.attitude]`: a fleet with attitude on every
+  satellite is propagated with the spacecraft dynamics `orts serve` uses
+  (attitude state + coupled gravity gradient), and the CSV gains the quaternion
+  and body-frame angular-velocity columns. Previously `run` propagated the orbit
+  only unless every satellite had a controller, discarding attitude, actuator
+  and sensor config without a warning — the README quick-start config among
+  them. The mode rule (orbit-only / spacecraft / controlled) now lives in one
+  place shared by `orts run`, `ServeEngine::build` and serve's WebSocket config
+  validation, so the same config cannot get attitude dynamics under one entry
+  point and not the other. ([#335](https://github.com/sksat/orts/pull/335))
+- Config that the running mode cannot act on is reported instead of dropped:
+  `orts run` rejects a `[[command]]` timeline with no controller to deliver to
+  and rejects declared stream-io `streams` (the run loop has no transport to
+  pump them); both entry points reject a fleet that mixes controller config (the
+  control loop steps the whole fleet or none of it, so those controllers would
+  never run); a WebSocket `start_simulation` now applies the same
+  `[[command]]` rejection as `orts serve --config`; adding a satellite carrying
+  a `controller` to a running orbit-only simulation is rejected; and `sensors` /
+  `reaction_wheels` / `magnetorquers` / `thruster` declared without a controller
+  warn on stderr and in `orts run --json`'s `warnings`. ([#335](https://github.com/sksat/orts/pull/335))
+- The README quick-start config parses: `[satellites.reaction_wheels]` was
+  missing the required `max_momentum`. ([#335](https://github.com/sksat/orts/pull/335))
 
 ### `orts-plugin-sdk` (Rust, crates.io)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,9 +140,10 @@ section is subdivided by package.
 - A `[satellites.controller]` with no `config` table starts the guest on its own
   defaults. The omitted table reached the guest as the string `"null"`, which
   failed its `init`. ([#335](https://github.com/sksat/orts/pull/335))
-- The README quick-start config parses and runs as shown: it drives the wheels
-  with the `pd-rw-control` example plugin, and `[satellites.reaction_wheels]` was
-  missing the required `max_momentum`. ([#335](https://github.com/sksat/orts/pull/335))
+- The README quick-start config runs as shown, driving the wheels with the
+  `pd-rw-control` example plugin. It declared `sensors` and
+  `[satellites.reaction_wheels]` with no controller, so nothing commanded
+  them. ([#335](https://github.com/sksat/orts/pull/335))
 
 ### `orts-plugin-sdk` (Rust, crates.io)
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ max_momentum = 5.0
 max_torque = 0.5
 ```
 
+Sensors and actuators are driven by a plugin controller (see below); without
+one, `orts run` propagates orbit and attitude and reports that those blocks are
+inert.
+
 ### WASM Plugin
 
 Write satellite attitude controllers in any language that compiles to WebAssembly.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,16 @@ orts replay output.rrd
 orts convert output.rrd --format csv
 ```
 
-Example config (`orts.toml`):
+Example config (`orts.toml`). It points at a controller plugin, so build one
+first. The plugin sources ship in this repository, so this part needs a
+checkout — from its root:
+
+```bash
+cargo install cargo-component
+rustup target add wasm32-wasip1
+cargo component build --release \
+  --manifest-path plugin-sdk/examples/pd-rw-control/Cargo.toml
+```
 
 ```toml
 body = "earth"
@@ -79,36 +88,34 @@ type = "three_axis"
 inertia = 0.01
 max_momentum = 5.0
 max_torque = 0.5
+
+# PD attitude control: hold the identity quaternion using the wheels.
+[satellites.controller]
+type = "wasm"
+path = "plugin-sdk/examples/target/wasm32-wasip1/release/orts_example_plugin_pd_rw_control.wasm"
 ```
 
-Sensors and actuators are driven by a plugin controller (see below); without
-one, `orts run` propagates orbit and attitude and reports that those blocks are
-inert.
+`path` is resolved against the working directory, so run `orts` from the
+repository root too, or make it absolute.
+
+The controller is what reads the sensors and commands the wheels. Drop it and
+`orts run` propagates orbit and attitude, and warns that the `sensors` and
+`reaction_wheels` blocks have no effect.
 
 ### WASM Plugin
 
 Write satellite attitude controllers in any language that compiles to WebAssembly.
 Plugins receive sensor readings (magnetometer, gyroscope, star tracker, etc.) each tick and return actuator commands (reaction wheels, magnetorquers) — the simulator handles all dynamics and environment models.
 
-```bash
-# Install cargo-component
-cargo install cargo-component
-
-# Build an example plugin
-cd plugin-sdk/examples/pd-rw-control
-cargo component build --release
-```
-
-Add a plugin controller to your config:
+The quick start above builds and wires up `pd-rw-control`. Its gains and the
+attitude it holds come from `[satellites.controller.config]`, which every field
+defaults so it can be omitted:
 
 ```toml
-[satellites.controller]
-type = "wasm"
-path = "target/wasm32-wasip1/release/orts_example_plugin_pd_rw_control.wasm"
-
 [satellites.controller.config]
 kp = 1.0
 kd = 2.0
+target_q = [1.0, 0.0, 0.0, 0.0]
 sample_period = 0.1
 ```
 

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -3,7 +3,7 @@ use std::ops::ControlFlow;
 use arika::body::KnownBody;
 use arika::frame::{SimpleEci, Vec3};
 use orts::OrbitalState;
-use orts::group::{IndependentGroup, IntegratorConfig};
+use orts::group::{HasPosition, IndependentGroup, IntegratorConfig};
 use orts::orbital::kepler::KeplerianElements;
 use orts::record::archetypes::OrbitalState as RecordOrbitalState;
 use orts::record::components::{
@@ -18,7 +18,12 @@ use orts::visibility::{StationContact, VisibilityMonitor};
 use crate::cli::{IntegratorChoice, OutputFormat, SimArgs};
 use crate::commands::CmdError;
 use crate::satellite::OrbitSpec;
+use crate::sim::mode::{
+    SimMode, ensure_commands_deliverable, ensure_streams_supported, select_sim_mode,
+    unhonored_config_warnings,
+};
 use crate::sim::params::SimParams;
+use utsuroi::DynamicalSystem;
 
 /// Apply the config-file validation rules to the direct-CLI argument path.
 ///
@@ -76,22 +81,28 @@ pub fn run_simulation_cmd(
     params.plugin_backend_threshold = sim.plugin_backend_threshold;
     params.plugin_backend_async_mode = sim.plugin_backend_async_mode;
 
-    // 全衛星が controller 付きなら制御ループへディスパッチ。
-    let has_controller = !params.satellites.is_empty()
-        && params
-            .satellites
-            .iter()
-            .all(|s| s.controller_config.is_some());
-    let rec = if has_controller {
-        run_controlled_simulation(&params, sim)?
-    } else {
-        run_simulation(&params)?
+    // どのダイナミクスで回すかは serve と共有の規則で決める。`run` だけが
+    // orbit-only に落ちて姿勢・アクチュエータ設定を黙って捨てることがないように。
+    let mode = select_sim_mode(&params.satellites).map_err(CmdError::usage)?;
+    // 時刻指定コマンドと stream-io ストリームは制御ループがなければ届かない。
+    ensure_commands_deliverable(mode, params.commands.len()).map_err(CmdError::usage)?;
+    ensure_streams_supported(mode, &params.satellites).map_err(CmdError::usage)?;
+    // 選択したモードで効かない設定は、無視する前に知らせる。
+    let warnings = unhonored_config_warnings(&params.satellites, mode);
+    for w in &warnings {
+        eprintln!("Warning: {w}");
+    }
+
+    let rec = match mode {
+        SimMode::Controlled => run_controlled_simulation(&params, sim)?,
+        SimMode::Spacecraft => run_spacecraft_simulation(&params)?,
+        SimMode::OrbitOnly => run_simulation(&params)?,
     };
 
     let artifact = write_simulation_output(&rec, &params, &sink, format)?;
 
     if json {
-        let summary = build_run_summary(&params, &rec, artifact);
+        let summary = build_run_summary(&params, &rec, artifact, warnings);
         use std::io::Write;
         let mut stdout = std::io::stdout().lock();
         serde_json::to_writer_pretty(&mut stdout, &summary)
@@ -269,6 +280,7 @@ fn build_run_summary(
     params: &SimParams,
     rec: &Recording,
     artifact: Option<Artifact>,
+    warnings: Vec<String>,
 ) -> RunSummary {
     let satellites = params
         .satellites
@@ -307,7 +319,7 @@ fn build_run_summary(
         },
         satellites,
         artifacts: artifact.into_iter().collect(),
-        warnings: Vec::new(),
+        warnings,
     }
 }
 
@@ -446,19 +458,9 @@ fn report_contact_windows(params: &SimParams, monitors: Vec<VisibilityMonitor<Si
     }
 }
 
-/// Run the simulation and return a Recording.
-pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
-    use crate::sim::core::sat_params;
-    use orts::setup::{build_orbital_system, default_third_bodies};
-
-    let mut rec = Recording::new();
-    let body_path = EntityPath::parse(&format!("/world/{}", params.body.properties().name));
-
-    rec.log_static(&body_path, &GravitationalParameter(params.mu));
-    rec.log_static(&body_path, &BodyRadius(params.body.properties().radius));
-
-    // Build integrator config
-    let config = match params.integrator {
+/// Integrator selection for the `run` propagation loop.
+fn integrator_config(params: &SimParams) -> IntegratorConfig {
+    match params.integrator {
         IntegratorChoice::Rk4 => IntegratorConfig::Rk4 { dt: params.dt },
         IntegratorChoice::Dp45 => IntegratorConfig::Dp45 {
             dt: params.dt,
@@ -468,13 +470,20 @@ pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
             dt: params.dt,
             tolerances: params.tolerances.clone(),
         },
-    };
+    }
+}
 
-    // Build event checker (collision + atmospheric entry)
+/// Terminate a satellite on surface impact or atmospheric entry.
+///
+/// Generic over the state so the orbit-only and spacecraft paths share one
+/// termination rule: both only need the position.
+fn body_event_checker<S: HasPosition>(
+    params: &SimParams,
+) -> impl Fn(f64, &S) -> ControlFlow<String> + Send + 'static {
     let props = params.body.properties();
     let body_radius = props.radius;
     let atmosphere_altitude = props.atmosphere_altitude;
-    let event_checker = move |_t: f64, state: &OrbitalState| -> ControlFlow<String> {
+    move |_t: f64, state: &S| {
         let r = state.position().magnitude();
         if r < body_radius {
             ControlFlow::Break(format!("collision at {:.1} km altitude", r - body_radius))
@@ -490,13 +499,16 @@ pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
         } else {
             ControlFlow::Continue(())
         }
-    };
+    }
+}
 
-    // Build group with all satellites
-    let mut group = IndependentGroup::new(config).with_event_checker(event_checker);
+/// Run the orbit-only simulation and return a Recording.
+pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
+    use crate::sim::core::sat_params;
+    use orts::setup::{build_orbital_system, default_third_bodies};
 
-    // Track entity paths per satellite for recording
-    let sat_paths: Vec<EntityPath> = params.satellites.iter().map(|s| s.entity_path()).collect();
+    let mut group = IndependentGroup::new(integrator_config(params))
+        .with_event_checker(body_event_checker::<OrbitalState>(params));
 
     let third_bodies = default_third_bodies(&params.body);
     for sat in &params.satellites {
@@ -515,6 +527,101 @@ pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
         group = group.add_satellite_until(sat.id.as_str(), initial, sat.period, system);
     }
 
+    propagate_and_record(params, group, |rec, entity, tp, state| {
+        let os = RecordOrbitalState::new(*state.position(), *state.velocity());
+        rec.log_orbital_state(entity, tp, &os);
+    })
+}
+
+/// Run the orbit + attitude simulation (`[satellites.attitude]` without a
+/// plugin controller) and return a Recording.
+///
+/// Builds the same dynamics `orts serve` builds in spacecraft mode
+/// (`SpacecraftDynamics` plus the coupled gravity-gradient torque), so the
+/// same config is propagated identically by both entry points. The recording
+/// carries the attitude quaternion and body-frame angular velocity in
+/// addition to the orbital state.
+pub fn run_spacecraft_simulation(params: &SimParams) -> Result<Recording, CmdError> {
+    use crate::sim::core::sat_params;
+    use orts::attitude::CoupledGravityGradient;
+    use orts::setup::{build_spacecraft_dynamics, default_third_bodies};
+    use orts::spacecraft::SpacecraftState;
+
+    let mut group =
+        IndependentGroup::new(integrator_config(params)).with_event_checker(body_event_checker::<
+            orts::effector::AugmentedState<SpacecraftState>,
+        >(params));
+
+    let third_bodies = default_third_bodies(&params.body);
+    for sat in &params.satellites {
+        // Reject a singular inertia tensor / non-positive mass before
+        // `build_spacecraft_dynamics` panics on the inverse.
+        crate::sim::mode::validate_satellite_spec(sat).map_err(CmdError::usage)?;
+        let att = sat
+            .attitude_config
+            .as_ref()
+            .expect("spacecraft mode requires attitude config on every satellite");
+        let inertia = att.inertia_matrix();
+        let mut dynamics = build_spacecraft_dynamics(
+            &params.body,
+            params.mu,
+            params.epoch,
+            &sat_params(sat),
+            &third_bodies,
+            inertia,
+            params.build_atmosphere_model(),
+        );
+        dynamics = dynamics.with_model(CoupledGravityGradient::new(params.mu, inertia));
+
+        let orbit = sat
+            .initial_state(params.mu, params.epoch)
+            .map_err(|e| CmdError::failure(format!("satellite '{}': {e}", sat.id)))?;
+        let plant = SpacecraftState {
+            orbit,
+            attitude: orts::attitude::AttitudeState {
+                quaternion: nalgebra::Vector4::from_row_slice(&att.initial_quaternion),
+                angular_velocity: nalgebra::Vector3::from_row_slice(&att.initial_angular_velocity),
+            },
+            mass: att.mass,
+        };
+        let initial = dynamics.initial_augmented_state(plant);
+        group = group.add_satellite_until(sat.id.as_str(), initial, sat.period, dynamics);
+    }
+
+    propagate_and_record(params, group, |rec, entity, tp, state| {
+        let sc = &state.plant;
+        let os = RecordOrbitalState::new(*sc.orbit.position(), *sc.orbit.velocity());
+        let q = Quaternion4D(sc.attitude.quaternion);
+        let w = AngularVelocity3D(sc.attitude.angular_velocity);
+        rec.log_orbital_state_with_attitude(entity, tp, &os, Some(&q), Some(&w));
+    })
+}
+
+/// Propagate an already-populated group in `output_interval` chunks and
+/// record each satellite's state through `log_state`.
+///
+/// Shared by the orbit-only and spacecraft paths: everything except the
+/// dynamics and what a sample contains is identical, so termination
+/// reporting, ground-station visibility and the recording metadata have one
+/// implementation instead of one per mode.
+fn propagate_and_record<D>(
+    params: &SimParams,
+    mut group: IndependentGroup<D>,
+    log_state: impl Fn(&mut Recording, &EntityPath, &TimePoint, &D::State),
+) -> Result<Recording, CmdError>
+where
+    D: DynamicalSystem,
+    D::State: HasPosition,
+{
+    let mut rec = Recording::new();
+    let body_path = EntityPath::parse(&format!("/world/{}", params.body.properties().name));
+
+    rec.log_static(&body_path, &GravitationalParameter(params.mu));
+    rec.log_static(&body_path, &BodyRadius(params.body.properties().radius));
+
+    // Track entity paths per satellite for recording
+    let sat_paths: Vec<EntityPath> = params.satellites.iter().map(|s| s.entity_path()).collect();
+
     // Ground-station visibility monitors, fed from accepted integrator
     // steps via the propagation observer (independent of output_interval).
     let mut visibility = build_visibility_monitors(params);
@@ -531,8 +638,7 @@ pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
     let mut last_output_t: Vec<f64> = vec![0.0; params.satellites.len()];
     for (i, (entry, _)) in group.satellites_with_dynamics().enumerate() {
         let tp = TimePoint::new().with_sim_time(0.0).with_step(0);
-        let os = RecordOrbitalState::new(*entry.state.position(), *entry.state.velocity());
-        rec.log_orbital_state(&sat_paths[i], &tp, &os);
+        log_state(&mut rec, &sat_paths[i], &tp, &entry.state);
         steps[i] = 1;
     }
     if let Some(monitors) = visibility.as_mut() {
@@ -541,7 +647,7 @@ pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
             &mut vis_last_t,
             group
                 .satellites_with_dynamics()
-                .map(|(e, _)| (e.t, *e.state.position())),
+                .map(|(e, _)| (e.t, e.state.position())),
         );
     }
 
@@ -569,7 +675,7 @@ pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
                         return;
                     };
                     if ts > vis_last_t[i] {
-                        monitors[i].update(ts, &Vec3::from_raw(*state.position()));
+                        monitors[i].update(ts, &Vec3::from_raw(state.position()));
                         vis_last_t[i] = ts;
                     }
                 })
@@ -584,8 +690,7 @@ pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
         for (i, (entry, _)) in group.satellites_with_dynamics().enumerate() {
             if !entry.terminated && entry.t >= t - 1e-9 {
                 let tp = TimePoint::new().with_sim_time(entry.t).with_step(steps[i]);
-                let os = RecordOrbitalState::new(*entry.state.position(), *entry.state.velocity());
-                rec.log_orbital_state(&sat_paths[i], &tp, &os);
+                log_state(&mut rec, &sat_paths[i], &tp, &entry.state);
                 steps[i] += 1;
                 last_output_t[i] = entry.t;
             }
@@ -605,8 +710,7 @@ pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
                 && let Some(entry) = group.satellite(&term.satellite_id)
             {
                 let tp = TimePoint::new().with_sim_time(entry.t).with_step(steps[i]);
-                let os = RecordOrbitalState::new(*entry.state.position(), *entry.state.velocity());
-                rec.log_orbital_state(&sat_paths[i], &tp, &os);
+                log_state(&mut rec, &sat_paths[i], &tp, &entry.state);
                 steps[i] += 1;
             }
         }
@@ -617,8 +721,7 @@ pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
     for (i, (entry, _)) in group.satellites_with_dynamics().enumerate() {
         if !entry.terminated && (entry.t - last_output_t[i]) > 1e-9 {
             let tp = TimePoint::new().with_sim_time(entry.t).with_step(steps[i]);
-            let os = RecordOrbitalState::new(*entry.state.position(), *entry.state.velocity());
-            rec.log_orbital_state(&sat_paths[i], &tp, &os);
+            log_state(&mut rec, &sat_paths[i], &tp, &entry.state);
         }
     }
 
@@ -626,7 +729,15 @@ pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
         report_contact_windows(params, monitors);
     }
 
-    // Use first satellite for metadata (backward compatibility)
+    rec.metadata = sim_metadata(params);
+
+    Ok(rec)
+}
+
+/// Recording metadata describing the run's central body, epoch and the first
+/// satellite's orbit (kept for backward compatibility with single-satellite
+/// consumers).
+fn sim_metadata(params: &SimParams) -> orts::record::recording::SimMetadata {
     let first_sat = params.satellites.first();
     let orbit_desc = first_sat.map(|s| match &s.orbit {
         OrbitSpec::Circular { altitude, r0, .. } => {
@@ -644,7 +755,7 @@ pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
             )
         }
     });
-    rec.metadata = orts::record::recording::SimMetadata {
+    orts::record::recording::SimMetadata {
         epoch_jd: params.epoch.map(|e| e.jd()),
         epoch_iso: params.epoch.map(|e| e.to_datetime().to_string()),
         mu: Some(params.mu),
@@ -653,9 +764,7 @@ pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
         altitude: first_sat.map(|s| s.altitude(&params.body)),
         period: first_sat.map(|s| s.period),
         orbit_description: orbit_desc,
-    };
-
-    Ok(rec)
+    }
 }
 
 /// Print a Recording as CSV to stdout.
@@ -1120,33 +1229,7 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Result<Record
         report_contact_windows(params, monitors);
     }
 
-    let first_sat = params.satellites.first();
-    let orbit_desc = first_sat.map(|s| match &s.orbit {
-        OrbitSpec::Circular { altitude, r0, .. } => {
-            format!(
-                "Initial orbit: circular at {} km altitude (r = {} km)",
-                altitude, r0
-            )
-        }
-        OrbitSpec::Omm { omm } => {
-            format!(
-                "Initial orbit: from TLE/OMM (a = {:.1} km, e = {:.6}, i = {:.2}°)",
-                omm.semi_major_axis(params.mu),
-                omm.fields().eccentricity,
-                omm.fields().inclination.to_degrees()
-            )
-        }
-    });
-    rec.metadata = orts::record::recording::SimMetadata {
-        epoch_jd: params.epoch.map(|e| e.jd()),
-        epoch_iso: params.epoch.map(|e| e.to_datetime().to_string()),
-        mu: Some(params.mu),
-        body_radius: Some(params.body.properties().radius),
-        body_name: Some(params.body.properties().name.to_string()),
-        altitude: first_sat.map(|s| s.altitude(&params.body)),
-        period: first_sat.map(|s| s.period),
-        orbit_description: orbit_desc,
-    };
+    rec.metadata = sim_metadata(params);
 
     Ok(rec)
 }

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -19,7 +19,7 @@ use crate::cli::{IntegratorChoice, OutputFormat, SimArgs};
 use crate::commands::CmdError;
 use crate::satellite::OrbitSpec;
 use crate::sim::mode::{
-    SimMode, ensure_commands_deliverable, ensure_streams_supported, select_sim_mode,
+    SimMode, ensure_commands_deliverable, ensure_streams_unused, select_sim_mode,
     unhonored_config_warnings,
 };
 use crate::sim::params::SimParams;
@@ -84,9 +84,10 @@ pub fn run_simulation_cmd(
     // どのダイナミクスで回すかは serve と共有の規則で決める。`run` だけが
     // orbit-only に落ちて姿勢・アクチュエータ設定を黙って捨てることがないように。
     let mode = select_sim_mode(&params.satellites).map_err(CmdError::usage)?;
-    // 時刻指定コマンドと stream-io ストリームは制御ループがなければ届かない。
+    // 時刻指定コマンドは制御ループがなければ届かず、stream-io ストリームは
+    // `orts run` にそもそも pump する transport がない。
     ensure_commands_deliverable(mode, params.commands.len()).map_err(CmdError::usage)?;
-    ensure_streams_supported(mode, &params.satellites).map_err(CmdError::usage)?;
+    ensure_streams_unused(&params.satellites).map_err(CmdError::usage)?;
     // 選択したモードで効かない設定は、無視する前に知らせる。
     let warnings = unhonored_config_warnings(&params.satellites, mode);
     for w in &warnings {

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -94,6 +94,14 @@ pub fn run_simulation_cmd(
         eprintln!("Warning: {w}");
     }
 
+    // Before the dispatch, so every mode gets the same check: an attitude
+    // config that cannot be integrated is rejected here rather than failing
+    // partway through the run (or in the controlled path, inside
+    // `build_controlled_satellite`).
+    for sat in &params.satellites {
+        crate::sim::mode::validate_satellite_spec(sat).map_err(CmdError::usage)?;
+    }
+
     let rec = match mode {
         SimMode::Controlled => run_controlled_simulation(&params, sim)?,
         SimMode::Spacecraft => run_spacecraft_simulation(&params)?,
@@ -555,9 +563,9 @@ pub fn run_spacecraft_simulation(params: &SimParams) -> Result<Recording, CmdErr
 
     let third_bodies = default_third_bodies(&params.body);
     for sat in &params.satellites {
-        // Reject a singular inertia tensor / non-positive mass before
-        // `build_spacecraft_dynamics` panics on the inverse.
-        crate::sim::mode::validate_satellite_spec(sat).map_err(CmdError::usage)?;
+        // `run_simulation_cmd` validated every satellite before dispatching
+        // here, so `build_spacecraft_dynamics` cannot be reached with an
+        // inertia tensor it would fail to invert.
         let att = sat
             .attitude_config
             .as_ref()
@@ -580,7 +588,7 @@ pub fn run_spacecraft_simulation(params: &SimParams) -> Result<Recording, CmdErr
         let plant = SpacecraftState {
             orbit,
             attitude: orts::attitude::AttitudeState {
-                quaternion: nalgebra::Vector4::from_row_slice(&att.initial_quaternion),
+                quaternion: att.normalized_initial_quaternion(),
                 angular_velocity: nalgebra::Vector3::from_row_slice(&att.initial_angular_velocity),
             },
             mass: att.mass,

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -969,9 +969,25 @@ impl ServeEngine {
                     .to_string(),
             );
         }
+        // A controller here would never be stepped: the orbit-only group has no
+        // control loop, and the mode is fixed at construction. Reject rather
+        // than accept the satellite and drop its controller.
+        if satellite.controller.is_some() {
+            return Err(
+                "Cannot add a controlled satellite to orbit-only simulation: the control \
+                 loop is not running, so the controller would never be stepped. Start with \
+                 a controller on every satellite to use controlled mode."
+                    .to_string(),
+            );
+        }
 
         let sat_index = self.metas.len();
         let spec = satellite.to_satellite_spec(sat_index, self.params.body, self.params.mu);
+        // Sensors / actuators only act through a control loop; say so instead
+        // of accepting them into an orbit-only fleet unnoticed.
+        for w in unhonored_config_warnings(std::slice::from_ref(&spec), SimMode::OrbitOnly) {
+            eprintln!("Warning: {w}");
+        }
         // SGP4/TEME is Earth-centered; reject a TLE/OMM orbit on a non-Earth sim.
         crate::sim::params::validate_omm_body(self.params.body, std::slice::from_ref(&spec))?;
         let third_bodies = default_third_bodies(&self.params.body);
@@ -1381,6 +1397,25 @@ orbit = { type = "circular", altitude = 50 }
         .expect("valid satellite config");
         let err = init.engine.add_satellite(cfg).err().unwrap();
         assert!(err.contains("orbit-only simulation"), "got: {err}");
+    }
+
+    /// A controller on a satellite added to an orbit-only sim would never be
+    /// stepped (the mode is fixed at construction), so the add is rejected
+    /// rather than silently dropping the controller.
+    #[test]
+    fn add_controlled_satellite_to_orbit_only_is_rejected() {
+        let mut init = engine_from_toml(ORBIT_ONLY).expect("engine builds");
+        let cfg: SatelliteConfig = serde_json::from_str(
+            r#"{
+                "id": "ctrl",
+                "orbit": { "type": "circular", "altitude": 700 },
+                "controller": { "type": "wasm", "path": "ctrl.wasm" }
+            }"#,
+        )
+        .expect("valid satellite config");
+        let err = init.engine.add_satellite(cfg).err().unwrap();
+        assert!(err.contains("orbit-only simulation"), "got: {err}");
+        assert!(err.contains("control loop"), "got: {err}");
     }
 
     #[test]

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -37,6 +37,10 @@ use crate::sim::core::{
     AttitudePayload, AttitudeSource, HistoryState, accel_breakdown, make_history_state, sat_params,
     spacecraft_accel_breakdown,
 };
+use crate::sim::mode::{
+    SimMode, ensure_streams_supported, select_sim_mode, unhonored_config_warnings,
+    validate_satellite_spec,
+};
 use crate::sim::params::SimParams;
 use orts::setup::{build_orbital_system, build_spacecraft_dynamics, default_third_bodies};
 
@@ -392,30 +396,16 @@ impl ServeEngine {
         let body_radius = params.body.properties().radius;
         let atmosphere_altitude = params.body.properties().atmosphere_altitude;
 
-        // Determine mode: use SpacecraftDynamics if all satellites have attitude config.
-        // Empty satellite list → orbit-only (to support dynamic add_satellite).
-        let any_attitude = params
-            .satellites
-            .iter()
-            .any(|s| s.attitude_config.is_some());
-        let all_attitude = !params.satellites.is_empty()
-            && params
-                .satellites
-                .iter()
-                .all(|s| s.attitude_config.is_some());
-        if any_attitude && !all_attitude {
-            return Err(
-                "Mixed attitude config: some satellites have attitude, some don't. \
-                 Specify attitude for all satellites or remove it from all."
-                    .to_string(),
-            );
+        // Mode selection is shared with `orts run` so the same config cannot
+        // get attitude dynamics under one entry point and not the other.
+        let mode = select_sim_mode(&params.satellites)?;
+        // No logger is installed in the CLI, so warnings go to stderr
+        // directly rather than through `log`.
+        for w in unhonored_config_warnings(&params.satellites, mode) {
+            eprintln!("Warning: {w}");
         }
-        let use_spacecraft = all_attitude;
-        let has_controller = !params.satellites.is_empty()
-            && params
-                .satellites
-                .iter()
-                .all(|s| s.controller_config.is_some());
+        let use_spacecraft = mode == SimMode::Spacecraft;
+        let has_controller = mode == SimMode::Controlled;
 
         let mut metas: Vec<SatMeta> = Vec::new();
         let third_bodies = default_third_bodies(&params.body);
@@ -622,14 +612,8 @@ impl ServeEngine {
             .collect();
         // Streams are pumped through the controller; in orbit-only /
         // spacecraft mode the endpoints would be black holes (accepted but
-        // never drained). Reject loudly instead.
-        if !stream_keys.is_empty() && !matches!(group, SimGroup::Controlled(_)) {
-            return Err(
-                "stream-io streams are declared but no satellite has a controller; \
-                 streams require a plugin-controlled simulation"
-                    .to_string(),
-            );
-        }
+        // never drained). Rejected by the same rule `orts run` applies.
+        ensure_streams_supported(mode, &params.satellites)?;
         // A duplicate (sat, stream) pair would pump the same controller
         // stream twice per tick and alias one endpoint; reject it. Both
         // parts also become URL path segments (`/stream/{sat}/{stream}`),
@@ -1247,30 +1231,6 @@ fn build_info_message(params: &SimParams) -> WsMessage {
     }
 }
 
-/// Validate a single satellite's attitude configuration so that
-/// `build_spacecraft_dynamics` cannot panic on a singular inertia
-/// tensor or a non-positive mass. Used from both the startup config
-/// validator and the runtime `add_satellite` path.
-pub(super) fn validate_satellite_spec(spec: &SatelliteSpec) -> Result<(), String> {
-    let Some(att) = &spec.attitude_config else {
-        return Ok(());
-    };
-    let inertia = att.inertia_matrix();
-    if inertia.determinant().abs() < 1e-30 {
-        return Err(format!(
-            "Satellite '{}' has singular inertia tensor (not invertible)",
-            spec.id
-        ));
-    }
-    if att.mass <= 0.0 {
-        return Err(format!(
-            "Satellite '{}' has non-positive mass: {}",
-            spec.id, att.mass
-        ));
-    }
-    Ok(())
-}
-
 /// Whether `s` cannot be used as one path segment of a stream endpoint URL
 /// (`/stream/{sat}/{stream}`): empty or containing a path separator.
 fn invalid_path_segment(s: &str) -> bool {
@@ -1455,6 +1415,32 @@ orbit = { type = "circular", altitude = 600 }
         .err()
         .unwrap();
         assert!(err.contains("Mixed attitude config"), "got: {err}");
+    }
+
+    /// The group the engine builds must be the mode `select_sim_mode` names —
+    /// the same function `orts run` dispatches on. Without this, `serve` can
+    /// drift back to its own inline condition and the two entry points can
+    /// silently disagree about whether a config has attitude dynamics.
+    #[test]
+    fn serve_group_matches_shared_mode_selection() {
+        const ATTITUDE: &str = r#"
+[[satellites]]
+id = "sat-a"
+orbit = { type = "circular", altitude = 500 }
+attitude = { inertia_diag = [10, 20, 30], mass = 50 }
+"#;
+        for toml in [ORBIT_ONLY, ATTITUDE] {
+            let config: crate::config::SimConfig = toml::from_str(toml).expect("valid test toml");
+            let params = SimParams::from_config(&config);
+            let mode = select_sim_mode(&params.satellites).expect("valid fleet");
+            let init = engine_from_toml(toml).expect("engine builds");
+            let group_mode = match init.engine.group {
+                SimGroup::OrbitOnly(_) => SimMode::OrbitOnly,
+                SimGroup::Spacecraft(_) => SimMode::Spacecraft,
+                SimGroup::Controlled(_) => SimMode::Controlled,
+            };
+            assert_eq!(group_mode, mode, "config:{toml}");
+        }
     }
 
     #[test]

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -399,6 +399,12 @@ impl ServeEngine {
         // Mode selection is shared with `orts run` so the same config cannot
         // get attitude dynamics under one entry point and not the other.
         let mode = select_sim_mode(&params.satellites)?;
+        // The same check the runtime `add_satellite` path applies, so a config
+        // that starts the server is held to it too: `serve --config` reaches
+        // here without passing through `validate_sim_config`.
+        for spec in &params.satellites {
+            validate_satellite_spec(spec)?;
+        }
         // No logger is installed in the CLI, so warnings go to stderr
         // directly rather than through `log`.
         for w in unhonored_config_warnings(&params.satellites, mode) {
@@ -501,7 +507,7 @@ impl ServeEngine {
                 let plant = SpacecraftState {
                     orbit,
                     attitude: orts::attitude::AttitudeState {
-                        quaternion: nalgebra::Vector4::from_row_slice(&att.initial_quaternion),
+                        quaternion: att.normalized_initial_quaternion(),
                         angular_velocity: nalgebra::Vector3::from_row_slice(
                             &att.initial_angular_velocity,
                         ),
@@ -1476,6 +1482,25 @@ attitude = { inertia_diag = [10, 20, 30], mass = 50 }
             };
             assert_eq!(group_mode, mode, "config:{toml}");
         }
+    }
+
+    /// `serve --config` reaches `build` without passing through
+    /// `validate_sim_config`, so the attitude check has to live here too — the
+    /// runtime `add_satellite` path already applied it, which left a config
+    /// that starts the server held to a weaker standard than one added later.
+    #[test]
+    fn unintegrable_attitude_is_rejected_at_construction() {
+        let err = engine_from_toml(
+            r#"
+[[satellites]]
+id = "sat-a"
+orbit = { type = "circular", altitude = 500 }
+attitude = { inertia_diag = [nan, 20, 30], mass = 50 }
+"#,
+        )
+        .err()
+        .expect("a non-finite inertia component should be rejected");
+        assert!(err.contains("non-finite"), "got: {err}");
     }
 
     #[test]

--- a/cli/src/commands/serve/manager.rs
+++ b/cli/src/commands/serve/manager.rs
@@ -12,13 +12,14 @@ use std::time::Duration;
 
 use tokio::sync::{broadcast, mpsc, oneshot};
 
-use super::engine::{EngineInit, ServeEngine, StreamIo, validate_satellite_spec};
+use super::engine::{EngineInit, ServeEngine, StreamIo};
 use super::history::HistoryBuffer;
 use super::protocol::WsMessage;
 use super::stream_bridge::{OutboundPush, StreamBridge, StreamEndpoint, StreamKey};
 use crate::cli::{PluginBackendChoice, SimArgs};
 use crate::config::{SatelliteConfig, SimConfig};
 use crate::satellite::{SatelliteInfo, SatelliteSpec};
+use crate::sim::mode::validate_satellite_spec;
 use crate::sim::params::SimParams;
 use orts::setup::default_third_bodies;
 
@@ -228,15 +229,10 @@ fn validate_sim_config(config: &SimConfig) -> Result<(), String> {
     // WebSocket `StartSimulation` returns an error to the client instead of
     // reaching the panic in `SimParams::from_config`.
     crate::sim::params::validate_omm_body(body, &specs)?;
-    let any_att = specs.iter().any(|s| s.attitude_config.is_some());
-    let all_att = !specs.is_empty() && specs.iter().all(|s| s.attitude_config.is_some());
-    if any_att && !all_att {
-        return Err(
-            "Mixed attitude config: some satellites have attitude, some don't. \
-             Specify attitude for all satellites or remove it from all."
-                .to_string(),
-        );
-    }
+    // Reject fleets that no single mode can honor (mixed attitude / mixed
+    // controller) with the same rule `ServeEngine::build` and `orts run` use,
+    // so a WebSocket `StartSimulation` fails here instead of at engine build.
+    crate::sim::mode::select_sim_mode(&specs)?;
     // Validate inertia tensors are invertible
     for spec in &specs {
         validate_satellite_spec(spec)?;

--- a/cli/src/commands/serve/manager.rs
+++ b/cli/src/commands/serve/manager.rs
@@ -216,6 +216,10 @@ fn validate_sim_config(config: &SimConfig) -> Result<(), String> {
     // `StartSimulation` cannot smuggle in thruster config that panics later
     // in `ThrusterSpec::new()`.
     config.validate()?;
+    // The serve loop does not drain a `[[command]]` timeline, so a config that
+    // `orts serve --config` rejects must not slip in through a WebSocket
+    // `start_simulation` and have its uplinks dropped instead.
+    config.ensure_serve_supported()?;
 
     let body = crate::satellite::parse_body(&config.body);
     let mu = body.properties().mu;
@@ -622,6 +626,57 @@ async fn run_simulation_loop(
 mod tests {
     use super::*;
     use arika::body::KnownBody;
+
+    /// A WebSocket `start_simulation` goes through the same config gate as
+    /// `orts serve --config`: the serve loop never drains a `[[command]]`
+    /// timeline, so accepting one here would drop every scheduled uplink.
+    #[test]
+    fn ws_start_rejects_a_command_timeline() {
+        let config: SimConfig = toml::from_str(
+            r#"
+body = "earth"
+dt = 1.0
+
+[[satellites]]
+id = "sat-a"
+orbit = { type = "circular", altitude = 500 }
+
+[[command]]
+t = 10.0
+sat = "sat-a"
+kind = "orts.cmd.set-mode.v1"
+"#,
+        )
+        .expect("valid test toml");
+        let err = validate_sim_config(&config).unwrap_err();
+        assert!(err.contains("`[[command]]`"), "got: {err}");
+    }
+
+    /// A fleet where only some satellites have a controller cannot be honored
+    /// by any mode, and is rejected here rather than at engine build.
+    #[test]
+    fn ws_start_rejects_mixed_controller_config() {
+        let config: SimConfig = toml::from_str(
+            r#"
+body = "earth"
+dt = 1.0
+
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 500 }
+attitude = { inertia_diag = [10, 10, 10], mass = 50 }
+controller = { type = "wasm", path = "ctrl.wasm" }
+
+[[satellites]]
+id = "b"
+orbit = { type = "circular", altitude = 600 }
+attitude = { inertia_diag = [10, 10, 10], mass = 50 }
+"#,
+        )
+        .expect("valid test toml");
+        let err = validate_sim_config(&config).unwrap_err();
+        assert!(err.contains("Mixed controller config"), "got: {err}");
+    }
 
     #[test]
     fn body_names_for_earth_includes_sun_and_moon() {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -270,6 +270,134 @@ impl AttitudeConfig {
             ixz, iyz, izz,
         )
     }
+
+    /// The configured initial quaternion, normalized.
+    ///
+    /// The config accepts any non-zero quaternion, but the simulation should
+    /// start from the unit quaternion it denotes rather than from its scale.
+    /// Integrating the raw one lets a large quaternion grow until its sum of
+    /// squares overflows, and the post-step projection then divides every
+    /// component by infinity and hands back all zeros — a state that passes
+    /// `is_finite`, so nothing stops the run, and that normalizes to `NaN` when
+    /// a sensor reads it.
+    ///
+    /// Assumes [`validate`](Self::validate) has passed: the norm is positive
+    /// and finite there. Falls back to identity rather than producing `NaN` if
+    /// it has not.
+    pub fn normalized_initial_quaternion(&self) -> nalgebra::Vector4<f64> {
+        let q = nalgebra::Vector4::from_row_slice(&self.initial_quaternion);
+        let norm = q.norm();
+        if norm > 0.0 && norm.is_finite() {
+            q / norm
+        } else {
+            nalgebra::Vector4::new(1.0, 0.0, 0.0, 0.0)
+        }
+    }
+
+    /// Reject the attitude configs that this config alone shows the dynamics
+    /// cannot be built from or started.
+    ///
+    /// Lives on the config type so every entry point that loads a config gets
+    /// it — `orts config validate` included, which would otherwise report a
+    /// config as valid that `run` and `serve` then refuse.
+    ///
+    /// The scope is what the config alone determines: that the inertia tensor
+    /// inverts to something usable, and that the *torque-free* derivative at
+    /// `t = 0` is finite. It is not the derivative the simulation actually
+    /// starts from — that includes the gravity-gradient torque, which needs the
+    /// orbit. An inertia scaled so far from the orbit that the gravity gradient
+    /// alone overflows therefore passes here and stops at the first step with
+    /// [`utsuroi::IntegrationError::NonFiniteState`].
+    pub fn validate(&self) -> Result<(), String> {
+        // Non-finite first: every comparison below is false for `NaN`, so a
+        // `NaN` mass would pass `mass <= 0.0` and a `NaN` determinant would
+        // pass the singularity check. The state then integrates to `NaN` and
+        // the run fails partway through instead of at the config.
+        for (name, values) in [
+            ("inertia_diag", &self.inertia_diag[..]),
+            ("inertia_off_diag", &self.inertia_off_diag[..]),
+            ("mass", std::slice::from_ref(&self.mass)),
+            ("initial_quaternion", &self.initial_quaternion[..]),
+            (
+                "initial_angular_velocity",
+                &self.initial_angular_velocity[..],
+            ),
+        ] {
+            if let Some(bad) = values.iter().find(|v| !v.is_finite()) {
+                return Err(format!("non-finite `{name}` component: {bad}"));
+            }
+        }
+        // Ask the question the way the dynamics do: `SpacecraftDynamics::new`
+        // takes `try_inverse().expect(…)`, so the test is whether that inverse
+        // exists and is usable. A magnitude threshold on the determinant cannot
+        // answer it — the determinant carries the cube of the units, so
+        // `[1e-11; 3]` is perfectly conditioned yet its determinant is 1e-33,
+        // while `[5e-324, 1e154, 1e154]` has a determinant near 5e-16 and an
+        // inverse whose first component is infinite.
+        //
+        // Checking the product rather than the inverse's components catches the
+        // quieter failure too: nalgebra's 3x3 inverse divides cofactors by the
+        // determinant, so `[1e154; 3]` — condition number 1 — overflows both to
+        // give `Some(zero matrix)`. Every component is finite, and a spacecraft
+        // built on it would answer every torque with zero angular acceleration.
+        // `I · I⁻¹` is dimensionless, so one tolerance holds at every scale.
+        let inertia = self.inertia_matrix();
+        let inverse = inertia.try_inverse().filter(|inv| {
+            let residual = inertia * inv - nalgebra::Matrix3::identity();
+            residual.iter().all(|v| v.abs() < 1e-6)
+        });
+        let Some(inverse) = inverse else {
+            return Err(format!(
+                "inertia tensor cannot be inverted: {:?} with off-diagonal {:?}",
+                self.inertia_diag, self.inertia_off_diag
+            ));
+        };
+        // The quaternion need not be normalized — `AttitudeState::orientation`
+        // normalizes on use and `OdeState::project` renormalizes after every
+        // step — but it has to be something those can normalize. Both divide by
+        // the sum of squares, so the test is that sum, not the components: an
+        // all-zero quaternion names no attitude, `[1e-200, 0, 0, 0]` squares to
+        // zero, and `[1e200, 0, 0, 0]` squares to infinity. Each leaves the
+        // orientation undefined even though the components themselves are
+        // finite and non-zero.
+        let quat_norm_sq: f64 = self.initial_quaternion.iter().map(|q| q * q).sum();
+        if !(quat_norm_sq > 0.0 && quat_norm_sq.is_finite()) {
+            return Err(format!(
+                "`initial_quaternion` cannot be normalized \
+                 (its components square to {quat_norm_sq}); it names no attitude"
+            ));
+        }
+        // A usable inverse is not yet an integrable state: the torque-free Euler
+        // term `I⁻¹ (−ω × Iω)` can overflow on its own. `[1e-308, 1, 2]` with
+        // `ω = [1, 2, 2]` inverts cleanly and still starts at an infinite
+        // angular acceleration.
+        let omega = nalgebra::Vector3::from_row_slice(&self.initial_angular_velocity);
+        let alpha = inverse * -omega.cross(&(inertia * omega));
+        if !alpha.iter().all(|v| v.is_finite()) {
+            return Err(format!(
+                "the initial angular acceleration is not finite ({:?}): the inertia tensor \
+                 {:?} and `initial_angular_velocity` {:?} are too far apart in scale to \
+                 integrate",
+                alpha.as_slice(),
+                self.inertia_diag,
+                self.initial_angular_velocity
+            ));
+        }
+        // The other half of the derivative, `q̇ = ½ q ⊗ (0, ω)`, needs no check
+        // of its own. Each component is a three-term inner product `q · ½ω`, so
+        // for the unit quaternion the state is built from
+        // (`normalized_initial_quaternion`) Cauchy-Schwarz bounds it by
+        // `½ ‖q‖ √3 max|ω| = ½ √3 f64::MAX ≈ 1.56e308`, inside the range for any
+        // finite `ω` — and `ω` is finite by the check above.
+        //
+        // The bound holds of the partial sums too only because `q_dot` halves
+        // `ω` before forming the products. Halving the sum afterwards instead
+        // lets it overflow at twice the answer's magnitude.
+        if self.mass <= 0.0 {
+            return Err(format!("non-positive mass: {}", self.mass));
+        }
+        Ok(())
+    }
 }
 
 /// コントローラ設定。
@@ -609,6 +737,9 @@ impl SatelliteConfig {
     pub fn validate(&self) -> Result<(), String> {
         if let Some(thruster) = &self.thruster {
             thruster.validate().map_err(|e| format!("thruster: {e}"))?;
+        }
+        if let Some(attitude) = &self.attitude {
+            attitude.validate().map_err(|e| format!("attitude: {e}"))?;
         }
         // A non-finite orbit number propagates into the derived orbital
         // period. `run` then loops on `while !group.all_finished()` with a NaN

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -360,7 +360,16 @@ fn build_controller(
     match config {
         #[cfg(feature = "plugin-wasm")]
         ControllerConfig::Wasm { path, config } => {
-            let config_str = config.to_string();
+            // An omitted `[satellites.controller.config]` deserializes to
+            // `Value::Null`, whose `to_string()` is `"null"` — not something a
+            // guest can parse as its config struct. `Plugin::init` takes the
+            // empty string to mean "use the defaults", which is what an absent
+            // config block asks for.
+            let config_str = if config.is_null() {
+                String::new()
+            } else {
+                config.to_string()
+            };
             let wasm_path = std::path::Path::new(path);
             match ctx.plugin_backend {
                 ResolvedPluginBackend::Sync => {

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -173,7 +173,7 @@ pub fn build_controlled_satellite(
     let plant = SpacecraftState {
         orbit,
         attitude: orts::attitude::AttitudeState {
-            quaternion: nalgebra::Vector4::from_row_slice(&att.initial_quaternion),
+            quaternion: att.normalized_initial_quaternion(),
             angular_velocity: nalgebra::Vector3::from_row_slice(&att.initial_angular_velocity),
         },
         mass: att.mass,

--- a/cli/src/sim/mod.rs
+++ b/cli/src/sim/mod.rs
@@ -1,4 +1,5 @@
 pub mod command_schedule;
 pub mod controlled;
 pub mod core;
+pub mod mode;
 pub mod params;

--- a/cli/src/sim/mode.rs
+++ b/cli/src/sim/mode.rs
@@ -177,27 +177,18 @@ pub fn ensure_streams_unused(satellites: &[SatelliteSpec]) -> Result<(), String>
     )
 }
 
-/// 単一衛星の姿勢設定を検証し、`build_spacecraft_dynamics` が特異な慣性テンソルや
-/// 非正の質量で panic しないようにする。起動時の config 検証と、
-/// serve の実行時 `add_satellite` の両経路から使う。
+/// 単一衛星の姿勢設定を検証し、`build_spacecraft_dynamics` が伝播できない姿勢で
+/// panic しないようにする。
+///
+/// 検査そのものは [`crate::config::AttitudeConfig::validate`] にあり、config を
+/// 読む経路（`orts config validate` を含む）と、spec しか持たない serve の実行時
+/// `add_satellite` 経路が同じ規則を通るようにしている。
 pub fn validate_satellite_spec(spec: &SatelliteSpec) -> Result<(), String> {
     let Some(att) = &spec.attitude_config else {
         return Ok(());
     };
-    let inertia = att.inertia_matrix();
-    if inertia.determinant().abs() < 1e-30 {
-        return Err(format!(
-            "Satellite '{}' has singular inertia tensor (not invertible)",
-            spec.id
-        ));
-    }
-    if att.mass <= 0.0 {
-        return Err(format!(
-            "Satellite '{}' has non-positive mass: {}",
-            spec.id, att.mass
-        ));
-    }
-    Ok(())
+    att.validate()
+        .map_err(|e| format!("Satellite '{}' has {e}", spec.id))
 }
 
 #[cfg(test)]
@@ -228,6 +219,169 @@ orbit = { type = "circular", altitude = 400 }
     #[test]
     fn empty_fleet_is_orbit_only() {
         assert_eq!(select_sim_mode(&[]), Ok(SimMode::OrbitOnly));
+    }
+
+    /// One attitude config with `attitude` filled in from `fields`.
+    fn attitude_spec(fields: &str) -> SatelliteSpec {
+        let toml = format!(
+            r#"
+body = "earth"
+[[satellites]]
+id = "a"
+orbit = {{ type = "circular", altitude = 400 }}
+[satellites.attitude]
+{fields}
+"#
+        );
+        specs(&toml).pop().expect("one satellite")
+    }
+
+    /// Every comparison against `NaN` is false, so a config carrying one slips
+    /// past a validator written only as range checks and fails partway through
+    /// the run instead.
+    #[test]
+    fn non_finite_attitude_fields_are_rejected() {
+        for (field, fields) in [
+            ("inertia_diag", "inertia_diag = [nan, 10, 10]\nmass = 500"),
+            (
+                "inertia_off_diag",
+                "inertia_diag = [10, 10, 10]\nmass = 500\ninertia_off_diag = [inf, 0, 0]",
+            ),
+            ("mass", "inertia_diag = [10, 10, 10]\nmass = nan"),
+            (
+                "initial_quaternion",
+                "inertia_diag = [10, 10, 10]\nmass = 500\ninitial_quaternion = [1, 0, -inf, 0]",
+            ),
+            (
+                "initial_angular_velocity",
+                "inertia_diag = [10, 10, 10]\nmass = 500\ninitial_angular_velocity = [0, nan, 0]",
+            ),
+        ] {
+            let err = validate_satellite_spec(&attitude_spec(fields))
+                .expect_err(&format!("{field} should be rejected"));
+            assert!(
+                err.contains(field) && err.contains("non-finite"),
+                "{field}: got {err}"
+            );
+        }
+    }
+
+    /// Downstream normalization divides by the sum of squares, so a quaternion
+    /// is unusable whenever that sum is not positive and finite — which
+    /// includes components that are themselves finite and non-zero.
+    #[test]
+    fn quaternions_that_cannot_be_normalized_are_rejected() {
+        for quat in [
+            "[0, 0, 0, 0]",
+            // Squares to zero.
+            "[1e-200, 0, 0, 0]",
+            "[5e-324, 0, 0, 0]",
+            // Squares to infinity.
+            "[1e200, 0, 0, 0]",
+        ] {
+            let fields =
+                format!("inertia_diag = [10, 10, 10]\nmass = 500\ninitial_quaternion = {quat}");
+            let err = validate_satellite_spec(&attitude_spec(&fields))
+                .expect_err(&format!("{quat} should be rejected"));
+            assert!(err.contains("initial_quaternion"), "{quat}: got {err}");
+        }
+    }
+
+    /// An unnormalized quaternion is still the attitude it points at: it is
+    /// normalized on use and renormalized after every step.
+    #[test]
+    fn an_unnormalized_quaternion_is_accepted() {
+        for quat in [
+            "[1e-16, 0, 0, 0]",
+            "[0.5, 0.5, 0.5, 0.5]",
+            "[3, 0, 0, 4]",
+            "[1e150, 0, 0, 0]",
+        ] {
+            let fields =
+                format!("inertia_diag = [10, 10, 10]\nmass = 500\ninitial_quaternion = {quat}");
+            validate_satellite_spec(&attitude_spec(&fields))
+                .unwrap_or_else(|e| panic!("{quat} should be accepted: {e}"));
+        }
+    }
+
+    /// The test is whether the inverse the dynamics take exists and is finite,
+    /// which a threshold on the determinant cannot decide: the determinant
+    /// carries the cube of the units, so a small one does not mean the tensor is
+    /// ill-conditioned and a large one does not mean the inverse is usable.
+    #[test]
+    fn inertia_is_judged_by_the_inverse_the_dynamics_take() {
+        for (label, fields) in [
+            ("all zero", "inertia_diag = [0, 0, 0]\nmass = 500"),
+            (
+                "products overflow to inf - inf",
+                "inertia_diag = [1e200, 1e200, 1e200]\nmass = 500\n\
+                 inertia_off_diag = [1e200, 1e200, 1e200]",
+            ),
+            (
+                "inverse has an infinite component",
+                "inertia_diag = [5e-324, 1e154, 1e154]\nmass = 500",
+            ),
+            // Condition number 1, but cofactors and determinant both overflow,
+            // so the inverse comes back as a finite matrix of zeros.
+            (
+                "inverse is silently all zeros",
+                "inertia_diag = [1e154, 1e154, 1e154]\nmass = 500",
+            ),
+        ] {
+            let err = validate_satellite_spec(&attitude_spec(fields))
+                .expect_err(&format!("{label} should be rejected"));
+            assert!(err.contains("inertia tensor"), "{label}: got {err}");
+        }
+
+        // Perfectly conditioned, determinant 1e-33: a magnitude threshold on the
+        // determinant would have rejected this.
+        validate_satellite_spec(&attitude_spec(
+            "inertia_diag = [1e-11, 1e-11, 1e-11]\nmass = 500",
+        ))
+        .expect("a well-conditioned tensor is accepted whatever its determinant");
+    }
+
+    /// An invertible tensor is not yet an integrable state: the torque-free
+    /// Euler term can overflow from the inertia and the rate alone.
+    #[test]
+    fn an_initial_state_that_starts_at_infinite_acceleration_is_rejected() {
+        let err = validate_satellite_spec(&attitude_spec(
+            "inertia_diag = [1e-308, 1, 2]\nmass = 500\ninitial_angular_velocity = [1, 2, 2]",
+        ))
+        .expect_err("an infinite initial angular acceleration should be rejected");
+        assert!(err.contains("angular acceleration"), "got {err}");
+
+        // The same inertia at rest has nothing to diverge.
+        validate_satellite_spec(&attitude_spec("inertia_diag = [1e-308, 1, 2]\nmass = 500"))
+            .expect("a resting spacecraft integrates whatever its inertia");
+    }
+
+    /// The simulation starts from the unit quaternion the config denotes, not
+    /// from its scale.
+    ///
+    /// Integrating the raw one lets a large quaternion grow until its sum of
+    /// squares overflows; the post-step projection then divides by infinity and
+    /// yields all zeros, which passes `is_finite` — so nothing stops the run —
+    /// and normalizes to `NaN` the moment a sensor reads it.
+    #[test]
+    fn the_initial_quaternion_is_normalized_before_it_is_integrated() {
+        let spec = attitude_spec(
+            "inertia_diag = [1, 1, 1]\nmass = 500\n\
+             initial_quaternion = [1e150, 0, 0, 0]\ninitial_angular_velocity = [1e4, 0, 0]",
+        );
+        let att = spec.attitude_config.as_ref().expect("attitude config");
+        let q = att.normalized_initial_quaternion();
+        assert!(
+            (q.norm() - 1.0).abs() < 1e-12,
+            "expected a unit quaternion, got {q:?}"
+        );
+        assert!((q[0] - 1.0).abs() < 1e-12, "expected identity, got {q:?}");
+    }
+
+    #[test]
+    fn a_finite_attitude_config_is_accepted() {
+        validate_satellite_spec(&attitude_spec("inertia_diag = [10, 10, 10]\nmass = 500"))
+            .expect("a well-formed attitude config is accepted");
     }
 
     #[test]

--- a/cli/src/sim/mode.rs
+++ b/cli/src/sim/mode.rs
@@ -1,0 +1,343 @@
+//! どのダイナミクスで fleet を回すかの決定。
+//!
+//! `orts run` と `orts serve` は同じ fleet を伝播するので、モード選択は
+//! 各エントリポイントではなくここで一度だけ行う。`serve` で姿勢が伝播される
+//! config は `run` でも姿勢が伝播されなければならない。
+
+use crate::satellite::SatelliteSpec;
+
+/// Fleet 全体に対して選択されたダイナミクス。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SimMode {
+    /// 並進運動のみ。
+    OrbitOnly,
+    /// 軌道 + 姿勢 (`[satellites.attitude]`)。制御ループなし。
+    Spacecraft,
+    /// 軌道 + 姿勢 + プラグインコントローラによる離散制御ループ。
+    Controlled,
+}
+
+impl SimMode {
+    /// 診断メッセージ用の短い名前。
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::OrbitOnly => "orbit-only",
+            Self::Spacecraft => "spacecraft",
+            Self::Controlled => "controlled",
+        }
+    }
+}
+
+/// `satellites` に対するモードを選ぶ。
+///
+/// 姿勢設定・コントローラ設定は fleet 単位で全か無かでなければならない:
+/// どちらも「一部の衛星だけ」では、その設定を持つ衛星の分が黙って捨てられる
+/// （制御ループは fleet 全体を回すか全く回さないかのどちらか）。
+///
+/// 空の fleet は orbit-only。`serve` が衛星なしで起動して
+/// `add_satellite` で増やせるようにするため。
+pub fn select_sim_mode(satellites: &[SatelliteSpec]) -> Result<SimMode, String> {
+    if satellites.is_empty() {
+        return Ok(SimMode::OrbitOnly);
+    }
+    let n = satellites.len();
+    let with_attitude = satellites
+        .iter()
+        .filter(|s| s.attitude_config.is_some())
+        .count();
+    if with_attitude != 0 && with_attitude != n {
+        return Err(
+            "Mixed attitude config: some satellites have attitude, some don't. \
+             Specify attitude for all satellites or remove it from all."
+                .to_string(),
+        );
+    }
+    let with_controller = satellites
+        .iter()
+        .filter(|s| s.controller_config.is_some())
+        .count();
+    if with_controller != 0 && with_controller != n {
+        return Err(format!(
+            "Mixed controller config: {with_controller} of {n} satellites have \
+             `[satellites.controller]`. The control loop steps the whole fleet or none of it, \
+             so those controllers would never run. Specify a controller for all satellites \
+             or remove it from all."
+        ));
+    }
+    if with_controller == n {
+        return Ok(SimMode::Controlled);
+    }
+    if with_attitude == n {
+        return Ok(SimMode::Spacecraft);
+    }
+    Ok(SimMode::OrbitOnly)
+}
+
+/// 選択されたモードでは効かない設定キーについての警告文。
+///
+/// センサ・アクチュエータは制御ループが読み書きして初めて効く。コントローラ
+/// なしで宣言してもシミュレーションに影響しないので、黙って捨てずに知らせる。
+pub fn unhonored_config_warnings(satellites: &[SatelliteSpec], mode: SimMode) -> Vec<String> {
+    if mode == SimMode::Controlled {
+        return Vec::new();
+    }
+    let mut warnings = Vec::new();
+    for spec in satellites {
+        let mut keys: Vec<&str> = Vec::new();
+        if spec.sensor_choices.is_some() {
+            keys.push("sensors");
+        }
+        if spec.rw_config.is_some() {
+            keys.push("reaction_wheels");
+        }
+        if spec.mtq_config.is_some() {
+            keys.push("magnetorquers");
+        }
+        if spec.thruster_config.is_some() {
+            keys.push("thruster");
+        }
+        if keys.is_empty() {
+            continue;
+        }
+        warnings.push(format!(
+            "satellite '{}': {} {} declared without `[satellites.controller]`; \
+             nothing reads the sensors or commands the actuators, so {} no effect in \
+             {} mode",
+            spec.id,
+            keys.iter()
+                .map(|k| format!("`{k}`"))
+                .collect::<Vec<_>>()
+                .join(", "),
+            if keys.len() == 1 { "is" } else { "are" },
+            if keys.len() == 1 {
+                "it has"
+            } else {
+                "they have"
+            },
+            mode.as_str(),
+        ));
+    }
+    warnings
+}
+
+/// `[[command]]` は届け先のコントローラが必要。
+///
+/// コマンドは制御ループが tick ごとに配送するので、コントローラのない run では
+/// 一件も届かない。黙って捨てるのではなく拒否する。
+pub fn ensure_commands_deliverable(mode: SimMode, command_count: usize) -> Result<(), String> {
+    if command_count == 0 || mode == SimMode::Controlled {
+        return Ok(());
+    }
+    Err(format!(
+        "config has {command_count} `[[command]]` timeline entr{}, but no satellite has \
+         `[satellites.controller]`: commands are delivered to a plugin controller on each \
+         control tick, so in {} mode they would never be delivered. Add a controller or \
+         remove the command timeline.",
+        if command_count == 1 { "y" } else { "ies" },
+        mode.as_str(),
+    ))
+}
+
+/// 宣言された stream-io ストリームは配送先のコントローラが必要。
+///
+/// ストリームはコントローラを通して pump されるので、orbit-only / spacecraft
+/// では受け取り手がなく、書いても読まれない（serve ならエンドポイントが
+/// black hole になる）。
+pub fn ensure_streams_supported(mode: SimMode, satellites: &[SatelliteSpec]) -> Result<(), String> {
+    if mode == SimMode::Controlled || satellites.iter().all(|s| s.streams.is_empty()) {
+        return Ok(());
+    }
+    Err(
+        "stream-io streams are declared but no satellite has a controller; \
+         streams require a plugin-controlled simulation"
+            .to_string(),
+    )
+}
+
+/// 単一衛星の姿勢設定を検証し、`build_spacecraft_dynamics` が特異な慣性テンソルや
+/// 非正の質量で panic しないようにする。起動時の config 検証と、
+/// serve の実行時 `add_satellite` の両経路から使う。
+pub fn validate_satellite_spec(spec: &SatelliteSpec) -> Result<(), String> {
+    let Some(att) = &spec.attitude_config else {
+        return Ok(());
+    };
+    let inertia = att.inertia_matrix();
+    if inertia.determinant().abs() < 1e-30 {
+        return Err(format!(
+            "Satellite '{}' has singular inertia tensor (not invertible)",
+            spec.id
+        ));
+    }
+    if att.mass <= 0.0 {
+        return Err(format!(
+            "Satellite '{}' has non-positive mass: {}",
+            spec.id, att.mass
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::SimConfig;
+    use crate::satellite::parse_body;
+
+    fn specs(toml: &str) -> Vec<SatelliteSpec> {
+        let config: SimConfig = toml::from_str(toml).expect("config parses");
+        let body = parse_body(&config.body);
+        let mu = body.properties().mu;
+        config
+            .satellites
+            .iter()
+            .enumerate()
+            .map(|(i, s)| s.to_satellite_spec(i, body, mu))
+            .collect()
+    }
+
+    const ORBIT: &str = r#"
+body = "earth"
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 400 }
+"#;
+
+    #[test]
+    fn empty_fleet_is_orbit_only() {
+        assert_eq!(select_sim_mode(&[]), Ok(SimMode::OrbitOnly));
+    }
+
+    #[test]
+    fn orbit_config_is_orbit_only() {
+        assert_eq!(select_sim_mode(&specs(ORBIT)), Ok(SimMode::OrbitOnly));
+    }
+
+    #[test]
+    fn attitude_without_controller_is_spacecraft() {
+        let toml = r#"
+body = "earth"
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 400 }
+attitude = { inertia_diag = [10, 10, 10], mass = 500 }
+"#;
+        assert_eq!(select_sim_mode(&specs(toml)), Ok(SimMode::Spacecraft));
+    }
+
+    #[test]
+    fn mixed_attitude_is_rejected() {
+        let toml = r#"
+body = "earth"
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 400 }
+attitude = { inertia_diag = [10, 10, 10], mass = 500 }
+[[satellites]]
+id = "b"
+orbit = { type = "circular", altitude = 500 }
+"#;
+        let err = select_sim_mode(&specs(toml)).unwrap_err();
+        assert!(err.contains("Mixed attitude config"), "got: {err}");
+    }
+
+    #[test]
+    fn mixed_controller_is_rejected() {
+        // Both satellites have attitude, so the fleet is a valid spacecraft
+        // fleet — but only one has a controller, and the control loop steps
+        // the whole fleet or none of it. Running spacecraft mode here would
+        // silently drop 'a's controller.
+        let toml = r#"
+body = "earth"
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 400 }
+attitude = { inertia_diag = [10, 10, 10], mass = 500 }
+controller = { type = "wasm", path = "ctrl.wasm" }
+[[satellites]]
+id = "b"
+orbit = { type = "circular", altitude = 500 }
+attitude = { inertia_diag = [10, 10, 10], mass = 500 }
+"#;
+        let err = select_sim_mode(&specs(toml)).unwrap_err();
+        assert!(err.contains("Mixed controller config"), "got: {err}");
+        assert!(err.contains("1 of 2"), "got: {err}");
+    }
+
+    #[test]
+    fn all_controllers_is_controlled() {
+        let toml = r#"
+body = "earth"
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 400 }
+attitude = { inertia_diag = [10, 10, 10], mass = 500 }
+controller = { type = "wasm", path = "ctrl.wasm" }
+"#;
+        assert_eq!(select_sim_mode(&specs(toml)), Ok(SimMode::Controlled));
+    }
+
+    #[test]
+    fn actuators_without_controller_warn() {
+        let toml = r#"
+body = "earth"
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 400 }
+sensors = ["gyroscope"]
+attitude = { inertia_diag = [10, 10, 10], mass = 500 }
+reaction_wheels = { type = "three_axis", inertia = 0.01, max_momentum = 1.0, max_torque = 0.5 }
+"#;
+        let specs = specs(toml);
+        let warnings = unhonored_config_warnings(&specs, SimMode::Spacecraft);
+        assert_eq!(warnings.len(), 1, "got: {warnings:?}");
+        assert!(warnings[0].contains("`sensors`"), "got: {}", warnings[0]);
+        assert!(
+            warnings[0].contains("`reaction_wheels`"),
+            "got: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn controlled_mode_honors_actuators() {
+        let toml = r#"
+body = "earth"
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 400 }
+sensors = ["gyroscope"]
+attitude = { inertia_diag = [10, 10, 10], mass = 500 }
+controller = { type = "wasm", path = "ctrl.wasm" }
+"#;
+        assert!(unhonored_config_warnings(&specs(toml), SimMode::Controlled).is_empty());
+    }
+
+    #[test]
+    fn streams_need_a_controller() {
+        let toml = r#"
+body = "earth"
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 400 }
+streams = ["comlink"]
+"#;
+        let streamed = specs(toml);
+        assert!(ensure_streams_supported(SimMode::Controlled, &streamed).is_ok());
+        let err = ensure_streams_supported(SimMode::OrbitOnly, &streamed).unwrap_err();
+        assert!(err.contains("streams require"), "got: {err}");
+        assert!(ensure_streams_supported(SimMode::OrbitOnly, &specs(ORBIT)).is_ok());
+    }
+
+    #[test]
+    fn commands_need_a_controller() {
+        assert!(ensure_commands_deliverable(SimMode::Controlled, 3).is_ok());
+        assert!(ensure_commands_deliverable(SimMode::Spacecraft, 0).is_ok());
+        let err = ensure_commands_deliverable(SimMode::Spacecraft, 1).unwrap_err();
+        assert!(err.contains("`[[command]]`"), "got: {err}");
+        let err = ensure_commands_deliverable(SimMode::OrbitOnly, 2).unwrap_err();
+        assert!(
+            err.contains("2 `[[command]]` timeline entries"),
+            "got: {err}"
+        );
+    }
+}

--- a/cli/src/sim/mode.rs
+++ b/cli/src/sim/mode.rs
@@ -138,18 +138,41 @@ pub fn ensure_commands_deliverable(mode: SimMode, command_count: usize) -> Resul
     ))
 }
 
-/// 宣言された stream-io ストリームは配送先のコントローラが必要。
+fn declares_streams(satellites: &[SatelliteSpec]) -> bool {
+    satellites.iter().any(|s| !s.streams.is_empty())
+}
+
+/// serve: 宣言された stream-io ストリームは配送先のコントローラが必要。
 ///
 /// ストリームはコントローラを通して pump されるので、orbit-only / spacecraft
-/// では受け取り手がなく、書いても読まれない（serve ならエンドポイントが
-/// black hole になる）。
+/// では受け取り手がなく、エンドポイントが black hole になる。
 pub fn ensure_streams_supported(mode: SimMode, satellites: &[SatelliteSpec]) -> Result<(), String> {
-    if mode == SimMode::Controlled || satellites.iter().all(|s| s.streams.is_empty()) {
+    if mode == SimMode::Controlled || !declares_streams(satellites) {
         return Ok(());
     }
     Err(
         "stream-io streams are declared but no satellite has a controller; \
          streams require a plugin-controlled simulation"
+            .to_string(),
+    )
+}
+
+/// run: stream-io ストリームは `orts run` では扱えない。
+///
+/// ストリームを実際に pump するのは serve の realtime ループ（WS / stdio
+/// bridge）だけで、`orts run` の制御ループには対向する transport がない。
+/// controlled モードでも inbound は永遠に届かず、guest が書いた outbound は
+/// 誰も取り出さないまま溜まって overrun する。開けない口を黙って開けるより
+/// 拒否する。
+pub fn ensure_streams_unused(satellites: &[SatelliteSpec]) -> Result<(), String> {
+    if !declares_streams(satellites) {
+        return Ok(());
+    }
+    Err(
+        "stream-io streams are declared but `orts run` has no transport to pump them: \
+         inbound bytes would never arrive and the guest's outbound writes would pile up \
+         until the stream faults. Use `orts serve` (WebSocket or --stream-stdio) for \
+         streams, or remove the `streams` declaration."
             .to_string(),
     )
 }
@@ -326,6 +349,27 @@ streams = ["comlink"]
         let err = ensure_streams_supported(SimMode::OrbitOnly, &streamed).unwrap_err();
         assert!(err.contains("streams require"), "got: {err}");
         assert!(ensure_streams_supported(SimMode::OrbitOnly, &specs(ORBIT)).is_ok());
+    }
+
+    /// `orts run` has no stream transport at all, so even controlled mode has
+    /// to reject declared streams — accepting them would leave inbound bytes
+    /// undelivered and outbound writes piling up until the stream faults.
+    #[test]
+    fn run_rejects_streams_in_every_mode() {
+        let toml = r#"
+body = "earth"
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 400 }
+attitude = { inertia_diag = [10, 10, 10], mass = 500 }
+controller = { type = "wasm", path = "ctrl.wasm" }
+streams = ["comlink"]
+"#;
+        let streamed = specs(toml);
+        assert_eq!(select_sim_mode(&streamed), Ok(SimMode::Controlled));
+        let err = ensure_streams_unused(&streamed).unwrap_err();
+        assert!(err.contains("`orts run` has no transport"), "got: {err}");
+        assert!(ensure_streams_unused(&specs(ORBIT)).is_ok());
     }
 
     #[test]

--- a/cli/tests/config_e2e.rs
+++ b/cli/tests/config_e2e.rs
@@ -220,3 +220,49 @@ fn test_config_validate_rejects_bad_epoch() {
     );
     std::fs::remove_dir_all(&dir).ok();
 }
+
+/// An attitude config the simulation would refuse must not validate as OK.
+///
+/// `config validate` reports on `SimConfig::load`, so a check applied only at
+/// the run and serve entry points would leave this command calling a config
+/// valid that both of them then reject.
+#[test]
+fn test_config_validate_rejects_unintegrable_attitude() {
+    for (tag, attitude) in [
+        ("nan-inertia", "inertia_diag = [nan, 10, 10]\nmass = 500"),
+        (
+            "huge-inertia",
+            "inertia_diag = [1e200, 1e200, 1e200]\nmass = 500\n\
+             inertia_off_diag = [1e200, 1e200, 1e200]",
+        ),
+        ("zero-mass", "inertia_diag = [10, 10, 10]\nmass = 0"),
+        (
+            "zero-quat",
+            "inertia_diag = [10, 10, 10]\nmass = 500\ninitial_quaternion = [0, 0, 0, 0]",
+        ),
+    ] {
+        let dir = unique_dir(tag);
+        let path = dir.join("bad.toml");
+        std::fs::write(
+            &path,
+            format!(
+                "body = \"earth\"\ndt = 1.0\n\n[[satellites]]\nid = \"a\"\n\
+                 orbit = {{ type = \"circular\", altitude = 500 }}\n\n\
+                 [satellites.attitude]\n{attitude}\n"
+            ),
+        )
+        .unwrap();
+
+        let out = orts()
+            .args(["config", "validate", path.to_str().unwrap(), "--json"])
+            .output()
+            .expect("validate --json");
+        assert_eq!(out.status.code(), Some(2), "{tag}: expected exit code 2");
+        let v: serde_json::Value = serde_json::from_str(&String::from_utf8_lossy(&out.stdout))
+            .expect("validate --json should print JSON even on error");
+        assert_eq!(v["status"], "error", "{tag}");
+        let msg = v["error"].as_str().unwrap_or_default();
+        assert!(msg.contains("attitude"), "{tag}: got {msg}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/cli/tests/run_mode_e2e.rs
+++ b/cli/tests/run_mode_e2e.rs
@@ -420,8 +420,8 @@ attitude = { inertia_diag = [10, 10, 10], mass = 500 }
 /// `path` rewritten to an absolute one so the test does not depend on its cwd.
 ///
 /// Reading the README rather than restating it is deliberate: the quick-start
-/// config shipped un-runnable for a long time (a required `max_momentum` was
-/// missing), which a copy in this file would not have caught.
+/// config has shipped un-runnable before, once for a missing required field,
+/// which a copy in this file would not have caught.
 fn readme_quickstart_toml(wasm: &std::path::Path) -> String {
     let readme = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/../README.md"))
         .expect("README.md is readable");

--- a/cli/tests/run_mode_e2e.rs
+++ b/cli/tests/run_mode_e2e.rs
@@ -1,0 +1,383 @@
+//! E2E tests for `orts run`'s dynamics-mode selection.
+//!
+//! `run` and `serve` share one mode rule (`crate::sim::mode::select_sim_mode`),
+//! so a config that gets attitude dynamics under `serve` gets them under `run`
+//! too, and a config no mode can honor is rejected instead of being partly
+//! ignored.
+
+use std::process::Command;
+
+fn orts() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_orts"))
+}
+
+fn unique_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "orts-e2e-run-mode-{tag}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Write `config` into a fresh directory and run `orts run --config … --format csv`
+/// with the data on stdout. Returns the process output.
+fn run_config(tag: &str, config: &str) -> std::process::Output {
+    let dir = unique_dir(tag);
+    let path = dir.join("orts.toml");
+    std::fs::write(&path, config).unwrap();
+    let out = orts()
+        .args([
+            "run",
+            "--config",
+            path.to_str().unwrap(),
+            "--output",
+            "-",
+            "--format",
+            "csv",
+        ])
+        .output()
+        .expect("failed to execute orts");
+    std::fs::remove_dir_all(&dir).ok();
+    out
+}
+
+fn header_line(stdout: &str) -> &str {
+    stdout
+        .lines()
+        .find(|l| l.starts_with("# t[s]"))
+        .unwrap_or_else(|| panic!("no CSV header in output:\n{stdout}"))
+}
+
+fn data_lines(stdout: &str) -> Vec<&str> {
+    stdout
+        .lines()
+        .filter(|l| !l.starts_with('#') && !l.is_empty())
+        .collect()
+}
+
+/// The README quick-start config: `[satellites.attitude]` + `sensors` +
+/// `[satellites.reaction_wheels]`, no controller. It must parse, run, and
+/// output the propagated attitude — before this it silently produced an
+/// orbit-only CSV.
+#[test]
+fn readme_quickstart_config_outputs_attitude() {
+    let config = r#"
+body = "earth"
+dt = 0.01
+duration = 120.0
+
+[[satellites]]
+id = "sat-1"
+sensors = ["gyroscope", "star_tracker"]
+
+[satellites.orbit]
+type = "circular"
+altitude = 400
+
+[satellites.attitude]
+inertia_diag = [10, 10, 10]
+mass = 500
+
+[satellites.reaction_wheels]
+type = "three_axis"
+inertia = 0.01
+max_momentum = 1.0
+max_torque = 0.5
+"#;
+    let out = run_config("readme", config);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "run failed: {stderr}");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let header = header_line(&stdout);
+    for col in ["qw", "qx", "qy", "qz", "wx", "wy", "wz"] {
+        assert!(
+            header.split(',').any(|c| c == col),
+            "attitude column '{col}' missing from header: {header}"
+        );
+    }
+
+    // Every data row carries the attitude columns as well.
+    let ncols = header.trim_start_matches("# ").split(',').count();
+    for line in data_lines(&stdout).iter().take(3) {
+        assert_eq!(
+            line.split(',').count(),
+            ncols,
+            "row does not match the header width: {line}"
+        );
+    }
+
+    // `sensors` / `reaction_wheels` need a controller; the run says so rather
+    // than dropping them silently.
+    assert!(
+        stderr.contains("`sensors`") && stderr.contains("`reaction_wheels`"),
+        "no warning about the un-honored keys: {stderr}"
+    );
+}
+
+/// The propagated quaternion is a real integration result, not a logged
+/// constant: with an asymmetric inertia tensor the coupled gravity-gradient
+/// torque spins the body up, and the quaternion stays a unit quaternion.
+#[test]
+fn spacecraft_mode_integrates_attitude() {
+    let config = r#"
+body = "earth"
+dt = 1.0
+duration = 3000.0
+output_interval = 100.0
+
+[[satellites]]
+id = "sat-1"
+
+[satellites.orbit]
+type = "circular"
+altitude = 400
+
+[satellites.attitude]
+inertia_diag = [10.0, 40.0, 80.0]
+mass = 500
+initial_quaternion = [0.9238795325112867, 0.0, 0.3826834323650898, 0.0]
+initial_angular_velocity = [0.0, 0.0, 0.0]
+"#;
+    let out = run_config("gg", config);
+    assert!(
+        out.status.success(),
+        "run failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let header = header_line(&stdout);
+    let cols: Vec<&str> = header.trim_start_matches("# ").split(',').collect();
+    let idx = |name: &str| {
+        cols.iter()
+            .position(|c| *c == name)
+            .unwrap_or_else(|| panic!("column '{name}' missing: {header}"))
+    };
+    let (iqw, iqx, iqy, iqz) = (idx("qw"), idx("qx"), idx("qy"), idx("qz"));
+    let (iwx, iwy, iwz) = (idx("wx"), idx("wy"), idx("wz"));
+
+    let rows = data_lines(&stdout);
+    assert!(rows.len() > 10, "expected many rows, got {}", rows.len());
+
+    let field =
+        |line: &str, i: usize| -> f64 { line.split(',').nth(i).unwrap().trim().parse().unwrap() };
+
+    // Unit-norm quaternion is an invariant of rigid-body attitude
+    // integration; it holds without any external reference data.
+    let mut max_w = 0.0_f64;
+    let mut max_dq = 0.0_f64;
+    let first = rows[0];
+    for line in &rows {
+        let norm = (field(line, iqw).powi(2)
+            + field(line, iqx).powi(2)
+            + field(line, iqy).powi(2)
+            + field(line, iqz).powi(2))
+        .sqrt();
+        assert!(
+            (norm - 1.0).abs() < 1e-6,
+            "quaternion norm {norm} drifted off 1: {line}"
+        );
+        max_w = max_w.max(
+            field(line, iwx)
+                .abs()
+                .max(field(line, iwy).abs())
+                .max(field(line, iwz).abs()),
+        );
+        for i in [iqw, iqx, iqy, iqz] {
+            max_dq = max_dq.max((field(line, i) - field(first, i)).abs());
+        }
+    }
+    // Gravity gradient torques an asymmetric body away from rest.
+    assert!(
+        max_w > 1e-6,
+        "angular velocity never left zero (max |w| = {max_w}); the attitude \
+         state is not being integrated"
+    );
+    assert!(
+        max_dq > 1e-3,
+        "quaternion never moved (max delta = {max_dq})"
+    );
+}
+
+/// An orbit-only config keeps the 13-column CSV contract that `orts convert`
+/// and the viewer consume. Pins the mode rule against widening: a config
+/// without `[satellites.attitude]` must not fall into spacecraft mode.
+#[test]
+fn orbit_only_config_keeps_thirteen_columns() {
+    let config = r#"
+body = "earth"
+dt = 1.0
+duration = 60.0
+
+[[satellites]]
+id = "sat-1"
+
+[satellites.orbit]
+type = "circular"
+altitude = 400
+"#;
+    let out = run_config("orbit-only", config);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "run failed: {stderr}");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        header_line(&stdout),
+        "# t[s],x[km],y[km],z[km],vx[km/s],vy[km/s],vz[km/s],a[km],e[-],i[rad],raan[rad],omega[rad],nu[rad]",
+    );
+    for line in data_lines(&stdout) {
+        assert_eq!(
+            line.split(',').count(),
+            13,
+            "orbit-only row is not 13 columns: {line}"
+        );
+    }
+    assert!(
+        !stderr.contains("Warning:"),
+        "a plain orbit-only config should not warn: {stderr}"
+    );
+}
+
+/// `[[command]]` entries are delivered by the control loop, so a fleet with no
+/// controller cannot honor them. Rejected instead of dropped.
+#[test]
+fn command_timeline_without_controller_is_rejected() {
+    let config = r#"
+body = "earth"
+dt = 1.0
+duration = 60.0
+
+[[satellites]]
+id = "sat-1"
+
+[satellites.orbit]
+type = "circular"
+altitude = 400
+
+[[command]]
+t = 10.0
+sat = "sat-1"
+kind = "orts.cmd.set-mode.v1"
+args = { mode = "safe" }
+"#;
+    let out = run_config("cmd-no-ctrl", config);
+    assert!(
+        !out.status.success(),
+        "a command timeline without a controller must fail, stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("[[command]]") && stderr.contains("controller"),
+        "unhelpful rejection message: {stderr}"
+    );
+}
+
+/// Attitude has to be all-or-nothing across the fleet — the same rule `serve`
+/// enforces at engine construction.
+#[test]
+fn mixed_attitude_config_is_rejected() {
+    let config = r#"
+body = "earth"
+dt = 1.0
+duration = 60.0
+
+[[satellites]]
+id = "with-attitude"
+orbit = { type = "circular", altitude = 400 }
+attitude = { inertia_diag = [10, 10, 10], mass = 500 }
+
+[[satellites]]
+id = "without"
+orbit = { type = "circular", altitude = 500 }
+"#;
+    let out = run_config("mixed-att", config);
+    assert!(!out.status.success(), "mixed attitude must be rejected");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Mixed attitude config"),
+        "unexpected message: {stderr}"
+    );
+}
+
+/// The control loop steps the whole fleet or none of it, so a controller on
+/// only some satellites would never run. Rejected rather than ignored.
+#[test]
+fn mixed_controller_config_is_rejected() {
+    let config = r#"
+body = "earth"
+dt = 1.0
+duration = 60.0
+
+[[satellites]]
+id = "controlled"
+orbit = { type = "circular", altitude = 400 }
+attitude = { inertia_diag = [10, 10, 10], mass = 500 }
+controller = { type = "wasm", path = "does-not-exist.wasm" }
+
+[[satellites]]
+id = "uncontrolled"
+orbit = { type = "circular", altitude = 500 }
+attitude = { inertia_diag = [10, 10, 10], mass = 500 }
+"#;
+    let out = run_config("mixed-ctrl", config);
+    assert!(!out.status.success(), "mixed controller must be rejected");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Mixed controller config"),
+        "unexpected message: {stderr}"
+    );
+}
+
+/// `--json` reports the un-honored keys in the machine-readable summary, not
+/// only on stderr, so an agent driving the CLI can see them.
+#[test]
+fn json_summary_lists_unhonored_keys() {
+    let dir = unique_dir("json-warn");
+    let config_path = dir.join("orts.toml");
+    let csv_path = dir.join("out.csv");
+    std::fs::write(
+        &config_path,
+        r#"
+body = "earth"
+dt = 1.0
+duration = 60.0
+
+[[satellites]]
+id = "sat-1"
+sensors = ["gyroscope"]
+orbit = { type = "circular", altitude = 400 }
+attitude = { inertia_diag = [10, 10, 10], mass = 500 }
+"#,
+    )
+    .unwrap();
+
+    let out = orts()
+        .args([
+            "run",
+            "--config",
+            config_path.to_str().unwrap(),
+            "--output",
+            csv_path.to_str().unwrap(),
+            "--format",
+            "csv",
+            "--json",
+        ])
+        .output()
+        .expect("failed to execute orts");
+    assert!(
+        out.status.success(),
+        "run failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let summary: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stdout is the JSON summary");
+    let warnings = summary["warnings"].as_array().expect("warnings array");
+    assert_eq!(warnings.len(), 1, "got: {warnings:?}");
+    assert!(
+        warnings[0].as_str().unwrap().contains("`sensors`"),
+        "got: {warnings:?}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/cli/tests/run_mode_e2e.rs
+++ b/cli/tests/run_mode_e2e.rs
@@ -274,6 +274,34 @@ args = { mode = "safe" }
     );
 }
 
+/// stream-io streams are pumped by `orts serve`'s realtime loop; `orts run`
+/// has no transport for them, so declaring one is rejected instead of leaving
+/// the endpoints dead.
+#[test]
+fn declared_streams_are_rejected_by_run() {
+    let config = r#"
+body = "earth"
+dt = 1.0
+duration = 60.0
+
+[[satellites]]
+id = "sat-1"
+orbit = { type = "circular", altitude = 400 }
+streams = ["comlink"]
+"#;
+    let out = run_config("streams", config);
+    assert!(
+        !out.status.success(),
+        "declared streams must fail under run, stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("orts serve") && stderr.contains("streams"),
+        "unhelpful rejection message: {stderr}"
+    );
+}
+
 /// Attitude has to be all-or-nothing across the fleet — the same rule `serve`
 /// enforces at engine construction.
 #[test]

--- a/cli/tests/run_mode_e2e.rs
+++ b/cli/tests/run_mode_e2e.rs
@@ -7,7 +7,12 @@
 
 use std::process::Command;
 
+/// Honor `ORTS_BIN` so the plugin-backend CI job, which downloads a prebuilt
+/// binary instead of building one, can run these tests too.
 fn orts() -> Command {
+    if let Ok(path) = std::env::var("ORTS_BIN") {
+        return Command::new(path);
+    }
     Command::new(env!("CARGO_BIN_EXE_orts"))
 }
 
@@ -57,12 +62,13 @@ fn data_lines(stdout: &str) -> Vec<&str> {
         .collect()
 }
 
-/// The README quick-start config: `[satellites.attitude]` + `sensors` +
-/// `[satellites.reaction_wheels]`, no controller. It must parse, run, and
-/// output the propagated attitude — before this it silently produced an
-/// orbit-only CSV.
+/// `[satellites.attitude]` + `sensors` + `[satellites.reaction_wheels]` with no
+/// controller must parse, run, and output the propagated attitude — before this
+/// it silently produced an orbit-only CSV. The README's quick start adds a
+/// controller on top of this shape; `readme_quickstart_config_runs_controlled`
+/// covers that config as it ships.
 #[test]
-fn readme_quickstart_config_outputs_attitude() {
+fn attitude_without_controller_outputs_attitude() {
     let config = r#"
 body = "earth"
 dt = 0.01
@@ -408,4 +414,142 @@ attitude = { inertia_diag = [10, 10, 10], mass = 500 }
         "got: {warnings:?}"
     );
     std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Extract the README quick-start TOML block, with the controller's cwd-relative
+/// `path` rewritten to an absolute one so the test does not depend on its cwd.
+///
+/// Reading the README rather than restating it is deliberate: the quick-start
+/// config shipped un-runnable for a long time (a required `max_momentum` was
+/// missing), which a copy in this file would not have caught.
+fn readme_quickstart_toml(wasm: &std::path::Path) -> String {
+    let readme = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/../README.md"))
+        .expect("README.md is readable");
+    let after = readme
+        .split_once("Example config (`orts.toml`)")
+        .expect("README has the quick-start config section")
+        .1;
+    let block = after
+        .split("```toml")
+        .nth(1)
+        .expect("a toml code block follows")
+        .split("```")
+        .next()
+        .expect("the toml block is closed");
+    let mut rewritten = 0;
+    let toml = block
+        .lines()
+        .map(|l| {
+            let key = l.split('=').next().unwrap_or_default().trim();
+            if key == "path" {
+                rewritten += 1;
+                format!("path = {:?}", wasm.to_str().unwrap())
+            } else {
+                l.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    // Without this the relative path in the README would resolve by accident
+    // when the tests happen to run from the repository root, and the rewrite
+    // silently covering nothing would look like a pass.
+    assert_eq!(
+        rewritten, 1,
+        "expected exactly one `path` to rewrite in the quick-start config: {toml}"
+    );
+    toml
+}
+
+/// Resolve the pd-rw-control guest WASM the README points at, or `None` if it
+/// has not been built.
+fn pd_rw_guest_wasm() -> Option<std::path::PathBuf> {
+    let path = std::path::PathBuf::from(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../plugin-sdk/examples/target/wasm32-wasip1/release/",
+        "orts_example_plugin_pd_rw_control.wasm"
+    ));
+    if path.exists() {
+        return Some(path);
+    }
+    eprintln!(
+        "WASM not found: {}\n\
+         Build: cargo +1.91.0 component build --release \
+         --manifest-path plugin-sdk/examples/pd-rw-control/Cargo.toml\n\
+         Skipping the README quick-start e2e test.",
+        path.display()
+    );
+    None
+}
+
+/// A `[satellites.controller]` with no `config` table starts the guest on its
+/// own defaults. The omitted table arrives as JSON `null`, whose `to_string()`
+/// is `"null"` — which the guest cannot parse as its config struct however many
+/// `#[serde(default)]`s it carries.
+#[test]
+fn controller_without_config_table_uses_guest_defaults() {
+    let Some(wasm) = pd_rw_guest_wasm() else {
+        return;
+    };
+    let config = format!(
+        r#"
+body = "earth"
+dt = 0.1
+duration = 10.0
+
+[[satellites]]
+id = "sat-1"
+sensors = ["gyroscope", "star_tracker"]
+orbit = {{ type = "circular", altitude = 400 }}
+attitude = {{ inertia_diag = [10, 10, 10], mass = 500 }}
+reaction_wheels = {{ type = "three_axis", inertia = 0.01, max_momentum = 1.0, max_torque = 0.5 }}
+
+[satellites.controller]
+type = "wasm"
+path = {:?}
+"#,
+        wasm.to_str().unwrap()
+    );
+    let out = run_config("ctrl-no-config", &config);
+    assert!(
+        out.status.success(),
+        "run failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The README quick-start config, as it ships, runs in controlled mode: the
+/// wheels are commanded, so nothing is reported as un-honored.
+#[test]
+fn readme_quickstart_config_runs_controlled() {
+    let Some(wasm) = pd_rw_guest_wasm() else {
+        return;
+    };
+    let config = readme_quickstart_toml(&wasm);
+    assert!(
+        config.contains("[satellites.controller]"),
+        "the README quick start no longer declares a controller: {config}"
+    );
+
+    let out = run_config("readme-quickstart", &config);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "run failed: {stderr}");
+    assert!(
+        !stderr.contains("declared without `[satellites.controller]`"),
+        "the shipped config warns about un-honored keys: {stderr}"
+    );
+
+    // The wheel-command and wheel-momentum columns only exist when the control
+    // loop runs, so they are what distinguishes controlled from spacecraft mode
+    // — the attitude columns alone appear in both.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let header = header_line(&stdout);
+    for col in [
+        "qw", "qx", "qy", "qz", "wx", "wy", "wz", "rw_tx", "rw_ty", "rw_tz", "rw_hx", "rw_hy",
+        "rw_hz",
+    ] {
+        assert!(
+            header.split(',').any(|c| c == col),
+            "column '{col}' missing from header: {header}"
+        );
+    }
 }

--- a/cli/tests/run_mode_e2e.rs
+++ b/cli/tests/run_mode_e2e.rs
@@ -517,6 +517,112 @@ path = {:?}
     );
 }
 
+/// A large unnormalized quaternion runs to completion, with a finite attitude
+/// throughout.
+///
+/// Integrated raw, it grows until its sum of squares overflows; the post-step
+/// projection then divides by infinity and publishes all zeros, which
+/// `is_finite` accepts — so the run reports success while every attitude row
+/// from that point on is meaningless.
+#[test]
+fn a_large_unnormalized_quaternion_still_integrates() {
+    let config = r#"
+body = "earth"
+dt = 0.1
+duration = 30.0
+
+[[satellites]]
+id = "sat-1"
+orbit = { type = "circular", altitude = 400 }
+attitude = { inertia_diag = [1, 1, 1], mass = 500, initial_quaternion = [1e150, 0, 0, 0], initial_angular_velocity = [1e4, 0, 0] }
+"#;
+    let out = run_config("huge-quat", config);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "run failed: {stderr}");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let header = header_line(&stdout);
+    let cols: Vec<&str> = header.trim_start_matches("# ").split(',').collect();
+    // Looked up by name one at a time: the quaternion columns are not
+    // necessarily adjacent, so slicing four wide from `qw` reads whatever
+    // happens to follow it.
+    let quat: Vec<usize> = ["qw", "qx", "qy", "qz"]
+        .iter()
+        .map(|name| {
+            cols.iter()
+                .position(|c| c == name)
+                .unwrap_or_else(|| panic!("column '{name}' missing: {header}"))
+        })
+        .collect();
+
+    let mut rows = 0;
+    for line in data_lines(&stdout) {
+        let fields: Vec<&str> = line.split(',').collect();
+        let norm_sq: f64 = quat
+            .iter()
+            .map(|i| {
+                let f = fields[*i];
+                let v: f64 = f.parse().unwrap_or_else(|e| panic!("{f:?}: {e}"));
+                assert!(v.is_finite(), "non-finite quaternion component in: {line}");
+                v * v
+            })
+            .sum();
+        // The failure mode this pins is the all-zero quaternion: integrated
+        // raw, the components grow until their sum of squares overflows and the
+        // post-step projection divides each by infinity. How closely the norm
+        // tracks 1 is a separate question — the adaptive solvers do not project
+        // between steps — so this asks only that the attitude still names one.
+        // `is_finite` on the sum too: each component can be finite while their
+        // squares overflow, and `inf > 0.5` would wave that through.
+        assert!(
+            norm_sq.is_finite() && norm_sq > 0.5,
+            "quaternion no longer names an attitude (norm² = {norm_sq}) in: {line}"
+        );
+        rows += 1;
+    }
+    assert!(
+        rows > 10,
+        "expected the whole span to be recorded, got {rows}"
+    );
+}
+
+/// An attitude config that cannot be integrated is rejected before the run
+/// starts, in controlled mode too.
+///
+/// The controlled path builds its satellites inside
+/// `build_controlled_satellite` rather than through the spacecraft path, so a
+/// check placed in the latter left this entry point uncovered.
+///
+/// The controller path is never loaded — the config is refused first — so this
+/// names a `.wasm` that does not exist rather than requiring the guest to be
+/// built. That keeps the test running everywhere: were the check removed, the
+/// run would fail on the missing plugin instead, with a different message and
+/// exit code, and the assertions below would still catch it.
+#[test]
+fn controlled_run_rejects_unintegrable_attitude() {
+    let config = r#"
+body = "earth"
+dt = 0.1
+duration = 10.0
+
+[[satellites]]
+id = "sat-1"
+orbit = { type = "circular", altitude = 400 }
+attitude = { inertia_diag = [nan, 10, 10], mass = 500 }
+
+[satellites.controller]
+type = "wasm"
+path = "definitely-not-a-plugin.wasm"
+"#;
+    let out = run_config("ctrl-nan-inertia", config);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!out.status.success(), "run should have failed: {stderr}");
+    assert!(
+        stderr.contains("attitude") && stderr.contains("inertia_diag"),
+        "got: {stderr}"
+    );
+}
+
 /// The README quick-start config, as it ships, runs in controlled mode: the
 /// wheels are commanded, so nothing is reported as un-honored.
 #[test]

--- a/utsuroi/src/integrator.rs
+++ b/utsuroi/src/integrator.rs
@@ -24,9 +24,10 @@ pub trait Integrator {
     ///
     /// Panics if the arguments cannot produce a terminating integration —
     /// `dt <= 0`, a non-finite `dt`, `t_end < t0`, or a `dt` so small relative
-    /// to `t` that `t + dt` rounds back to `t`. Use
-    /// [`try_integrate`](Integrator::try_integrate) to handle those cases
-    /// without panicking. Previously these inputs spun forever instead.
+    /// to `t` that `t + dt` rounds back to `t` — and if a step produces a
+    /// non-finite state. Use [`try_integrate`](Integrator::try_integrate) to
+    /// handle those cases without panicking. Previously the invalid arguments
+    /// spun forever and the non-finite state ran to the end of the span.
     fn integrate<S, F>(
         &self,
         system: &S,
@@ -49,7 +50,10 @@ pub trait Integrator {
     /// Fallible variant of [`integrate`](Integrator::integrate).
     ///
     /// Returns `Err` instead of panicking when the step size or time span
-    /// cannot produce a terminating integration.
+    /// cannot produce a terminating integration, and stops with
+    /// [`IntegrationError::NonFiniteState`] at the first step whose result is
+    /// not finite — the state after that step is not a trajectory, and every
+    /// step taken from it is wasted.
     fn try_integrate<S, F>(
         &self,
         system: &S,
@@ -78,6 +82,15 @@ pub trait Integrator {
             }
             state = self.step(system, t, &state, h);
             t += h;
+
+            // The same check `integrate_with_events` makes. Without it the
+            // controlled path — the one caller that uses `try_integrate` — read
+            // sensors off a `NaN` state and fed it to a controller, and the run
+            // reported success.
+            if !state.is_finite() {
+                return Err(IntegrationError::NonFiniteState { t });
+            }
+
             callback(t, &state);
         }
 
@@ -207,6 +220,40 @@ mod tests {
             .try_integrate(&system(), initial(), 1.0, 1.0, 0.1, |_, _| {})
             .expect("empty span should be a no-op, not an error");
         assert_eq!(state.y()[0], 0.0);
+    }
+
+    /// `try_integrate` stops where `integrate_with_events` does. It used to run
+    /// the whole span on a non-finite state and return `Ok`, so the controlled
+    /// simulation — its one caller — read sensors off `NaN` and reported success.
+    #[test]
+    fn try_integrate_stops_at_a_non_finite_state() {
+        struct Exploding;
+        impl DynamicalSystem for Exploding {
+            type State = State<3, 2>;
+            fn derivatives(&self, t: f64, state: &Self::State) -> Self::State {
+                let accel = if t > 0.3 {
+                    vector![f64::INFINITY, 0.0, 0.0]
+                } else {
+                    vector![0.0, 0.0, 0.0]
+                };
+                State::<3, 2>::from_derivative(*state.dy(), accel)
+            }
+        }
+
+        let initial = State::<3, 2>::new(vector![1.0, 0.0, 0.0], vector![0.0, 0.0, 0.0]);
+        let err = Rk4
+            .try_integrate(&Exploding, initial, 0.0, 10.0, 0.1, |_, _| {})
+            .expect_err("a non-finite state should stop the integration");
+        match err {
+            IntegrationError::NonFiniteState { t } => {
+                assert!(t > 0.3, "should stop after the blow-up, got t={t}");
+                assert!(
+                    t < 10.0,
+                    "should stop before the end of the span, got t={t}"
+                );
+            }
+            other => panic!("expected NonFiniteState, got {other:?}"),
+        }
     }
 
     /// At `t = 2^53` the f64 spacing exceeds 1, so `t + 0.5 == t`: `dt` is

--- a/utsuroi/src/solver/verlet.rs
+++ b/utsuroi/src/solver/verlet.rs
@@ -59,7 +59,8 @@ impl StormerVerlet {
     ///
     /// # Panics
     ///
-    /// Panics if the arguments cannot produce a terminating integration; see
+    /// Panics if the arguments cannot produce a terminating integration, and if
+    /// a step produces a non-finite state; see
     /// [`try_integrate`](Self::try_integrate) for the fallible form.
     pub fn integrate<const DIM: usize, S, F>(
         &self,
@@ -84,7 +85,8 @@ impl StormerVerlet {
     ///
     /// Mirrors [`Integrator::try_integrate`](crate::Integrator::try_integrate)
     /// so that "use `try_integrate` to avoid the panic" holds for every
-    /// integrator in the crate, not just the trait-based ones.
+    /// integrator in the crate, not just the trait-based ones — including
+    /// stopping at the first step whose result is not finite.
     pub fn try_integrate<const DIM: usize, S, F>(
         &self,
         system: &S,
@@ -110,6 +112,9 @@ impl StormerVerlet {
             }
             state = self.step(system, t, &state, h);
             t += h;
+            if !state.is_finite() {
+                return Err(IntegrationError::NonFiniteState { t });
+            }
             callback(t, &state);
         }
         Ok(state)
@@ -167,6 +172,24 @@ mod tests {
     use crate::{IntegrationError, IntegrationOutcome, State};
 
     use super::*;
+
+    /// The inherent `try_integrate` has to stop where the trait's does, or
+    /// "use `try_integrate` to avoid the panic" buys a silent `Ok` on a state
+    /// that is no longer a trajectory.
+    #[test]
+    fn try_integrate_stops_at_a_non_finite_state() {
+        let system = ConstantAcceleration {
+            acceleration: vector![f64::INFINITY, 0.0, 0.0],
+        };
+        let initial = State::<3, 2>::new(vector![0.0, 0.0, 0.0], vector![0.0, 0.0, 0.0]);
+        let err = StormerVerlet
+            .try_integrate(&system, initial, 0.0, 1.0, 0.1, |_, _| {})
+            .expect_err("a non-finite state should stop the integration");
+        assert!(
+            matches!(err, IntegrationError::NonFiniteState { t } if t < 1.0),
+            "should stop before the end of the span, got {err:?}"
+        );
+    }
 
     // Basic correctness
 

--- a/utsuroi/src/solver/yoshida.rs
+++ b/utsuroi/src/solver/yoshida.rs
@@ -109,7 +109,8 @@ macro_rules! impl_yoshida {
             /// # Panics
             ///
             /// Panics if the arguments cannot produce a terminating
-            /// integration; see `try_integrate` for the fallible form.
+            /// integration, and if a step produces a non-finite state; see
+            /// `try_integrate` for the fallible form.
             pub fn integrate<const DIM: usize, S, F>(
                 &self,
                 system: &S,
@@ -156,6 +157,9 @@ macro_rules! impl_yoshida {
                     }
                     state = self.step(system, t, &state, h);
                     t += h;
+                    if !state.is_finite() {
+                        return Err(IntegrationError::NonFiniteState { t });
+                    }
                     callback(t, &state);
                 }
                 Ok(state)
@@ -220,6 +224,37 @@ mod tests {
     use crate::test_systems::*;
 
     use super::*;
+
+    /// Each order's inherent `try_integrate` has to stop where the trait's
+    /// does, or "use `try_integrate` to avoid the panic" buys a silent `Ok` on
+    /// a state that is no longer a trajectory.
+    #[test]
+    fn try_integrate_stops_at_a_non_finite_state() {
+        let system = ConstantAcceleration {
+            acceleration: vector![f64::INFINITY, 0.0, 0.0],
+        };
+        let initial = State::<3, 2>::new(vector![0.0, 0.0, 0.0], vector![0.0, 0.0, 0.0]);
+
+        macro_rules! assert_stops {
+            ($solver:expr) => {
+                let err = $solver
+                    .try_integrate(&system, initial.clone(), 0.0, 1.0, 0.1, |_, _| {})
+                    .expect_err(concat!(
+                        stringify!($solver),
+                        ": a non-finite state should stop the integration"
+                    ));
+                assert!(
+                    matches!(err, crate::IntegrationError::NonFiniteState { t } if t < 1.0),
+                    "{}: should stop before the end of the span, got {err:?}",
+                    stringify!($solver)
+                );
+            };
+        }
+
+        assert_stops!(Yoshida4);
+        assert_stops!(Yoshida6);
+        assert_stops!(Yoshida8);
+    }
 
     // Basic correctness
 


### PR DESCRIPTION
`orts run` は `[satellites.attitude]` を警告なしに捨てていた。README のクイックスタート設定を渡しても軌道だけが伝播され、CSV は 13 列のまま姿勢が出てこない。

原因は `run` に `serve` の 3-way モード選択（orbit-only / spacecraft / controlled）が無かったこと。`run` は「全衛星が controller を持つか」だけを見て、持たなければ無条件に orbit-only へ落ちていた。同じ判定が serve engine・serve manager・run に三重実装されていた。

**この PR は 6 点を含む。** 1 が本体で、2〜4 はモード選択を集約した結果として出てきた同種の問題、5〜6 は README を controller 付きにしたことで踏んだ欠陥。

1. モード選択を 1 箇所に集約し、`run` が spacecraft ダイナミクスに到達できるようにする
2. 選択したモードで効かない設定を、黙って捨てずに拒否または警告する
3. 姿勢設定の検証を、config を読む全経路で同じにする
4. `try_integrate` が非有限状態で止まるようにする（`utsuroi`）
5. README のクイックスタートを controller 付きにする
6. `[satellites.controller.config]` 省略時に guest の既定値で起動する

## 1. モード選択の共有 (`cli/src/sim/mode.rs`)

`select_sim_mode(&[SatelliteSpec]) -> Result<SimMode, String>` を新設し、`ServeEngine::build`・serve の `validate_sim_config`・`orts run` が同じ関数を呼ぶ。判定規則は serve の既存挙動そのまま（空の fleet は orbit-only、姿勢や controller が一部の衛星だけなら拒否、全付きならそのモード）。

`run_spacecraft_simulation` を追加し、serve と同じ `SpacecraftDynamics` + `CoupledGravityGradient` を組む。CSV は列を recording から生成するので姿勢列 `qw..wz` がそのまま出る。軌道のみ経路と共通だった伝播ループは `propagate_and_record` に切り出して状態型でジェネリックにし、4 箇所あった同一のイベントチェッカも 1 つにした。

## 2. honor できない設定の扱い

| 設定 | 従来 | 変更後 |
|---|---|---|
| `[[command]]`（controller なし） | 黙って捨てる | 拒否（exit 2） |
| stream-io の `streams`（`run`） | controlled なら受理 | 拒否 |
| controller が一部の衛星だけ | serve は spacecraft として受理し controller を無視 | 拒否 |
| `sensors` / `reaction_wheels` / `magnetorquers` / `thruster`（controller なし） | 黙って捨てる | 警告（stderr と `run --json` の `warnings`） |

`streams` を `run` で拒否するのは、run のループに serve の stream pump に相当するものがないため。inbound は永遠に届かず、guest の outbound は誰も取り出さないまま溜まって overrun する。

同じ性質の経路が serve 側に 3 つ残っていたので合わせて閉じた。WebSocket の `start_simulation` は `ensure_serve_supported` を通っておらず `orts serve --config` が拒否する `[[command]]` を受理していた。実行中の orbit-only シミュレーションへの動的追加は姿勢しか検査せず、`controller` 付きの衛星を受理してその controller を無視していた。

## 3. 姿勢設定の検証

検査はこの 2 つだけだった。

```rust
if inertia.determinant().abs() < 1e-30 { /* singular */ }
if att.mass <= 0.0 { /* non-positive mass */ }
```

`NaN` に対する比較はすべて false になるので、`NaN` の質量が `mass <= 0.0` を、`NaN` の行列式が特異判定をすり抜ける。その後 state が `NaN` に発散し、config ではなく伝播の途中で失敗する。

行列式の閾値そのものもスケール依存だった。行列式は単位の 3 乗を持つので、条件数 1 の `[1e-11; 3]` が 1e-33 で拒否され、`[1e154; 3]` は受理される。後者では nalgebra の 3x3 逆行列（余因子を行列式で割る、両方 overflow）が**有限のゼロ行列**を返し、どんなトルクを与えても角加速度が 0 になる宇宙機ができる。ダイナミクスが取る逆行列そのもので判定するようにした。

```rust
let inverse = inertia.try_inverse().filter(|inv| {
    let residual = inertia * inv - Matrix3::identity();
    residual.iter().all(|v| v.abs() < 1e-6)   // I·I⁻¹ は無次元なので閾値が全スケールで通る
});
```

加えて、torque-free な `t = 0` の角加速度が有限であること（逆行列が取れることは積分できることを意味しない。`[1e-308, 1, 2]` に `ω = [1, 2, 2]` は逆行列はきれいに取れて初期角加速度が無限になる）と、四元数の二乗和が正かつ有限であること（`[1e-200, 0, 0, 0]` は 0 に、`[1e200, 0, 0, 0]` は無限になり、下流の正規化はその和で割る）を要求する。

config 単体で判定できる範囲に限る。シミュレーションが実際に始める微分には gravity-gradient torque が含まれ、それには軌道が必要。軌道に対して極端にスケールした慣性はここを通り、最初のステップで止まる。

**検証を広げたところ、そもそも全経路から呼ばれていなかった。**

- `orts run` は spacecraft 経路の中でだけ適用しており、`build_controlled_satellite` で衛星を組む controlled 経路は通っていなかった
- `serve --config` は `validate_sim_config` を通らず `ServeEngine::build` に届くので、サーバを起動する config が、後から追加される衛星より緩い基準で通っていた
- `orts config validate` は `SimConfig::load` の結果を報告するので、`run` と `serve` が拒否する config を valid と報告していた

そこで検査を `AttitudeConfig` に置き（隣の `thruster` の検査と同じ形）、`SatelliteConfig::validate` から呼ぶようにした。これで config を読む全経路が揃う。`validate_satellite_spec` は委譲だけになり、spec しか持たない実行時 `add_satellite` のために残している。

`initial_quaternion` は積分の前に正規化する。config は元から非ゼロの四元数を受理していたが、書かれた値をそのまま積分すると、大きな四元数は二乗和が overflow するまで成長し、ステップ後の `project` が全成分を無限で割ることになる。config の値から state を組んでいた 3 箇所を 1 つの accessor に寄せた。

## 4. `try_integrate` が非有限状態で止まらない

`integrate_with_events` は各ステップの結果を検査していたが、`try_integrate` は検査していなかった。

```diff
 state = self.step(system, t, &state, h);
 t += h;
+if !state.is_finite() {
+    return Err(IntegrationError::NonFiniteState { t });
+}
 callback(t, &state);
```

span 全体を回して `Ok` を返すので、唯一の呼び出し元である `orts serve` / `orts run` の controlled ループが `NaN` の state からセンサを読み、plugin controller に渡し、実行を成功として報告していた。

`StormerVerlet` と `Yoshida{4,6,8}` は trait のものではなく自前の `try_integrate` を持ち（Verlet の rustdoc は `Integrator::try_integrate` を mirror すると書いている）、両方に同じ検査を入れた。

## 5. README のクイックスタート

`sensors` と `[satellites.reaction_wheels]` を controller なしで宣言していたので、上の警告がそのまま当たる。このまま ship すると、読者の最初の `orts run` が README からコピペした設定について警告を出すことになる。

`pd-rw-control` example を指すようにして、宣言したアクチュエータが実際に駆動される構成にした。欠けていた `max_momentum` も補った。`path` は cwd 相対に解決されるので checkout の root から実行する旨を書き、ビルド手順に `rustup target add wasm32-wasip1` と「plugin ソースはこの repository に同梱」を足した（`cargo install orts-cli` の利用者にはどちらも成立しない）。

## 6. controller config 省略時の既定値

`[satellites.controller.config]` を書かないと guest には文字列 `"null"` が渡り、init に失敗して起動しなかった。`Plugin::init` は空文字列を「既定値を使う」と定義している（`plugin-sdk/src/lib.rs`）ので、config ブロックがない場合はそれを渡す。正規化するのは `Value::Null` だけで、空の config テーブルは `"{}"` のまま渡る（guest が parse すべき正当な JSON document なので）。

## 挙動の変化

- `[satellites.attitude]` を持つ config を `orts run` に渡すと CSV が 13 列から 20 列になる（姿勢 7 列追加）。従来この設定は無視されていた。
- 軌道のみの config の CSV は 13 列のまま（`orts convert` / viewer の消費側は不変）。E2E でヘッダ文字列を pin した。
- `orts run` が新たに非 0 終了: 姿勢設定の混在、controller 設定の混在、controller なしの `[[command]]`、`streams` の宣言。いずれも従来は黙って一部の設定を捨てて exit 0 していた。
- `orts serve` が新たに拒否: controller 設定の混在、WebSocket `start_simulation` の `[[command]]`、orbit-only への controller 付き衛星の動的追加。
- `[satellites.controller.config]` を省いた config が動く。従来は guest の init が `invalid type: null, expected struct Config` で失敗していた。
- 単位四元数でない `initial_quaternion` は、正規化後の値が `t = 0` の出力に出る。

## テスト

`cli/tests/run_mode_e2e.rs`（新規 12 本）と `cli/src/sim/mode.rs`（18 本）が中心。モード選択の dispatch を修正前に戻すと `run_mode_e2e` の 7 本が落ちる（残る 1 本は軌道のみ 13 列の pin なので、修正前でも通るのが正しい）。

**`readme_quickstart_config_runs_controlled`** — README.md から toml コードブロックを実際に読み出し、plugin path の行だけ絶対パスに書き換えて実行する。テスト側にコピーを置くと、クイックスタートが長期間動かないまま ship されていた事実を検出できない。書き換えが 1 行にちょうど一致したことを assert しているので、0 件でも通ることはない。assert するのは wheel command 列と wheel momentum 列（`rw_tx..rw_hz`）で、これは制御ループが回ったときだけ存在する（姿勢列は spacecraft モードでも出るので controlled の証拠にならない）。

**`serve_group_matches_shared_mode_selection`** — engine が構築した `SimGroup` の種別が `select_sim_mode` の結果と一致することを assert する。serve 側が独自の inline 条件に戻れば落ちる。

README と controller config のテストは guest WASM を要求するので、それをビルドする plugin-backend の CI job で `run_mode_e2e` を回すようにした。その job は prebuilt binary を download して渡す設計なので、`run_mode_e2e` も他の E2E と同様 `ORTS_BIN` を尊重する。guest をビルドしない `rust-test` では soft-skip する。

既存の `readme_quickstart_config_outputs_attitude` は `attitude_without_controller_outputs_attitude` に改名した。spacecraft モードの経路は引き続きカバーしているが、README の設定ではなくなったため。
