### PR TITLE
fix: 適応ソルバでステップ後の状態射影が抜けていた（四元数ノルム・ホイール運動量上限）

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -36,6 +36,16 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   `StateEffector<S>` 実装はそのままコンパイル可能。([#148](https://github.com/sksat/orts/pull/148))
 
 #### Fixed
+- `AttitudeState::q_dot` が、和を計算した後でなく積を作る前に角速度を半分にする
+  ようになった。結果が有限な入力で overflow しなくなる: `q = [0, 1/√2, 1/√2, 0]`、
+  `ω = [1.4e308, 1.4e308, 0]` の `q̇.w` は約 -9.9e307 だが、途中の和が -1.98e308 に
+  達し、後から 0.5 を掛けても無限は戻らなかった。([#343](https://github.com/sksat/orts/pull/343))
+- `AttitudeState::is_finite` が、成分の有限性だけでなく四元数ノルムが正かつ有限で
+  あることを要求するようになった。成分が 1e157 程度なら各々有限でも二乗和は無限に
+  なり、その四元数は姿勢を指さない (`orientation()` はそのノルムで割る)。`project` は
+  それをもっともらしいゼロに潰さず放置するので、拒否するのは integrator の有限性
+  検査しかない。従来はそれを生んだステップが成功として報告され、その状態が
+  センサと plugin controller に渡っていた。([#343](https://github.com/sksat/orts/pull/343))
 - `SpacecraftDynamics` の不正な frame 再タグを除去。`ExternalLoads<SimpleEci>`
   とタグ付けされた effector 荷重を変換なしで host frame `F` に貼り替えており、
   `F != SimpleEci` (例: `Gcrs`) で座標を黙って誤ラベルしていた。出荷済み

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,19 @@ section is subdivided by package.
   existing `StateEffector<S>` impls compiling unchanged. ([#148](https://github.com/sksat/orts/pull/148))
 
 #### Fixed
+- `AttitudeState::q_dot` halves the angular velocity before forming the
+  products rather than the sum afterwards, so it no longer overflows where its
+  result is finite: `q = [0, 1/√2, 1/√2, 0]` with `ω = [1.4e308, 1.4e308, 0]`
+  has a `q̇.w` near -9.9e307, but the intermediate sum reached -1.98e308 and the
+  later halving could not bring the infinity back. ([#343](https://github.com/sksat/orts/pull/343))
+- `AttitudeState::is_finite` requires a positive, finite quaternion norm, not
+  just finite components. Components around 1e157 are each finite while their
+  squares sum to infinity, and such a quaternion names no orientation —
+  `orientation()` divides by that norm. `project` leaves it alone rather than
+  collapsing it to a plausible-looking zero, so the integrators' finiteness
+  check is what has to reject it; until it did, a step that produced one was
+  reported as success and its state reached sensors and a plugin
+  controller. ([#343](https://github.com/sksat/orts/pull/343))
 - Removed an unsound frame re-tag in `SpacecraftDynamics`: effector loads tagged
   `ExternalLoads<SimpleEci>` were relabeled as the host frame `F` without
   conversion, silently mislabeling coordinates for any `F != SimpleEci`. Latent

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -167,9 +167,23 @@ pub trait OdeState: Clone + Sized {
     fn scale(&self, factor: f64) -> Self;
     fn is_finite(&self) -> bool;
     fn error_norm(&self, y_next: &Self, error: &Self, tol: &Tolerances) -> f64;
-    fn project(&mut self, _t: f64) {}  // 四元数正規化等 (default no-op)
+    fn project(&mut self, _t: f64) -> Projection { Projection::Unchanged }  // 四元数正規化・境界 clamp 等
 }
 ```
+
+`project` は各積分器が「採用したステップの結果を publish する直前」に一度だけ呼ぶ
+(reject した候補や中間 stage には呼ばない)。callback と event_check は projection 後の
+状態を受け取る。戻り値 `Projection::{Unchanged, Changed}` は「実際に状態を書き換えたか」を
+表し、FSAL (First Same As Last) を持つ適応解法がキャッシュした終端微分を再利用できるかの
+判定に使う。複合 state は子の結果の OR を返す。
+
+accept/reject の判定は projection 前の生の候補で行う。誤差ベクトルは生の候補に対応する量で、
+projection 後の状態と混ぜると数値的に非一貫になる。
+
+Yoshida (高次シンプレクティック) は汎用 projection を適用しない。一般の正規化・clamp は
+シンプレクティック写像ではなく、substep 間に挟むと合成の構造が壊れるため、projection を
+持たない Verlet kernel を合成する。Störmer-Verlet 単体は契約を揃えるため full step の末尾で
+呼ぶ (受け付ける状態型 `State<DIM, 2>` では default の no-op)。
 
 **DynamicalSystem trait**: Associated type で状態型を指定。
 

--- a/orts/src/attitude/state.rs
+++ b/orts/src/attitude/state.rs
@@ -1,14 +1,23 @@
 use arika::frame::{self, Rotation};
 use nalgebra::{UnitQuaternion, Vector3, Vector4};
-use utsuroi::{OdeState, Tolerances};
+use utsuroi::{OdeState, Projection, Tolerances};
 
 use crate::model::HasAttitude;
+
+/// Tolerance on `|q| - 1` below which [`OdeState::project`] leaves the
+/// quaternion alone.
+///
+/// A few ulp of norm drift changes no orientation — `orientation()`
+/// normalizes on read — so correcting it would only cost the adaptive solvers
+/// their FSAL derivative for nothing.
+const QUATERNION_NORM_TOLERANCE: f64 = 8.0 * f64::EPSILON;
 
 /// Attitude state: unit quaternion (orientation) + angular velocity in body frame.
 ///
 /// The quaternion is stored as `[w, x, y, z]` (Hamilton scalar-first convention).
 /// During integration, the quaternion may deviate slightly from unit norm;
-/// [`OdeState::project`] renormalizes it after each step.
+/// [`OdeState::project`] renormalizes it after each accepted step once the
+/// drift exceeds a few ulp.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AttitudeState {
     /// Orientation quaternion `[w, x, y, z]` (body-to-inertial rotation).
@@ -163,10 +172,19 @@ impl OdeState for AttitudeState {
         (sum_sq / n as f64).sqrt()
     }
 
-    fn project(&mut self, _t: f64) {
+    /// Renormalize the quaternion when it has drifted off the unit sphere.
+    ///
+    /// The tolerance keeps the FSAL cache of the adaptive solvers alive: a
+    /// correction of a few ulp buys no accuracy (`orientation()` normalizes on
+    /// read anyway) but reporting it as a change costs one extra derivative
+    /// evaluation per step.
+    fn project(&mut self, _t: f64) -> Projection {
         let norm = self.quaternion.magnitude();
-        if norm > 0.0 {
+        if norm > 0.0 && (norm - 1.0).abs() > QUATERNION_NORM_TOLERANCE {
             self.quaternion /= norm;
+            Projection::Changed
+        } else {
+            Projection::Unchanged
         }
     }
 }
@@ -234,7 +252,7 @@ mod tests {
             quaternion: Vector4::new(2.0, 0.0, 0.0, 0.0),
             angular_velocity: Vector3::new(1.0, 2.0, 3.0),
         };
-        state.project(0.0);
+        assert_eq!(state.project(0.0), Projection::Changed);
         let norm = state.quaternion.magnitude();
         assert!((norm - 1.0).abs() < 1e-15);
         // Angular velocity should be unchanged
@@ -244,8 +262,34 @@ mod tests {
     #[test]
     fn ode_state_project_preserves_unit() {
         let mut state = AttitudeState::identity();
-        state.project(0.0);
+        assert_eq!(state.project(0.0), Projection::Unchanged);
         assert!((state.quaternion.magnitude() - 1.0).abs() < 1e-15);
+    }
+
+    /// Drift of a few ulp is left alone: `orientation()` normalizes on read,
+    /// so correcting it buys nothing and would cost the adaptive solvers their
+    /// FSAL derivative.
+    #[test]
+    fn ode_state_project_ignores_ulp_scale_drift() {
+        let drift = 1.0 + 2.0 * f64::EPSILON;
+        let mut state = AttitudeState {
+            quaternion: Vector4::new(drift, 0.0, 0.0, 0.0),
+            angular_velocity: Vector3::zeros(),
+        };
+        assert_eq!(state.project(0.0), Projection::Unchanged);
+        assert_eq!(state.quaternion[0], drift);
+    }
+
+    /// Drift large enough to matter is corrected, and reported as a change so
+    /// the solvers drop the derivative taken at the unprojected state.
+    #[test]
+    fn ode_state_project_reports_correction() {
+        let mut state = AttitudeState {
+            quaternion: Vector4::new(1.0 + 1e-9, 0.0, 0.0, 0.0),
+            angular_velocity: Vector3::zeros(),
+        };
+        assert_eq!(state.project(0.0), Projection::Changed);
+        assert!((state.quaternion.magnitude() - 1.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/orts/src/attitude/state.rs
+++ b/orts/src/attitude/state.rs
@@ -89,17 +89,24 @@ impl AttitudeState {
             self.quaternion[2],
             self.quaternion[3],
         );
+        // Halve ω before multiplying rather than the sum afterwards. Each term
+        // is then bounded by `|q_i| · ½|ω|`, so a unit quaternion keeps the sum
+        // within `½ √3 f64::MAX` by Cauchy-Schwarz. Scaling last lets the sum
+        // overflow at a rate the result is nowhere near: with
+        // `q = [0, 1/√2, 1/√2, 0]` and `ω = [1.4e308, 1.4e308, 0]` the true
+        // `q̇.w` is about -9.9e307, while `-x·wx - y·wy` reaches -1.98e308 and
+        // becomes `-inf` that the later `0.5` cannot bring back.
         let (wx, wy, wz) = (
-            self.angular_velocity[0],
-            self.angular_velocity[1],
-            self.angular_velocity[2],
+            0.5 * self.angular_velocity[0],
+            0.5 * self.angular_velocity[1],
+            0.5 * self.angular_velocity[2],
         );
         // dq/dt = 0.5 * q ⊗ (0, ω)
         Vector4::new(
-            0.5 * (-x * wx - y * wy - z * wz),
-            0.5 * (w * wx + y * wz - z * wy),
-            0.5 * (w * wy + z * wx - x * wz),
-            0.5 * (w * wz + x * wy - y * wx),
+            -x * wx - y * wy - z * wz,
+            w * wx + y * wz - z * wy,
+            w * wy + z * wx - x * wz,
+            w * wz + x * wy - y * wx,
         )
     }
 
@@ -145,8 +152,20 @@ impl OdeState for AttitudeState {
         }
     }
 
+    /// Finite components are not enough for the quaternion: its norm has to be
+    /// usable too.
+    ///
+    /// Components around 1e157 are each finite while their squares sum to
+    /// infinity, and such a quaternion names no orientation — `orientation()`
+    /// divides by that norm. `project` deliberately leaves it alone rather than
+    /// turning it into a plausible-looking zero, which makes this the check that
+    /// has to catch it. Reported here, the integrators stop at the step that
+    /// produced it instead of handing it to sensors and a controller first.
     fn is_finite(&self) -> bool {
-        self.quaternion.iter().all(|v| v.is_finite())
+        let norm_sq = self.quaternion.norm_squared();
+        norm_sq.is_finite()
+            && norm_sq > 0.0
+            && self.quaternion.iter().all(|v| v.is_finite())
             && self.angular_velocity.iter().all(|v| v.is_finite())
     }
 
@@ -199,6 +218,58 @@ impl OdeState for AttitudeState {
 mod tests {
     use super::*;
     use std::f64::consts::PI;
+
+    /// Scaling ω before the products, not the sum after them: with these
+    /// values the mathematical result is comfortably finite while the
+    /// intermediate sum is not, so multiplying by 0.5 last returned `-inf`.
+    #[test]
+    fn q_dot_does_not_overflow_where_its_result_is_finite() {
+        let state = AttitudeState {
+            quaternion: Vector4::new(0.0, 1.0 / 2.0_f64.sqrt(), 1.0 / 2.0_f64.sqrt(), 0.0),
+            angular_velocity: Vector3::new(1.4e308, 1.4e308, 0.0),
+        };
+        let q_dot = state.q_dot();
+        assert!(
+            q_dot.iter().all(|v| v.is_finite()),
+            "q_dot overflowed: {q_dot:?}"
+        );
+        // -(x·wx + y·wy)/2 with x = y = 1/√2 and wx = wy = 1.4e308.
+        let expected = -1.4e308 / 2.0_f64.sqrt();
+        assert!(
+            (q_dot[0] - expected).abs() < expected.abs() * 1e-12,
+            "expected about {expected}, got {}",
+            q_dot[0]
+        );
+    }
+
+    /// A quaternion whose components are finite but whose norm is not names no
+    /// orientation, and `project` leaves it alone rather than collapsing it to
+    /// zero — so this is the check that has to reject it.
+    #[test]
+    fn a_quaternion_whose_norm_overflows_is_not_finite() {
+        let state = AttitudeState {
+            quaternion: Vector4::new(1e157, 1e157, 0.0, 0.0),
+            angular_velocity: Vector3::zeros(),
+        };
+        assert!(
+            state.quaternion.iter().all(|v| v.is_finite()),
+            "the components are meant to be finite"
+        );
+        assert!(
+            !state.quaternion.norm_squared().is_finite(),
+            "the sum of squares is meant to overflow"
+        );
+        assert!(!state.is_finite(), "should be reported as non-finite");
+    }
+
+    #[test]
+    fn an_all_zero_quaternion_is_not_finite() {
+        let state = AttitudeState {
+            quaternion: Vector4::zeros(),
+            angular_velocity: Vector3::zeros(),
+        };
+        assert!(!state.is_finite(), "a zero quaternion names no orientation");
+    }
 
     #[test]
     fn ode_state_zero_like() {

--- a/orts/src/attitude/state.rs
+++ b/orts/src/attitude/state.rs
@@ -178,9 +178,15 @@ impl OdeState for AttitudeState {
     /// correction of a few ulp buys no accuracy (`orientation()` normalizes on
     /// read anyway) but reporting it as a change costs one extra derivative
     /// evaluation per step.
+    ///
+    /// A zero norm is left alone: it carries no orientation to rescale, and
+    /// snapping to identity would invent one and hide the failure instead. A
+    /// non-finite norm is left alone for the opposite reason — dividing by it
+    /// would turn an infinite quaternion into a plausible-looking zero one and
+    /// defeat the integrators' finiteness checks.
     fn project(&mut self, _t: f64) -> Projection {
         let norm = self.quaternion.magnitude();
-        if norm > 0.0 && (norm - 1.0).abs() > QUATERNION_NORM_TOLERANCE {
+        if norm.is_finite() && norm > 0.0 && (norm - 1.0).abs() > QUATERNION_NORM_TOLERANCE {
             self.quaternion /= norm;
             Projection::Changed
         } else {
@@ -290,6 +296,34 @@ mod tests {
         };
         assert_eq!(state.project(0.0), Projection::Changed);
         assert!((state.quaternion.magnitude() - 1.0).abs() < f64::EPSILON);
+    }
+
+    /// A degenerate quaternion is passed through untouched. Rescaling a zero
+    /// norm is impossible, and rescaling an infinite one would produce a
+    /// finite-looking zero quaternion that the integrators' `is_finite`
+    /// checks would then wave through.
+    #[test]
+    fn ode_state_project_leaves_degenerate_quaternions_alone() {
+        for q in [
+            Vector4::zeros(),
+            Vector4::new(f64::INFINITY, 0.0, 0.0, 0.0),
+            Vector4::new(f64::NAN, 0.0, 0.0, 0.0),
+        ] {
+            let mut state = AttitudeState {
+                quaternion: q,
+                angular_velocity: Vector3::zeros(),
+            };
+            assert_eq!(state.project(0.0), Projection::Unchanged);
+            assert!(
+                state
+                    .quaternion
+                    .iter()
+                    .zip(q.iter())
+                    .all(|(a, b)| a.to_bits() == b.to_bits()),
+                "degenerate quaternion {q:?} must be passed through, got {:?}",
+                state.quaternion
+            );
+        }
     }
 
     #[test]

--- a/orts/src/effector.rs
+++ b/orts/src/effector.rs
@@ -8,7 +8,7 @@
 
 use arika::epoch::Epoch;
 use arika::frame::{self, SimpleEci};
-use utsuroi::{OdeState, Tolerances};
+use utsuroi::{OdeState, Projection, Tolerances};
 
 use crate::model::ExternalLoads;
 
@@ -147,12 +147,17 @@ impl<S: OdeState> OdeState for AugmentedState<S> {
         plant_norm.max(aux_norm)
     }
 
-    fn project(&mut self, t: f64) {
-        self.plant.project(t);
+    fn project(&mut self, t: f64) -> Projection {
+        let mut projection = self.plant.project(t);
         // Clamp auxiliary state to bounds (e.g., reaction wheel momentum limits)
         for (i, &(lo, hi)) in self.aux_bounds.iter().enumerate() {
-            self.aux[i] = self.aux[i].clamp(lo, hi);
+            let clamped = self.aux[i].clamp(lo, hi);
+            if clamped != self.aux[i] {
+                self.aux[i] = clamped;
+                projection = projection.or(Projection::Changed);
+            }
         }
+        projection
     }
 }
 
@@ -325,7 +330,7 @@ mod tests {
             aux: vec![5.0, 10.0],
             aux_bounds: vec![],
         };
-        s.project(0.0);
+        assert_eq!(s.project(0.0), Projection::Changed);
         let norm = s.plant.quaternion.magnitude();
         assert!((norm - 1.0).abs() < 1e-15);
         // Aux should be unchanged (no bounds set)
@@ -339,10 +344,21 @@ mod tests {
             aux: vec![15.0, -5.0, 3.0],
             aux_bounds: vec![(-10.0, 10.0), (-2.0, 2.0), (0.0, 100.0)],
         };
-        s.project(0.0);
+        assert_eq!(s.project(0.0), Projection::Changed);
         assert!((s.aux[0] - 10.0).abs() < 1e-15); // clamped from 15 to 10
         assert!((s.aux[1] - (-2.0)).abs() < 1e-15); // clamped from -5 to -2
         assert!((s.aux[2] - 3.0).abs() < 1e-15); // within bounds, unchanged
+    }
+
+    #[test]
+    fn project_reports_unchanged_when_aux_within_bounds() {
+        let mut s = AugmentedState {
+            plant: AttitudeState::identity(),
+            aux: vec![3.0, -1.0],
+            aux_bounds: vec![(-10.0, 10.0), (-2.0, 2.0)],
+        };
+        assert_eq!(s.project(0.0), Projection::Unchanged);
+        assert_eq!(s.aux, vec![3.0, -1.0]);
     }
 
     #[test]

--- a/orts/src/group/state.rs
+++ b/orts/src/group/state.rs
@@ -1,4 +1,4 @@
-use utsuroi::{OdeState, Tolerances};
+use utsuroi::{OdeState, Projection, Tolerances};
 
 /// Composite ODE state for N satellites.
 ///
@@ -72,10 +72,12 @@ impl<S: OdeState> OdeState for GroupState<S> {
             .fold(0.0_f64, f64::max)
     }
 
-    fn project(&mut self, t: f64) {
+    fn project(&mut self, t: f64) -> Projection {
+        let mut projection = Projection::Unchanged;
         for s in &mut self.states {
-            s.project(t);
+            projection = projection.or(s.project(t));
         }
+        projection
     }
 }
 
@@ -220,9 +222,22 @@ mod tests {
             mass: 500.0,
         };
         let mut group = GroupState::new(vec![sc]);
-        group.project(0.0);
+        // A change in any member is reported for the whole group.
+        assert_eq!(group.project(0.0), Projection::Changed);
         let q_norm = group.states[0].attitude.quaternion.magnitude();
         assert!((q_norm - 1.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn project_reports_unchanged_when_no_element_changes() {
+        let mut group = two_orbit_group();
+        assert_eq!(group.project(0.0), Projection::Unchanged);
+    }
+
+    #[test]
+    fn project_of_empty_group_is_unchanged() {
+        let mut empty: GroupState<OrbitalState> = GroupState::new(vec![]);
+        assert_eq!(empty.project(0.0), Projection::Unchanged);
     }
 
     #[test]

--- a/orts/src/orbital/state.rs
+++ b/orts/src/orbital/state.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use arika::frame::{Eci, SimpleEci, Vec3};
 use nalgebra::Vector3;
-use utsuroi::{OdeState, State, Tolerances};
+use utsuroi::{OdeState, Projection, State, Tolerances};
 
 use crate::model::HasOrbit;
 
@@ -168,7 +168,7 @@ impl<F: Eci> OdeState for OrbitalState<F> {
         self.0.error_norm(&y_next.0, &error.0, tol)
     }
 
-    fn project(&mut self, t: f64) {
-        self.0.project(t);
+    fn project(&mut self, t: f64) -> Projection {
+        self.0.project(t)
     }
 }

--- a/orts/src/spacecraft/state.rs
+++ b/orts/src/spacecraft/state.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use arika::frame::{Eci, SimpleEci};
 use nalgebra::{Vector3, Vector4};
-use utsuroi::{OdeState, Tolerances};
+use utsuroi::{OdeState, Projection, Tolerances};
 
 use crate::attitude::AttitudeState;
 use crate::model::{HasAttitude, HasMass, HasOrbit};
@@ -162,8 +162,8 @@ impl<F: Eci> OdeState for SpacecraftState<F> {
         orbit_norm.max(attitude_norm).max(mass_norm)
     }
 
-    fn project(&mut self, t: f64) {
-        self.attitude.project(t);
+    fn project(&mut self, t: f64) -> Projection {
+        self.attitude.project(t)
     }
 }
 
@@ -357,7 +357,7 @@ mod tests {
         let orbit_before = state.orbit.clone();
         let mass_before = state.mass;
 
-        state.project(0.0);
+        assert_eq!(state.project(0.0), Projection::Changed);
 
         assert!((state.attitude.quaternion.magnitude() - 1.0).abs() < 1e-15);
         assert_eq!(state.orbit, orbit_before);

--- a/orts/tests/oracle_attitude.rs
+++ b/orts/tests/oracle_attitude.rs
@@ -327,13 +327,58 @@ fn dp45_attitude_integration() {
     let l_err = (l_final - l0).magnitude() / l0.magnitude();
     assert!(l_err < 1e-9, "DP45 angular momentum error: {l_err:.2e}");
 
-    // Quaternion should be close to unit (project() renormalizes each step,
-    // but adaptive stepping may accumulate small drift)
+    // The solver projects every state it publishes, so the norm error left
+    // over is at most the projection tolerance (a few ulp) — not the drift
+    // accumulated over the whole integration. The previous 1e-8 bound was
+    // loose enough to pass while no projection happened at all.
     let q_norm = final_state.quaternion.magnitude();
     assert!(
-        (q_norm - 1.0).abs() < 1e-8,
+        (q_norm - 1.0).abs() < 1e-14,
         "Quaternion not normalized: {q_norm}"
     );
+}
+
+/// The same check at the tolerances the CLI actually uses. They are 100x
+/// looser than the ones above, so unprojected norm drift is 100x larger —
+/// which is exactly the case a bound calibrated on tight tolerances misses.
+#[test]
+fn dp45_attitude_quaternion_stays_unit_at_default_tolerance() {
+    let inertia = diagonal_inertia(10.0, 20.0, 30.0);
+    let system = AttitudeSystem::new(inertia);
+
+    let initial = AttitudeState {
+        quaternion: Vector4::new(1.0, 0.0, 0.0, 0.0),
+        angular_velocity: Vector3::new(0.5, 0.3, 0.1),
+    };
+
+    // cli/src/config.rs defaults.
+    let tol = Tolerances {
+        atol: 1e-10,
+        rtol: 1e-8,
+    };
+
+    let mut worst = 0.0_f64;
+    let outcome: IntegrationOutcome<AttitudeState, ()> = DormandPrince
+        .integrate_adaptive_with_events(
+            &system,
+            initial,
+            0.0,
+            3600.0,
+            0.1,
+            &tol,
+            |_, state| worst = worst.max((state.quaternion.magnitude() - 1.0).abs()),
+            |_, _| ControlFlow::Continue(()),
+        );
+    let final_state = match outcome {
+        IntegrationOutcome::Completed(s) => s,
+        other => panic!("DP45 failed: {other:?}"),
+    };
+
+    assert!(
+        worst < 1e-14,
+        "worst published quaternion norm error over an hour: {worst:.2e}"
+    );
+    assert!((final_state.quaternion.magnitude() - 1.0).abs() < 1e-14);
 }
 
 #[test]

--- a/orts/tests/projection_contract.rs
+++ b/orts/tests/projection_contract.rs
@@ -1,0 +1,166 @@
+//! The state invariants declared through [`utsuroi::OdeState::project`] must
+//! hold no matter which integrator runs the simulation.
+//!
+//! Reaction wheel momentum saturation is enforced *only* by the `aux_bounds`
+//! projection of `AugmentedState`: the wheel model zeroes torque in the
+//! saturating direction, which bounds the overshoot within a step but does not
+//! remove it. The default integrator is `dp45`, so the adaptive steppers have
+//! to honour the projection as well as `Rk4` does.
+
+use std::ops::ControlFlow;
+
+use nalgebra::{Matrix3, Vector3};
+use utsuroi::{Dop853, DormandPrince, Integrator, Rk4, Tolerances};
+
+use orts::attitude::{AttitudeState, AugmentedAttitudeSystem};
+use orts::effector::AugmentedState;
+use orts::spacecraft::{ReactionWheelAssembly, RwCommand};
+
+const MAX_MOMENTUM: f64 = 0.5;
+const MAX_TORQUE: f64 = 0.1;
+/// Time to saturation is `MAX_MOMENTUM / MAX_TORQUE = 5 s`; run well past it.
+const T_END: f64 = 20.0;
+
+fn saturating_system() -> AugmentedAttitudeSystem {
+    let inertia = Matrix3::from_diagonal(&Vector3::new(10.0, 10.0, 10.0));
+    let mut rw = ReactionWheelAssembly::three_axis(0.01, MAX_MOMENTUM, MAX_TORQUE);
+    rw.command = RwCommand::Torques(rw.core().allocate(&Vector3::new(0.0, 0.0, MAX_TORQUE)));
+    AugmentedAttitudeSystem::circular_orbit(inertia, 398600.4418, 7000.0, 100.0).with_effector(rw)
+}
+
+fn initial_state(system: &AugmentedAttitudeSystem) -> AugmentedState<AttitudeState> {
+    AugmentedState {
+        plant: AttitudeState::identity(),
+        aux: system.initial_aux_state(),
+        aux_bounds: system.initial_aux_bounds(),
+    }
+}
+
+/// Worst violation of `aux_bounds` over a published trajectory, in absolute
+/// momentum units. Zero or negative means every published state was inside
+/// its bounds.
+fn worst_overshoot(state: &AugmentedState<AttitudeState>) -> f64 {
+    state
+        .aux
+        .iter()
+        .zip(&state.aux_bounds)
+        .map(|(&h, &(lo, hi))| (lo - h).max(h - hi))
+        .fold(f64::NEG_INFINITY, f64::max)
+}
+
+fn tolerances() -> Vec<Tolerances> {
+    vec![
+        // cli/src/config.rs defaults.
+        Tolerances {
+            atol: 1e-10,
+            rtol: 1e-8,
+        },
+        // A looser setting, where the adaptive step grows and the overshoot
+        // with it.
+        Tolerances {
+            atol: 1e-3,
+            rtol: 1e-3,
+        },
+    ]
+}
+
+#[test]
+fn rk4_keeps_wheel_momentum_within_bounds() {
+    let system = saturating_system();
+    let mut worst = f64::NEG_INFINITY;
+    let final_state = Rk4.integrate(
+        &system,
+        initial_state(&system),
+        0.0,
+        T_END,
+        0.01,
+        |_t, s| {
+            worst = worst.max(worst_overshoot(s));
+        },
+    );
+    assert!(
+        worst <= 0.0,
+        "Rk4 published wheel momentum {worst:.3e} beyond aux_bounds"
+    );
+    assert!((final_state.aux[2] + MAX_MOMENTUM).abs() < 0.01);
+}
+
+#[test]
+fn dp45_keeps_wheel_momentum_within_bounds() {
+    for tol in tolerances() {
+        let system = saturating_system();
+        let mut stepper = DormandPrince.stepper(&system, initial_state(&system), 0.0, 1.0, tol);
+        let mut worst = f64::NEG_INFINITY;
+        stepper
+            .advance_to::<_, _, ()>(
+                T_END,
+                |_t, s| worst = worst.max(worst_overshoot(s)),
+                |_t, _s| ControlFlow::Continue(()),
+            )
+            .expect("integration should reach the target");
+        assert!(
+            worst <= 0.0,
+            "dp45 published wheel momentum {worst:.3e} beyond aux_bounds \
+             (limit {MAX_MOMENTUM}, reached {})",
+            stepper.state().aux[2]
+        );
+        // The wheel still absorbs the reaction up to its limit — the bound is
+        // held by clamping, not by the integration stalling.
+        assert!(
+            (stepper.state().aux[2] + MAX_MOMENTUM).abs() < 0.01,
+            "Z-wheel should saturate at -{MAX_MOMENTUM}, got {}",
+            stepper.state().aux[2]
+        );
+    }
+}
+
+#[test]
+fn dop853_keeps_wheel_momentum_within_bounds() {
+    for tol in tolerances() {
+        let system = saturating_system();
+        let mut stepper = Dop853.stepper(&system, initial_state(&system), 0.0, 1.0, tol);
+        let mut worst = f64::NEG_INFINITY;
+        stepper
+            .advance_to::<_, _, ()>(
+                T_END,
+                |_t, s| worst = worst.max(worst_overshoot(s)),
+                |_t, _s| ControlFlow::Continue(()),
+            )
+            .expect("integration should reach the target");
+        assert!(
+            worst <= 0.0,
+            "dop853 published wheel momentum {worst:.3e} beyond aux_bounds \
+             (limit {MAX_MOMENTUM}, reached {})",
+            stepper.state().aux[2]
+        );
+        assert!(
+            (stepper.state().aux[2] + MAX_MOMENTUM).abs() < 0.01,
+            "Z-wheel should saturate at -{MAX_MOMENTUM}, got {}",
+            stepper.state().aux[2]
+        );
+    }
+}
+
+/// The fixed-step entry point of the adaptive solvers must project too — it is
+/// what `Integrator::integrate` drives.
+#[test]
+fn fixed_step_adaptive_solvers_keep_wheel_momentum_within_bounds() {
+    let system = saturating_system();
+    let mut worst_dp45 = f64::NEG_INFINITY;
+    DormandPrince.integrate(&system, initial_state(&system), 0.0, T_END, 0.1, |_t, s| {
+        worst_dp45 = worst_dp45.max(worst_overshoot(s))
+    });
+    assert!(
+        worst_dp45 <= 0.0,
+        "DormandPrince::step published wheel momentum {worst_dp45:.3e} beyond aux_bounds"
+    );
+
+    let mut worst_dop853 = f64::NEG_INFINITY;
+    Dop853.integrate(&system, initial_state(&system), 0.0, T_END, 0.1, |_t, s| {
+        worst_dop853 = worst_dop853.max(worst_overshoot(s))
+    });
+    assert!(
+        worst_dop853 <= 0.0,
+        "Dop853::step published wheel momentum {worst_dop853:.3e} beyond aux_bounds"
+    );
+}

--- a/utsuroi/src/lib.rs
+++ b/utsuroi/src/lib.rs
@@ -9,6 +9,8 @@ mod state;
 #[cfg(test)]
 mod comparison;
 #[cfg(test)]
+mod projection;
+#[cfg(test)]
 pub(crate) mod test_systems;
 
 pub use error::{IntegrationError, IntegrationOutcome, Tolerances, validate_step_size};
@@ -18,7 +20,7 @@ pub use solver::dp45::{AdaptiveStepper, AdvanceOutcome, DormandPrince};
 pub use solver::rk4::Rk4;
 pub use solver::verlet::StormerVerlet;
 pub use solver::yoshida::{Yoshida4, Yoshida6, Yoshida8};
-pub use state::{DynamicalSystem, OdeState, State};
+pub use state::{DynamicalSystem, OdeState, Projection, State};
 
 #[cfg(test)]
 mod tests {
@@ -197,7 +199,7 @@ mod tests {
     fn ode_state_project_is_noop() {
         let mut state = State::<3, 2>::new(vector![1.0, 2.0, 3.0], vector![4.0, 5.0, 6.0]);
         let original = state.clone();
-        state.project(0.0);
+        assert_eq!(state.project(0.0), crate::Projection::Unchanged);
         assert_eq!(state, original);
     }
 }

--- a/utsuroi/src/projection.rs
+++ b/utsuroi/src/projection.rs
@@ -1,0 +1,474 @@
+//! Cross-solver tests for the [`OdeState::project`] contract.
+//!
+//! Every integrator in this crate must project the state it publishes, and
+//! must not pay for the projection when the state type does not use it. Both
+//! halves are pinned here with spy state types that record what the solvers
+//! actually do, so the contract does not depend on any particular domain type
+//! (attitude quaternions, effector bounds) implementing it.
+
+use core::cell::Cell;
+use core::ops::ControlFlow;
+
+use crate::{
+    Dop853, DormandPrince, DynamicalSystem, Integrator, OdeState, Projection, Rk4, Tolerances,
+};
+
+// Bounded scalar: project() clamps into [0, 1]
+
+/// Scalar state whose projection clamps it into `[0, 1]`.
+///
+/// `y' = 1` starting from `y = 0` overshoots the bound in a single step of
+/// `dt = 2`, so any solver that skips `project` is visible immediately.
+#[derive(Debug, Clone, PartialEq)]
+struct Bounded {
+    y: f64,
+}
+
+impl OdeState for Bounded {
+    fn zero_like(&self) -> Self {
+        Bounded { y: 0.0 }
+    }
+
+    fn axpy(&self, scale: f64, other: &Self) -> Self {
+        Bounded {
+            y: self.y + scale * other.y,
+        }
+    }
+
+    fn scale(&self, factor: f64) -> Self {
+        Bounded { y: factor * self.y }
+    }
+
+    fn is_finite(&self) -> bool {
+        self.y.is_finite()
+    }
+
+    fn error_norm(&self, y_next: &Self, error: &Self, tol: &Tolerances) -> f64 {
+        let sc = tol.atol + tol.rtol * self.y.abs().max(y_next.y.abs());
+        (error.y / sc).abs()
+    }
+
+    fn project(&mut self, _t: f64) -> Projection {
+        let clamped = self.y.clamp(0.0, 1.0);
+        if clamped == self.y {
+            Projection::Unchanged
+        } else {
+            self.y = clamped;
+            Projection::Changed
+        }
+    }
+}
+
+/// `y' = 1`: the exact solution leaves the bound behind linearly.
+struct Ramp;
+
+impl DynamicalSystem for Ramp {
+    type State = Bounded;
+
+    fn derivatives(&self, _t: f64, _state: &Bounded) -> Bounded {
+        Bounded { y: 1.0 }
+    }
+}
+
+fn tol() -> Tolerances {
+    // The CLI defaults.
+    Tolerances {
+        atol: 1e-10,
+        rtol: 1e-8,
+    }
+}
+
+#[test]
+fn rk4_step_projects() {
+    let y = Rk4.step(&Ramp, 0.0, &Bounded { y: 0.0 }, 2.0);
+    assert_eq!(y.y, 1.0, "RK4 step must publish a projected state");
+}
+
+#[test]
+fn dp45_fixed_step_projects() {
+    let y = DormandPrince.step(&Ramp, 0.0, &Bounded { y: 0.0 }, 2.0);
+    assert_eq!(y.y, 1.0, "DP45 step must publish a projected state");
+}
+
+#[test]
+fn dop853_fixed_step_projects() {
+    let y = Dop853.step(&Ramp, 0.0, &Bounded { y: 0.0 }, 2.0);
+    assert_eq!(y.y, 1.0, "DOP853 step must publish a projected state");
+}
+
+#[test]
+fn dp45_adaptive_projects_every_published_state() {
+    let mut stepper = DormandPrince.stepper(&Ramp, Bounded { y: 0.0 }, 0.0, 0.5, tol());
+    let mut worst = 0.0_f64;
+    let outcome = stepper
+        .advance_to::<_, _, ()>(
+            2.0,
+            |_t, s| worst = worst.max(s.y),
+            |_t, s| {
+                // The event check must see the projected state too.
+                assert!(s.y <= 1.0, "event check saw unprojected y = {}", s.y);
+                ControlFlow::Continue(())
+            },
+        )
+        .expect("integration should reach the target");
+    assert!(matches!(outcome, crate::AdvanceOutcome::Reached));
+    assert!(
+        worst <= 1.0,
+        "DP45 published a state outside the bound: y = {worst}"
+    );
+    assert_eq!(stepper.state().y, 1.0);
+}
+
+#[test]
+fn dop853_adaptive_projects_every_published_state() {
+    let mut stepper = Dop853.stepper(&Ramp, Bounded { y: 0.0 }, 0.0, 0.5, tol());
+    let mut worst = 0.0_f64;
+    let outcome = stepper
+        .advance_to::<_, _, ()>(
+            2.0,
+            |_t, s| worst = worst.max(s.y),
+            |_t, s| {
+                assert!(s.y <= 1.0, "event check saw unprojected y = {}", s.y);
+                ControlFlow::Continue(())
+            },
+        )
+        .expect("integration should reach the target");
+    assert!(matches!(outcome, crate::AdvanceOutcome853::Reached));
+    assert!(
+        worst <= 1.0,
+        "DOP853 published a state outside the bound: y = {worst}"
+    );
+    assert_eq!(stepper.state().y, 1.0);
+}
+
+/// `step_full` is the low-level entry point: it returns the raw candidate so
+/// that a caller running its own step-size control can weigh it against the
+/// error estimate that belongs to it. Projecting an accepted candidate is that
+/// caller's job, and this pins the split.
+#[test]
+fn step_full_returns_the_unprojected_candidate() {
+    let (y5, _, _) = DormandPrince.step_full(&Ramp, 0.0, &Bounded { y: 0.0 }, 2.0);
+    assert!(
+        (y5.y - 2.0).abs() < 1e-12,
+        "step_full must not project, got y = {}",
+        y5.y
+    );
+    let mut accepted = y5;
+    assert_eq!(accepted.project(2.0), Projection::Changed);
+    assert_eq!(accepted.y, 1.0);
+
+    let (y8, _, _) = Dop853.step_full(&Ramp, 0.0, &Bounded { y: 0.0 }, 2.0);
+    assert!(
+        (y8.y - 2.0).abs() < 1e-12,
+        "step_full must not project, got y = {}",
+        y8.y
+    );
+    let mut accepted = y8;
+    assert_eq!(accepted.project(2.0), Projection::Changed);
+    assert_eq!(accepted.y, 1.0);
+}
+
+// Evaluation counting: how much does honouring the contract cost?
+
+/// Counts calls to [`DynamicalSystem::derivatives`].
+///
+/// Step-count callbacks fire only on accepted steps, so they cannot measure
+/// what a solver spends: they miss every rejected trial and every derivative
+/// reused through FSAL. This wrapper counts the real thing.
+pub(crate) struct Counting<'a, S> {
+    inner: &'a S,
+    count: Cell<u64>,
+}
+
+impl<'a, S> Counting<'a, S> {
+    pub(crate) fn new(inner: &'a S) -> Self {
+        Self {
+            inner,
+            count: Cell::new(0),
+        }
+    }
+
+    pub(crate) fn count(&self) -> u64 {
+        self.count.get()
+    }
+}
+
+impl<S: DynamicalSystem> DynamicalSystem for Counting<'_, S> {
+    type State = S::State;
+
+    fn derivatives(&self, t: f64, state: &Self::State) -> Self::State {
+        self.count.set(self.count.get() + 1);
+        self.inner.derivatives(t, state)
+    }
+}
+
+/// Counters read from inside a spy state.
+///
+/// `error_norm` is called exactly once per accept/reject decision, so counting
+/// it counts *trials* — a quantity independent of the derivative count under
+/// test. Deriving the trial count from the derivative count instead would only
+/// confirm that the latter is divisible by the stage count, and would accept a
+/// solver that spent twice as many evaluations per trial.
+#[derive(Debug, Default)]
+struct Spy {
+    trials: Cell<u64>,
+}
+
+/// State with a decaying value plus a "marker" component that only exists to
+/// make `project` report [`Projection::Changed`].
+///
+/// The marker is excluded from `error_norm`, and nothing in the dynamics reads
+/// it, so switching `reset_marker` on changes *only* whether the projection
+/// reports a change — the accepted step sequence stays identical. That makes
+/// the difference in derivative evaluations attributable to the projection
+/// alone.
+#[derive(Debug, Clone)]
+struct Marked<'a> {
+    y: f64,
+    marker: f64,
+    reset_marker: bool,
+    spy: &'a Spy,
+}
+
+impl OdeState for Marked<'_> {
+    fn zero_like(&self) -> Self {
+        Marked {
+            y: 0.0,
+            marker: 0.0,
+            reset_marker: self.reset_marker,
+            spy: self.spy,
+        }
+    }
+
+    fn axpy(&self, scale: f64, other: &Self) -> Self {
+        Marked {
+            y: self.y + scale * other.y,
+            marker: self.marker + scale * other.marker,
+            reset_marker: self.reset_marker,
+            spy: self.spy,
+        }
+    }
+
+    fn scale(&self, factor: f64) -> Self {
+        Marked {
+            y: factor * self.y,
+            marker: factor * self.marker,
+            reset_marker: self.reset_marker,
+            spy: self.spy,
+        }
+    }
+
+    fn is_finite(&self) -> bool {
+        self.y.is_finite() && self.marker.is_finite()
+    }
+
+    fn error_norm(&self, y_next: &Self, error: &Self, tol: &Tolerances) -> f64 {
+        // One call per accept/reject decision, i.e. one per trial.
+        self.spy.trials.set(self.spy.trials.get() + 1);
+        let sc = tol.atol + tol.rtol * self.y.abs().max(y_next.y.abs());
+        (error.y / sc).abs()
+    }
+
+    fn project(&mut self, _t: f64) -> Projection {
+        if self.reset_marker && self.marker != 0.0 {
+            self.marker = 0.0;
+            Projection::Changed
+        } else {
+            Projection::Unchanged
+        }
+    }
+}
+
+/// `y' = -y`, `marker' = 1`.
+struct Decay<'a> {
+    spy: &'a Spy,
+}
+
+impl<'a> DynamicalSystem for Decay<'a> {
+    type State = Marked<'a>;
+
+    fn derivatives(&self, _t: f64, state: &Marked<'a>) -> Marked<'a> {
+        Marked {
+            y: -state.y,
+            marker: 1.0,
+            reset_marker: state.reset_marker,
+            spy: self.spy,
+        }
+    }
+}
+
+fn initial(reset_marker: bool, spy: &Spy) -> Marked<'_> {
+    Marked {
+        y: 1.0,
+        marker: 0.0,
+        reset_marker,
+        spy,
+    }
+}
+
+/// What one integration spent.
+struct Cost {
+    /// Calls to [`DynamicalSystem::derivatives`].
+    evals: u64,
+    /// Accepted steps (callback invocations).
+    accepted: u64,
+    /// Accept/reject decisions, counted inside the state.
+    trials: u64,
+}
+
+fn dp45_cost(reset_marker: bool) -> Cost {
+    let spy = Spy::default();
+    let decay = Decay { spy: &spy };
+    let system = Counting::new(&decay);
+    let mut stepper = DormandPrince.stepper(&system, initial(reset_marker, &spy), 0.0, 0.1, tol());
+    let mut accepted = 0_u64;
+    stepper
+        .advance_to::<_, _, ()>(
+            5.0,
+            |_t, _s| accepted += 1,
+            |_t, _s| ControlFlow::Continue(()),
+        )
+        .expect("integration should reach the target");
+    Cost {
+        evals: system.count(),
+        accepted,
+        trials: spy.trials.get(),
+    }
+}
+
+fn dop853_cost(reset_marker: bool) -> Cost {
+    let spy = Spy::default();
+    let decay = Decay { spy: &spy };
+    let system = Counting::new(&decay);
+    let mut stepper = Dop853.stepper(&system, initial(reset_marker, &spy), 0.0, 0.1, tol());
+    let mut accepted = 0_u64;
+    stepper
+        .advance_to::<_, _, ()>(
+            5.0,
+            |_t, _s| accepted += 1,
+            |_t, _s| ControlFlow::Continue(()),
+        )
+        .expect("integration should reach the target");
+    Cost {
+        evals: system.count(),
+        accepted,
+        trials: spy.trials.get(),
+    }
+}
+
+/// A state that never reports a change must cost exactly what the FSAL scheme
+/// promises: 6 evaluations per trial plus the single initial derivative.
+#[test]
+fn dp45_no_op_projection_costs_nothing() {
+    let cost = dp45_cost(false);
+    assert!(
+        cost.accepted > 5,
+        "expected several steps, got {}",
+        cost.accepted
+    );
+    assert_eq!(
+        cost.trials, cost.accepted,
+        "y' = -y at these tolerances should not need a retry \
+         ({} trials for {} accepted steps)",
+        cost.trials, cost.accepted
+    );
+    assert_eq!(
+        cost.evals,
+        1 + 6 * cost.trials,
+        "DP45 with a no-op projection: {} evaluations for {} trials",
+        cost.evals,
+        cost.trials
+    );
+}
+
+/// Only a projection that actually changes the state costs an extra
+/// evaluation, and only one per changed step — the last one is never paid,
+/// because the invalidated derivative is re-evaluated lazily by the *next*
+/// step.
+#[test]
+fn dp45_changed_projection_costs_one_extra_evaluation_per_step() {
+    let noop = dp45_cost(false);
+    let changed = dp45_cost(true);
+    assert_eq!(
+        (noop.accepted, noop.trials),
+        (changed.accepted, changed.trials),
+        "the marker must not perturb the step sequence"
+    );
+    assert_eq!(
+        changed.evals - noop.evals,
+        changed.accepted - 1,
+        "expected one extra evaluation per changed step except the last \
+         ({} -> {} over {} steps)",
+        noop.evals,
+        changed.evals,
+        changed.accepted
+    );
+}
+
+/// DOP853's 13th stage *is* the next step's first stage, so it is evaluated at
+/// the projected state by the next step. The projection is therefore free, and
+/// the count is the same whether or not it changes the state.
+#[test]
+fn dop853_projection_is_free() {
+    let noop = dop853_cost(false);
+    let changed = dop853_cost(true);
+    assert_eq!(
+        (noop.accepted, noop.trials, noop.evals),
+        (changed.accepted, changed.trials, changed.evals),
+        "the projection must cost nothing for DOP853"
+    );
+    assert!(
+        noop.accepted > 3,
+        "expected several steps, got {}",
+        noop.accepted
+    );
+    assert_eq!(
+        noop.trials, noop.accepted,
+        "y' = -y at these tolerances should not need a retry"
+    );
+    assert_eq!(
+        noop.evals,
+        11 * noop.trials + noop.accepted,
+        "DOP853: 11 stages per trial plus one first-stage evaluation per step \
+         ({} evaluations for {} trials, {} accepted)",
+        noop.evals,
+        noop.trials,
+        noop.accepted
+    );
+}
+
+/// A rejected trial must not cost the 13th stage: DOP853 spends 11
+/// evaluations on a candidate it throws away, not 12.
+#[test]
+fn dop853_rejected_trial_costs_eleven_evaluations() {
+    let spy = Spy::default();
+    let decay = Decay { spy: &spy };
+    let system = Counting::new(&decay);
+    let tol = Tolerances {
+        atol: 1e-14,
+        rtol: 1e-14,
+    };
+    // A far too large first step is rejected, then retried smaller.
+    let mut stepper = Dop853.stepper(&system, initial(false, &spy), 0.0, 5.0, tol);
+    let mut accepted = 0_u64;
+    stepper
+        .advance_to::<_, _, ()>(
+            5.0,
+            |_t, _s| accepted += 1,
+            |_t, _s| ControlFlow::Continue(()),
+        )
+        .expect("integration should reach the target");
+    let evals = system.count();
+    let trials = spy.trials.get();
+    assert!(
+        trials > accepted,
+        "this setup should reject at least one trial (trials={trials}, accepted={accepted})"
+    );
+    // Each trial costs 11 evaluations; each step start additionally pays the
+    // single first-stage evaluation, exactly once per accepted step.
+    assert_eq!(
+        evals,
+        11 * trials + accepted,
+        "{evals} evaluations for {trials} trials and {accepted} accepted steps"
+    );
+}

--- a/utsuroi/src/solver/dop853/mod.rs
+++ b/utsuroi/src/solver/dop853/mod.rs
@@ -18,19 +18,23 @@ use crate::{
 /// used for error estimation. Based on Hairer, Norsett & Wanner (1993).
 pub struct Dop853;
 
-/// Internal 12-stage DOP853 computation.
+/// Internal DOP853 candidate computation: stages 2..12 (11 evaluations).
 ///
-/// Returns `(y8, error, k13)` where:
+/// Returns `(y8, error)` where:
 /// - `y8`: 8th-order solution
 /// - `error`: composite error estimate (combined 5th + 3rd order)
-/// - `k13`: derivative at y8 (reusable as k1 of next step via FSAL)
-fn dop853_step_impl<S: DynamicalSystem>(
+///
+/// The 13th stage `k13 = f(t + dt, y8)` is *not* computed here. It plays no
+/// part in the error estimate, so a rejected candidate never needs it, and an
+/// accepted one needs it evaluated at the projected state rather than at the
+/// raw candidate.
+fn dop853_candidate<S: DynamicalSystem>(
     system: &S,
     t: f64,
     state: &S::State,
     dt: f64,
     k1: &S::State,
-) -> (S::State, S::State, S::State) {
+) -> (S::State, S::State) {
     // Stage 2
     let s2 = state.axpy(dt * A21, k1);
     let k2 = system.derivatives(t + C2 * dt, &s2);
@@ -131,9 +135,6 @@ fn dop853_step_impl<S: DynamicalSystem>(
         .axpy(dt * B11, &k11)
         .axpy(dt * B12, &k12);
 
-    // Stage 13 (FSAL: evaluated at y8)
-    let k13 = system.derivatives(t + dt, &y8);
-
     // Error estimation: combine 5th-order and 3rd-order errors
     // 5th-order error: dt * (er1*k1 + er6*k6 + ... + er12*k12)
     let err5 = k1
@@ -174,13 +175,34 @@ fn dop853_step_impl<S: DynamicalSystem>(
     let _ = err3; // Will be used for combined norm later if needed
     let error = err5;
 
+    (y8, error)
+}
+
+/// [`dop853_candidate`] plus the FSAL stage `k13 = f(t + dt, y8)`, evaluated
+/// at the raw candidate.
+///
+/// The adaptive stepper does not use this: it evaluates the next first stage
+/// at the *projected* state instead. This backs [`Dop853::step_full`], whose
+/// published contract includes `k13`.
+fn dop853_step_with_fsal<S: DynamicalSystem>(
+    system: &S,
+    t: f64,
+    state: &S::State,
+    dt: f64,
+    k1: &S::State,
+) -> (S::State, S::State, S::State) {
+    let (y8, error) = dop853_candidate(system, t, state, dt, k1);
+    let k13 = system.derivatives(t + dt, &y8);
     (y8, error, k13)
 }
 
 impl Integrator for Dop853 {
     fn step<S: DynamicalSystem>(&self, system: &S, t: f64, state: &S::State, dt: f64) -> S::State {
         let k1 = system.derivatives(t, state);
-        let (y8, _, _) = dop853_step_impl(system, t, state, dt, &k1);
+        let (mut y8, _) = dop853_candidate(system, t, state, dt, &k1);
+        // Fixed-step use keeps no derivative across steps, so the FSAL cache
+        // cannot go stale here.
+        let _ = y8.project(t + dt);
         y8
     }
 }
@@ -203,7 +225,12 @@ pub struct AdaptiveStepper853<'a, S: DynamicalSystem> {
     state: S::State,
     t: f64,
     dt: f64,
-    k1: S::State,
+    /// Cached first-stage derivative. `None` means "not known at the current
+    /// state": the next step evaluates it. DOP853's FSAL stage
+    /// `k13 = f(t + h, y_next)` is exactly that evaluation, so accepting a
+    /// step simply leaves this `None` and the next step performs it — at the
+    /// projected state, and only if there is a next step.
+    k1: Option<S::State>,
     tol: Tolerances,
     /// Minimum step size below which integration fails.
     pub dt_min: f64,
@@ -236,13 +263,20 @@ impl<'a, S: DynamicalSystem> AdaptiveStepper853<'a, S> {
                 return Err(IntegrationError::TimeStagnated { t: self.t, dt: h });
             }
 
-            let (y8, error, k13) = dop853_step_impl(self.system, self.t, &self.state, h, &self.k1);
+            let k1 = match self.k1.take() {
+                Some(k1) => k1,
+                None => self.system.derivatives(self.t, &self.state),
+            };
+            let (y8, error) = dop853_candidate(self.system, self.t, &self.state, h, &k1);
 
             // NaN/Inf check
             if !y8.is_finite() {
                 return Err(IntegrationError::NonFiniteState { t: self.t + h });
             }
 
+            // Accept/reject is decided on the raw candidate: the error vector
+            // belongs to it, and comparing it against a projected state would
+            // mix two different solutions.
             let err = self.state.error_norm(&y8, &error, &self.tol);
             // A NaN norm compares false against both the accept threshold and
             // the `dt_min` floor below, so without this guard the same step is
@@ -256,9 +290,20 @@ impl<'a, S: DynamicalSystem> AdaptiveStepper853<'a, S> {
 
             if err <= 1.0 {
                 // Accept step
-                self.state = y8;
-                self.t += h;
-                self.k1 = k13; // FSAL
+                let t_next = self.t + h;
+                let mut y = y8;
+                // FSAL stage 13 is `f(t_next, y)`, which is exactly what the
+                // next step's first stage evaluates: the cache stays empty and
+                // the next step does it, at the projected state. Whether the
+                // projection changed anything is therefore irrelevant here.
+                let _ = y.project(t_next);
+                // A projection can also produce non-finite values (a division
+                // by a zero norm, say); the raw check above cannot see that.
+                if !y.is_finite() {
+                    return Err(IntegrationError::NonFiniteState { t: t_next });
+                }
+                self.state = y;
+                self.t = t_next;
 
                 callback(self.t, &self.state);
 
@@ -277,6 +322,9 @@ impl<'a, S: DynamicalSystem> AdaptiveStepper853<'a, S> {
                 // Reject step, shrink
                 let factor = (SAFETY * err.powf(-ORDER_EXP)).clamp(MIN_FACTOR, 1.0);
                 self.dt = h * factor;
+                // The state did not move, so the first-stage derivative is
+                // still the one for the retry.
+                self.k1 = Some(k1);
 
                 if self.dt < self.dt_min {
                     return Err(IntegrationError::StepSizeTooSmall {
@@ -321,14 +369,15 @@ impl Dop853 {
         dt: f64,
         tol: Tolerances,
     ) -> AdaptiveStepper853<'a, S> {
-        let k1 = system.derivatives(t0, &initial);
         let dt_min = 1e-12 * (dt * 100.0).abs().max(1.0);
         AdaptiveStepper853 {
             system,
             state: initial,
             t: t0,
             dt,
-            k1,
+            // Evaluated by the first step rather than here, so a stepper that
+            // never advances costs nothing.
+            k1: None,
             tol,
             dt_min,
         }
@@ -337,9 +386,22 @@ impl Dop853 {
     /// Perform a single DOP853 step with full output.
     ///
     /// Returns `(y8, error, k13)` where:
-    /// - `y8`: 8th-order solution (to propagate)
-    /// - `error`: error estimate
-    /// - `k13`: derivative at y8 (reusable as k1 of next step via FSAL)
+    /// - `y8`: the raw 8th-order candidate, **not projected**
+    /// - `error`: error estimate, belonging to that raw candidate
+    /// - `k13`: 13th-stage derivative, `f(t + dt, y8)`
+    ///
+    /// This is the low-level building block for a caller running its own
+    /// step-size control, so it stops short of the projection: `error` pairs
+    /// with the raw candidate, and mixing it with a projected state is
+    /// inconsistent. A caller that accepts the step owes the state its
+    /// [`OdeState::project`] call, and may reuse `k13` as the next first stage
+    /// only while that projection reports [`Projection::Unchanged`]
+    /// (`Projection::Changed` means `k13` was evaluated at a state that no
+    /// longer exists). [`Integrator::step`] and [`AdaptiveStepper853`] do this
+    /// for you — the stepper re-evaluates the first stage at the projected
+    /// state instead of carrying `k13` over.
+    ///
+    /// [`Projection::Unchanged`]: crate::Projection::Unchanged
     pub fn step_full<S: DynamicalSystem>(
         &self,
         system: &S,
@@ -348,7 +410,7 @@ impl Dop853 {
         dt: f64,
     ) -> (S::State, S::State, S::State) {
         let k1 = system.derivatives(t, state);
-        dop853_step_impl(system, t, state, dt, &k1)
+        dop853_step_with_fsal(system, t, state, dt, &k1)
     }
 
     /// Integrate adaptively with event detection and NaN/Inf checking.
@@ -948,12 +1010,15 @@ mod tests {
     }
 
     /// At tight tolerances, DOP853 requires fewer total function evaluations
-    /// than DP45. DOP853 uses 13 stages/step (12 new with FSAL) vs DP45's
-    /// 7 (6 new with FSAL), but its larger stable step size more than
-    /// compensates.
+    /// than DP45: it spends more per trial (11 stages against DP45's 6, both
+    /// with FSAL) but its larger stable step size more than compensates.
+    ///
+    /// The evaluations are counted at the source. The accepted-step callback
+    /// cannot stand in for them: it never fires for a rejected trial, and a
+    /// per-step stage count double-counts the derivative that FSAL reuses.
     #[test]
     fn tight_tolerance_dop853_fewer_evaluations() {
-        let system = HarmonicOscillator;
+        let system = crate::projection::Counting::new(&HarmonicOscillator);
         let initial = State::<3, 2>::new(vector![1.0, 0.0, 0.0], vector![0.0, 0.0, 0.0]);
         let t_end = 10.0 * 2.0 * std::f64::consts::PI; // 10 periods
         let tol = Tolerances {
@@ -961,7 +1026,6 @@ mod tests {
             rtol: 1e-13,
         };
 
-        // Count steps → function evaluations
         let mut dop853_steps = 0u64;
         let _: IntegrationOutcome<State<3, 2>, ()> = Dop853.integrate_adaptive_with_events(
             &system,
@@ -975,8 +1039,9 @@ mod tests {
             },
             |_t, _state| ControlFlow::Continue(()),
         );
-        let dop853_evals = dop853_steps * 13; // 13 stages per step
+        let dop853_evals = system.count();
 
+        let system = crate::projection::Counting::new(&HarmonicOscillator);
         let mut dp45_steps = 0u64;
         let _: IntegrationOutcome<State<3, 2>, ()> = crate::DormandPrince
             .integrate_adaptive_with_events(
@@ -991,11 +1056,28 @@ mod tests {
                 },
                 |_t, _state| ControlFlow::Continue(()),
             );
-        let dp45_evals = dp45_steps * 7; // 7 stages per step
+        let dp45_evals = system.count();
+
+        // Pin the stage structure: DOP853 spends 11 evaluations per trial plus
+        // one first-stage evaluation per accepted step; DP45 spends 6 per
+        // trial plus a single one at the very start (FSAL covers the rest).
+        assert_eq!(
+            (dop853_evals - dop853_steps) % 11,
+            0,
+            "DOP853 evaluations {dop853_evals} do not decompose into 11 per trial \
+             plus one per accepted step ({dop853_steps} steps)"
+        );
+        assert_eq!(
+            (dp45_evals - 1) % 6,
+            0,
+            "DP45 evaluations {dp45_evals} do not decompose into 6 per trial \
+             plus the initial one"
+        );
 
         assert!(
             dop853_evals < dp45_evals,
-            "DOP853 evals {dop853_evals} (={dop853_steps}×13) should be < DP45 evals {dp45_evals} (={dp45_steps}×7)"
+            "DOP853 evals {dop853_evals} ({dop853_steps} accepted steps) should be < \
+             DP45 evals {dp45_evals} ({dp45_steps} accepted steps)"
         );
     }
 

--- a/utsuroi/src/solver/dp45/mod.rs
+++ b/utsuroi/src/solver/dp45/mod.rs
@@ -91,7 +91,10 @@ fn dp_step_impl<S: DynamicalSystem>(
 impl Integrator for DormandPrince {
     fn step<S: DynamicalSystem>(&self, system: &S, t: f64, state: &S::State, dt: f64) -> S::State {
         let k1 = system.derivatives(t, state);
-        let (y5, _, _) = dp_step_impl(system, t, state, dt, &k1);
+        let (mut y5, _, _) = dp_step_impl(system, t, state, dt, &k1);
+        // Fixed-step use keeps no derivative across steps, so the FSAL cache
+        // cannot go stale here.
+        let _ = y5.project(t + dt);
         y5
     }
 }
@@ -115,7 +118,11 @@ pub struct AdaptiveStepper<'a, S: DynamicalSystem> {
     state: S::State,
     t: f64,
     dt: f64,
-    k1: S::State,
+    /// Cached first-stage derivative (FSAL). `None` means "not known at the
+    /// current state": the next step evaluates it. It is cleared whenever a
+    /// projection changes the accepted state, so the stale derivative taken at
+    /// the unprojected candidate is never reused.
+    k1: Option<S::State>,
     tol: Tolerances,
     /// Minimum step size below which integration fails. Can be overridden
     /// after construction to match the total integration interval.
@@ -153,13 +160,20 @@ impl<'a, S: DynamicalSystem> AdaptiveStepper<'a, S> {
                 return Err(IntegrationError::TimeStagnated { t: self.t, dt: h });
             }
 
-            let (y5, error, k7) = dp_step_impl(self.system, self.t, &self.state, h, &self.k1);
+            let k1 = match self.k1.take() {
+                Some(k1) => k1,
+                None => self.system.derivatives(self.t, &self.state),
+            };
+            let (y5, error, k7) = dp_step_impl(self.system, self.t, &self.state, h, &k1);
 
             // NaN/Inf check
             if !y5.is_finite() {
                 return Err(IntegrationError::NonFiniteState { t: self.t + h });
             }
 
+            // Accept/reject is decided on the raw candidate: the error vector
+            // belongs to it, and comparing it against a projected state would
+            // mix two different solutions.
             let err = self.state.error_norm(&y5, &error, &self.tol);
             // A NaN norm compares false against both the accept threshold and
             // the `dt_min` floor below, so without this guard the same step is
@@ -173,9 +187,21 @@ impl<'a, S: DynamicalSystem> AdaptiveStepper<'a, S> {
 
             if err <= 1.0 {
                 // Accept step
-                self.state = y5;
-                self.t += h;
-                self.k1 = k7; // FSAL
+                let t_next = self.t + h;
+                let mut y = y5;
+                let projection = y.project(t_next);
+                // A projection can also produce non-finite values (a division
+                // by a zero norm, say); the raw check above cannot see that.
+                if !y.is_finite() {
+                    return Err(IntegrationError::NonFiniteState { t: t_next });
+                }
+                self.state = y;
+                self.t = t_next;
+                // FSAL: k7 = f(t+h, y5) is the next first stage only while the
+                // projection left y5 alone. Otherwise drop it and let the next
+                // step evaluate f at the projected state (one extra evaluation
+                // per changed step, none when nothing changed).
+                self.k1 = if projection.changed() { None } else { Some(k7) };
 
                 callback(self.t, &self.state);
 
@@ -194,6 +220,9 @@ impl<'a, S: DynamicalSystem> AdaptiveStepper<'a, S> {
                 // Reject step, shrink
                 let factor = (DP_SAFETY * err.powf(-0.2)).clamp(DP_MIN_FACTOR, 1.0);
                 self.dt = h * factor;
+                // The state did not move, so the first-stage derivative is
+                // still the one for the retry.
+                self.k1 = Some(k1);
 
                 if self.dt < self.dt_min {
                     return Err(IntegrationError::StepSizeTooSmall {
@@ -238,14 +267,15 @@ impl DormandPrince {
         dt: f64,
         tol: Tolerances,
     ) -> AdaptiveStepper<'a, S> {
-        let k1 = system.derivatives(t0, &initial);
         let dt_min = 1e-12 * (dt * 100.0).abs().max(1.0);
         AdaptiveStepper {
             system,
             state: initial,
             t: t0,
             dt,
-            k1,
+            // Evaluated by the first step rather than here, so a stepper that
+            // never advances costs nothing.
+            k1: None,
             tol,
             dt_min,
         }
@@ -254,9 +284,21 @@ impl DormandPrince {
     /// Perform a single Dormand-Prince step with full output.
     ///
     /// Returns `(y5, error, k7)` where:
-    /// - `y5`: 5th-order solution (to propagate)
-    /// - `error`: embedded error estimate
-    /// - `k7`: 7th-stage derivative (reusable as k1 of next step via FSAL)
+    /// - `y5`: the raw 5th-order candidate, **not projected**
+    /// - `error`: embedded error estimate, belonging to that raw candidate
+    /// - `k7`: 7th-stage derivative, `f(t + dt, y5)`
+    ///
+    /// This is the low-level building block for a caller running its own
+    /// step-size control, so it stops short of the projection: `error` pairs
+    /// with the raw candidate, and mixing it with a projected state is
+    /// inconsistent. A caller that accepts the step owes the state its
+    /// [`OdeState::project`] call, and may reuse `k7` as the next first stage
+    /// only while that projection reports [`Projection::Unchanged`]
+    /// (`Projection::Changed` means `k7` was evaluated at a state that no
+    /// longer exists). [`Integrator::step`] and [`AdaptiveStepper`] do this
+    /// for you.
+    ///
+    /// [`Projection::Unchanged`]: crate::Projection::Unchanged
     pub fn step_full<S: DynamicalSystem>(
         &self,
         system: &S,

--- a/utsuroi/src/solver/rk4.rs
+++ b/utsuroi/src/solver/rk4.rs
@@ -27,7 +27,9 @@ impl Integrator for Rk4 {
         // y + dt/6 * (k1 + 2*k2 + 2*k3 + k4)
         let k_sum = k1.axpy(2.0, &k2).axpy(2.0, &k3).axpy(1.0, &k4);
         let mut result = state.axpy(dt / 6.0, &k_sum);
-        result.project(t + dt);
+        // RK4 keeps no stage derivative across steps, so it can ignore whether
+        // the projection changed the state.
+        let _ = result.project(t + dt);
         result
     }
 }

--- a/utsuroi/src/solver/verlet.rs
+++ b/utsuroi/src/solver/verlet.rs
@@ -32,6 +32,34 @@ impl StormerVerlet {
     where
         S: DynamicalSystem<State = State<DIM, 2>>,
     {
+        let mut result = self.step_unprojected(system, t, state, dt);
+        // A generic projection (normalization, clamping) is not a symplectic
+        // map, so applying one breaks the very property this integrator
+        // exists for. It is applied here anyway for contract parity with the
+        // Runge-Kutta methods, and it is harmless in practice because
+        // `State<DIM, 2>` — the only state type this integrator accepts —
+        // uses the default no-op `project`. Compositions of Verlet substeps
+        // (see the Yoshida methods) use `step_unprojected` so that no
+        // projection can be interleaved between substeps.
+        let _ = result.project(t + dt);
+        result
+    }
+
+    /// One Störmer-Verlet step without the post-step projection.
+    ///
+    /// This is the symplectic kernel: it is exactly the kick-drift-kick map
+    /// and nothing else, so it can be composed (see the Yoshida methods)
+    /// without a non-symplectic projection sneaking in between substeps.
+    pub(crate) fn step_unprojected<const DIM: usize, S>(
+        &self,
+        system: &S,
+        t: f64,
+        state: &State<DIM, 2>,
+        dt: f64,
+    ) -> State<DIM, 2>
+    where
+        S: DynamicalSystem<State = State<DIM, 2>>,
+    {
         // Evaluate acceleration at current state
         let deriv = system.derivatives(t, state);
         let a_n = *deriv.dy();
@@ -50,9 +78,7 @@ impl StormerVerlet {
         // Second half-kick
         let v_next: SVector<f64, DIM> = v_half + (dt / 2.0) * a_next;
 
-        let mut result = State::<DIM, 2>::new(q_next, v_next);
-        result.project(t + dt);
-        result
+        State::<DIM, 2>::new(q_next, v_next)
     }
 
     /// Integrate from `t0` to `t_end` with fixed step size `dt`.

--- a/utsuroi/src/solver/yoshida.rs
+++ b/utsuroi/src/solver/yoshida.rs
@@ -49,6 +49,16 @@ const Y8_WEIGHTS: [f64; 15] = [
 ];
 
 /// Compose a sequence of Störmer-Verlet substeps with given weights.
+///
+/// The substeps use the unprojected Verlet kernel: the composition is what
+/// makes the method high-order symplectic, and a generic
+/// [`OdeState::project`](crate::OdeState::project) (normalization, clamping)
+/// is not a symplectic map, so interleaving one between substeps would
+/// destroy that structure. No projection is applied at the end of the
+/// composed step either, for the same reason. These integrators only accept
+/// `State<DIM, 2>`, whose `project` is the default no-op, so nothing is lost
+/// today; a state type with a real projection needs a projection-aware
+/// splitting scheme rather than a post-hoc fix-up.
 fn yoshida_step<const DIM: usize, S>(
     weights: &[f64],
     system: &S,
@@ -63,7 +73,7 @@ where
     let mut t_current = t;
     for &w in weights {
         let sub_dt = w * dt;
-        current = StormerVerlet.step(system, t_current, &current, sub_dt);
+        current = StormerVerlet.step_unprojected(system, t_current, &current, sub_dt);
         t_current += sub_dt;
     }
     current

--- a/utsuroi/src/state.rs
+++ b/utsuroi/src/state.rs
@@ -29,8 +29,57 @@ pub trait OdeState: Clone + Sized {
     ///   err = sqrt(1/N * sum((delta_i / sc_i)^2))
     fn error_norm(&self, y_next: &Self, error: &Self, tol: &Tolerances) -> f64;
 
-    /// Post-step projection (e.g., quaternion normalization). Default no-op.
-    fn project(&mut self, _t: f64) {}
+    /// Post-step projection (e.g., quaternion normalization, bound clamping).
+    ///
+    /// Integrators call this once per accepted step, on the state that is
+    /// about to be published (so callbacks and event checks see the projected
+    /// state). It is never called on rejected candidates or on intermediate
+    /// stages. The one exception is the low-level `step_full` of the adaptive
+    /// solvers, which hands back the raw candidate and its error estimate for
+    /// a caller running its own step-size control; projecting an accepted
+    /// candidate is then that caller's job.
+    ///
+    /// The return value tells the integrator whether the state was actually
+    /// modified. Adaptive methods with the FSAL property reuse the last stage
+    /// derivative as the first stage of the next step; that derivative was
+    /// evaluated at the *unprojected* candidate, so it is only valid when the
+    /// projection left the state alone. Returning
+    /// [`Projection::Unchanged`] after modifying the state therefore feeds the
+    /// next step a derivative taken at a different point.
+    ///
+    /// The default implementation is a no-op and returns
+    /// [`Projection::Unchanged`].
+    fn project(&mut self, _t: f64) -> Projection {
+        Projection::Unchanged
+    }
+}
+
+/// Whether [`OdeState::project`] modified the state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use = "adaptive integrators must invalidate their FSAL cache when the projection changed the state"]
+pub enum Projection {
+    /// The state was left exactly as it was; a cached derivative taken at the
+    /// unprojected state is still valid.
+    Unchanged,
+    /// The state was modified; any derivative cached at the unprojected state
+    /// must be discarded.
+    Changed,
+}
+
+impl Projection {
+    /// Combine the results of projecting the parts of a composite state:
+    /// `Changed` if either part changed.
+    pub fn or(self, other: Projection) -> Projection {
+        match (self, other) {
+            (Projection::Unchanged, Projection::Unchanged) => Projection::Unchanged,
+            _ => Projection::Changed,
+        }
+    }
+
+    /// Whether the projection modified the state.
+    pub fn changed(self) -> bool {
+        self == Projection::Changed
+    }
 }
 
 /// N-th order ODE state: `ORDER` vectors of `DIM` components each.


### PR DESCRIPTION
> **PR #335 はこの PR に依存します。これを先にマージしてください。**

`OdeState::project` は、ステップ後の状態を制約を満たす値に直す。積分器は微分方程式を解くだけで状態側の制約を知らないので、四元数はノルムが 1 からずれ、ホイール運動量は上限を超えて進む。状態型が自分の制約を `project` として宣言し、積分器がステップごとに呼ぶ（制約のない `OrbitalState` などでは何もしない）。

DESIGN.md は積分器の契約として明記しているが、実際に呼んでいたのは `Rk4::step` と `StormerVerlet::step` だけだった。既定の integrator は `dp45` で、`IndependentGroup` / `CoupledGroup` の本番経路はどちらも adaptive stepper を使うため、**既定設定では契約が守られていなかった**。

```diff
-    fn project(&mut self, _t: f64) {}  // 四元数正規化等 (default no-op)
+    fn project(&mut self, _t: f64) -> Projection { Projection::Unchanged }
```

破れる不変条件は 2 つ。

- **四元数の単位ノルム**。CLI 既定 tolerance で 1 時間積分すると `|q| - 1` が 8.1e-7 まで単調に増える。`AttitudeState::orientation()` が読み出し時に正規化するので回転を使う側には影響しないが、生値を外に出す経路（WebSocket テレメトリの `quaternion_wxyz`、rerun 記録）には出る。Three.js は quaternion を正規化しないので描画に影響する。
- **リアクションホイールの運動量上限**。飽和は `AugmentedState::project` の `aux_bounds` clamp だけが担保している。3 軸ホイールを飽和させ続けると、publish された運動量が上限 ±0.5 N·m·s を dp45 で 3.5e-7、dop853 で 6.7e-9、固定ステップの `DormandPrince::step` (dt = 0.1 s) で **4.1e-3（上限の 0.8%）**超える。超過が有界にとどまるのはホイールモデル自身が飽和方向のトルクを 0 にするためで、一般の effector にこの二重の防御はない。

## 変更内容

修正の本体は、**adaptive stepper に `project` 呼び出しを追加したこと** — つまり実装を DESIGN.md に合わせる修正。`project` を積分器の契約とすること自体は元から doc にあった。

あわせて DESIGN.md に 3 点を追記した。いずれも元の doc に書かれておらず、実装が Rk4 だけだった間は問題にならなかった判断。

用語: 適応解法は 1 ステップで、刻み幅 `h` の**候補**（次の状態の試算値）と誤差推定を計算し、誤差が許容内なら採用（accept）して時刻を進め、超えていれば却下（reject）して `h` を縮めてやり直す。候補は複数の**段**（stage、`k1`, `k2`, … の微分評価）から作る。DP45 は 7 段、DOP853 は 13 段。

1. **呼ぶタイミング** — 採用したステップの結果を publish する直前に一度だけ。reject した候補や中間 stage には呼ばない。callback と event_check は projection 後を受け取る。
2. **accept/reject は `project` 前の候補で判定する** — 誤差推定は `project` 前の候補に対する量なので、`project` 後の状態と組み合わせると整合しない。適応解法が `project` を持つことで初めて生じる判断。
3. **Yoshida には汎用の `project` を適用しない** — 契約に意図的に穴を空ける決定なので、理由とともに doc に残した。

`OdeState::project` の戻り値変更も trait のシグネチャ変更なので設計レベル（理由は下記の FSAL の項）。

**adaptive stepper の順序**

```rust
let (candidate, error, k_last) = self.step_full(system, t, &state, h);
if self.accept(&state, &candidate, &error) {   // 判定は project 前の候補で
    let mut next = candidate;
    let projection = next.project(t + h);      // accept したときだけ
    if !next.is_finite() {                     // project で初めて生じる除算もある
        return Err(NonFiniteState { t: t + h });
    }
    self.k1 = match projection {
        Projection::Unchanged => Some(k_last),  // FSAL 再利用
        Projection::Changed => None,            // 遅延無効化
    };
    // callback と event_check には`project` 後の next を渡す
}
```

accept/reject を `project` 前で判定するのは、誤差推定が `project` 前の候補に対する量で、`project` 後の状態と組み合わせると整合しないため。

**FSAL キャッシュと `Projection` 戻り値** — `project` を追加すると新しい義務が生まれる。FSAL は「今のステップの終端微分は次のステップの第 1 段と同じ」という前提でキャッシュを再利用するが、`project` が状態を書き換えたら、その微分は書き換え**前**の状態に対する値なので無効になる。そこで `project` の戻り値を `Projection::{Unchanged, Changed}` にして「実際に書き換えたか」を返し、キャッシュを `Option<S::State>` にして `Changed` なら `None` にする（次のステップ開始時に`project` 後の状態で第 1 段を評価する遅延無効化）。`Unchanged` なら従来どおり再利用し、reject 時は状態が動いていないのでそのまま戻す。

戻り値は `#[must_use]`。見落とすと古い微分を静かに再利用することになるため。複合 state は子の結果を `Projection::or` で OR する。なお `#[must_use]` は「`project` を呼んでいない」場合には効かないので、そちらは下記の cross-solver テストで固定している。

**DOP853 の 13 段目** — 候補と誤差推定を作る計算から `k13` を外した。DOP853 の誤差式（`E3` / `E5`）は `k13` の係数がともにゼロで、実際には使っていない。それなのに候補と同時に計算していたので、reject したステップでは 1 評価が無駄になっていた。

`k13` は `f(t + h, y_next)` の評価で、accept 後は次ステップの第 1 段がまさに同じ点（正確には`project` 後の `y_next`）を評価する。したがって accept あたりの評価回数は 12 のままで、reject だけが 12 → 11 に減る。

**閾値** — `AttitudeState::project` は `|q| - 1` が `8 * f64::EPSILON` を超えたときだけ正規化する。数 ulp の補正は `orientation()` の読み出し時正規化と実質同じ結果になる一方、`Changed` を報告すると FSAL を 1 評価分捨てることになるため。`AugmentedState::project` は clamp が実際に値を変えたときだけ `Changed` を返す。

**Yoshida には適用しない** — 一般の正規化・clamp はシンプレクティック写像ではなく、substep 間に挟むと合成の構造が壊れる。`project` を呼ばない `StormerVerlet::step_unprojected` を分離して Yoshida はそれを合成する。方針は DESIGN.md とコードのコメントに書いた。

固定ステップの `Integrator::step` も Rk4 と揃えて`project` を呼ぶ。`step_full` は低レベル API のまま残し、「accept したら呼び出し側が `project` する」「終端微分の再利用は `Unchanged` のときだけ」を rustdoc に明記した。

### `AttitudeState` の有限性

上記の設計では、`project` はノルムが非有限の四元数をゼロに置き換えない（置き換えると無限だった四元数が有限のゼロになり、integrator の有限性チェックを通過する）。したがってそれを拒否できるのは有限性チェック側だけだが、`is_finite` は成分しか見ていなかった。成分が 1e157 程度なら各々有限でも二乗和は無限になり、その四元数は姿勢を指さない（`orientation()` はそのノルムで割る）。`q=[1,0,0,0]`, `ω=[1e41,0,0]` が RK4 `dt=0.1` で 1 ステップで到達し、そのステップは成功として報告され、状態がセンサと plugin controller に渡っていた。**ノルムが正かつ有限であることも要求する**ようにした。

```diff
 fn is_finite(&self) -> bool {
-    self.quaternion.iter().all(|v| v.is_finite())
+    let norm_sq = self.quaternion.norm_squared();
+    norm_sq.is_finite()
+        && norm_sq > 0.0
+        && self.quaternion.iter().all(|v| v.is_finite())
         && self.angular_velocity.iter().all(|v| v.is_finite())
 }
```

あわせて `q_dot` の中間和の overflow を直した。3 つの積を足してから 0.5 を掛けていたので、和が答えの 2 倍に達しうる: `q = [0, 1/√2, 1/√2, 0]`、`ω = [1.4e308, 1.4e308, 0]` で真の `q̇.w` は約 -9.9e307 だが、`-x·wx - y·wy` が -1.98e308 になり、後から 0.5 を掛けても無限は戻らない。ω を先に半分にすると、単位四元数なら Cauchy-Schwarz で各項が `½ ‖q‖ √3 f64::MAX` 以内に収まる。通常のスケールでは 0.5 が 2 の冪なのでビット単位で同一。

```diff
-let (wx, wy, wz) = (self.angular_velocity[0], /* … */);
+let (wx, wy, wz) = (0.5 * self.angular_velocity[0], /* … */);
 Vector4::new(
-    0.5 * (-x * wx - y * wy - z * wz),
+    -x * wx - y * wy - z * wz,
     /* … */
 )
```

## 挙動の変化

- no-op な projection しか持たない状態型（軌道のみの `OrbitalState` など）は、評価する点も回数も従来と同じで軌道が変化しない。
- `Changed` を返す状態型では DP45 が 1 ステップあたり 1 評価増える。姿勢のみの伝播（慣性 diag(10, 20, 30)、ω = (0.5, 0.3, 0.1) rad/s、CLI 既定 tolerance、1 時間）で 104,689 → 121,483 評価（16,795 accepted step、6.23 → 7.23 評価/step、**+16%**）。同条件で publish される `|q| - 1` の最大値は 8.05e-7 → 2.22e-16。
- DOP853 は accept ごとに第 1 段を必ず評価するので増分はない。

## テスト

**`utsuroi/src/projection.rs`** — clamp する spy 状態型で、全ソルバ経路（Rk4 / DP45 / DOP853 の固定ステップと adaptive）が`project` 後の状態しか publish しないことを固定する。event_check が受け取る状態も検査する。

評価回数は `DynamicalSystem::derivatives` の呼び出しを直接数える wrapper で測る（accepted step 数 × stage 数という代理指標では、reject した試行の評価も FSAL の再利用も数えられない）。試行数は `error_norm` の呼び出しで独立に数え、`評価数 == 1 + 6 × 試行数`（DP45）と `評価数 == 11 × 試行数 + accept 数`（DOP853）を固定した。

**`orts/tests/projection_contract.rs`** — 3 軸ホイールを飽和させ続け、publish された全ステップで運動量が `aux_bounds` 内であることを Rk4 / dp45 / dop853 で確認する。CLI 既定と緩い tolerance の両方で回す。

**`orts/tests/oracle_attitude.rs`** — 四元数ノルムの閾値を 1e-8 から 1e-14 に厳格化した。1e-8 は `project` が一度も走っていない状態でも通る緩さだった。CLI 既定 tolerance（従来のテストより 100 倍緩い）で 1 時間積分する同等のテストを追加した。

修正を戻すと utsuroi 側 7 件、`projection_contract` 3 件、`oracle_attitude` 2 件が落ちる。有限性の 3 件（`q_dot` の overflow、ノルム overflow の拒否、ゼロ四元数の拒否）は `orts` 側。

## 対象外

`utsuroi/src/comparison.rs` の RK4 時間可逆性 proptest は変更していない。平衡解 (x0 = v0 = 0) で絶対閾値 1e-14 を割るという懸念は、`Range<f64>` strategy が範囲内一様サンプリングで、失敗領域（振幅 <= 7.2e-9）を引く確率が 1 実行あたり ~3e-16 のため実質到達しない。
