### PR TITLE
feat(ci): support macOS (aarch64 and x86_64 apple-darwin)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -668,20 +668,70 @@ jobs:
           cargo test --locked -p orts --lib
           cargo test --locked -p orts --doc
 
+  # macOS portability gate on macos-latest (arm64).
+  #
+  # Same scope as rust-test-arm64: the whole workspace plus unit and doc tests.
+  # The integration suites stay Linux-only — they are the slowest jobs in CI and
+  # cover physics and protocol behaviour, which does not vary by platform. What
+  # does vary is compilation, path handling and process spawning, and these
+  # tests reach that.
+  #
+  # No wild here: `.cargo/config.toml` scopes its linker line to the Linux gnu
+  # triples, so darwin links with Apple's ld.
+  rust-test-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Parse rust-toolchain.toml
+        id: rust-toolchain
+        uses: ./.github/actions/parse-rust-toolchain
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+
+      # Its own cache namespace: a different platform shares no artifacts with
+      # the Linux jobs.
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: rust-macos
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Test (all except orts)
+        run: cargo test --locked --workspace --exclude orts
+
+      - name: Test (orts unit + doc)
+        run: |
+          cargo test --locked -p orts --lib
+          cargo test --locked -p orts --doc
 
   rust-dist:
     if: >-
       github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/tags/v')
       || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: [rust-build, viewer-build]
     strategy:
       matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
-          - aarch64-unknown-linux-gnu
+        # `include` rather than a bare target list: each target names the runner
+        # it builds on. macos-latest is arm64 and its Xcode carries both macOS
+        # SDKs, so it produces the x86_64 binary too and no Intel runner is
+        # needed.
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -692,7 +742,9 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-musl'
         uses: ./.github/actions/setup-wild
 
+      # Linux-only action, and only the Linux builds are large enough to need it.
       - name: Free disk space
+        if: runner.os == 'Linux'
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
@@ -764,6 +816,18 @@ jobs:
         env:
           ORTS_REQUIRE_LICENSE_NOTICE: "1"
         run: cargo build --locked --release -p orts-cli --target ${{ matrix.target }}
+
+      # Both darwin targets build with plain cargo on the arm64 runner; the
+      # x86_64 one is a cross-compile against the SDK Xcode already ships.
+      # Stripped here rather than in the release job: that job runs on Linux,
+      # whose GNU strip cannot read Mach-O.
+      - name: Build CLI with embedded viewer (darwin)
+        if: endsWith(matrix.target, '-apple-darwin')
+        env:
+          ORTS_REQUIRE_LICENSE_NOTICE: "1"
+        run: |
+          cargo build --locked --release -p orts-cli --target ${{ matrix.target }}
+          strip -x "target/${{ matrix.target }}/release/orts"
 
       - name: Upload CLI binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -1382,7 +1446,19 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [rust-dist, build-example-plugins, crate-package-verify, npm-publish-dry-run, rust-test, rust-test-orts, rust-test-orts-integration, rust-test-plugin-wasm, viewer-e2e, cli-plugin-backend-e2e, rust-test-arm64]
+    needs:
+      - rust-dist
+      - build-example-plugins
+      - crate-package-verify
+      - npm-publish-dry-run
+      - rust-test
+      - rust-test-orts
+      - rust-test-orts-integration
+      - rust-test-plugin-wasm
+      - viewer-e2e
+      - cli-plugin-backend-e2e
+      - rust-test-arm64
+      - rust-test-macos
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1482,6 +1558,18 @@ jobs:
           name: orts-cli-release-aarch64-unknown-linux-gnu
           path: ./bin-arm64-gnu
 
+      - name: Download CLI binary (arm64 darwin)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: orts-cli-release-aarch64-apple-darwin
+          path: ./bin-arm64-darwin
+
+      - name: Download CLI binary (x86_64 darwin)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: orts-cli-release-x86_64-apple-darwin
+          path: ./bin-x86_64-darwin
+
       # The release runner is x86_64, so its `strip` cannot touch the arm64
       # binary.
       - name: Install arm64 binutils
@@ -1495,12 +1583,17 @@ jobs:
           ALL_FILES=""
 
           for TARGET in x86_64-unknown-linux-gnu x86_64-unknown-linux-musl \
-                        aarch64-unknown-linux-gnu; do
+                        aarch64-unknown-linux-gnu \
+                        aarch64-apple-darwin x86_64-apple-darwin; do
             # Match the full triple: `*gnu` alone would catch both gnu targets.
+            # The darwin binaries were stripped on the macOS runner, since this
+            # job's GNU strip cannot read Mach-O — hence the `:` no-op.
             case "$TARGET" in
-              x86_64-unknown-linux-gnu)  BIN_DIR=bin-gnu;       STRIP=strip ;;
-              x86_64-unknown-linux-musl) BIN_DIR=bin-musl;      STRIP=strip ;;
-              aarch64-unknown-linux-gnu) BIN_DIR=bin-arm64-gnu; STRIP=aarch64-linux-gnu-strip ;;
+              x86_64-unknown-linux-gnu)  BIN_DIR=bin-gnu;          STRIP=strip ;;
+              x86_64-unknown-linux-musl) BIN_DIR=bin-musl;         STRIP=strip ;;
+              aarch64-unknown-linux-gnu) BIN_DIR=bin-arm64-gnu;    STRIP=aarch64-linux-gnu-strip ;;
+              aarch64-apple-darwin)      BIN_DIR=bin-arm64-darwin; STRIP=: ;;
+              x86_64-apple-darwin)       BIN_DIR=bin-x86_64-darwin; STRIP=: ;;
               *) echo "unhandled target: $TARGET" >&2; exit 1 ;;
             esac
 


### PR DESCRIPTION
## 変更

macOS に対応する。`aarch64-apple-darwin` と `x86_64-apple-darwin` の release artifact と、macOS テストジョブ。

**#342 の上に積んでいる**（base は `platform-arm-linux`）。`rust-dist` の matrix を共有するため。

### release

- `rust-dist` の matrix を `include` 形式にして、各 target が build する runner を指定できるようにした。`runs-on` はそれに追従する
- **macos-latest は arm64 で、Xcode が両方の macOS SDK を持つ**ので、1 つの runner から両バイナリが出る。Intel runner は不要
- darwin バイナリの strip は macOS runner 側で行う。release job は Linux で動き、GNU strip は Mach-O を読めない。asset ループはこの 2 target について strip を `:`（no-op）にする
- `Free disk space` を `runner.os == 'Linux'` で gate した。Linux 専用 action であり、サイズが問題になるのも Linux ビルドだけ
- cargo-binstall は変更不要（`pkg-url` が `{ target }` でパラメータ化されている）

### CI テスト

`rust-test-macos` を macos-latest で回す。範囲は `rust-test-arm64` と同じで、orts 以外のテストと orts の unit / doc テスト。`release` job の `needs` にも入れた。

統合スイートは Linux 限定のまま。CI で最も遅く、内容は物理とプロトコルの振る舞いでプラットフォームによって変わらない。
変わるのはコンパイル、パス処理、プロセス起動で、これらのテストがそこに届く。

darwin に wild は入れない。`.cargo/config.toml` の linker 行は Linux gnu triple にスコープされているので、macOS は Apple の ld でリンクする。

## 既知の POSIX 依存

`cli/src/commands/serve/textures.rs` の `/tmp/orts/textures` が唯一のハードコードされた POSIX パスだが、macOS では `/tmp` が `/private/tmp` への symlink なので機能する。
Windows では実際に問題になるので、そちらの PR で `std::env::temp_dir()` に直す。

## 検証したこと

- `ci.yml` の YAML パース、23 jobs
- `rust-dist` の matrix が 5 entry で、各 target の runner が意図どおり
- base ブランチとの job 単位 diff: 追加は `rust-test-macos` のみ、`needs` の変更は `release` のみ（他ジョブは不変）

CI での実行結果は下記のとおり。

## レビューの観点

- `strip -x` は Mach-O 向けの指定。Apple の strip はローカルシンボルのみ落とす
- `x86_64-apple-darwin` は arm64 runner からのクロスコンパイル。SDK は Xcode 同梱のものを使う
- macOS runner は Linux runner より課金レートが高い。テストの範囲を絞っているのはそれも理由

## CI での実測結果

テストジョブと release ビルドの両方が通った。
release ビルドは `workflow_dispatch` でマージ前に実行した（run 32950480110、6 target すべて success）。

その run 自体は全体として failure で終わっているが、原因は当時まだ修正前だった
`rust-test-windows` である。`rust-dist` は `orts-cli` の release バイナリをビルドするだけで
`cli/tests/` を一切コンパイルしないので、その後の unix gate 修正は `rust-dist` の結果を変えない。

| | テストジョブ | release ビルド |
|---|---|---|
| Linux x86_64 gnu | pass | **success** |
| Linux x86_64 musl | pass | **success** |
| Linux aarch64 gnu | **pass** | **success** |
| macOS aarch64 | **pass** | **success** |
| macOS x86_64 | **pass** | **success** |
| Windows x86_64 msvc | **pass** | **success** |

関連: #342（arm64 linux、base）、#340（wild）、#316


