### PR TITLE
perf(ci): link with wild instead of mold

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,12 +4,28 @@
 [env]
 TS_RS_EXPORT_DIR = { value = "viewer/src/protocol/generated", relative = true }
 
-# Local dev fast-linking with mold (sudo apt install mold / pacman -S mold).
+# Fast-linking with wild (cargo install wild-linker, or the prebuilt tarball
+# from its GitHub releases — that is what CI uses).
+#
 # The linker is folded into `rustflags` (via -Clinker) on purpose: that makes
 # it a single knob — a non-empty global RUSTFLAGS replaces this whole line and
 # falls back to plain cc/gcc. The release gnu `cross` build relies on exactly
-# that (its container has no clang/mold); see Cross.toml.
+# that (its container has no clang/wild); see Cross.toml.
+#
+# It has to live under `[target.x86_64-unknown-linux-gnu]` rather than in a
+# RUSTFLAGS env var: RUSTFLAGS is not target-scoped, so it would hand
+# `--ld-path=wild` to the wasm32 builds as well and break them.
+#
+# wild over mold, measured on `cargo test --locked --workspace --no-run`
+# (46 links, pure link time, minimum of N runs):
+#
+#   4 vCPU (what CI runs on)   mold 204.1 s   wild 137.1 s   (0.67x)
+#   16 core                    mold 147.6 s   wild 170.1 s   (1.15x)
+#
+# mold's parallelism wins on many cores and loses on few, so the ranking
+# flips. CI is the 4-core case and dominates total build time, hence wild.
+# On a many-core workstation the full-workspace link is ~15% slower, while the
+# common `cargo test -p orts` loop (24 smaller binaries) is ~28% faster.
+# Reproduce with `.github/workflows/linker-bench.yml`.
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-Clinker=clang", "-Clink-arg=-fuse-ld=mold"]
-# wild (~2x faster than mold): cargo install wild-linker, then swap to:
-#rustflags = ["-Clinker=clang", "-Clink-arg=--ld-path=wild"]
+rustflags = ["-Clinker=clang", "-Clink-arg=--ld-path=wild"]

--- a/.github/actions/install-wild/action.yml
+++ b/.github/actions/install-wild/action.yml
@@ -1,0 +1,49 @@
+name: Install wild linker
+description: >-
+  Install the wild linker from its prebuilt release tarball, checksum-verified.
+  `.cargo/config.toml` names wild as the linker for x86_64-unknown-linux-gnu,
+  so every job that compiles for the host needs it on PATH.
+
+inputs:
+  version:
+    description: wild release to install
+    required: false
+    default: "0.10.0"
+  sha256:
+    description: >-
+      Checksum of wild-linker-<version>-x86_64-unknown-linux-gnu.tar.gz.
+      Must be updated together with `version`.
+    required: false
+    default: "641265506a7c06cfb03181b8916ab663ec8407855db6d4db7f8450667d105283"
+
+runs:
+  using: composite
+  steps:
+    # wild is not packaged in Ubuntu, and `cargo install wild-linker` would add
+    # minutes to every job. The upstream tarball is a single static binary.
+    - name: Install wild
+      shell: bash
+      env:
+        WILD_VERSION: ${{ inputs.version }}
+        WILD_SHA256: ${{ inputs.sha256 }}
+      run: |
+        set -euo pipefail
+        tarball="wild-linker-${WILD_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+        url="https://github.com/davidlattimore/wild/releases/download/${WILD_VERSION}/${tarball}"
+        curl -fsSL -o "/tmp/${tarball}" "$url"
+        echo "${WILD_SHA256}  /tmp/${tarball}" | sha256sum -c -
+        mkdir -p /tmp/wild-extract
+        tar -xzf "/tmp/${tarball}" -C /tmp/wild-extract
+        sudo install -m 0755 \
+          "/tmp/wild-extract/wild-linker-${WILD_VERSION}-x86_64-unknown-linux-gnu/wild" \
+          /usr/local/bin/wild
+        rm -rf "/tmp/${tarball}" /tmp/wild-extract
+        wild --version
+
+    # `.cargo/config.toml` drives the linker through `-Clinker=clang`, so clang
+    # has to be present too. ubuntu-latest ships it, but the `free-disk-space`
+    # step in several jobs is configured with `large-packages: false` precisely
+    # to keep it — assert rather than assume.
+    - name: Check clang is available
+      shell: bash
+      run: clang --version | head -1

--- a/.github/actions/setup-wild/action.yml
+++ b/.github/actions/setup-wild/action.yml
@@ -34,9 +34,16 @@ runs:
         echo "${WILD_SHA256}  /tmp/${tarball}" | sha256sum -c -
         mkdir -p /tmp/wild-extract
         tar -xzf "/tmp/${tarball}" -C /tmp/wild-extract
-        sudo install -m 0755 \
-          "/tmp/wild-extract/wild-linker-${WILD_VERSION}-x86_64-unknown-linux-gnu/wild" \
-          /usr/local/bin/wild
+        # Locate the binary rather than assuming the archive's internal layout,
+        # so a repackaging upstream does not break this. The checksum above is
+        # what pins the contents.
+        bin="$(find /tmp/wild-extract -type f -name wild -perm -u+x | head -1)"
+        if [ -z "$bin" ]; then
+          echo "no executable named 'wild' in ${tarball}:" >&2
+          find /tmp/wild-extract >&2
+          exit 1
+        fi
+        sudo install -m 0755 "$bin" /usr/local/bin/wild
         rm -rf "/tmp/${tarball}" /tmp/wild-extract
         wild --version
 

--- a/.github/actions/setup-wild/action.yml
+++ b/.github/actions/setup-wild/action.yml
@@ -1,4 +1,4 @@
-name: Install wild linker
+name: Set up wild linker
 description: >-
   Install the wild linker from its prebuilt release tarball, checksum-verified.
   `.cargo/config.toml` names wild as the linker for x86_64-unknown-linux-gnu,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -621,8 +621,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Only the musl arm compiles on the host. The gnu arm runs cargo inside
-      # the `cross` container, which overrides RUSTFLAGS and links with cc.
+      # Only the musl target compiles on the host. The gnu target runs cargo
+      # inside the `cross` container, which overrides RUSTFLAGS and links with
+      # cc. Both matrix entries are x86_64.
       - name: Set up wild linker
         if: matrix.target == 'x86_64-unknown-linux-musl'
         uses: ./.github/actions/setup-wild

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install wild linker
-        uses: ./.github/actions/install-wild
+      - name: Set up wild linker
+        uses: ./.github/actions/setup-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -214,8 +214,8 @@ jobs:
           docker-images: true
           swap-storage: false
 
-      - name: Install wild linker
-        uses: ./.github/actions/install-wild
+      - name: Set up wild linker
+        uses: ./.github/actions/setup-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -263,8 +263,8 @@ jobs:
           docker-images: true
           swap-storage: false
 
-      - name: Install wild linker
-        uses: ./.github/actions/install-wild
+      - name: Set up wild linker
+        uses: ./.github/actions/setup-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -315,8 +315,8 @@ jobs:
           docker-images: true
           swap-storage: false
 
-      - name: Install wild linker
-        uses: ./.github/actions/install-wild
+      - name: Set up wild linker
+        uses: ./.github/actions/setup-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -358,8 +358,8 @@ jobs:
           docker-images: true
           swap-storage: false
 
-      - name: Install wild linker
-        uses: ./.github/actions/install-wild
+      - name: Set up wild linker
+        uses: ./.github/actions/setup-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -403,8 +403,8 @@ jobs:
           docker-images: true
           swap-storage: false
 
-      - name: Install wild linker
-        uses: ./.github/actions/install-wild
+      - name: Set up wild linker
+        uses: ./.github/actions/setup-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -454,8 +454,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install wild linker
-        uses: ./.github/actions/install-wild
+      - name: Set up wild linker
+        uses: ./.github/actions/setup-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -539,8 +539,8 @@ jobs:
           docker-images: true
           swap-storage: false
 
-      - name: Install wild linker
-        uses: ./.github/actions/install-wild
+      - name: Set up wild linker
+        uses: ./.github/actions/setup-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -881,9 +881,9 @@ jobs:
         if: steps.changes.outputs.docs == 'true'
         run: pnpm install --frozen-lockfile
 
-      - name: Install wild linker
+      - name: Set up wild linker
         if: steps.changes.outputs.docs == 'true'
-        uses: ./.github/actions/install-wild
+        uses: ./.github/actions/setup-wild
 
       - name: Parse rust-toolchain.toml
         if: steps.changes.outputs.docs == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -621,7 +621,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Only the musl arm compiles on the host. The gnu arm runs cargo inside
+      # the `cross` container, which overrides RUSTFLAGS and links with cc.
       - name: Set up wild linker
+        if: matrix.target == 'x86_64-unknown-linux-musl'
         uses: ./.github/actions/setup-wild
 
       - name: Free disk space

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  # No base-branch filter: a stacked PR targets the branch below it in the
+  # stack rather than main, and a `branches: [main]` filter would leave every
+  # one of them with no checks at all.
   pull_request:
-    branches: [main]
   # Run the same checks on merge-queue groups so required checks are
   # validated against (main + queued PRs) before landing. The 14 PR
   # jobs have no event guard, so they run here too; the main/tag-only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install mold linker
-        run: sudo apt-get install -y mold
+      - name: Install wild linker
+        uses: ./.github/actions/install-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -200,7 +200,7 @@ jobs:
       # reclaim ~17 GB by removing runtimes we don't need (Android,
       # .NET, Haskell, Docker). Large-packages is intentionally off
       # because it would also remove LLVM/clang, which our
-      # `.cargo/config.toml` uses as the linker driver for mold.
+      # `.cargo/config.toml` uses as the linker driver for wild.
       # Tool-cache is kept so setup-rust / setup-node stay hot, and
       # swap is kept because the linker occasionally peaks memory.
       - name: Free disk space
@@ -214,8 +214,8 @@ jobs:
           docker-images: true
           swap-storage: false
 
-      - name: Install mold linker
-        run: sudo apt-get install -y mold
+      - name: Install wild linker
+        uses: ./.github/actions/install-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -263,8 +263,8 @@ jobs:
           docker-images: true
           swap-storage: false
 
-      - name: Install mold linker
-        run: sudo apt-get install -y mold
+      - name: Install wild linker
+        uses: ./.github/actions/install-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -315,8 +315,8 @@ jobs:
           docker-images: true
           swap-storage: false
 
-      - name: Install mold linker
-        run: sudo apt-get install -y mold
+      - name: Install wild linker
+        uses: ./.github/actions/install-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -358,8 +358,8 @@ jobs:
           docker-images: true
           swap-storage: false
 
-      - name: Install mold linker
-        run: sudo apt-get install -y mold
+      - name: Install wild linker
+        uses: ./.github/actions/install-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -403,8 +403,8 @@ jobs:
           docker-images: true
           swap-storage: false
 
-      - name: Install mold linker
-        run: sudo apt-get install -y mold
+      - name: Install wild linker
+        uses: ./.github/actions/install-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -454,8 +454,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install mold linker
-        run: sudo apt-get install -y mold
+      - name: Install wild linker
+        uses: ./.github/actions/install-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -539,8 +539,8 @@ jobs:
           docker-images: true
           swap-storage: false
 
-      - name: Install mold linker
-        run: sudo apt-get install -y mold
+      - name: Install wild linker
+        uses: ./.github/actions/install-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -633,7 +633,7 @@ jobs:
           swap-storage: false
 
       # gnu is built via `cross` so its glibc floor is pinned and
-      # host-independent (see Cross.toml); no host mold/clang needed. musl
+      # host-independent (see Cross.toml); no host wild/clang needed. musl
       # stays a native static build.
       - name: Install cross (gnu target)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
@@ -678,7 +678,7 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         env:
           ORTS_REQUIRE_LICENSE_NOTICE: "1"
-          # .cargo/config.toml's clang+mold rustflags line can't run in the
+          # .cargo/config.toml's clang+wild rustflags line can't run in the
           # container; a non-empty RUSTFLAGS replaces it, falling back to
           # cc/gcc. Must be non-empty (empty is ignored); target-cpu=x86-64 is
           # the default baseline no-op. Forwarded via Cross.toml passthrough.
@@ -881,9 +881,9 @@ jobs:
         if: steps.changes.outputs.docs == 'true'
         run: pnpm install --frozen-lockfile
 
-      - name: Install mold linker
+      - name: Install wild linker
         if: steps.changes.outputs.docs == 'true'
-        run: sudo apt-get update && sudo apt-get install -y mold
+        uses: ./.github/actions/install-wild
 
       - name: Parse rust-toolchain.toml
         if: steps.changes.outputs.docs == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   # stack rather than main, and a `branches: [main]` filter would leave every
   # one of them with no checks at all.
   pull_request:
+  # Lets the main/tag-only jobs — rust-dist above all — be exercised from a
+  # topic branch before merging. Their ref guards are false on a PR, so the
+  # release build path is otherwise unverified until it is already on main.
+  workflow_dispatch:
   # Run the same checks on merge-queue groups so required checks are
   # validated against (main + queued PRs) before landing. The 14 PR
   # jobs have no event guard, so they run here too; the main/tag-only
@@ -612,7 +616,10 @@ jobs:
   # Build CLI release binary for each target. Matrix produces one
   # artifact per target that the release job assembles into tarballs.
   rust-dist:
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      github.ref == 'refs/heads/main'
+      || startsWith(github.ref, 'refs/tags/v')
+      || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: [rust-build, viewer-build]
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -621,6 +621,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Set up wild linker
+        uses: ./.github/actions/setup-wild
+
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
@@ -752,6 +755,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up wild linker
+        uses: ./.github/actions/setup-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -957,6 +963,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Set up wild linker
+        uses: ./.github/actions/setup-wild
+
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
         uses: ./.github/actions/parse-rust-toolchain
@@ -1030,6 +1039,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up wild linker
+        uses: ./.github/actions/setup-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -1129,6 +1141,9 @@ jobs:
     needs: [rust-build, uneri]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up wild linker
+        uses: ./.github/actions/setup-wild
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install wild linker
-        uses: ./.github/actions/install-wild
+      - name: Set up wild linker
+        uses: ./.github/actions/setup-wild
 
       - name: Cache viewer textures (4k/8k)
         id: texture-cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install mold linker
-        run: sudo apt-get update && sudo apt-get install -y mold
+      - name: Install wild linker
+        uses: ./.github/actions/install-wild
 
       - name: Cache viewer textures (4k/8k)
         id: texture-cache

--- a/.github/workflows/linker-bench.yml
+++ b/.github/workflows/linker-bench.yml
@@ -30,6 +30,12 @@ on:
           Source file touched before each run to force a relink. Must be a file
           the chosen workload actually rebuilds.
         default: "orts/src/lib.rs"
+      threads:
+        description: >-
+          Linker thread count (--thread-count). Empty lets each linker decide,
+          which for wild means asking cargo's jobserver — pin it to compare the
+          linkers on equal terms.
+        default: ""
 
 jobs:
   bench:
@@ -96,6 +102,9 @@ jobs:
             wild) extra=(--ld-path=wild) ;;
             *) echo "ldwrap: unknown LDWRAP_CHOICE=$LDWRAP_CHOICE" >&2; exit 2 ;;
           esac
+          if [ -n "${LDWRAP_THREADS:-}" ]; then
+            extra+=("-Wl,--thread-count=${LDWRAP_THREADS}")
+          fi
           out=""; prev=""
           for a in "$@"; do [ "$prev" = "-o" ] && out="$a"; prev="$a"; done
           t0=$(date +%s%N)
@@ -120,6 +129,7 @@ jobs:
           LINKERS: ${{ inputs.linkers || 'mold wild' }}
           CARGO_ARGS: ${{ inputs.cargo_args || '--locked --workspace --no-run' }}
           TOUCH: ${{ inputs.touch || 'orts/src/lib.rs' }}
+          THREADS: ${{ inputs.threads }}
         run: |
           python3 - <<'PY' | tee /tmp/result.txt
           import os, shlex, subprocess
@@ -127,11 +137,14 @@ jobs:
           linkers = os.environ["LINKERS"].split()
           args = shlex.split(os.environ["CARGO_ARGS"])
           touch = os.environ["TOUCH"]
+          threads = os.environ.get("THREADS", "")
           log = "/tmp/ldwrap.log"
           results = {}
           for choice in linkers:
               env = {**os.environ, "RUSTFLAGS": "-Clinker=/tmp/ldwrap.sh",
                      "LDWRAP_CHOICE": choice, "LDWRAP_LOG": log}
+              if threads:
+                  env["LDWRAP_THREADS"] = threads
               samples = []
               for _ in range(reps):
                   open(log, "w").close()
@@ -156,7 +169,8 @@ jobs:
               base_name = next((c for c in linkers if results.get(c)), None)
           base = results.get(base_name) if base_name else None
 
-          print(f"\nnproc={os.cpu_count()}  reps={reps}  touch={touch}")
+          print(f"\nnproc={os.cpu_count()}  reps={reps}  touch={touch}"
+                f"  threads={threads or 'linker default'}")
           print(f"cargo test {' '.join(args)}\n")
           header_rel = f"vs {base_name}" if base_name else "vs -"
           print(f"{'linker':8s} {'total':>10s} {'links':>6s} {'ms/link':>9s}  {header_rel}")

--- a/.github/workflows/linker-bench.yml
+++ b/.github/workflows/linker-bench.yml
@@ -25,6 +25,11 @@ on:
       cargo_args:
         description: "cargo test args for the workload"
         default: "--locked --workspace --no-run"
+      touch:
+        description: >-
+          Source file touched before each run to force a relink. Must be a file
+          the chosen workload actually rebuilds.
+        default: "orts/src/lib.rs"
 
 jobs:
   bench:
@@ -114,12 +119,14 @@ jobs:
           REPS: ${{ inputs.reps || '2' }}
           LINKERS: ${{ inputs.linkers || 'mold wild' }}
           CARGO_ARGS: ${{ inputs.cargo_args || '--locked --workspace --no-run' }}
+          TOUCH: ${{ inputs.touch || 'orts/src/lib.rs' }}
         run: |
           python3 - <<'PY' | tee /tmp/result.txt
           import os, shlex, subprocess
           reps = int(os.environ["REPS"])
           linkers = os.environ["LINKERS"].split()
           args = shlex.split(os.environ["CARGO_ARGS"])
+          touch = os.environ["TOUCH"]
           log = "/tmp/ldwrap.log"
           results = {}
           for choice in linkers:
@@ -128,7 +135,7 @@ jobs:
               samples = []
               for _ in range(reps):
                   open(log, "w").close()
-                  os.utime("orts/src/lib.rs", None)
+                  os.utime(touch, None)
                   r = subprocess.run(["cargo", "test"] + args, env=env,
                                      stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
                   if r.returncode != 0:
@@ -141,9 +148,18 @@ jobs:
                       samples.append((sum(ms), len(ms)))
               results[choice] = min(samples) if samples else None
 
-          base = results.get("mold")
-          print(f"\nnproc={os.cpu_count()}  reps={reps}  cargo test {' '.join(args)}\n")
-          print(f"{'linker':8s} {'total':>10s} {'links':>6s} {'ms/link':>9s}  vs mold")
+          # Ratios are against mold when it was measured, otherwise against the
+          # first linker that produced a result, so the column stays meaningful
+          # for any subset of linkers.
+          base_name = next((c for c in ("mold",) if results.get(c)), None)
+          if base_name is None:
+              base_name = next((c for c in linkers if results.get(c)), None)
+          base = results.get(base_name) if base_name else None
+
+          print(f"\nnproc={os.cpu_count()}  reps={reps}  touch={touch}")
+          print(f"cargo test {' '.join(args)}\n")
+          header_rel = f"vs {base_name}" if base_name else "vs -"
+          print(f"{'linker':8s} {'total':>10s} {'links':>6s} {'ms/link':>9s}  {header_rel}")
           for choice in linkers:
               v = results.get(choice)
               if not v:

--- a/.github/workflows/linker-bench.yml
+++ b/.github/workflows/linker-bench.yml
@@ -1,0 +1,165 @@
+name: linker-bench
+
+# Manual-only. Compares linkers on a real GHA runner (4 vCPU / 16 GB).
+#
+# The ranking depends on core count: mold's advantage comes from parallelism,
+# so it wins on a many-core workstation and loses on a 4-vCPU runner. That is
+# why `.cargo/config.toml` names wild. Re-run this when the runner size, the
+# linker versions, or the shape of the link graph changes.
+#
+# Measures PURE link time: a wrapper sits in -Clinker and times only the
+# linker-driver call, so rustc codegen is excluded. The linker choice arrives
+# via an env var rather than RUSTFLAGS, which keeps every rustc fingerprint
+# identical across configs — switching linkers therefore triggers no rebuild
+# and each linker sees a byte-identical argv.
+on:
+  workflow_dispatch:
+    inputs:
+      reps:
+        description: "Timed repetitions per linker (min is reported)"
+        default: "2"
+      linkers:
+        description: "Space-separated subset of: bfd lld mold wild"
+        default: "mold wild"
+      cargo_args:
+        description: "cargo test args for the workload"
+        default: "--locked --workspace --no-run"
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
+
+      - name: Show runner size
+        run: |
+          echo "nproc: $(nproc)"
+          free -g | head -2
+          df -h / | tail -1
+
+      # mold and lld are the comparison baselines, so this workflow keeps
+      # installing them even though `.cargo/config.toml` no longer uses mold.
+      - name: Install comparison linkers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mold lld clang
+          mold --version
+          ld.lld --version | head -1
+          clang --version | head -1
+
+      - name: Set up wild linker
+        uses: ./.github/actions/setup-wild
+
+      - name: Parse rust-toolchain.toml
+        id: rust-toolchain
+        uses: ./.github/actions/parse-rust-toolchain
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+
+      # Piggyback on rust-build's cache so the warm-up is not a cold build.
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: rust-native
+          save-if: false
+
+      - name: Write linker wrapper
+        run: |
+          cat > /tmp/ldwrap.sh <<'WRAP'
+          #!/usr/bin/env bash
+          set -u
+          extra=()
+          case "${LDWRAP_CHOICE:-bfd}" in
+            bfd)  extra=() ;;
+            lld)  extra=(-fuse-ld=lld) ;;
+            mold) extra=(-fuse-ld=mold) ;;
+            wild) extra=(--ld-path=wild) ;;
+            *) echo "ldwrap: unknown LDWRAP_CHOICE=$LDWRAP_CHOICE" >&2; exit 2 ;;
+          esac
+          out=""; prev=""
+          for a in "$@"; do [ "$prev" = "-o" ] && out="$a"; prev="$a"; done
+          t0=$(date +%s%N)
+          clang "$@" "${extra[@]}"
+          rc=$?
+          t1=$(date +%s%N)
+          [ -n "${LDWRAP_LOG:-}" ] && printf '%s %s %s\n' \
+            "$(( (t1 - t0) / 1000000 ))" "${LDWRAP_CHOICE:-bfd}" "$out" >> "$LDWRAP_LOG"
+          exit $rc
+          WRAP
+          chmod +x /tmp/ldwrap.sh
+
+      - name: Warm up (untimed)
+        env:
+          RUSTFLAGS: -Clinker=/tmp/ldwrap.sh
+          LDWRAP_CHOICE: bfd
+        run: cargo test ${{ inputs.cargo_args || '--locked --workspace --no-run' }}
+
+      - name: Benchmark
+        env:
+          REPS: ${{ inputs.reps || '2' }}
+          LINKERS: ${{ inputs.linkers || 'mold wild' }}
+          CARGO_ARGS: ${{ inputs.cargo_args || '--locked --workspace --no-run' }}
+        run: |
+          python3 - <<'PY' | tee /tmp/result.txt
+          import os, shlex, subprocess, time
+          reps = int(os.environ["REPS"])
+          linkers = os.environ["LINKERS"].split()
+          args = shlex.split(os.environ["CARGO_ARGS"])
+          log = "/tmp/ldwrap.log"
+          results = {}
+          for choice in linkers:
+              env = {**os.environ, "RUSTFLAGS": "-Clinker=/tmp/ldwrap.sh",
+                     "LDWRAP_CHOICE": choice, "LDWRAP_LOG": log}
+              samples = []
+              for _ in range(reps):
+                  open(log, "w").close()
+                  os.utime("orts/src/lib.rs", None)
+                  r = subprocess.run(["cargo", "test"] + args, env=env,
+                                     stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+                  if r.returncode != 0:
+                      print(f"{choice}: cargo failed")
+                      print(r.stderr.decode(errors="replace")[-1500:])
+                      samples = []
+                      break
+                  ms = [int(l.split()[0]) for l in open(log) if l.strip()]
+                  if ms:
+                      samples.append((sum(ms), len(ms)))
+              results[choice] = min(samples) if samples else None
+
+          base = results.get("mold")
+          print(f"\nnproc={os.cpu_count()}  reps={reps}  cargo test {' '.join(args)}\n")
+          print(f"{'linker':8s} {'total':>10s} {'links':>6s} {'ms/link':>9s}  vs mold")
+          for choice in linkers:
+              v = results.get(choice)
+              if not v:
+                  print(f"{choice:8s} {'FAILED':>10s}")
+                  continue
+              total, n = v
+              rel = f"{total / base[0]:.2f}x" if base else "-"
+              print(f"{choice:8s} {total:9d}ms {n:6d} {total / n:8.0f}  {rel:>6s}")
+          PY
+
+      - name: Publish to step summary
+        if: always()
+        run: |
+          {
+            echo '### linker-bench'
+            echo
+            echo '```'
+            cat /tmp/result.txt || echo "(no result)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/linker-bench.yml
+++ b/.github/workflows/linker-bench.yml
@@ -10,8 +10,9 @@ name: linker-bench
 # Measures PURE link time: a wrapper sits in -Clinker and times only the
 # linker-driver call, so rustc codegen is excluded. The linker choice arrives
 # via an env var rather than RUSTFLAGS, which keeps every rustc fingerprint
-# identical across configs — switching linkers therefore triggers no rebuild
-# and each linker sees a byte-identical argv.
+# identical across configs, so switching linkers triggers no rebuild and the
+# argv rustc hands the wrapper is the same every time. The wrapper then appends
+# one selector flag (-fuse-ld=mold, --ld-path=wild, ...) before calling clang.
 on:
   workflow_dispatch:
     inputs:
@@ -115,7 +116,7 @@ jobs:
           CARGO_ARGS: ${{ inputs.cargo_args || '--locked --workspace --no-run' }}
         run: |
           python3 - <<'PY' | tee /tmp/result.txt
-          import os, shlex, subprocess, time
+          import os, shlex, subprocess
           reps = int(os.environ["REPS"])
           linkers = os.environ["LINKERS"].split()
           args = shlex.split(os.environ["CARGO_ARGS"])


### PR DESCRIPTION
## 変更

linker を mold から wild に替えて CI のリンク時間を削る。

- `.cargo/config.toml` の `[target.x86_64-unknown-linux-gnu]` の rustflags を `--ld-path=wild` に
- `apt-get install -y mold` を composite action `.github/actions/setup-wild` に置換（ci.yml 9 ジョブ + deploy.yml 1 ジョブ）。version と sha256 を input に明示
- 再現用の `linker-bench.yml`（workflow_dispatch のみ）を同梱
- `rust-dist` を `workflow_dispatch` でも回せるようにした（release ビルドは PR では skip されるため、マージ前に試す手段がなかった）

## 根拠

**CI runner（4 vCPU、専用マシン）での実測。** `-Clinker` にラッパを挟んで linker 呼び出しだけを計時し（codegen を除外）、source を touch して再リンクを強制、最小値を取った。

`cargo test --locked --workspace --no-run` = 46 リンク:

| linker | 合計 | 1 リンクあたり |
|---|---|---|
| mold | 204.1 s | 4438 ms |
| **wild** | **137.1 s** | **2980 ms** |

**wild が 33% 速い。** `rust-build` の純リンク時間が 67 秒縮み、リンクする全ジョブに効く。

## コア数との関係について

当初は「多コアでは mold、少コアでは wild」と考えたが、**その説明は支持できない**。根拠は 3 つ。

1. **wild は cargo の jobserver からスレッド数を取る**（`available_parallelism()` は jobserver が無いときのみ）。mold は jobserver に参加しない。`cargo build` 経由の比較は、両者を default のままにすると**リンカの速度ではなく jobserver への態度の差**を測ってしまう
2. upstream のベンチは 16 core Ryzen と Raspberry Pi 5 の**両方で wild が mold 以上**と報告しており、交差点は文書化されていない
3. 「多コアで mold 有利」と読めた数字は 16 コアの共有ワークステーションで取ったもので、他のビルドが同時に走る環境だった。load average が 100 を超える状態では `--thread-count` を指定しても実際のコア数を保証できず、測定として成立しない

そのため判断は **CI runner での上記の数字** に置いている。専用マシンで、両者が同じ条件で走ったもの。

スケーリングの形は `linker-bench.yml` の `threads` input（`--thread-count`）で測れる。

### スレッド数を振った実測

`--thread-count` を両者に明示して jobserver の変数を外し、CI runner（4 vCPU）で測った。
ワークロードは `cargo test --locked -p orts --tests --no-run`（24 リンク）、純リンク時間の
2 回の最小値。

| threads | mold | wild | wild/mold |
|---|---|---|---|
| 1 | 47142 ms | 33256 ms | 0.71x |
| 2 | 40979 ms | 25320 ms | 0.62x |
| 4 | 36651 ms | 22902 ms | 0.62x |

**全スレッド数で wild が速く、交差点はない。**
1 thread、つまり並列性を完全に排除した条件でも wild が 29% 速いので、
優位の源はシングルスレッドの効率である。
スケーリング効率も wild の方が良い（1→4 threads で mold は 22% 短縮、wild は 31% 短縮）。


## 設計判断

設定は `.cargo/config.toml` に置いた。
target 単位で書けるので host のリンクだけに限定される。
RUSTFLAGS 環境変数は全 target に一律適用されるため、wasm32 ビルドにも `--ld-path=wild` が渡ってしまう。

既存の single-knob 契約は維持している。
`rust-dist` の gnu ビルドは、非空の RUSTFLAGS がこの行を丸ごと置き換えて cc/gcc に落ちることに依存する（`cross` コンテナに clang がないため）。その挙動は変わらない。

wild は Ubuntu にパッケージされておらず、`cargo install wild-linker` は毎ジョブに数分乗るので、upstream の release tarball（単一の静的バイナリ）を使う。
checksum 検証は既存の `install-wasm-pack` と `Cross.toml` の cargo-about に揃えた。
action 名は `setup-*` にした（バイナリ配置に加えて clang の存在も検査するため）。

## レビューの観点

- `build-site` ジョブの `if: steps.changes.outputs.docs == 'true'` を保持している（唯一の条件付き install）
- action は clang の存在も検査する。`free-disk-space` が `large-packages: false` なのは LLVM/clang を残すためで、その前提に依存している
- wild の version を上げるときは sha256 も同時に更新する

## 検証したこと

- `cargo test --locked -p orts --lib --no-run` — host が wild でリンクされる
- `cargo build --locked -p rrd-wasm --target wasm32-unknown-unknown --features wasm` — wasm32 は影響を受けない
- ci.yml / deploy.yml / action.yml の YAML パース、ci.yml は 21 jobs 維持
- リポジトリから mold への参照が消えたこと
- `setup-wild` の抽出ロジックを実 tarball に対して実行（checksum 一致、`find` が binary を特定）

関連: #316（ビルド時間の tracking issue、linker の項目）

