### PR TITLE
feat(ci): support x86_64-pc-windows-msvc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -734,8 +734,6 @@ jobs:
         with:
           toolchain: ${{ steps.rust-toolchain.outputs.channel }}
 
-      # Its own cache namespace: a different platform shares no artifacts with
-      # the Linux jobs.
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -1659,8 +1657,6 @@ jobs:
               *) echo "unhandled target: $TARGET" >&2; exit 1 ;;
             esac
 
-            # MSVC keeps debug info in a .pdb, so there is nothing to strip; the
-            # suffix is what actually differs.
             case "$TARGET" in
               *-pc-windows-*) EXE=.exe ;;
               *)              EXE= ;;
@@ -1694,14 +1690,11 @@ jobs:
             cat "${ARCHIVE}.sha256"
             ALL_FILES="${ALL_FILES}${ARCHIVE}\n${ARCHIVE}.sha256\n"
 
-            # Windows additionally gets a zip: Explorer cannot expand a
-            # .tar.gz from its context menu, and Windows' own bsdtar means the
-            # tarball is only convenient from a shell. binstall is not pointed
-            # at it. Wraps STAGE_DIR like the tarball, so one `bin-dir`
-            # template resolves in both. -X drops extra file attributes, which
-            # is as far as this goes: unlike the tarball's fixed --mtime, the
-            # zip still records each entry's timestamp, so it is not
-            # byte-reproducible across builds.
+            # Windows additionally gets a zip, since Explorer cannot expand a
+            # .tar.gz from its context menu. Wraps STAGE_DIR like the tarball so
+            # one `bin-dir` template resolves in both. -X drops extra file
+            # attributes, but timestamps remain, so unlike the tarballs with
+            # their fixed --mtime this is not byte-reproducible.
             if [ "$EXE" = ".exe" ]; then
               ZIP="${STAGE_DIR}.zip"
               zip -qrX "${ZIP}" "${STAGE_DIR}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1682,10 +1682,9 @@ jobs:
               cp "$f" "${STAGE_DIR}/examples/plugins/${short}.wasm"
             done
 
-            # Every target gets a tarball, including Windows: that is the
-            # shape the default binstall metadata asks for, so an install
-            # resolves even when the zip override is not in play. Windows 10
-            # and later ship bsdtar, so it is usable by hand there too.
+            # Every target gets a tarball, including Windows. That is what
+            # keeps the cargo-binstall metadata free of per-target exceptions:
+            # one `pkg-fmt = "tgz"` covers the whole matrix.
             ARCHIVE="${STAGE_DIR}.tar.gz"
             tar --sort=name \
                 --owner=0 --group=0 --numeric-owner \
@@ -1695,11 +1694,12 @@ jobs:
             cat "${ARCHIVE}.sha256"
             ALL_FILES="${ALL_FILES}${ARCHIVE}\n${ARCHIVE}.sha256\n"
 
-            # Windows additionally gets a zip, the format its users expect from
-            # a manual download, and the one binstall prefers via the override.
-            # Wraps STAGE_DIR like the tarball, so one `bin-dir` template covers
-            # both. -X drops extra file attributes so the archive is
-            # reproducible.
+            # Windows additionally gets a zip: Explorer cannot expand a
+            # .tar.gz from its context menu, and Windows' own bsdtar means the
+            # tarball is only convenient from a shell. binstall is not pointed
+            # at it. Wraps STAGE_DIR like the tarball, so one `bin-dir`
+            # template resolves in both. -X drops extra file attributes so the
+            # archive is reproducible.
             if [ "$EXE" = ".exe" ]; then
               ZIP="${STAGE_DIR}.zip"
               zip -qrX "${ZIP}" "${STAGE_DIR}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1682,29 +1682,36 @@ jobs:
               cp "$f" "${STAGE_DIR}/examples/plugins/${short}.wasm"
             done
 
-            # Windows gets a zip, which is what its users expect and what
-            # cargo-binstall is told to look for; everything else gets a tarball.
-            if [ "$EXE" = ".exe" ]; then
-              ARCHIVE="${STAGE_DIR}.zip"
-              # Wraps STAGE_DIR, same layout as the tarballs, so binstall's
-              # bin-dir template works unchanged. -X drops extra file
-              # attributes so the archive is reproducible.
-              zip -qrX "${ARCHIVE}" "${STAGE_DIR}"
-            else
-              ARCHIVE="${STAGE_DIR}.tar.gz"
-              tar --sort=name \
-                  --owner=0 --group=0 --numeric-owner \
-                  --mtime='UTC 2020-01-01' \
-                  -czf "${ARCHIVE}" "${STAGE_DIR}"
-            fi
+            # Every target gets a tarball, including Windows: that is the
+            # shape the default binstall metadata asks for, so an install
+            # resolves even when the zip override is not in play. Windows 10
+            # and later ship bsdtar, so it is usable by hand there too.
+            ARCHIVE="${STAGE_DIR}.tar.gz"
+            tar --sort=name \
+                --owner=0 --group=0 --numeric-owner \
+                --mtime='UTC 2020-01-01' \
+                -czf "${ARCHIVE}" "${STAGE_DIR}"
             sha256sum "${ARCHIVE}" > "${ARCHIVE}.sha256"
             cat "${ARCHIVE}.sha256"
+            ALL_FILES="${ALL_FILES}${ARCHIVE}\n${ARCHIVE}.sha256\n"
+
+            # Windows additionally gets a zip, the format its users expect from
+            # a manual download, and the one binstall prefers via the override.
+            # Wraps STAGE_DIR like the tarball, so one `bin-dir` template covers
+            # both. -X drops extra file attributes so the archive is
+            # reproducible.
+            if [ "$EXE" = ".exe" ]; then
+              ZIP="${STAGE_DIR}.zip"
+              zip -qrX "${ZIP}" "${STAGE_DIR}"
+              sha256sum "${ZIP}" > "${ZIP}.sha256"
+              cat "${ZIP}.sha256"
+              ALL_FILES="${ALL_FILES}${ZIP}\n${ZIP}.sha256\n"
+            fi
 
             # Standalone binary
             BINARY="orts-${TARGET}${EXE}"
             cp "${STAGE_DIR}/orts${EXE}" "${BINARY}"
-
-            ALL_FILES="${ALL_FILES}${ARCHIVE}\n${ARCHIVE}.sha256\n${BINARY}\n"
+            ALL_FILES="${ALL_FILES}${BINARY}\n"
           done
 
           echo -e "$ALL_FILES" | grep -v '^$' > /tmp/release-files.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1698,8 +1698,10 @@ jobs:
             # .tar.gz from its context menu, and Windows' own bsdtar means the
             # tarball is only convenient from a shell. binstall is not pointed
             # at it. Wraps STAGE_DIR like the tarball, so one `bin-dir`
-            # template resolves in both. -X drops extra file attributes so the
-            # archive is reproducible.
+            # template resolves in both. -X drops extra file attributes, which
+            # is as far as this goes: unlike the tarball's fixed --mtime, the
+            # zip still records each entry's timestamp, so it is not
+            # byte-reproducible across builds.
             if [ "$EXE" = ".exe" ]; then
               ZIP="${STAGE_DIR}.zip"
               zip -qrX "${ZIP}" "${STAGE_DIR}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -711,6 +711,45 @@ jobs:
           cargo test --locked -p orts --lib
           cargo test --locked -p orts --doc
 
+  # Windows portability gate on windows-latest (x86_64 msvc).
+  #
+  # Same scope as rust-test-arm64 and rust-test-macos: the non-orts tests plus
+  # orts' unit and doc tests. The integration suites stay Linux-only. Several of
+  # them drive the `kble` bridge over stdio, which is where the platform
+  # assumptions actually live, and they are the slowest jobs in CI besides.
+  #
+  # No wild here either: `.cargo/config.toml` scopes its linker line to the
+  # Linux gnu triples, so msvc links with link.exe.
+  rust-test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Parse rust-toolchain.toml
+        id: rust-toolchain
+        uses: ./.github/actions/parse-rust-toolchain
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+
+      # Its own cache namespace: a different platform shares no artifacts with
+      # the Linux jobs.
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: rust-windows
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Test (all except orts)
+        run: cargo test --locked --workspace --exclude orts
+
+      - name: Test (orts unit + doc)
+        run: |
+          cargo test --locked -p orts --lib
+          cargo test --locked -p orts --doc
+
   rust-dist:
     if: >-
       github.ref == 'refs/heads/main'
@@ -735,6 +774,8 @@ jobs:
             os: macos-latest
           - target: x86_64-apple-darwin
             os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -832,11 +873,20 @@ jobs:
           cargo build --locked --release -p orts-cli --target ${{ matrix.target }}
           strip -x "target/${{ matrix.target }}/release/orts"
 
+      # No strip: MSVC keeps debug info in a separate .pdb, which is not shipped.
+      - name: Build CLI with embedded viewer (windows)
+        if: endsWith(matrix.target, '-pc-windows-msvc')
+        env:
+          ORTS_REQUIRE_LICENSE_NOTICE: "1"
+        run: cargo build --locked --release -p orts-cli --target ${{ matrix.target }}
+
       - name: Upload CLI binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: orts-cli-release-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/orts
+          path: >-
+            target/${{ matrix.target }}/release/orts${{
+              endsWith(matrix.target, '-pc-windows-msvc') && '.exe' || '' }}
           retention-days: 1
 
   # Verify crate package contents before release. Runs on a clean
@@ -1462,6 +1512,7 @@ jobs:
       - cli-plugin-backend-e2e
       - rust-test-arm64
       - rust-test-macos
+      - rust-test-windows
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1573,6 +1624,12 @@ jobs:
           name: orts-cli-release-x86_64-apple-darwin
           path: ./bin-x86_64-darwin
 
+      - name: Download CLI binary (windows msvc)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: orts-cli-release-x86_64-pc-windows-msvc
+          path: ./bin-windows
+
       # The release runner is x86_64, so its `strip` cannot touch the arm64
       # binary.
       - name: Install arm64 binutils
@@ -1587,7 +1644,8 @@ jobs:
 
           for TARGET in x86_64-unknown-linux-gnu x86_64-unknown-linux-musl \
                         aarch64-unknown-linux-gnu \
-                        aarch64-apple-darwin x86_64-apple-darwin; do
+                        aarch64-apple-darwin x86_64-apple-darwin \
+                        x86_64-pc-windows-msvc; do
             # Match the full triple: `*gnu` alone would catch both gnu targets.
             # The darwin binaries were stripped on the macOS runner, since this
             # job's GNU strip cannot read Mach-O — hence the `:` no-op.
@@ -1597,15 +1655,23 @@ jobs:
               aarch64-unknown-linux-gnu) BIN_DIR=bin-arm64-gnu;    STRIP=aarch64-linux-gnu-strip ;;
               aarch64-apple-darwin)      BIN_DIR=bin-arm64-darwin; STRIP=: ;;
               x86_64-apple-darwin)       BIN_DIR=bin-x86_64-darwin; STRIP=: ;;
+              x86_64-pc-windows-msvc)    BIN_DIR=bin-windows;      STRIP=: ;;
               *) echo "unhandled target: $TARGET" >&2; exit 1 ;;
+            esac
+
+            # MSVC keeps debug info in a .pdb, so there is nothing to strip; the
+            # suffix is what actually differs.
+            case "$TARGET" in
+              *-pc-windows-*) EXE=.exe ;;
+              *)              EXE= ;;
             esac
 
             STAGE_DIR="orts-cli-${VERSION}-${TARGET}"
             mkdir -p "${STAGE_DIR}/examples/plugins"
 
-            cp "${BIN_DIR}/orts" "${STAGE_DIR}/orts"
-            chmod +x "${STAGE_DIR}/orts"
-            "$STRIP" "${STAGE_DIR}/orts"
+            cp "${BIN_DIR}/orts${EXE}" "${STAGE_DIR}/orts${EXE}"
+            chmod +x "${STAGE_DIR}/orts${EXE}"
+            "$STRIP" "${STAGE_DIR}/orts${EXE}"
             cp README.md "${STAGE_DIR}/README.md"
             cp LICENSE "${STAGE_DIR}/LICENSE"
 
@@ -1616,18 +1682,27 @@ jobs:
               cp "$f" "${STAGE_DIR}/examples/plugins/${short}.wasm"
             done
 
-            # Create tarball
-            ARCHIVE="${STAGE_DIR}.tar.gz"
-            tar --sort=name \
-                --owner=0 --group=0 --numeric-owner \
-                --mtime='UTC 2020-01-01' \
-                -czf "${ARCHIVE}" "${STAGE_DIR}"
+            # Windows gets a zip, which is what its users expect and what
+            # cargo-binstall is told to look for; everything else gets a tarball.
+            if [ "$EXE" = ".exe" ]; then
+              ARCHIVE="${STAGE_DIR}.zip"
+              # Wraps STAGE_DIR, same layout as the tarballs, so binstall's
+              # bin-dir template works unchanged. -X drops extra file
+              # attributes so the archive is reproducible.
+              zip -qrX "${ARCHIVE}" "${STAGE_DIR}"
+            else
+              ARCHIVE="${STAGE_DIR}.tar.gz"
+              tar --sort=name \
+                  --owner=0 --group=0 --numeric-owner \
+                  --mtime='UTC 2020-01-01' \
+                  -czf "${ARCHIVE}" "${STAGE_DIR}"
+            fi
             sha256sum "${ARCHIVE}" > "${ARCHIVE}.sha256"
             cat "${ARCHIVE}.sha256"
 
             # Standalone binary
-            BINARY="orts-${TARGET}"
-            cp "${STAGE_DIR}/orts" "${BINARY}"
+            BINARY="orts-${TARGET}${EXE}"
+            cp "${STAGE_DIR}/orts${EXE}" "${BINARY}"
 
             ALL_FILES="${ALL_FILES}${ARCHIVE}\n${ARCHIVE}.sha256\n${BINARY}\n"
           done

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -87,8 +87,6 @@ tempfile = "3"
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }{ archive-suffix }"
 pkg-fmt = "tgz"
 bin-dir = "{ name }-{ version }-{ target }/{ bin }{ binary-ext }"
-
-# Windows ships a zip rather than a tarball. The layout inside matches the
-# tarballs, so `bin-dir` above still applies.
-[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
-pkg-fmt = "zip"
+# No per-target exception: every target ships a tarball, Windows included. The
+# release also carries a Windows zip, for people downloading by hand, but
+# binstall has no reason to prefer it — the two hold the same layout.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -87,3 +87,8 @@ tempfile = "3"
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }{ archive-suffix }"
 pkg-fmt = "tgz"
 bin-dir = "{ name }-{ version }-{ target }/{ bin }{ binary-ext }"
+
+# Windows ships a zip rather than a tarball. The layout inside matches the
+# tarballs, so `bin-dir` above still applies.
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -87,6 +87,5 @@ tempfile = "3"
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }{ archive-suffix }"
 pkg-fmt = "tgz"
 bin-dir = "{ name }-{ version }-{ target }/{ bin }{ binary-ext }"
-# No per-target exception: every target ships a tarball, Windows included. The
-# release also carries a Windows zip, for people downloading by hand, but
-# binstall has no reason to prefer it — the two hold the same layout.
+# Every target ships a tarball, Windows included, so no per-target override is
+# needed. The release also carries a Windows zip for manual downloads.

--- a/cli/src/commands/serve/textures.rs
+++ b/cli/src/commands/serve/textures.rs
@@ -183,8 +183,8 @@ impl TextureCache {
     pub fn new() -> Self {
         // `env::temp_dir()` rather than a literal /tmp: this is the only path in
         // the tree that assumed POSIX, and it has to resolve on Windows too.
-        // On Linux it still lands in tmpfs, which is what the module doc means
-        // by caching there.
+        // Whether the result is memory-backed is up to the system ($TMPDIR, or
+        // /tmp, which is not always tmpfs), so nothing here depends on that.
         let cache_dir = std::env::temp_dir().join("orts").join("textures");
         let mut embedded = HashMap::new();
         for tex in EMBEDDED {

--- a/cli/src/commands/serve/textures.rs
+++ b/cli/src/commands/serve/textures.rs
@@ -2,7 +2,7 @@
 //!
 //! 2K textures for all bodies are compiled into the binary via `include_bytes!`.
 //! Higher resolutions are downloaded from NASA/USGS in the background on server
-//! start, converted/resized, and cached as JPEG in a tmpfs directory.
+//! start, converted/resized, and cached as JPEG under the system temp dir.
 
 use std::collections::{HashMap, HashSet};
 use std::io::{Cursor, Read};
@@ -181,7 +181,11 @@ pub struct TextureCache {
 
 impl TextureCache {
     pub fn new() -> Self {
-        let cache_dir = PathBuf::from("/tmp/orts/textures");
+        // `env::temp_dir()` rather than a literal /tmp: this is the only path in
+        // the tree that assumed POSIX, and it has to resolve on Windows too.
+        // On Linux it still lands in tmpfs, which is what the module doc means
+        // by caching there.
+        let cache_dir = std::env::temp_dir().join("orts").join("textures");
         let mut embedded = HashMap::new();
         for tex in EMBEDDED {
             embedded.insert(tex.filename, tex.data);

--- a/cli/src/commands/serve/textures.rs
+++ b/cli/src/commands/serve/textures.rs
@@ -182,9 +182,12 @@ pub struct TextureCache {
 impl TextureCache {
     pub fn new() -> Self {
         // `env::temp_dir()` rather than a literal /tmp: this is the only path in
-        // the tree that assumed POSIX, and it has to resolve on Windows too.
-        // Whether the result is memory-backed is up to the system ($TMPDIR, or
-        // /tmp, which is not always tmpfs), so nothing here depends on that.
+        // the tree that assumed POSIX, and it has to resolve on Windows too,
+        // where it follows %TMP% / %TEMP% rather than $TMPDIR.
+        //
+        // Whether the result is memory-backed is up to the system — on Linux
+        // $TMPDIR or /tmp, and /tmp is not always tmpfs — so nothing here
+        // depends on that.
         let cache_dir = std::env::temp_dir().join("orts").join("textures");
         let mut embedded = HashMap::new();
         for tex in EMBEDDED {

--- a/cli/src/commands/serve/textures.rs
+++ b/cli/src/commands/serve/textures.rs
@@ -181,13 +181,8 @@ pub struct TextureCache {
 
 impl TextureCache {
     pub fn new() -> Self {
-        // `env::temp_dir()` rather than a literal /tmp: this is the only path in
-        // the tree that assumed POSIX, and it has to resolve on Windows too,
-        // where it follows %TMP% / %TEMP% rather than $TMPDIR.
-        //
-        // Whether the result is memory-backed is up to the system — on Linux
-        // $TMPDIR or /tmp, and /tmp is not always tmpfs — so nothing here
-        // depends on that.
+        // Not a literal /tmp: this path has to resolve on Windows too. Nothing
+        // here depends on the location being memory-backed.
         let cache_dir = std::env::temp_dir().join("orts").join("textures");
         let mut embedded = HashMap::new();
         for tex in EMBEDDED {

--- a/cli/tests/serve_kble_stdio_e2e.rs
+++ b/cli/tests/serve_kble_stdio_e2e.rs
@@ -15,10 +15,8 @@
 //! Soft-skips when the kble binary (PATH / KBLE_BIN) or the guest WASM is
 //! missing (same as serve_kble_e2e).
 
-// `unix` as well as the feature: the topology is the point of this test — kble
-// spawns orts through an `exec:` plug, which needs a `#!/bin/sh` launcher
-// marked executable. There is no Windows equivalent to port it to, so the
-// whole file is gated rather than parts of it.
+// unix-gated: kble spawns orts through an `exec:` plug, which needs a
+// `#!/bin/sh` launcher marked executable.
 #![cfg(all(unix, feature = "plugin-wasm-async"))]
 
 use std::io::{BufRead, BufReader, Write};

--- a/cli/tests/serve_kble_stdio_e2e.rs
+++ b/cli/tests/serve_kble_stdio_e2e.rs
@@ -15,7 +15,11 @@
 //! Soft-skips when the kble binary (PATH / KBLE_BIN) or the guest WASM is
 //! missing (same as serve_kble_e2e).
 
-#![cfg(feature = "plugin-wasm-async")]
+// `unix` as well as the feature: the topology is the point of this test — kble
+// spawns orts through an `exec:` plug, which needs a `#!/bin/sh` launcher
+// marked executable. There is no Windows equivalent to port it to, so the
+// whole file is gated rather than parts of it.
+#![cfg(all(unix, feature = "plugin-wasm-async"))]
 
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Stdio};


### PR DESCRIPTION
## 変更

`x86_64-pc-windows-msvc` に対応する。release artifact、Windows テストジョブ、そしてこのプラットフォームが実際に必要とする唯一のコード修正。

**#345 の上に積んでいる**（base は `platform-macos`）。

### コード修正

`cli/src/commands/serve/textures.rs` がキャッシュ先を `/tmp` リテラルから作っていた。
これがツリー内で唯一のハードコードされた POSIX パスで（library と CLI に `cfg(unix)` も `std::os::unix` も存在しない）、Windows では解決できない。

`env::temp_dir()` に変更した。Linux では引き続き tmpfs に落ちるので module doc の記述はそのまま成り立ち、他プラットフォームで嘘にならなくなる。

### release

- `rust-dist` に windows-latest の target を追加。strip なし（MSVC は debug info を別の .pdb に置き、それは配布しない）
- artifact のパスと staged binary は triple から `.exe` を導出する
- Windows の asset は **tar.gz と zip の両方**。tar.gz は他の target と揃うので binstall の metadata が target 別の例外を持たずに済み、zip は Explorer が `.tar.gz` を右クリック展開できないため手動 download 用に置く
- 両形式は同じく stage ディレクトリを包むので、1 つの `bin-dir` テンプレートが双方で解決する。binstall の override は不要

### CI テスト

`rust-test-windows` は arm64 と macOS のジョブと同じ構成。orts 以外のテストと orts の unit / doc テストで、`release` job の `needs` にも入れた。

統合スイートは Linux 限定のまま。いくつかは `kble` bridge を stdio 経由で駆動しており、プラットフォーム前提が実際に潜んでいるのはそこで、かつ CI で最も遅いジョブ群でもある。

`.cargo/config.toml` の linker 行は Linux gnu triple にスコープされているので、msvc は link.exe でリンクする。

## 検証したこと

- `cargo clippy --locked -p orts-cli -- -D warnings` pass
- `cargo fmt --all -- --check` pass
- `ci.yml` の YAML パース、24 jobs、matrix 6 entry
- `cli/Cargo.toml` の TOML パース（binstall metadata に target 別の例外が無いこと）
- base ブランチとの job 単位 diff: 追加は `rust-test-windows` のみ、`needs` の変更は `release` のみ

CI での実行結果は下記のとおり。

## ローカルで観測した既存の失敗

`cargo test -p orts-cli --bins` で `commands::serve::history::tests::flush_performance` が落ちるが、base ブランチでも同じように落ち、単独実行では pass する。
負荷に敏感な性能テストで、この変更とは無関係。

## レビューの観点

- zip の再現性は `-X`（追加のファイル属性を落とす）に依存している。tarball 側の `--mtime` 固定と違い、タイムスタンプは残る
- `release` job は `zip` コマンドに依存する。ubuntu-latest に同梱で、ステップ冒頭の `set -euo pipefail` により不在なら落ちる
- `cargo test --workspace --exclude orts` は orts-cli の統合テストも選択する。kble stdio の E2E は `#![cfg(all(unix, ...))]` で除外し、他の kble テストは binary 不在で soft-skip する

## CI での実測結果

テストジョブと release ビルドの両方が通った。
release ビルドは `workflow_dispatch` でマージ前に実行した（run 32950480110、6 target すべて success）。

その run 自体は全体として failure で終わっているが、原因は当時まだ修正前だった
`rust-test-windows` である。`rust-dist` は `orts-cli` の release バイナリをビルドするだけで
`cli/tests/` を一切コンパイルしないので、その後の unix gate 修正は `rust-dist` の結果を変えない。

| | テストジョブ | release ビルド |
|---|---|---|
| Linux x86_64 gnu | pass | **success** |
| Linux x86_64 musl | pass | **success** |
| Linux aarch64 gnu | **pass** | **success** |
| macOS aarch64 | **pass** | **success** |
| macOS x86_64 | **pass** | **success** |
| Windows x86_64 msvc | **pass** | **success** |

## cargo binstall の検証

`cargo binstall --dry-run --manifest-path cli --targets <T>` を debug ログで走らせて
要求 URL を採取し、release job が生成するファイル名と突き合わせた。
公開済みリリースを待たずに検証できる。

| target | リリースが公開する | binstall の候補に含まれるか |
|---|---|---|
| x86_64-unknown-linux-gnu | `orts-cli-<v>-…-gnu.tar.gz` | OK |
| x86_64-unknown-linux-musl | `…-musl.tar.gz` | OK |
| aarch64-unknown-linux-gnu | `…-gnu.tar.gz` | OK |
| aarch64-apple-darwin | `…-darwin.tar.gz` | OK |
| x86_64-apple-darwin | `…-darwin.tar.gz` | OK |
| x86_64-pc-windows-msvc | `…-msvc.tar.gz`（+ `…-msvc.zip`） | OK |

既存の v0.2.0 に対する dry-run も成功する（tarball を取得して中の `orts` を特定）ので、
テンプレートの解釈自体の裏取りも取れている。

**override を入れずに済ませた経緯。** `pkg-fmt = "tgz"` は形式を固定するので、Windows に zip
しか置かないなら `overrides.x86_64-pc-windows-msvc` で `pkg-fmt = "zip"` が必須になる
(override 無しでは `.tar.gz` / `.tgz` しか試さないことを実測で確認した)。
Windows にも tar.gz を置くことで、その例外自体が不要になった。

**binstall はメタデータを crates.io の公開 crate から読む**（リポジトリではなく）。
この metadata の変更は次回 publish から有効になる。
リリース後に binstall の挙動が想定と違うときは、まず publish 済みの版を疑う。

関連: #345（macOS、base）、#342（arm64 linux）、#340（wild）、#316




