### PR TITLE
fix: keep serve history when a segment write fails, and refuse serve sim args nothing honors

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -322,7 +322,7 @@ pub enum PluginBackendChoice {
     Auto,
 }
 
-#[derive(Debug, Clone, Copy, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, ValueEnum)]
 pub enum IntegratorChoice {
     /// Fixed-step 4th-order Runge-Kutta
     Rk4,
@@ -332,7 +332,7 @@ pub enum IntegratorChoice {
     Dop853,
 }
 
-#[derive(Debug, Clone, Copy, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, ValueEnum)]
 pub enum AtmosphereChoice {
     /// Piecewise exponential (US Standard Atmosphere 1976)
     Exponential,

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -79,25 +79,25 @@ impl EntityOverview {
     }
 }
 
-/// Bounded buffer that accumulates history states and periodically spills the
+/// Bounded buffer that accumulates history states and periodically flushes the
 /// oldest half to a segment file on disk.
 pub struct HistoryBuffer {
     /// Recent states kept in memory.
     pub states: VecDeque<HistoryState>,
     /// Maximum number of states to keep in memory before flushing.
     pub capacity: usize,
-    /// Directory for spilled segment files.
+    /// Directory for flushed segment files.
     pub data_dir: PathBuf,
     /// Number of segment files written so far.
     pub segment_count: u32,
-    /// In-memory length above which the next `push` attempts a spill.
+    /// In-memory length above which the next `push` attempts a flush.
     ///
-    /// Normally `capacity`. After a failed spill it is raised so the retry
+    /// Normally `capacity`. After a failed flush it is raised so the retry
     /// happens once the buffer has grown by another `capacity` states
     /// rather than on every push.
     flush_at: usize,
-    /// Consecutive failed spill attempts (reset by the next success).
-    failed_spills: u32,
+    /// Consecutive failed flush attempts (reset by the next success).
+    failed_flushes: u32,
     /// Gravitational parameter (for computing Keplerian elements from loaded data).
     pub mu: f64,
     /// Central body radius [km] (for computing derived values from loaded data).
@@ -108,7 +108,7 @@ pub struct HistoryBuffer {
     // Maintained in O(1) amortized per `push()` call, read in
     // O(num_entities * OVERVIEW_MAX_POINTS_PER_ENTITY) with no disk I/O.
     // This lets re-connects to long-running simulations return the history
-    // overview instantly, without re-reading every spilled segment from disk
+    // overview instantly, without re-reading every flushed segment from disk
     // on the manager task. Per-entity bookkeeping ensures every satellite
     // gets fair coverage regardless of push order or count.
     overview_per_entity: HashMap<EntityPath, EntityOverview>,
@@ -123,14 +123,14 @@ impl HistoryBuffer {
             data_dir,
             segment_count: 0,
             flush_at: capacity,
-            failed_spills: 0,
+            failed_flushes: 0,
             mu,
             body_radius,
             overview_per_entity: HashMap::new(),
         }
     }
 
-    /// Push a state into the buffer. Spills to disk if capacity is exceeded,
+    /// Push a state into the buffer. Flushes to disk if capacity is exceeded,
     /// and incrementally updates the per-entity overview buffers.
     ///
     /// Clone cost: non-sampling pushes perform one `state.clone()` into
@@ -168,7 +168,7 @@ impl HistoryBuffer {
         }
         // The cap is a promise about memory, so it holds on every push. The
         // retry cadence above only decides when the next write is attempted:
-        // measured before this call was here, a failing spill at capacity 4
+        // measured before this call was here, a failing flush at capacity 4
         // reached 35 states against a cap of 32, because the backoff moved the
         // next attempt three pushes past it.
         self.enforce_memory_cap();
@@ -191,11 +191,11 @@ impl HistoryBuffer {
         all
     }
 
-    /// Spill the oldest half of the buffer to a segment file.
+    /// Flush the oldest half of the buffer to a segment file.
     ///
     /// The states are written from a borrow and drained only after the write
     /// succeeded, so the in-memory buffer stays the single source of truth
-    /// for everything not yet on disk: a failed spill degrades to "memory
+    /// for everything not yet on disk: a failed flush degrades to "memory
     /// holds more than `capacity`", never to lost history.
     pub fn flush(&mut self) {
         let flush_count = self.states.len() / 2;
@@ -209,23 +209,23 @@ impl HistoryBuffer {
                 self.states.drain(..flush_count);
                 self.segment_count += 1;
                 self.flush_at = self.capacity;
-                self.failed_spills = 0;
+                self.failed_flushes = 0;
             }
             Err(e) => {
                 // Drop a half-written file: the next attempt writes this
                 // same index, and leaving a truncated segment behind only
                 // invites reading it.
                 let _ = std::fs::remove_file(&seg_path);
-                self.failed_spills += 1;
+                self.failed_flushes += 1;
                 eprintln!(
-                    "Warning: failed to spill history to {}: {e} \
+                    "Warning: failed to flush history to {}: {e} \
                      ({} states kept in memory)",
                     seg_path.display(),
                     self.states.len()
                 );
                 self.enforce_memory_cap();
                 // Retry once the buffer has grown by another `capacity`
-                // states, so a permanently unwritable spill directory costs
+                // states, so a permanently unwritable segment directory costs
                 // one failed write per `capacity` pushes instead of one per
                 // push.
                 //
@@ -239,7 +239,7 @@ impl HistoryBuffer {
                 //
                 // `saturating_add`: the capacity comes from the caller, and a
                 // wrapped sum would put the retry threshold below the current
-                // length, spilling on every push — the opposite of the backoff.
+                // length, flushing on every push — the opposite of the backoff.
                 self.flush_at = self
                     .states
                     .len()
@@ -249,12 +249,12 @@ impl HistoryBuffer {
         }
     }
 
-    /// Drop the oldest states once a failing spill has grown the buffer past
+    /// Drop the oldest states once a failing flush has grown the buffer past
     /// `capacity * MAX_RETAINED_BUFFERS`.
     ///
     /// Retaining unflushed history is the right trade against a transient
     /// write failure, but `serve` is a long-running process and a
-    /// permanently unwritable spill directory would otherwise grow the
+    /// permanently unwritable segment directory would otherwise grow the
     /// buffer without bound. Past the cap bounded memory wins — loudly, and
     /// the per-entity overview still covers the discarded span.
     ///
@@ -280,9 +280,9 @@ impl HistoryBuffer {
         let drop_count = self.states.len() - keep;
         let until_t = self.states.get(drop_count).map(|s| s.t);
         eprintln!(
-            "Warning: history spill has failed {} times; discarding the {drop_count} oldest \
+            "Warning: history flush has failed {} times; discarding the {drop_count} oldest \
              states to keep memory bounded (full-fidelity history before t = {} is gone)",
-            self.failed_spills,
+            self.failed_flushes,
             until_t.map_or("end of run".to_string(), |t| format!("{t}"))
         );
         self.states.drain(..drop_count);
@@ -330,7 +330,7 @@ impl HistoryBuffer {
         Ok(states)
     }
 
-    /// Load all data: spilled segments + in-memory buffer, sorted by time.
+    /// Load all data: flushed segments + in-memory buffer, sorted by time.
     pub fn load_all(&self) -> Vec<HistoryState> {
         let mut all = Vec::new();
 
@@ -357,7 +357,7 @@ impl HistoryBuffer {
     /// - **Fast path (no disk I/O)**: if `t_min` is newer than the oldest
     ///   point currently in the in-memory tail (`self.states`), every state
     ///   in the requested window must already be in memory. Filter the
-    ///   tail and skip reading any spilled segments.
+    ///   tail and skip reading any flushed segments.
     /// - **Slow path (full load)**: otherwise, the window reaches into
     ///   flushed segments on disk; fall back to `load_all()` + filter.
     ///
@@ -405,14 +405,15 @@ impl HistoryBuffer {
     }
 }
 
-/// How many `capacity`-sized buffers may accumulate in memory while the
-/// spill keeps failing, before history is discarded to bound memory.
+/// How many `capacity`-sized buffers may accumulate in memory while flushes
+/// keep failing, before history is discarded to bound memory.
 const MAX_RETAINED_BUFFERS: usize = 8;
 
-/// One line of a spilled history segment.
+/// One line of a flushed history segment.
 ///
-/// The spill is a private implementation detail of `serve` — it lives in a
-/// per-pid temp directory and nothing outside this module reads it — so it
+/// The segment format is a private implementation detail of `serve` — it
+/// lives in a per-pid temp directory and nothing outside this module reads
+/// it — so it
 /// stores the payload verbatim instead of going through `.rrd`: `RrdRow` has
 /// no room for the per-force acceleration breakdown (a map with
 /// model-defined keys) or for reaction-wheel momentum (one entry per wheel),
@@ -497,7 +498,7 @@ impl SegmentRecord {
 
 /// A float that survives a JSON round-trip exactly.
 ///
-/// Two hazards make plain JSON numbers unsafe for a lossless spill.
+/// Two hazards make plain JSON numbers unsafe for a lossless flush.
 /// `serde_json` writes NaN and ±∞ as `null`, which then fails to read back —
 /// a diverging run would lose exactly the rows an operator wants to look at.
 /// And its default number parser does not guarantee that the `f64` read back
@@ -506,7 +507,7 @@ impl SegmentRecord {
 /// travels as text: Rust's `f64` `Display`/`FromStr` pair round-trips every
 /// finite value bit for bit, and carries `NaN` and `±inf` across as
 /// themselves. (A `NaN`'s sign and payload are not preserved — `Display`
-/// folds every `NaN` to `"NaN"` — which is what a spilled history needs:
+/// folds every `NaN` to `"NaN"` — which is what a flushed history needs:
 /// "this row diverged", not which bit pattern the FPU produced.)
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct F64(f64);
@@ -1675,7 +1676,7 @@ mod tests {
 
     /// A state carrying every optional payload field: the per-force
     /// acceleration breakdown and reaction-wheel momentum are the parts the
-    /// old `.rrd` spill silently dropped.
+    /// old `.rrd` segments silently dropped.
     fn make_state_full(t: f64) -> HistoryState {
         let pos = nalgebra::Vector3::new(6778.0 + t, t * 0.1, 0.0);
         let vel = nalgebra::Vector3::new(0.0, 7.669, 0.0);
@@ -1711,7 +1712,7 @@ mod tests {
         path
     }
 
-    /// A failed spill must not cost history: the buffer is the only source of
+    /// A failed flush must not cost history: the buffer is the only source of
     /// truth for states that are not on disk, so it keeps them.
     #[test]
     fn flush_failure_keeps_states_in_memory() {
@@ -1731,7 +1732,7 @@ mod tests {
         let _ = std::fs::remove_file(&dir);
     }
 
-    /// A permanently failing spill must not grow memory without bound: past
+    /// A permanently failing flush must not grow memory without bound: past
     /// `capacity * MAX_RETAINED_BUFFERS` the oldest states are discarded (with
     /// a warning) rather than retained forever.
     #[test]
@@ -1761,7 +1762,7 @@ mod tests {
         let _ = std::fs::remove_file(&dir);
     }
 
-    /// Full round-trip through the spill: accelerations and RW momentum come
+    /// Full round-trip through a segment file: accelerations and RW momentum come
     /// back too. Losing them made the viewer chart a gravity acceleration of
     /// 0 for every flushed window.
     #[test]
@@ -1773,7 +1774,7 @@ mod tests {
         for hs in &pushed {
             buf.push(hs.clone());
         }
-        assert!(buf.segment_count > 0, "precondition: must have spilled");
+        assert!(buf.segment_count > 0, "precondition: must have flushed");
 
         let all = buf.load_all();
         assert_eq!(all.len(), pushed.len());
@@ -1781,7 +1782,7 @@ mod tests {
             assert_eq!(
                 serde_json::to_value(expected).unwrap(),
                 serde_json::to_value(actual).unwrap(),
-                "state at t = {} changed across the spill",
+                "state at t = {} changed across the segment file",
                 expected.t
             );
         }
@@ -1790,34 +1791,34 @@ mod tests {
     }
 
     /// Two-path consistency: the same states read through the in-memory tail
-    /// and through the spill must produce identical payloads.
+    /// and through a segment file must produce identical payloads.
     #[test]
-    fn in_memory_and_spilled_paths_agree() {
+    fn in_memory_and_on_disk_paths_agree() {
         let mem_dir = temp_data_dir("two-path-mem");
         let disk_dir = temp_data_dir("two-path-disk");
-        // Same states, one buffer large enough to never spill and one that
-        // spills almost everything.
+        // Same states, one buffer large enough to never flush and one that
+        // flushes almost everything.
         let mut in_memory = HistoryBuffer::new(1000, mem_dir.clone(), TEST_MU, TEST_BODY_RADIUS);
-        let mut spilled = HistoryBuffer::new(4, disk_dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+        let mut on_disk = HistoryBuffer::new(4, disk_dir.clone(), TEST_MU, TEST_BODY_RADIUS);
 
         for i in 0..40 {
             let hs = make_state_full(i as f64 * 5.0);
             in_memory.push(hs.clone());
-            spilled.push(hs);
+            on_disk.push(hs);
         }
 
         assert_eq!(in_memory.segment_count, 0, "must stay in memory");
-        assert!(spilled.segment_count > 0, "must have spilled");
+        assert!(on_disk.segment_count > 0, "must have flushed");
 
         let from_memory = in_memory.query_range(0.0, 200.0, None, None);
-        let from_disk = spilled.query_range(0.0, 200.0, None, None);
+        let from_disk = on_disk.query_range(0.0, 200.0, None, None);
         assert_eq!(from_memory.len(), 40);
         assert_eq!(from_disk.len(), 40);
         for (mem, disk) in from_memory.iter().zip(from_disk.iter()) {
             assert_eq!(
                 serde_json::to_value(mem).unwrap(),
                 serde_json::to_value(disk).unwrap(),
-                "payload at t = {} differs between the in-memory and spilled paths",
+                "payload at t = {} differs between the in-memory and on-disk paths",
                 mem.t
             );
         }
@@ -1827,7 +1828,7 @@ mod tests {
     }
 
     /// A diverged run is exactly what an operator wants to read back, so
-    /// non-finite values must survive the spill instead of taking their row
+    /// non-finite values must survive a segment file instead of taking their row
     /// down with them.
     #[test]
     fn flush_round_trip_preserves_non_finite_values() {
@@ -1857,7 +1858,7 @@ mod tests {
                 }),
             ));
         }
-        assert!(buf.segment_count > 0, "precondition: must have spilled");
+        assert!(buf.segment_count > 0, "precondition: must have flushed");
 
         let all = buf.load_all();
         assert_eq!(all.len(), 5, "non-finite rows must not be dropped");
@@ -1884,7 +1885,7 @@ mod tests {
         cleanup_dir(&dir);
     }
 
-    /// Every value that a spilled float must survive as: finite values bit
+    /// Every value that a flushed float must survive as: finite values bit
     /// for bit, non-finite values as themselves. (`NaN` payload and sign are
     /// deliberately outside the contract, see [`F64`].)
     #[test]
@@ -1922,14 +1923,14 @@ mod tests {
         }
     }
 
-    /// The buffer spills once it holds `capacity` states, not one more.
+    /// The buffer flushes once it holds `capacity` states, not one more.
     ///
     /// `capacity` is documented as the most it keeps in memory before
-    /// flushing, and the retry after a failed spill as happening once the
+    /// flushing, and the retry after a failed flush as happening once the
     /// buffer has grown by another `capacity`. Both were reached one push
-    /// late: measured with `capacity = 4`, the first spill came on push 5.
+    /// late: measured with `capacity = 4`, the first flush came on push 5.
     #[test]
-    fn the_buffer_spills_at_capacity() {
+    fn the_buffer_flushes_at_capacity() {
         let dir = std::env::temp_dir().join(format!(
             "hist_cap_{}_{:?}",
             std::process::id(),
@@ -1955,7 +1956,7 @@ mod tests {
     /// with the cap enforced only there: capacity 4 reached 35 states against a
     /// cap of 32, and 63 of 200 pushes sat above it.
     #[test]
-    fn a_failing_spill_never_leaves_the_buffer_over_the_cap() {
+    fn a_failing_flush_never_leaves_the_buffer_over_the_cap() {
         let dir = temp_data_dir("cap-every-push");
         cleanup_dir(&dir);
         // A regular file where the directory should be: every write fails.
@@ -2004,9 +2005,9 @@ mod tests {
         }
         assert_eq!(buf.segment_count, 0, "every write failed");
         assert!(
-            buf.failed_spills > 1,
+            buf.failed_flushes > 1,
             "the run has to keep retrying for this to test anything: {} attempts",
-            buf.failed_spills
+            buf.failed_flushes
         );
         assert!(
             buf.flush_at <= capacity * MAX_RETAINED_BUFFERS,
@@ -2033,7 +2034,7 @@ mod tests {
         cleanup_dir(&dir);
     }
 
-    /// A failing spill costs one write per `capacity` pushes, not two.
+    /// A failing flush costs one write per `capacity` pushes, not two.
     ///
     /// The doc promises that cadence, and it is what keeps a permanently
     /// unwritable directory cheap. Measured while the cap only trimmed *past*
@@ -2041,7 +2042,7 @@ mod tests {
     /// sitting exactly at the cap with the threshold there too spent a second
     /// write on the same cycle.
     #[test]
-    fn a_failing_spill_attempts_one_write_per_capacity_pushes() {
+    fn a_failing_flush_attempts_one_write_per_capacity_pushes() {
         let dir = temp_data_dir("cadence");
         cleanup_dir(&dir);
         // A regular file where the directory should be: every write fails.
@@ -2054,9 +2055,9 @@ mod tests {
         let mut seen = 0u32;
         for i in 0..80 {
             buf.push(make_state(i as f64));
-            if buf.failed_spills != seen {
+            if buf.failed_flushes != seen {
                 attempts_at.push(i);
-                seen = buf.failed_spills;
+                seen = buf.failed_flushes;
             }
         }
 

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -1853,6 +1853,7 @@ mod tests {
     /// deliberately outside the contract, see [`F64`].)
     #[test]
     fn f64_json_round_trip() {
+        // Bit-for-bit, including the sign of zero and the infinities.
         for value in [
             0.0,
             -0.0,
@@ -1865,7 +1866,6 @@ mod tests {
             0.03 + 20.0 * 1e-6,
             f64::INFINITY,
             f64::NEG_INFINITY,
-            f64::NAN,
         ] {
             let json = serde_json::to_string(&F64(value)).unwrap();
             let back: F64 = serde_json::from_str(&json).unwrap();
@@ -1874,6 +1874,15 @@ mod tests {
                 value.to_bits(),
                 "{value} did not round-trip through {json}"
             );
+        }
+        // NaN comes back as a NaN. Asserting the bit pattern would claim more
+        // than the format carries: `Display` writes every NaN as "NaN", so
+        // the sign and payload do not survive (and are not wanted — what a
+        // reader needs is "this row diverged").
+        for value in [f64::NAN, -f64::NAN] {
+            let json = serde_json::to_string(&F64(value)).unwrap();
+            let back: F64 = serde_json::from_str(&json).unwrap();
+            assert!(back.0.is_nan(), "NaN did not survive as {json}");
         }
     }
 }

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 use std::collections::VecDeque;
-use std::path::PathBuf;
+use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
 
-use orts::record::archetypes::OrbitalState;
 use orts::record::entity_path::EntityPath;
-use orts::record::recording::Recording;
-use orts::record::timeline::TimePoint;
+use serde::de::{self, Deserializer};
+use serde::{Deserialize, Serialize, Serializer};
 
 use crate::sim::core::{AttitudePayload, AttitudeSource, HistoryState, make_history_state};
 
@@ -89,6 +89,14 @@ pub struct HistoryBuffer {
     pub data_dir: PathBuf,
     /// Number of segment files written so far.
     pub segment_count: u32,
+    /// In-memory length above which the next `push` attempts a spill.
+    ///
+    /// Normally `capacity`. After a failed spill it is raised so the retry
+    /// happens once the buffer has grown by another `capacity` states
+    /// rather than on every push.
+    flush_at: usize,
+    /// Consecutive failed spill attempts (reset by the next success).
+    failed_spills: u32,
     /// Gravitational parameter (for computing Keplerian elements from loaded data).
     pub mu: f64,
     /// Central body radius [km] (for computing derived values from loaded data).
@@ -113,6 +121,8 @@ impl HistoryBuffer {
             capacity,
             data_dir,
             segment_count: 0,
+            flush_at: capacity,
+            failed_spills: 0,
             mu,
             body_radius,
             overview_per_entity: HashMap::new(),
@@ -152,7 +162,7 @@ impl HistoryBuffer {
         }
 
         self.states.push_back(state);
-        if self.states.len() > self.capacity {
+        if self.states.len() > self.flush_at {
             self.flush();
         }
     }
@@ -174,90 +184,124 @@ impl HistoryBuffer {
         all
     }
 
-    /// Flush the oldest half of the buffer to a .rrd segment file.
+    /// Spill the oldest half of the buffer to a segment file.
+    ///
+    /// The states are written from a borrow and drained only after the write
+    /// succeeded, so the in-memory buffer stays the single source of truth
+    /// for everything not yet on disk: a failed spill degrades to "memory
+    /// holds more than `capacity`", never to lost history.
     pub fn flush(&mut self) {
         let flush_count = self.states.len() / 2;
         if flush_count == 0 {
             return;
         }
 
-        let to_flush: Vec<HistoryState> = self.states.drain(..flush_count).collect();
-
-        let mut rec = Recording::new();
-
-        for (i, hs) in to_flush.iter().enumerate() {
-            let sat_path = hs.entity_path.clone();
-            let tp = TimePoint::new().with_sim_time(hs.t).with_step(i as u64);
-            let os = OrbitalState::new(
-                nalgebra::Vector3::new(hs.position[0], hs.position[1], hs.position[2]),
-                nalgebra::Vector3::new(hs.velocity[0], hs.velocity[1], hs.velocity[2]),
-            );
-            let (q, w) = if let Some(att) = &hs.attitude {
-                (
-                    Some(orts::record::components::Quaternion4D(
-                        nalgebra::Vector4::from_row_slice(&att.quaternion_wxyz),
-                    )),
-                    Some(orts::record::components::AngularVelocity3D(
-                        nalgebra::Vector3::from_row_slice(&att.angular_velocity_body),
-                    )),
-                )
-            } else {
-                (None, None)
-            };
-            rec.log_orbital_state_with_attitude(&sat_path, &tp, &os, q.as_ref(), w.as_ref());
+        let seg_path = self.segment_path(self.segment_count);
+        match Self::write_segment(&seg_path, self.states.iter().take(flush_count)) {
+            Ok(()) => {
+                self.states.drain(..flush_count);
+                self.segment_count += 1;
+                self.flush_at = self.capacity;
+                self.failed_spills = 0;
+            }
+            Err(e) => {
+                // Drop a half-written file: the next attempt writes this
+                // same index, and leaving a truncated segment behind only
+                // invites reading it.
+                let _ = std::fs::remove_file(&seg_path);
+                self.failed_spills += 1;
+                eprintln!(
+                    "Warning: failed to spill history to {}: {e} \
+                     ({} states kept in memory)",
+                    seg_path.display(),
+                    self.states.len()
+                );
+                self.enforce_memory_cap();
+                // Retry once the buffer has grown by another `capacity`
+                // states, so a permanently unwritable spill directory costs
+                // one failed write per `capacity` pushes instead of one per
+                // push.
+                self.flush_at = self.states.len() + self.capacity;
+            }
         }
-
-        let seg_path = self
-            .data_dir
-            .join(format!("seg_{:04}.rrd", self.segment_count));
-        if let Err(e) =
-            orts::record::rerun_export::save_as_rrd(&rec, "orts", seg_path.to_str().unwrap())
-        {
-            eprintln!("Warning: failed to flush segment: {e}");
-            return;
-        }
-
-        self.segment_count += 1;
     }
 
-    /// Load all data: .rrd segments + in-memory buffer, sorted by time.
+    /// Drop the oldest states once a failing spill has grown the buffer past
+    /// `capacity * MAX_RETAINED_BUFFERS`.
+    ///
+    /// Retaining unflushed history is the right trade against a transient
+    /// write failure, but `serve` is a long-running process and a
+    /// permanently unwritable spill directory would otherwise grow the
+    /// buffer without bound. Past the cap bounded memory wins — loudly, and
+    /// the per-entity overview still covers the discarded span.
+    fn enforce_memory_cap(&mut self) {
+        let cap = self.capacity.saturating_mul(MAX_RETAINED_BUFFERS);
+        if self.states.len() <= cap {
+            return;
+        }
+        let keep = cap.saturating_sub(self.capacity);
+        let drop_count = self.states.len() - keep;
+        let until_t = self.states.get(drop_count).map(|s| s.t);
+        eprintln!(
+            "Warning: history spill has failed {} times; discarding the {drop_count} oldest \
+             states to keep memory bounded (full-fidelity history before t = {} is gone)",
+            self.failed_spills,
+            until_t.map_or("end of run".to_string(), |t| format!("{t}"))
+        );
+        self.states.drain(..drop_count);
+    }
+
+    fn segment_path(&self, index: u32) -> PathBuf {
+        self.data_dir.join(format!("seg_{index:04}.jsonl"))
+    }
+
+    /// Write `states` as one JSON record per line.
+    fn write_segment<'a>(
+        path: &Path,
+        states: impl Iterator<Item = &'a HistoryState>,
+    ) -> std::io::Result<()> {
+        let mut w = std::io::BufWriter::new(std::fs::File::create(path)?);
+        for hs in states {
+            serde_json::to_writer(&mut w, &SegmentRecord::from_state(hs))
+                .map_err(std::io::Error::other)?;
+            w.write_all(b"\n")?;
+        }
+        w.flush()
+    }
+
+    /// Read back a segment written by [`Self::write_segment`].
+    ///
+    /// A malformed line is reported and skipped rather than failing the whole
+    /// segment: one bad record must not cost the rest of the window.
+    fn read_segment(&self, path: &Path) -> std::io::Result<Vec<HistoryState>> {
+        let reader = std::io::BufReader::new(std::fs::File::open(path)?);
+        let mut states = Vec::new();
+        for (i, line) in reader.lines().enumerate() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<SegmentRecord>(&line) {
+                Ok(rec) => states.push(rec.into_state(self.mu, self.body_radius)),
+                Err(e) => eprintln!(
+                    "Warning: skipping malformed history record {}:{}: {e}",
+                    path.display(),
+                    i + 1
+                ),
+            }
+        }
+        Ok(states)
+    }
+
+    /// Load all data: spilled segments + in-memory buffer, sorted by time.
     pub fn load_all(&self) -> Vec<HistoryState> {
         let mut all = Vec::new();
 
-        // Read .rrd segment files in order
         for i in 0..self.segment_count {
-            let seg_path = self.data_dir.join(format!("seg_{i:04}.rrd"));
-            match orts::record::rerun_export::load_from_rrd(seg_path.to_str().unwrap()) {
-                Ok(rows) => {
-                    for row in rows {
-                        let pos = nalgebra::Vector3::new(row.x, row.y, row.z);
-                        let vel = nalgebra::Vector3::new(row.vx, row.vy, row.vz);
-                        let entity_path = row
-                            .entity_path
-                            .as_deref()
-                            .map(EntityPath::parse)
-                            .unwrap_or_else(|| EntityPath::parse("/world/sat/default"));
-                        let attitude = row.quaternion.map(|q| AttitudePayload {
-                            quaternion_wxyz: q,
-                            angular_velocity_body: row.angular_velocity.unwrap_or([0.0; 3]),
-                            source: AttitudeSource::Propagated,
-                            rw_momentum: None,
-                        });
-                        all.push(make_history_state(
-                            entity_path,
-                            row.t,
-                            &pos,
-                            &vel,
-                            self.mu,
-                            self.body_radius,
-                            HashMap::new(),
-                            attitude,
-                        ));
-                    }
-                }
-                Err(e) => {
-                    eprintln!("Warning: failed to read segment {i}: {e}");
-                }
+            let seg_path = self.segment_path(i);
+            match self.read_segment(&seg_path) {
+                Ok(states) => all.extend(states),
+                Err(e) => eprintln!("Warning: failed to read segment {i}: {e}"),
             }
         }
 
@@ -321,6 +365,122 @@ impl HistoryBuffer {
     /// Downsample a list of states to at most `max_points`, always preserving first and last.
     pub fn downsample(states: &[HistoryState], max_points: usize) -> Vec<HistoryState> {
         crate::sim::core::downsample_states(states, max_points)
+    }
+}
+
+/// How many `capacity`-sized buffers may accumulate in memory while the
+/// spill keeps failing, before history is discarded to bound memory.
+const MAX_RETAINED_BUFFERS: usize = 8;
+
+/// One line of a spilled history segment.
+///
+/// The spill is a private implementation detail of `serve` — it lives in a
+/// per-pid temp directory and nothing outside this module reads it — so it
+/// stores the payload verbatim instead of going through `.rrd`: `RrdRow` has
+/// no room for the per-force acceleration breakdown (a map with
+/// model-defined keys) or for reaction-wheel momentum (one entry per wheel),
+/// and dropping them made the viewer draw flushed windows with a gravity
+/// acceleration of 0.
+///
+/// Only the independent state is stored; the derived columns (Keplerian
+/// elements, altitude, energy, …) are rebuilt on load by
+/// [`make_history_state`] — the same function that produced them for the
+/// in-memory copy — so a state read back from disk is field-for-field
+/// identical to the one that was pushed.
+#[derive(Serialize, Deserialize)]
+struct SegmentRecord {
+    entity_path: EntityPath,
+    t: F64,
+    position: [F64; 3],
+    velocity: [F64; 3],
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    accelerations: HashMap<String, F64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    attitude: Option<SegmentAttitude>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct SegmentAttitude {
+    quaternion_wxyz: [F64; 4],
+    angular_velocity_body: [F64; 3],
+    source: AttitudeSource,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    rw_momentum: Option<Vec<F64>>,
+}
+
+impl SegmentRecord {
+    fn from_state(hs: &HistoryState) -> Self {
+        SegmentRecord {
+            entity_path: hs.entity_path.clone(),
+            t: F64(hs.t),
+            position: hs.position.map(F64),
+            velocity: hs.velocity.map(F64),
+            accelerations: hs
+                .accelerations
+                .iter()
+                .map(|(k, v)| (k.clone(), F64(*v)))
+                .collect(),
+            attitude: hs.attitude.as_ref().map(|att| SegmentAttitude {
+                quaternion_wxyz: att.quaternion_wxyz.map(F64),
+                angular_velocity_body: att.angular_velocity_body.map(F64),
+                source: att.source.clone(),
+                rw_momentum: att
+                    .rw_momentum
+                    .as_ref()
+                    .map(|h| h.iter().copied().map(F64).collect()),
+            }),
+        }
+    }
+
+    fn into_state(self, mu: f64, body_radius: f64) -> HistoryState {
+        let position = self.position.map(|f| f.0);
+        let velocity = self.velocity.map(|f| f.0);
+        make_history_state(
+            self.entity_path,
+            self.t.0,
+            &nalgebra::Vector3::from_row_slice(&position),
+            &nalgebra::Vector3::from_row_slice(&velocity),
+            mu,
+            body_radius,
+            self.accelerations
+                .into_iter()
+                .map(|(k, v)| (k, v.0))
+                .collect(),
+            self.attitude.map(|att| AttitudePayload {
+                quaternion_wxyz: att.quaternion_wxyz.map(|f| f.0),
+                angular_velocity_body: att.angular_velocity_body.map(|f| f.0),
+                source: att.source,
+                rw_momentum: att
+                    .rw_momentum
+                    .map(|h| h.into_iter().map(|f| f.0).collect()),
+            }),
+        )
+    }
+}
+
+/// A float that survives a JSON round-trip exactly.
+///
+/// Two hazards make plain JSON numbers unsafe for a lossless spill.
+/// `serde_json` writes NaN and ±∞ as `null`, which then fails to read back —
+/// a diverging run would lose exactly the rows an operator wants to look at.
+/// And its default number parser does not guarantee that the `f64` read back
+/// is the one that was written (that needs the `float_roundtrip` feature):
+/// `0.03 + 2e-5` comes back one ulp away. Both disappear when the value
+/// travels as text, because Rust's `f64` `Display`/`FromStr` pair round-trips
+/// every value bit for bit, non-finite included.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct F64(f64);
+
+impl Serialize for F64 {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for F64 {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let text = <&str>::deserialize(deserializer)?;
+        text.parse().map(F64).map_err(de::Error::custom)
     }
 }
 
@@ -932,7 +1092,7 @@ mod tests {
         }
 
         assert_eq!(buf.segment_count, 1);
-        assert!(dir.join("seg_0000.rrd").exists());
+        assert!(dir.join("seg_0000.jsonl").exists());
         assert_eq!(buf.states.len(), 3);
 
         cleanup_dir(&dir);
@@ -1471,5 +1631,242 @@ mod tests {
         }
 
         cleanup_dir(&dir);
+    }
+
+    /// A state carrying every optional payload field: the per-force
+    /// acceleration breakdown and reaction-wheel momentum are the parts the
+    /// old `.rrd` spill silently dropped.
+    fn make_state_full(t: f64) -> HistoryState {
+        let pos = nalgebra::Vector3::new(6778.0 + t, t * 0.1, 0.0);
+        let vel = nalgebra::Vector3::new(0.0, 7.669, 0.0);
+        let mut accels = HashMap::new();
+        accels.insert("gravity".to_string(), 8.68e-3 + t * 1e-9);
+        accels.insert("drag".to_string(), -1.234e-9);
+        accels.insert("j2".to_string(), 1.1e-5);
+        make_history_state(
+            EntityPath::parse("/world/sat/full"),
+            t,
+            &pos,
+            &vel,
+            TEST_MU,
+            TEST_BODY_RADIUS,
+            accels,
+            Some(AttitudePayload {
+                quaternion_wxyz: [0.5, 0.5, 0.5, 0.5],
+                angular_velocity_body: [0.01, -0.02, 0.03 + t * 1e-6],
+                source: AttitudeSource::Propagated,
+                // Four wheels: a variable-length payload the fixed 3-vector
+                // rrd components could not express either.
+                rw_momentum: Some(vec![0.1, -0.2, 0.3, 4.0e-3]),
+            }),
+        )
+    }
+
+    /// A `data_dir` that can never hold a segment: the path is an existing
+    /// *file*, so both `create_dir_all` and `File::create` under it fail.
+    fn unwritable_data_dir(name: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!("orts-test-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::write(&path, b"not a directory").expect("failed to create blocking file");
+        path
+    }
+
+    /// A failed spill must not cost history: the buffer is the only source of
+    /// truth for states that are not on disk, so it keeps them.
+    #[test]
+    fn flush_failure_keeps_states_in_memory() {
+        let dir = unwritable_data_dir("flush-fail-retain");
+        let mut buf = HistoryBuffer::new(4, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+
+        for i in 0..5 {
+            buf.push(make_state(i as f64 * 10.0));
+        }
+
+        assert_eq!(buf.segment_count, 0, "no segment can have been written");
+        let all = buf.load_all();
+        assert_eq!(all.len(), 5, "every pushed state must still be readable");
+        let times: Vec<f64> = all.iter().map(|s| s.t).collect();
+        assert_eq!(times, vec![0.0, 10.0, 20.0, 30.0, 40.0]);
+
+        let _ = std::fs::remove_file(&dir);
+    }
+
+    /// A permanently failing spill must not grow memory without bound: past
+    /// `capacity * MAX_RETAINED_BUFFERS` the oldest states are discarded (with
+    /// a warning) rather than retained forever.
+    #[test]
+    fn flush_failure_bounds_memory() {
+        let dir = unwritable_data_dir("flush-fail-bounded");
+        let capacity = 4;
+        let mut buf = HistoryBuffer::new(capacity, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+
+        for i in 0..500 {
+            buf.push(make_state(i as f64));
+        }
+
+        let cap = capacity * MAX_RETAINED_BUFFERS;
+        assert_eq!(buf.segment_count, 0);
+        assert!(
+            buf.states.len() <= cap,
+            "in-memory buffer grew to {} states, cap is {cap}",
+            buf.states.len()
+        );
+        // The newest states are the ones that survive.
+        assert!((buf.states.back().unwrap().t - 499.0).abs() < 1e-9);
+        // The overview still covers the discarded span, so a reconnecting
+        // client sees the whole run at reduced fidelity.
+        let overview = buf.overview();
+        assert!(overview.first().unwrap().t < 100.0);
+
+        let _ = std::fs::remove_file(&dir);
+    }
+
+    /// Full round-trip through the spill: accelerations and RW momentum come
+    /// back too. Losing them made the viewer chart a gravity acceleration of
+    /// 0 for every flushed window.
+    #[test]
+    fn flush_round_trip_preserves_full_payload() {
+        let dir = temp_data_dir("flush-full-payload");
+        let mut buf = HistoryBuffer::new(4, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+
+        let pushed: Vec<HistoryState> = (0..10).map(|i| make_state_full(i as f64 * 10.0)).collect();
+        for hs in &pushed {
+            buf.push(hs.clone());
+        }
+        assert!(buf.segment_count > 0, "precondition: must have spilled");
+
+        let all = buf.load_all();
+        assert_eq!(all.len(), pushed.len());
+        for (expected, actual) in pushed.iter().zip(all.iter()) {
+            assert_eq!(
+                serde_json::to_value(expected).unwrap(),
+                serde_json::to_value(actual).unwrap(),
+                "state at t = {} changed across the spill",
+                expected.t
+            );
+        }
+
+        cleanup_dir(&dir);
+    }
+
+    /// Two-path consistency: the same states read through the in-memory tail
+    /// and through the spill must produce identical payloads.
+    #[test]
+    fn in_memory_and_spilled_paths_agree() {
+        let mem_dir = temp_data_dir("two-path-mem");
+        let disk_dir = temp_data_dir("two-path-disk");
+        // Same states, one buffer large enough to never spill and one that
+        // spills almost everything.
+        let mut in_memory = HistoryBuffer::new(1000, mem_dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+        let mut spilled = HistoryBuffer::new(4, disk_dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+
+        for i in 0..40 {
+            let hs = make_state_full(i as f64 * 5.0);
+            in_memory.push(hs.clone());
+            spilled.push(hs);
+        }
+
+        assert_eq!(in_memory.segment_count, 0, "must stay in memory");
+        assert!(spilled.segment_count > 0, "must have spilled");
+
+        let from_memory = in_memory.query_range(0.0, 200.0, None, None);
+        let from_disk = spilled.query_range(0.0, 200.0, None, None);
+        assert_eq!(from_memory.len(), 40);
+        assert_eq!(from_disk.len(), 40);
+        for (mem, disk) in from_memory.iter().zip(from_disk.iter()) {
+            assert_eq!(
+                serde_json::to_value(mem).unwrap(),
+                serde_json::to_value(disk).unwrap(),
+                "payload at t = {} differs between the in-memory and spilled paths",
+                mem.t
+            );
+        }
+
+        cleanup_dir(&mem_dir);
+        cleanup_dir(&disk_dir);
+    }
+
+    /// A diverged run is exactly what an operator wants to read back, so
+    /// non-finite values must survive the spill instead of taking their row
+    /// down with them.
+    #[test]
+    fn flush_round_trip_preserves_non_finite_values() {
+        let dir = temp_data_dir("flush-non-finite");
+        let mut buf = HistoryBuffer::new(4, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+
+        for i in 0..5 {
+            let t = i as f64 * 10.0;
+            let pos = nalgebra::Vector3::new(6778.0, f64::INFINITY, 0.0);
+            let vel = nalgebra::Vector3::new(f64::NAN, 7.669, f64::NEG_INFINITY);
+            let mut accels = HashMap::new();
+            accels.insert("gravity".to_string(), f64::NAN);
+            accels.insert("drag".to_string(), f64::NEG_INFINITY);
+            buf.push(make_history_state(
+                EntityPath::parse("/world/sat/diverged"),
+                t,
+                &pos,
+                &vel,
+                TEST_MU,
+                TEST_BODY_RADIUS,
+                accels,
+                Some(AttitudePayload {
+                    quaternion_wxyz: [f64::NAN, 0.0, 0.0, 0.0],
+                    angular_velocity_body: [f64::INFINITY, 0.0, 0.0],
+                    source: AttitudeSource::Propagated,
+                    rw_momentum: Some(vec![f64::NAN, 1.0]),
+                }),
+            ));
+        }
+        assert!(buf.segment_count > 0, "precondition: must have spilled");
+
+        let all = buf.load_all();
+        assert_eq!(all.len(), 5, "non-finite rows must not be dropped");
+        for hs in &all {
+            assert_eq!(hs.position[1].to_bits(), f64::INFINITY.to_bits());
+            assert!(hs.velocity[0].is_nan());
+            assert_eq!(hs.velocity[2].to_bits(), f64::NEG_INFINITY.to_bits());
+            assert!(hs.accelerations["gravity"].is_nan());
+            assert_eq!(
+                hs.accelerations["drag"].to_bits(),
+                f64::NEG_INFINITY.to_bits()
+            );
+            let att = hs.attitude.as_ref().expect("attitude must survive");
+            assert!(att.quaternion_wxyz[0].is_nan());
+            assert_eq!(
+                att.angular_velocity_body[0].to_bits(),
+                f64::INFINITY.to_bits()
+            );
+            let rw = att.rw_momentum.as_ref().expect("rw momentum must survive");
+            assert!(rw[0].is_nan());
+            assert_eq!(rw[1], 1.0);
+        }
+
+        cleanup_dir(&dir);
+    }
+
+    #[test]
+    fn f64_json_round_trip() {
+        for value in [
+            0.0,
+            -0.0,
+            1.0,
+            -7.669,
+            f64::MIN_POSITIVE,
+            f64::MAX,
+            f64::MIN,
+            1e-300,
+            0.03 + 20.0 * 1e-6,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            f64::NAN,
+        ] {
+            let json = serde_json::to_string(&F64(value)).unwrap();
+            let back: F64 = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                back.0.to_bits(),
+                value.to_bits(),
+                "{value} did not round-trip through {json}"
+            );
+        }
     }
 }

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -268,7 +268,12 @@ impl HistoryBuffer {
 
     fn enforce_memory_cap(&mut self) {
         let cap = self.memory_cap();
-        if self.states.len() <= cap {
+        // At the cap, not only past it. A failed write leaves the length there
+        // and the retry threshold there, so waiting for one more push would
+        // spend a second failed write on the same cycle — measured, attempts
+        // landed on pushes 31 and 32, then 36 and 37, against a documented one
+        // per `capacity` pushes.
+        if self.states.len() < cap {
             return;
         }
         let keep = cap.saturating_sub(self.capacity);
@@ -2026,5 +2031,48 @@ mod tests {
         );
 
         cleanup_dir(&dir);
+    }
+
+    /// A failing spill costs one write per `capacity` pushes, not two.
+    ///
+    /// The doc promises that cadence, and it is what keeps a permanently
+    /// unwritable directory cheap. Measured while the cap only trimmed *past*
+    /// itself: attempts landed on pushes 31 and 32, then 36 and 37 — a length
+    /// sitting exactly at the cap with the threshold there too spent a second
+    /// write on the same cycle.
+    #[test]
+    fn a_failing_spill_attempts_one_write_per_capacity_pushes() {
+        let dir = temp_data_dir("cadence");
+        cleanup_dir(&dir);
+        // A regular file where the directory should be: every write fails.
+        std::fs::write(&dir, b"not a directory").expect("place the blocker");
+
+        let capacity = 4usize;
+        let cap = capacity * MAX_RETAINED_BUFFERS;
+        let mut buf = HistoryBuffer::new(capacity, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+        let mut attempts_at = Vec::new();
+        let mut seen = 0u32;
+        for i in 0..80 {
+            buf.push(make_state(i as f64));
+            if buf.failed_spills != seen {
+                attempts_at.push(i);
+                seen = buf.failed_spills;
+            }
+        }
+
+        // Past the cap the buffer is in its steady state, so the gaps are the
+        // cadence. Before it the buffer is still growing into the cap.
+        let steady: Vec<usize> = attempts_at.into_iter().filter(|i| *i > cap).collect();
+        assert!(
+            steady.len() > 5,
+            "enough cycles to read a cadence: {steady:?}"
+        );
+        let gaps: Vec<usize> = steady.windows(2).map(|w| w[1] - w[0]).collect();
+        assert!(
+            gaps.iter().all(|g| *g == capacity),
+            "one attempt per {capacity} pushes: gaps {gaps:?} at {steady:?}"
+        );
+
+        std::fs::remove_file(&dir).ok();
     }
 }

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -163,7 +163,7 @@ impl HistoryBuffer {
         }
 
         self.states.push_back(state);
-        if self.states.len() > self.flush_at {
+        if self.states.len() >= self.flush_at {
             self.flush();
         }
     }
@@ -222,7 +222,10 @@ impl HistoryBuffer {
                 // states, so a permanently unwritable spill directory costs
                 // one failed write per `capacity` pushes instead of one per
                 // push.
-                self.flush_at = self.states.len() + self.capacity;
+                // `saturating_add`: the capacity comes from the caller, and a
+                // wrapped sum would put the retry threshold below the current
+                // length, spilling on every push — the opposite of the backoff.
+                self.flush_at = self.states.len().saturating_add(self.capacity);
             }
         }
     }
@@ -1884,5 +1887,32 @@ mod tests {
             let back: F64 = serde_json::from_str(&json).unwrap();
             assert!(back.0.is_nan(), "NaN did not survive as {json}");
         }
+    }
+
+    /// The buffer spills once it holds `capacity` states, not one more.
+    ///
+    /// `capacity` is documented as the most it keeps in memory before
+    /// flushing, and the retry after a failed spill as happening once the
+    /// buffer has grown by another `capacity`. Both were reached one push
+    /// late: measured with `capacity = 4`, the first spill came on push 5.
+    #[test]
+    fn the_buffer_spills_at_capacity() {
+        let dir = std::env::temp_dir().join(format!(
+            "hist_cap_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let mut buf = HistoryBuffer::new(4, dir.clone(), 398600.4418, 6378.137);
+
+        for i in 0..3 {
+            buf.push(make_state(i as f64));
+        }
+        assert_eq!(buf.segment_count, 0, "three of four states is not full");
+
+        buf.push(make_state(3.0));
+        assert_eq!(buf.segment_count, 1, "the fourth state fills it");
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -228,10 +228,23 @@ impl HistoryBuffer {
                 // states, so a permanently unwritable spill directory costs
                 // one failed write per `capacity` pushes instead of one per
                 // push.
+                //
+                // Kept at or below the memory cap, because the cap is what
+                // bounds the length: a threshold above it is never reached
+                // again, and a directory that becomes writable later would
+                // never be tried. Measured with an unclamped threshold: after
+                // 100 failing pushes at capacity 4 the threshold sat at 36
+                // against a cap of 32, and 100 further pushes to a writable
+                // directory wrote no segment.
+                //
                 // `saturating_add`: the capacity comes from the caller, and a
                 // wrapped sum would put the retry threshold below the current
                 // length, spilling on every push — the opposite of the backoff.
-                self.flush_at = self.states.len().saturating_add(self.capacity);
+                self.flush_at = self
+                    .states
+                    .len()
+                    .saturating_add(self.capacity)
+                    .min(self.memory_cap());
             }
         }
     }
@@ -248,8 +261,13 @@ impl HistoryBuffer {
     /// Called from `push`, so the cap holds between write attempts too. A
     /// failed write moves the next attempt `capacity` pushes out, and those
     /// pushes would otherwise sit above the cap.
+    /// The most states the buffer holds while its writes keep failing.
+    fn memory_cap(&self) -> usize {
+        self.capacity.saturating_mul(MAX_RETAINED_BUFFERS)
+    }
+
     fn enforce_memory_cap(&mut self) {
-        let cap = self.capacity.saturating_mul(MAX_RETAINED_BUFFERS);
+        let cap = self.memory_cap();
         if self.states.len() <= cap {
             return;
         }
@@ -1958,5 +1976,55 @@ mod tests {
         assert_eq!(buf.segment_count, 0, "every write failed");
 
         std::fs::remove_file(&dir).ok();
+    }
+
+    /// A directory that becomes writable again is written to again.
+    ///
+    /// The retry threshold is `len + capacity`, and the memory cap holds the
+    /// length at or below `capacity * MAX_RETAINED_BUFFERS`. A threshold above
+    /// the cap is therefore never reached: measured without the clamp, after
+    /// 100 failing pushes at capacity 4 the threshold sat at 36 against a cap
+    /// of 32, and 100 further pushes to a writable directory wrote nothing.
+    #[test]
+    fn a_writable_directory_is_used_again_after_the_cap_is_reached() {
+        let dir = temp_data_dir("recover-after-cap");
+        cleanup_dir(&dir);
+        // A regular file where the directory should be: every write fails.
+        std::fs::write(&dir, b"not a directory").expect("place the blocker");
+
+        let capacity = 4usize;
+        let mut buf = HistoryBuffer::new(capacity, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+        for i in 0..100 {
+            buf.push(make_state(i as f64));
+        }
+        assert_eq!(buf.segment_count, 0, "every write failed");
+        assert!(
+            buf.failed_spills > 1,
+            "the run has to keep retrying for this to test anything: {} attempts",
+            buf.failed_spills
+        );
+        assert!(
+            buf.flush_at <= capacity * MAX_RETAINED_BUFFERS,
+            "the threshold has to stay reachable: {} against a cap of {}",
+            buf.flush_at,
+            capacity * MAX_RETAINED_BUFFERS
+        );
+
+        std::fs::remove_file(&dir).expect("remove the blocker");
+        std::fs::create_dir_all(&dir).expect("make the directory");
+        for i in 100..200 {
+            buf.push(make_state(i as f64));
+        }
+        assert!(
+            buf.segment_count > 0,
+            "writes resume once the directory takes them"
+        );
+        assert!(
+            buf.states.len() <= capacity,
+            "and the buffer drains back to the normal band: {}",
+            buf.states.len()
+        );
+
+        cleanup_dir(&dir);
     }
 }

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -196,7 +196,12 @@ impl HistoryBuffer {
     /// The states are written from a borrow and drained only after the write
     /// succeeded, so the in-memory buffer stays the single source of truth
     /// for everything not yet on disk: a failed flush degrades to "memory
-    /// holds more than `capacity`", never to lost history.
+    /// holds more than `capacity`" rather than to lost history.
+    ///
+    /// One flush costs no history. Repeated failures eventually do:
+    /// `enforce_memory_cap` discards the oldest states once the buffer
+    /// reaches `capacity * MAX_RETAINED_BUFFERS`, which is what bounds
+    /// memory in a long-running `serve`.
     pub fn flush(&mut self) {
         let flush_count = self.states.len() / 2;
         if flush_count == 0 {

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -466,8 +466,11 @@ impl SegmentRecord {
 /// And its default number parser does not guarantee that the `f64` read back
 /// is the one that was written (that needs the `float_roundtrip` feature):
 /// `0.03 + 2e-5` comes back one ulp away. Both disappear when the value
-/// travels as text, because Rust's `f64` `Display`/`FromStr` pair round-trips
-/// every value bit for bit, non-finite included.
+/// travels as text: Rust's `f64` `Display`/`FromStr` pair round-trips every
+/// finite value bit for bit, and carries `NaN` and `±inf` across as
+/// themselves. (A `NaN`'s sign and payload are not preserved — `Display`
+/// folds every `NaN` to `"NaN"` — which is what a spilled history needs:
+/// "this row diverged", not which bit pattern the FPU produced.)
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct F64(f64);
 
@@ -1844,6 +1847,9 @@ mod tests {
         cleanup_dir(&dir);
     }
 
+    /// Every value that a spilled float must survive as: finite values bit
+    /// for bit, non-finite values as themselves. (`NaN` payload and sign are
+    /// deliberately outside the contract, see [`F64`].)
     #[test]
     fn f64_json_round_trip() {
         for value in [

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -166,6 +166,12 @@ impl HistoryBuffer {
         if self.states.len() >= self.flush_at {
             self.flush();
         }
+        // The cap is a promise about memory, so it holds on every push. The
+        // retry cadence above only decides when the next write is attempted:
+        // measured before this call was here, a failing spill at capacity 4
+        // reached 35 states against a cap of 32, because the backoff moved the
+        // next attempt three pushes past it.
+        self.enforce_memory_cap();
     }
 
     /// Return a snapshot of the overview: the union of every entity's
@@ -238,6 +244,10 @@ impl HistoryBuffer {
     /// permanently unwritable spill directory would otherwise grow the
     /// buffer without bound. Past the cap bounded memory wins — loudly, and
     /// the per-entity overview still covers the discarded span.
+    ///
+    /// Called from `push`, so the cap holds between write attempts too. A
+    /// failed write moves the next attempt `capacity` pushes out, and those
+    /// pushes would otherwise sit above the cap.
     fn enforce_memory_cap(&mut self) {
         let cap = self.capacity.saturating_mul(MAX_RETAINED_BUFFERS);
         if self.states.len() <= cap {
@@ -1914,5 +1924,39 @@ mod tests {
         assert_eq!(buf.segment_count, 1, "the fourth state fills it");
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The memory cap holds on every push, not only when a write is attempted.
+    ///
+    /// A failed write moves the next attempt `capacity` pushes out. Measured
+    /// with the cap enforced only there: capacity 4 reached 35 states against a
+    /// cap of 32, and 63 of 200 pushes sat above it.
+    #[test]
+    fn a_failing_spill_never_leaves_the_buffer_over_the_cap() {
+        let dir = temp_data_dir("cap-every-push");
+        cleanup_dir(&dir);
+        // A regular file where the directory should be: every write fails.
+        std::fs::write(&dir, b"not a directory").expect("place the blocker");
+
+        let capacity = 4usize;
+        let cap = capacity * MAX_RETAINED_BUFFERS;
+        let mut buf = HistoryBuffer::new(capacity, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+        let mut high = 0usize;
+        for i in 0..200 {
+            buf.push(make_state(i as f64));
+            high = high.max(buf.states.len());
+            assert!(
+                buf.states.len() <= cap,
+                "push {i} left {} states, over the cap of {cap}",
+                buf.states.len()
+            );
+        }
+        assert!(
+            high > cap - capacity,
+            "the run has to reach the cap for this to test anything: high water {high}"
+        );
+        assert_eq!(buf.segment_count, 0, "every write failed");
+
+        std::fs::remove_file(&dir).ok();
     }
 }

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -79,13 +79,14 @@ impl EntityOverview {
     }
 }
 
-/// Bounded buffer that accumulates history states and periodically flushes to .rrd segments.
+/// Bounded buffer that accumulates history states and periodically spills the
+/// oldest half to a segment file on disk.
 pub struct HistoryBuffer {
     /// Recent states kept in memory.
     pub states: VecDeque<HistoryState>,
     /// Maximum number of states to keep in memory before flushing.
     pub capacity: usize,
-    /// Directory for .rrd segment files.
+    /// Directory for spilled segment files.
     pub data_dir: PathBuf,
     /// Number of segment files written so far.
     pub segment_count: u32,
@@ -107,7 +108,7 @@ pub struct HistoryBuffer {
     // Maintained in O(1) amortized per `push()` call, read in
     // O(num_entities * OVERVIEW_MAX_POINTS_PER_ENTITY) with no disk I/O.
     // This lets re-connects to long-running simulations return the history
-    // overview instantly, without re-reading every .rrd segment from disk
+    // overview instantly, without re-reading every spilled segment from disk
     // on the manager task. Per-entity bookkeeping ensures every satellite
     // gets fair coverage regardless of push order or count.
     overview_per_entity: HashMap<EntityPath, EntityOverview>,
@@ -129,7 +130,7 @@ impl HistoryBuffer {
         }
     }
 
-    /// Push a state into the buffer. Flushes to .rrd if capacity is exceeded,
+    /// Push a state into the buffer. Spills to disk if capacity is exceeded,
     /// and incrementally updates the per-entity overview buffers.
     ///
     /// Clone cost: non-sampling pushes perform one `state.clone()` into
@@ -320,7 +321,7 @@ impl HistoryBuffer {
     /// - **Fast path (no disk I/O)**: if `t_min` is newer than the oldest
     ///   point currently in the in-memory tail (`self.states`), every state
     ///   in the requested window must already be in memory. Filter the
-    ///   tail and skip reading any `.rrd` segments.
+    ///   tail and skip reading any spilled segments.
     /// - **Slow path (full load)**: otherwise, the window reaches into
     ///   flushed segments on disk; fall back to `load_all()` + filter.
     ///

--- a/cli/src/commands/serve/mod.rs
+++ b/cli/src/commands/serve/mod.rs
@@ -161,14 +161,27 @@ fn unhonored_sim_args(sim: &SimArgs) -> Vec<&'static str> {
     .filter_map(|(flag, differs)| differs.then_some(flag))
     .collect()
 }
+/// The largest control message `/ws` will read.
+///
+/// Every inbound frame is parsed into a `serde_json::Value` so the keys nothing
+/// reads can be named, and the tree costs several times the bytes on the wire.
+/// axum's default ceiling is 64 MiB per message, which is far past anything this
+/// endpoint has to carry: measured, a `start_simulation` runs about 256 bytes per
+/// satellite, so 250 KiB for a fleet of 1000 and 2.5 MiB for 10000. 8 MiB leaves
+/// room for a fleet larger than any this simulator runs while keeping what one
+/// unauthenticated client can make the server hold to something bounded.
+///
+/// Outbound messages are unaffected: this bounds what is read.
+const MAX_CONTROL_MESSAGE_BYTES: usize = 8 * 1024 * 1024;
 
 async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
     let rx = state.tx.subscribe();
     let cmd_tx = state.cmd_tx.clone();
-    ws.on_upgrade(move |socket| async move {
-        connection::handle_connection(socket, rx, cmd_tx).await;
-        eprintln!("Client disconnected");
-    })
+    ws.max_message_size(MAX_CONTROL_MESSAGE_BYTES)
+        .on_upgrade(move |socket| async move {
+            connection::handle_connection(socket, rx, cmd_tx).await;
+            eprintln!("Client disconnected");
+        })
 }
 
 /// Binary WS endpoint for a declared `stream-io` stream — the shape of a
@@ -212,10 +225,6 @@ async fn async_server(
         .map_err(|e| CmdError::failure(format!("binding to {addr}: {e}")))?;
 
     let actual_port = listener.local_addr().unwrap().port();
-    eprintln!("Server listening on http://localhost:{actual_port}");
-    #[cfg(feature = "viewer")]
-    eprintln!("Viewer:             http://localhost:{actual_port}/");
-    eprintln!("WebSocket endpoint: ws://localhost:{actual_port}/ws");
 
     let (tx, _rx) = broadcast::channel::<String>(256);
     let (cmd_tx, cmd_rx) = mpsc::channel::<SimCommand>(16);
@@ -223,9 +232,9 @@ async fn async_server(
     // Determine initial config: if CLI args specify simulation, auto-start.
     let initial_config = if has_explicit_sim_args(sim) {
         match sim.config.as_ref() {
-            Some(config_path) => Some(crate::config::SimConfig::load(std::path::Path::new(
-                config_path,
-            ))?),
+            Some(config_path) => Some(crate::config::load_config_reporting_unread_keys(
+                std::path::Path::new(config_path),
+            )?),
             None => None,
         }
     } else {
@@ -271,6 +280,7 @@ async fn async_server(
         // Same reason as in `run`: this path skips `SimConfig::validate`.
         crate::commands::run::validate_sim_args(sim)?;
         let params = Arc::new(SimParams::from_sim_args(sim, true));
+        crate::satellite::ensure_unique_ids(&params.satellites)?;
         tokio::spawn(manager::simulation_manager_with_params(
             params,
             plugin_overrides,
@@ -324,6 +334,16 @@ async fn async_server(
     let app = app.fallback(spa::spa_handler);
 
     let app = app.with_state(state);
+
+    // Announced only once every rejection above is behind us. This banner is
+    // what callers wait on to mean "the endpoint is up" — `cli/tests/ws_e2e.rs`
+    // matches the first line, the Playwright specs read the port out of the
+    // `ws://` one — so printing it before the config is loaded turned a
+    // rejected config into a connection that is refused with no explanation.
+    eprintln!("Server listening on http://localhost:{actual_port}");
+    #[cfg(feature = "viewer")]
+    eprintln!("Viewer:             http://localhost:{actual_port}/");
+    eprintln!("WebSocket endpoint: ws://localhost:{actual_port}/ws");
 
     match shutdown_rx {
         Some(rx) => {

--- a/cli/src/commands/serve/mod.rs
+++ b/cli/src/commands/serve/mod.rs
@@ -163,8 +163,14 @@ fn unhonored_sim_args(sim: &SimArgs) -> Vec<&'static str> {
         ),
         (
             "--stream-interval",
-            sim.stream_interval
-                .is_some_and(|v| clamp_stream(v) != output_interval),
+            sim.stream_interval.is_some_and(|v| {
+                // A value `validate_time_params` refuses is honored nowhere, so
+                // it is named whatever the clamp would make of it. Measured
+                // before this: `serve --stream-interval inf` clamped to the
+                // default, read as inert, and started the idle server without a
+                // word, while `--dt inf` was named.
+                !v.is_finite() || v <= 0.0 || clamp_stream(v) != output_interval
+            }),
         ),
         ("--epoch", sim.epoch.is_some()),
         ("--duration", sim.duration.is_some()),
@@ -594,6 +600,10 @@ mod tests {
             vec!["--dt", "NaN", "--stream-interval", "1"],
             vec!["--output-interval", "inf", "--stream-interval", "1"],
             vec!["--stream-interval", "NaN"],
+            // The clamp would fold these into the default and read them as
+            // inert; `validate_time_params` refuses them, so they are named.
+            vec!["--stream-interval", "inf"],
+            vec!["--stream-interval", "0"],
         ] {
             let named = unhonored_sim_args(&args(&extra));
             assert!(

--- a/cli/src/commands/serve/mod.rs
+++ b/cli/src/commands/serve/mod.rs
@@ -20,6 +20,8 @@ use axum::routing::get;
 use tokio::net::TcpListener;
 use tokio::sync::{broadcast, mpsc};
 
+use clap::Parser;
+
 use crate::cli::SimArgs;
 use crate::commands::CmdError;
 use crate::sim::params::SimParams;
@@ -50,6 +52,10 @@ pub fn run_server(sim: &SimArgs, port: u16, stream_stdio: Option<&str>) -> Resul
         ),
         None => None,
     };
+    // Sim args nothing will read are a usage error, in the same spirit as the
+    // config `[[command]]` rejection below: the server would otherwise come
+    // up having silently dropped every one of them.
+    reject_unhonored_sim_args(sim)?;
     let rt = tokio::runtime::Runtime::new()
         .map_err(|e| CmdError::failure(format!("creating the tokio runtime: {e}")))?;
     rt.block_on(async_server(sim, port, stdio_key))
@@ -67,31 +73,102 @@ fn parse_stream_stdio(s: &str) -> Result<stream_bridge::StreamKey, String> {
 }
 
 /// Detect whether CLI args specify an explicit simulation configuration.
+///
+/// Only a config file or an orbit describes a simulation to start; the
+/// remaining sim args (`--dt`, `--body`, `--integrator`, …) tune one that
+/// something else describes.
 fn has_explicit_sim_args(sim: &SimArgs) -> bool {
     sim.config.is_some() || sim.has_orbit_args()
 }
 
-/// The largest control message `/ws` will read.
+/// Refuse sim args that nothing on the way to a `SimParams` will read.
 ///
-/// Every inbound frame is parsed into a `serde_json::Value` so the keys nothing
-/// reads can be named, and the tree costs several times the bytes on the wire.
-/// axum's default ceiling is 64 MiB per message, which is far past anything this
-/// endpoint has to carry: measured, a `start_simulation` runs about 256 bytes per
-/// satellite, so 250 KiB for a fleet of 1000 and 2.5 MiB for 10000. 8 MiB leaves
-/// room for a fleet larger than any this simulator runs while keeping what one
-/// unauthenticated client can make the server hold to something bounded.
+/// The tuning args reach a simulation only through
+/// [`SimParams::from_sim_args`], i.e. the CLI-orbit path. The other two paths
+/// ignore them completely: an idle server takes its parameters from the
+/// client's `start_simulation`, and `--config` builds them with
+/// `SimParams::from_config`. Both used to drop every flag in silence — the
+/// documented `serve --dt 1 --output-interval 10` served forever without ever
+/// starting a simulation.
+fn reject_unhonored_sim_args(sim: &SimArgs) -> Result<(), CmdError> {
+    let unhonored = unhonored_sim_args(sim);
+    if unhonored.is_empty() {
+        return Ok(());
+    }
+    let flags = unhonored.join(", ");
+    match &sim.config {
+        // A config describes the whole simulation, so the command line has
+        // nowhere to put these. (The `--plugin-backend*` flags do get applied
+        // on top, which is why they are not on the list.)
+        Some(path) => Err(CmdError::usage(format!(
+            "{flags} cannot be honored: `serve --config {path}` builds its simulation from the \
+             config alone. Set the value in the config instead, or drop the flag."
+        ))),
+        None if !sim.has_orbit_args() => Err(CmdError::usage(format!(
+            "{flags} cannot be honored: without an orbit or a config, `serve` comes up idle and \
+             takes its simulation parameters from the client's start_simulation. Give it a \
+             simulation to apply them to (--sat altitude=400, --tle, --omm, --norad-id, or \
+             --config), or drop them."
+        ))),
+        // The CLI-orbit path: `SimParams::from_sim_args` reads all of them.
+        None => Ok(()),
+    }
+}
+
+/// The sim args that only [`SimParams::from_sim_args`] reads, named as they
+/// were written on the command line.
 ///
-/// Outbound messages are unaffected: this bounds what is read.
-const MAX_CONTROL_MESSAGE_BYTES: usize = 8 * 1024 * 1024;
+/// The plugin backend flags are deliberately absent: `PluginBackendOverrides`
+/// applies them to every `SimParams` the manager builds, whoever started the
+/// simulation.
+///
+/// Presence is decided by comparing against what the flag-less command line
+/// would mean rather than by asking whether the flag appeared (that needs the
+/// `ArgMatches` this layer never sees). The question is whether dropping the
+/// value changes anything: `--dt 10` asks for the default, `--dt 1` does not,
+/// and `--output-interval` equal to `dt` asks for the fallback that
+/// `from_sim_args` would have picked anyway. The blind spot is a flag written
+/// with its default value alongside a `--config` that sets a different one;
+/// silence there is the pre-existing behavior, not a new one.
+fn unhonored_sim_args(sim: &SimArgs) -> Vec<&'static str> {
+    let default = SimArgs::try_parse_from(["orts"])
+        .expect("every SimArgs field is optional or has a default");
+    // `from_sim_args`: output_interval falls back to dt, stream_interval to
+    // output_interval.
+    let output_interval = sim.output_interval.unwrap_or(sim.dt);
+    [
+        ("--body", sim.body != default.body),
+        ("--dt", sim.dt != default.dt),
+        (
+            "--output-interval",
+            sim.output_interval.is_some_and(|v| v != sim.dt),
+        ),
+        (
+            "--stream-interval",
+            sim.stream_interval.is_some_and(|v| v != output_interval),
+        ),
+        ("--epoch", sim.epoch.is_some()),
+        ("--duration", sim.duration.is_some()),
+        ("--integrator", sim.integrator != default.integrator),
+        ("--atol", sim.atol != default.atol),
+        ("--rtol", sim.rtol != default.rtol),
+        ("--atmosphere", sim.atmosphere != default.atmosphere),
+        ("--f107", sim.f107 != default.f107),
+        ("--ap", sim.ap != default.ap),
+        ("--space-weather", sim.space_weather.is_some()),
+    ]
+    .into_iter()
+    .filter_map(|(flag, differs)| differs.then_some(flag))
+    .collect()
+}
 
 async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
     let rx = state.tx.subscribe();
     let cmd_tx = state.cmd_tx.clone();
-    ws.max_message_size(MAX_CONTROL_MESSAGE_BYTES)
-        .on_upgrade(move |socket| async move {
-            connection::handle_connection(socket, rx, cmd_tx).await;
-            eprintln!("Client disconnected");
-        })
+    ws.on_upgrade(move |socket| async move {
+        connection::handle_connection(socket, rx, cmd_tx).await;
+        eprintln!("Client disconnected");
+    })
 }
 
 /// Binary WS endpoint for a declared `stream-io` stream — the shape of a
@@ -135,6 +212,10 @@ async fn async_server(
         .map_err(|e| CmdError::failure(format!("binding to {addr}: {e}")))?;
 
     let actual_port = listener.local_addr().unwrap().port();
+    eprintln!("Server listening on http://localhost:{actual_port}");
+    #[cfg(feature = "viewer")]
+    eprintln!("Viewer:             http://localhost:{actual_port}/");
+    eprintln!("WebSocket endpoint: ws://localhost:{actual_port}/ws");
 
     let (tx, _rx) = broadcast::channel::<String>(256);
     let (cmd_tx, cmd_rx) = mpsc::channel::<SimCommand>(16);
@@ -142,9 +223,9 @@ async fn async_server(
     // Determine initial config: if CLI args specify simulation, auto-start.
     let initial_config = if has_explicit_sim_args(sim) {
         match sim.config.as_ref() {
-            Some(config_path) => Some(crate::config::load_config_reporting_unread_keys(
-                std::path::Path::new(config_path),
-            )?),
+            Some(config_path) => Some(crate::config::SimConfig::load(std::path::Path::new(
+                config_path,
+            ))?),
             None => None,
         }
     } else {
@@ -190,7 +271,6 @@ async fn async_server(
         // Same reason as in `run`: this path skips `SimConfig::validate`.
         crate::commands::run::validate_sim_args(sim)?;
         let params = Arc::new(SimParams::from_sim_args(sim, true));
-        crate::satellite::ensure_unique_ids(&params.satellites)?;
         tokio::spawn(manager::simulation_manager_with_params(
             params,
             plugin_overrides,
@@ -245,16 +325,6 @@ async fn async_server(
 
     let app = app.with_state(state);
 
-    // Announced only once every rejection above is behind us. This banner is
-    // what callers wait on to mean "the endpoint is up" — `cli/tests/ws_e2e.rs`
-    // matches the first line, the Playwright specs read the port out of the
-    // `ws://` one — so printing it before the config is loaded turned a
-    // rejected config into a connection that is refused with no explanation.
-    eprintln!("Server listening on http://localhost:{actual_port}");
-    #[cfg(feature = "viewer")]
-    eprintln!("Viewer:             http://localhost:{actual_port}/");
-    eprintln!("WebSocket endpoint: ws://localhost:{actual_port}/ws");
-
     match shutdown_rx {
         Some(rx) => {
             axum::serve(listener, app)
@@ -271,7 +341,24 @@ async fn async_server(
 
 #[cfg(test)]
 mod tests {
-    use super::parse_stream_stdio;
+    use super::{
+        has_explicit_sim_args, parse_stream_stdio, reject_unhonored_sim_args, unhonored_sim_args,
+    };
+    use crate::cli::SimArgs;
+    use clap::Parser;
+
+    fn args(extra: &[&str]) -> SimArgs {
+        let mut argv = vec!["orts"];
+        argv.extend_from_slice(extra);
+        SimArgs::try_parse_from(argv).expect("valid args")
+    }
+
+    /// The refusal message, or `None` when the args are accepted.
+    fn refusal(extra: &[&str]) -> Option<String> {
+        reject_unhonored_sim_args(&args(extra))
+            .err()
+            .map(|e| e.to_string())
+    }
 
     #[test]
     fn parse_stream_stdio_accepts_sat_slash_stream() {
@@ -287,5 +374,125 @@ mod tests {
         assert!(parse_stream_stdio("/comlink").is_err());
         assert!(parse_stream_stdio("sat0/").is_err());
         assert!(parse_stream_stdio("sat0/a/b").is_err());
+    }
+
+    #[test]
+    fn bare_serve_has_no_sim_args_to_honor() {
+        let sim = args(&[]);
+        assert!(!has_explicit_sim_args(&sim));
+        assert!(unhonored_sim_args(&sim).is_empty());
+        assert!(refusal(&[]).is_none());
+    }
+
+    #[test]
+    fn tuning_args_are_reported_by_flag_name() {
+        assert_eq!(unhonored_sim_args(&args(&["--dt", "1"])), vec!["--dt"]);
+        assert_eq!(
+            unhonored_sim_args(&args(&["--dt", "1", "--output-interval", "10"])),
+            vec!["--dt", "--output-interval"]
+        );
+        assert_eq!(
+            unhonored_sim_args(&args(&["--body", "mars"])),
+            vec!["--body"]
+        );
+        assert_eq!(
+            unhonored_sim_args(&args(&["--epoch", "2024-03-20T12:00:00Z"])),
+            vec!["--epoch"]
+        );
+        assert_eq!(
+            unhonored_sim_args(&args(&["--duration", "600"])),
+            vec!["--duration"]
+        );
+        assert_eq!(
+            unhonored_sim_args(&args(&["--integrator", "rk4", "--rtol", "1e-6"])),
+            vec!["--integrator", "--rtol"]
+        );
+        assert_eq!(
+            unhonored_sim_args(&args(&["--atmosphere", "nrlmsise00", "--f107", "200"])),
+            vec!["--atmosphere", "--f107"]
+        );
+        assert_eq!(
+            unhonored_sim_args(&args(&["--space-weather", "auto"])),
+            vec!["--space-weather"]
+        );
+    }
+
+    /// A value equal to what the flag-less command line would mean changes
+    /// nothing, so there is nothing to refuse — the point of the check is
+    /// dropped *meaning*, not dropped text. For the two interval flags that
+    /// baseline is their documented fallback, not a literal default value.
+    #[test]
+    fn args_that_ask_for_the_default_are_not_reported() {
+        assert!(unhonored_sim_args(&args(&["--dt", "10"])).is_empty());
+        assert!(unhonored_sim_args(&args(&["--body", "earth"])).is_empty());
+        assert!(unhonored_sim_args(&args(&["--integrator", "dp45"])).is_empty());
+        // output_interval falls back to dt, stream_interval to output_interval.
+        assert!(unhonored_sim_args(&args(&["--output-interval", "10"])).is_empty());
+        assert!(
+            unhonored_sim_args(&args(&[
+                "--output-interval",
+                "30",
+                "--stream-interval",
+                "30"
+            ])) == vec!["--output-interval"]
+        );
+        assert!(unhonored_sim_args(&args(&["--stream-interval", "10"])).is_empty());
+    }
+
+    /// The plugin backend flags survive into a client-started simulation via
+    /// `PluginBackendOverrides`, so they must not be refused.
+    #[test]
+    fn plugin_backend_args_are_honored_when_idle() {
+        assert!(
+            unhonored_sim_args(&args(&[
+                "--plugin-backend",
+                "sync",
+                "--plugin-backend-threshold",
+                "64",
+            ]))
+            .is_empty()
+        );
+        assert!(
+            refusal(&[
+                "--plugin-backend",
+                "sync",
+                "--plugin-backend-threshold",
+                "64",
+            ])
+            .is_none()
+        );
+    }
+
+    /// The CLI-orbit path is the one `SimParams::from_sim_args` serves, so
+    /// there the same args are honored.
+    #[test]
+    fn an_orbit_makes_the_tuning_args_honorable() {
+        let sim = args(&["--sat", "altitude=800", "--dt", "1"]);
+        assert!(has_explicit_sim_args(&sim));
+        assert!(refusal(&["--sat", "altitude=800", "--dt", "1"]).is_none());
+    }
+
+    /// Idle: the message names every dropped flag and how to make it apply.
+    #[test]
+    fn idle_serve_refuses_tuning_args_by_name() {
+        let msg = refusal(&["--dt", "1", "--output-interval", "60"]).expect("must be refused");
+        assert!(msg.contains("--dt"), "{msg}");
+        assert!(msg.contains("--output-interval"), "{msg}");
+        assert!(msg.contains("--sat"), "{msg}");
+        assert!(msg.contains("start_simulation"), "{msg}");
+    }
+
+    /// `--config` builds the whole `SimParams` by itself, so a tuning arg
+    /// alongside it is dropped just as silently as in the idle case. The
+    /// message points at the config rather than at `--sat`.
+    #[test]
+    fn config_serve_refuses_tuning_args_it_cannot_apply() {
+        let msg = refusal(&["--config", "mission.toml", "--dt", "1"]).expect("must be refused");
+        assert!(msg.contains("--dt"), "{msg}");
+        assert!(msg.contains("mission.toml"), "{msg}");
+        assert!(
+            refusal(&["--config", "mission.toml"]).is_none(),
+            "a bare --config must still be accepted"
+        );
     }
 }

--- a/cli/src/commands/serve/mod.rs
+++ b/cli/src/commands/serve/mod.rs
@@ -141,7 +141,19 @@ fn unhonored_sim_args(sim: &SimArgs) -> Vec<&'static str> {
     // that range resolves to the same interval a bare command line would give.
     // Comparing the written value would refuse `serve --stream-interval 20`
     // (bare defaults clamp both to 10), which changes nothing when dropped.
-    let clamp_stream = |v: f64| v.clamp(sim.dt.min(output_interval), output_interval);
+    //
+    // `f64::clamp` panics on a `NaN` bound, and clap takes `NaN` for these
+    // flags: measured, `serve --output-interval NaN --stream-interval 1`
+    // panicked here with "min > max, or either was NaN". A non-finite interval
+    // is named as written, which is what the caller has to fix anyway — and
+    // `validate_sim_args` refuses it a moment later.
+    let clamp_stream = |v: f64| {
+        let low = sim.dt.min(output_interval);
+        if !low.is_finite() || !output_interval.is_finite() {
+            return v;
+        }
+        v.clamp(low, output_interval)
+    };
     [
         ("--body", sim.body != default.body),
         ("--dt", sim.dt != default.dt),
@@ -567,6 +579,32 @@ mod tests {
                 "50"
             ])),
             vec!["--dt", "--output-interval"]
+        );
+    }
+
+    /// A non-finite interval is named, not a panic.
+    ///
+    /// `f64::clamp` panics on a `NaN` bound, and clap takes `NaN` for these
+    /// flags. Measured before the guard: `serve --output-interval NaN
+    /// --stream-interval 1` panicked with "min > max, or either was NaN".
+    #[test]
+    fn a_non_finite_interval_is_named_rather_than_panicking() {
+        for extra in [
+            vec!["--output-interval", "NaN", "--stream-interval", "1"],
+            vec!["--dt", "NaN", "--stream-interval", "1"],
+            vec!["--output-interval", "inf", "--stream-interval", "1"],
+            vec!["--stream-interval", "NaN"],
+        ] {
+            let named = unhonored_sim_args(&args(&extra));
+            assert!(
+                named.contains(&"--stream-interval"),
+                "{extra:?} names the stream interval: {named:?}"
+            );
+        }
+        // The value itself is refused a moment later, by the shared check.
+        assert!(
+            crate::commands::run::validate_sim_args(&args(&["--dt", "NaN"])).is_err(),
+            "a non-finite dt is refused"
         );
     }
 }

--- a/cli/src/commands/serve/mod.rs
+++ b/cli/src/commands/serve/mod.rs
@@ -136,6 +136,12 @@ fn unhonored_sim_args(sim: &SimArgs) -> Vec<&'static str> {
     // `from_sim_args`: output_interval falls back to dt, stream_interval to
     // output_interval.
     let output_interval = sim.output_interval.unwrap_or(sim.dt);
+    // `SimParams::from_sim_args` clamps the stream interval into
+    // `[min(dt, output_interval), output_interval]`, so a written value outside
+    // that range resolves to the same interval a bare command line would give.
+    // Comparing the written value would refuse `serve --stream-interval 20`
+    // (bare defaults clamp both to 10), which changes nothing when dropped.
+    let clamp_stream = |v: f64| v.clamp(sim.dt.min(output_interval), output_interval);
     [
         ("--body", sim.body != default.body),
         ("--dt", sim.dt != default.dt),
@@ -145,7 +151,8 @@ fn unhonored_sim_args(sim: &SimArgs) -> Vec<&'static str> {
         ),
         (
             "--stream-interval",
-            sim.stream_interval.is_some_and(|v| v != output_interval),
+            sim.stream_interval
+                .is_some_and(|v| clamp_stream(v) != output_interval),
         ),
         ("--epoch", sim.epoch.is_some()),
         ("--duration", sim.duration.is_some()),
@@ -513,6 +520,53 @@ mod tests {
         assert!(
             refusal(&["--config", "mission.toml"]).is_none(),
             "a bare --config must still be accepted"
+        );
+    }
+
+    /// A stream interval the clamp erases is accepted; one it keeps is refused.
+    ///
+    /// `SimParams::from_sim_args` clamps the value into
+    /// `[min(dt, output_interval), output_interval]`, so `--stream-interval 20`
+    /// against the bare defaults resolves to the same 10 s a bare command line
+    /// gives. Refusing it would fail a command that changes nothing.
+    #[test]
+    fn a_stream_interval_the_clamp_erases_is_accepted() {
+        // Bare defaults: dt = output_interval = 10, so the clamp range is
+        // [10, 10] and any written value lands on 10.
+        assert_eq!(
+            unhonored_sim_args(&args(&["--stream-interval", "20"])),
+            Vec::<&str>::new()
+        );
+        assert_eq!(
+            unhonored_sim_args(&args(&["--stream-interval", "0.001"])),
+            Vec::<&str>::new()
+        );
+
+        // With room between dt and output_interval, a value inside the range
+        // survives the clamp and does change the resolved parameters.
+        assert_eq!(
+            unhonored_sim_args(&args(&[
+                "--dt",
+                "1",
+                "--output-interval",
+                "10",
+                "--stream-interval",
+                "5"
+            ])),
+            vec!["--dt", "--output-interval", "--stream-interval"]
+        );
+        // Above the range it is clamped back to `output_interval`, which is
+        // where a bare `--dt 1 --output-interval 10` would leave it anyway.
+        assert_eq!(
+            unhonored_sim_args(&args(&[
+                "--dt",
+                "1",
+                "--output-interval",
+                "10",
+                "--stream-interval",
+                "50"
+            ])),
+            vec!["--dt", "--output-interval"]
         );
     }
 }

--- a/cli/tests/serve_sim_args_e2e.rs
+++ b/cli/tests/serve_sim_args_e2e.rs
@@ -20,10 +20,31 @@ fn test_port(offset: u16) -> u16 {
 }
 
 /// A spawned `orts serve` with its stderr streamed into a shared buffer.
+///
+/// The child and its reader sit in `Option`s so that both the consuming
+/// methods and [`Drop`] can take them. Dropping a `std::process::Child` does
+/// not kill the process, so an assertion that panics before `shutdown` or
+/// `wait_for_exit` would otherwise leave an idle server holding its port for
+/// the rest of the suite.
 struct Server {
-    child: Child,
+    child: Option<Child>,
     lines: Arc<Mutex<Vec<String>>>,
-    reader: JoinHandle<()>,
+    reader: Option<JoinHandle<()>>,
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            child.kill().ok();
+            child.wait().ok();
+        }
+        if let Some(reader) = self.reader.take() {
+            // The child is gone, so the pipe is closed and the reader returns.
+            // `join` can only fail if the reader itself panicked, which the
+            // consuming methods report; a drop during unwinding stays quiet.
+            let _ = reader.join();
+        }
+    }
 }
 
 impl Server {
@@ -48,9 +69,9 @@ impl Server {
             }
         });
         Server {
-            child,
+            child: Some(child),
             lines,
-            reader,
+            reader: Some(reader),
         }
     }
 
@@ -93,16 +114,13 @@ impl Server {
     }
 
     /// Stop the server and drain its stderr to EOF.
-    fn shutdown(self) -> String {
-        let Server {
-            mut child,
-            lines,
-            reader,
-        } = self;
+    fn shutdown(mut self) -> String {
+        let mut child = self.child.take().expect("the server is spawned once");
+        let reader = self.reader.take().expect("the server is spawned once");
         child.kill().ok();
         child.wait().ok();
         reader.join().expect("stderr reader thread panicked");
-        lines.lock().unwrap().join("\n")
+        self.lines.lock().unwrap().join("\n")
     }
 
     /// Wait for the process to exit on its own and drain stderr to EOF.
@@ -110,12 +128,10 @@ impl Server {
     /// Waits with a deadline instead of `Command::output()`: a `serve` that
     /// does *not* refuse its args keeps serving forever, and that regression
     /// must fail the test rather than hang the suite.
-    fn wait_for_exit(self, timeout: Duration) -> (Option<i32>, String) {
-        let Server {
-            mut child,
-            lines,
-            reader,
-        } = self;
+    fn wait_for_exit(mut self, timeout: Duration) -> (Option<i32>, String) {
+        let mut child = self.child.take().expect("the server is spawned once");
+        let reader = self.reader.take().expect("the server is spawned once");
+        let lines = Arc::clone(&self.lines);
         let deadline = Instant::now() + timeout;
         let status = loop {
             match child.try_wait().expect("failed to poll orts serve") {

--- a/cli/tests/serve_sim_args_e2e.rs
+++ b/cli/tests/serve_sim_args_e2e.rs
@@ -1,0 +1,226 @@
+//! E2E tests for the `orts serve` argument contract.
+//!
+//! `serve` with no orbit and no config comes up idle and builds its
+//! `SimParams` from the client's `start_simulation`, so sim args like `--dt`
+//! never reach a simulation. They used to be dropped without a word; they are
+//! now refused by name.
+
+use futures_util::StreamExt;
+use std::io::{BufRead, BufReader};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex, mpsc};
+use std::time::{Duration, Instant};
+
+/// Ports derived from the pid, offset per test to avoid collisions. The
+/// 24000 band is this file's own: the other serve E2E suites run in separate
+/// processes (so a different pid) and claim 19000-23999.
+fn test_port(offset: u16) -> u16 {
+    24000 + (std::process::id() % 500) as u16 * 4 + offset
+}
+
+/// Spawn `orts serve` with stderr captured into a shared buffer, plus a
+/// channel that fires on the last line of the startup banner and the handle
+/// of the reader thread (join it before reading the buffer to be sure stderr
+/// was drained to EOF).
+fn spawn(
+    args: &[&str],
+) -> (
+    Child,
+    Arc<Mutex<Vec<String>>>,
+    mpsc::Receiver<()>,
+    std::thread::JoinHandle<()>,
+) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_orts"))
+        .env("ORTS_DISABLE_TEXTURE_DOWNLOAD", "1")
+        .arg("serve")
+        .args(args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn orts serve");
+
+    let stderr = child.stderr.take().expect("failed to capture stderr");
+    let collected = Arc::new(Mutex::new(Vec::<String>::new()));
+    let (tx, rx) = mpsc::channel::<()>();
+    let sink = Arc::clone(&collected);
+    let reader = std::thread::spawn(move || {
+        let mut signalled = false;
+        for line in BufReader::new(stderr).lines() {
+            let Ok(line) = line else { break };
+            eprintln!("[server stderr] {line}");
+            sink.lock().unwrap().push(line.clone());
+            // Last line of the startup banner, printed whether or not a
+            // simulation is started.
+            if !signalled && line.contains("WebSocket endpoint") {
+                let _ = tx.send(());
+                signalled = true;
+            }
+        }
+        if !signalled {
+            let _ = tx.send(());
+        }
+    });
+    (child, collected, rx, reader)
+}
+
+/// Spawn, wait for the startup banner, and return the child plus everything
+/// stderr printed by then.
+fn spawn_and_wait_for_startup(args: &[&str]) -> (Child, Vec<String>) {
+    let (child, collected, rx, _reader) = spawn(args);
+    rx.recv_timeout(Duration::from_secs(15))
+        .expect("server produced no startup banner within 15 seconds");
+    // The manager task prints its idle notice just after the banner; give it
+    // a moment so its absence means "started a simulation", not "too early".
+    std::thread::sleep(Duration::from_millis(1500));
+    let lines = collected.lock().unwrap().clone();
+    (child, lines)
+}
+
+/// Run `orts serve` expecting it to refuse the args and exit, and return
+/// (exit code, stderr).
+///
+/// Waits with a deadline instead of `Command::output()`: a `serve` that does
+/// *not* refuse keeps serving forever, and that regression must fail the test
+/// rather than hang the suite.
+fn run_expecting_exit(args: &[&str]) -> (Option<i32>, String) {
+    let (mut child, collected, _rx, reader) = spawn(args);
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let status = loop {
+        match child.try_wait().expect("failed to poll orts serve") {
+            Some(status) => break Some(status),
+            None if Instant::now() >= deadline => {
+                child.kill().ok();
+                child.wait().ok();
+                break None;
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    };
+    // The child has exited (or been killed), so its end of the pipe is
+    // closed: the reader thread reaches EOF and returns. Joining it before
+    // reading the buffer is what makes the message assertions deterministic.
+    reader.join().expect("stderr reader thread panicked");
+    let stderr = collected.lock().unwrap().join("\n");
+    let status = status.unwrap_or_else(|| {
+        panic!("orts serve did not exit within 20s; it accepted the args:\n{stderr}")
+    });
+    (status.code(), stderr)
+}
+
+/// Sim args with nothing to apply them to are a usage error (exit 2), and the
+/// message names every arg that could not be honored.
+#[test]
+fn serve_rejects_sim_args_with_no_simulation_to_apply_them_to() {
+    let (code, stderr) = run_expecting_exit(&[
+        "--dt",
+        "1",
+        "--output-interval",
+        "10",
+        "--port",
+        &test_port(0).to_string(),
+    ]);
+
+    assert_eq!(code, Some(2), "expected a usage error\nstderr: {stderr}");
+    assert!(
+        stderr.contains("--dt") && stderr.contains("--output-interval"),
+        "the error must name the args that were not honored:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("--sat"),
+        "the error must say how to make the args apply:\n{stderr}"
+    );
+}
+
+/// A non-Earth body is the case that would silently run Earth physics, so it
+/// is refused too rather than reaching the sim.
+#[test]
+fn serve_rejects_a_body_it_cannot_apply() {
+    let (code, stderr) =
+        run_expecting_exit(&["--body", "mars", "--port", &test_port(1).to_string()]);
+
+    assert_eq!(code, Some(2), "expected a usage error\nstderr: {stderr}");
+    assert!(
+        stderr.contains("--body"),
+        "the error must name --body:\n{stderr}"
+    );
+}
+
+/// Bare `orts serve` keeps coming up idle: the check must not turn the
+/// documented no-argument invocation into an error.
+#[test]
+fn bare_serve_still_comes_up_idle() {
+    let (mut child, lines) = spawn_and_wait_for_startup(&["--port", &test_port(2).to_string()]);
+    child.kill().ok();
+    child.wait().ok();
+
+    let joined = lines.join("\n");
+    assert!(
+        joined.contains("Server listening on"),
+        "server did not start:\n{joined}"
+    );
+    assert!(
+        joined.contains("idle, waiting for start_simulation"),
+        "server should be idle:\n{joined}"
+    );
+}
+
+/// With an orbit the args reach the simulation, so the server must accept
+/// them — and actually apply them.
+///
+/// Read back through the `info` message the server sends on connect rather
+/// than through the startup banner: the banner is printed before the manager
+/// task even builds its `SimParams`, so it cannot tell "started with dt = 1"
+/// from "died right after printing".
+#[tokio::test]
+async fn serve_with_an_orbit_honors_the_sim_args() {
+    let port = test_port(3);
+    let (mut child, lines) = spawn_and_wait_for_startup(&[
+        "--sat",
+        "altitude=400,id=argtest",
+        "--dt",
+        "1",
+        "--output-interval",
+        "10",
+        "--port",
+        &port.to_string(),
+    ]);
+    let joined = lines.join("\n");
+    assert!(
+        joined.contains("Server listening on"),
+        "server did not start:\n{joined}"
+    );
+    assert!(
+        !joined.contains("idle, waiting for start_simulation"),
+        "an explicit orbit must auto-start the simulation:\n{joined}"
+    );
+
+    let info = tokio::time::timeout(Duration::from_secs(20), async {
+        let url = format!("ws://localhost:{port}/ws");
+        let (ws, _) = tokio_tungstenite::connect_async(&url)
+            .await
+            .expect("failed to connect");
+        let (_write, mut read) = ws.split();
+        let msg = read
+            .next()
+            .await
+            .expect("expected the info message, got end of stream")
+            .expect("error reading the info message");
+        serde_json::from_str::<serde_json::Value>(msg.to_text().expect("info is not text"))
+            .expect("info is not JSON")
+    })
+    .await;
+    child.kill().ok();
+    child.wait().ok();
+
+    let info = info.expect("timed out waiting for the info message");
+    assert_eq!(info["type"], "info");
+    assert_eq!(info["dt"], 1.0, "--dt was not applied: {info}");
+    assert_eq!(
+        info["output_interval"], 10.0,
+        "--output-interval was not applied: {info}"
+    );
+    assert_eq!(
+        info["satellites"][0]["id"], "/world/sat/argtest",
+        "--sat was not applied: {info}"
+    );
+}

--- a/cli/tests/serve_sim_args_e2e.rs
+++ b/cli/tests/serve_sim_args_e2e.rs
@@ -8,7 +8,8 @@
 use futures_util::StreamExt;
 use std::io::{BufRead, BufReader};
 use std::process::{Child, Command, Stdio};
-use std::sync::{Arc, Mutex, mpsc};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 /// Ports derived from the pid, offset per test to avoid collisions. The
@@ -18,100 +19,132 @@ fn test_port(offset: u16) -> u16 {
     24000 + (std::process::id() % 500) as u16 * 4 + offset
 }
 
-/// Spawn `orts serve` with stderr captured into a shared buffer, plus a
-/// channel that fires on the last line of the startup banner and the handle
-/// of the reader thread (join it before reading the buffer to be sure stderr
-/// was drained to EOF).
-fn spawn(
-    args: &[&str],
-) -> (
-    Child,
-    Arc<Mutex<Vec<String>>>,
-    mpsc::Receiver<()>,
-    std::thread::JoinHandle<()>,
-) {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_orts"))
-        .env("ORTS_DISABLE_TEXTURE_DOWNLOAD", "1")
-        .arg("serve")
-        .args(args)
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("failed to spawn orts serve");
-
-    let stderr = child.stderr.take().expect("failed to capture stderr");
-    let collected = Arc::new(Mutex::new(Vec::<String>::new()));
-    let (tx, rx) = mpsc::channel::<()>();
-    let sink = Arc::clone(&collected);
-    let reader = std::thread::spawn(move || {
-        let mut signalled = false;
-        for line in BufReader::new(stderr).lines() {
-            let Ok(line) = line else { break };
-            eprintln!("[server stderr] {line}");
-            sink.lock().unwrap().push(line.clone());
-            // Last line of the startup banner, printed whether or not a
-            // simulation is started.
-            if !signalled && line.contains("WebSocket endpoint") {
-                let _ = tx.send(());
-                signalled = true;
-            }
-        }
-        if !signalled {
-            let _ = tx.send(());
-        }
-    });
-    (child, collected, rx, reader)
+/// A spawned `orts serve` with its stderr streamed into a shared buffer.
+struct Server {
+    child: Child,
+    lines: Arc<Mutex<Vec<String>>>,
+    reader: JoinHandle<()>,
 }
 
-/// Spawn, wait for the startup banner, and return the child plus everything
-/// stderr printed by then.
-fn spawn_and_wait_for_startup(args: &[&str]) -> (Child, Vec<String>) {
-    let (child, collected, rx, _reader) = spawn(args);
-    rx.recv_timeout(Duration::from_secs(15))
-        .expect("server produced no startup banner within 15 seconds");
-    // The manager task prints its idle notice just after the banner; give it
-    // a moment so its absence means "started a simulation", not "too early".
-    std::thread::sleep(Duration::from_millis(1500));
-    let lines = collected.lock().unwrap().clone();
-    (child, lines)
-}
+impl Server {
+    fn spawn(args: &[&str]) -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_orts"))
+            .env("ORTS_DISABLE_TEXTURE_DOWNLOAD", "1")
+            .arg("serve")
+            .args(args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn orts serve");
 
-/// Run `orts serve` expecting it to refuse the args and exit, and return
-/// (exit code, stderr).
-///
-/// Waits with a deadline instead of `Command::output()`: a `serve` that does
-/// *not* refuse keeps serving forever, and that regression must fail the test
-/// rather than hang the suite.
-fn run_expecting_exit(args: &[&str]) -> (Option<i32>, String) {
-    let (mut child, collected, _rx, reader) = spawn(args);
-    let deadline = Instant::now() + Duration::from_secs(20);
-    let status = loop {
-        match child.try_wait().expect("failed to poll orts serve") {
-            Some(status) => break Some(status),
-            None if Instant::now() >= deadline => {
-                child.kill().ok();
-                child.wait().ok();
-                break None;
+        let stderr = child.stderr.take().expect("failed to capture stderr");
+        let lines = Arc::new(Mutex::new(Vec::<String>::new()));
+        let sink = Arc::clone(&lines);
+        let reader = std::thread::spawn(move || {
+            for line in BufReader::new(stderr).lines() {
+                let Ok(line) = line else { break };
+                eprintln!("[server stderr] {line}");
+                sink.lock().unwrap().push(line);
             }
-            None => std::thread::sleep(Duration::from_millis(50)),
+        });
+        Server {
+            child,
+            lines,
+            reader,
         }
-    };
-    // The child has exited (or been killed), so its end of the pipe is
-    // closed: the reader thread reaches EOF and returns. Joining it before
-    // reading the buffer is what makes the message assertions deterministic.
-    reader.join().expect("stderr reader thread panicked");
-    let stderr = collected.lock().unwrap().join("\n");
-    let status = status.unwrap_or_else(|| {
-        panic!("orts serve did not exit within 20s; it accepted the args:\n{stderr}")
-    });
-    (status.code(), stderr)
+    }
+
+    /// Wait until a collected stderr line contains `needle`.
+    ///
+    /// Every wait in this file is on a specific line rather than on a fixed
+    /// sleep, so no assertion depends on how fast the reader thread happens
+    /// to be scheduled.
+    fn wait_for(&self, needle: &str, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if self
+                .lines
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|l| l.contains(needle))
+            {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    /// Wait for the last line of the startup banner, which is printed whether
+    /// or not a simulation is started.
+    fn wait_for_startup(&self) {
+        assert!(
+            self.wait_for("WebSocket endpoint", Duration::from_secs(15)),
+            "server produced no startup banner within 15 seconds:\n{}",
+            self.stderr()
+        );
+    }
+
+    fn stderr(&self) -> String {
+        self.lines.lock().unwrap().join("\n")
+    }
+
+    /// Stop the server and drain its stderr to EOF.
+    fn shutdown(self) -> String {
+        let Server {
+            mut child,
+            lines,
+            reader,
+        } = self;
+        child.kill().ok();
+        child.wait().ok();
+        reader.join().expect("stderr reader thread panicked");
+        lines.lock().unwrap().join("\n")
+    }
+
+    /// Wait for the process to exit on its own and drain stderr to EOF.
+    ///
+    /// Waits with a deadline instead of `Command::output()`: a `serve` that
+    /// does *not* refuse its args keeps serving forever, and that regression
+    /// must fail the test rather than hang the suite.
+    fn wait_for_exit(self, timeout: Duration) -> (Option<i32>, String) {
+        let Server {
+            mut child,
+            lines,
+            reader,
+        } = self;
+        let deadline = Instant::now() + timeout;
+        let status = loop {
+            match child.try_wait().expect("failed to poll orts serve") {
+                Some(status) => break Some(status),
+                None if Instant::now() >= deadline => break None,
+                None => std::thread::sleep(Duration::from_millis(25)),
+            }
+        };
+        if status.is_none() {
+            child.kill().ok();
+            child.wait().ok();
+        }
+        // The child is gone, so its end of the pipe is closed: the reader
+        // thread reaches EOF and returns. Joining before reading the buffer is
+        // what makes the message assertions deterministic.
+        reader.join().expect("stderr reader thread panicked");
+        let stderr = lines.lock().unwrap().join("\n");
+        let status = status.unwrap_or_else(|| {
+            panic!("orts serve did not exit within {timeout:?}; it accepted the args:\n{stderr}")
+        });
+        (status.code(), stderr)
+    }
 }
 
 /// Sim args with nothing to apply them to are a usage error (exit 2), and the
 /// message names every arg that could not be honored.
 #[test]
 fn serve_rejects_sim_args_with_no_simulation_to_apply_them_to() {
-    let (code, stderr) = run_expecting_exit(&[
+    let server = Server::spawn(&[
         "--dt",
         "1",
         "--output-interval",
@@ -119,6 +152,7 @@ fn serve_rejects_sim_args_with_no_simulation_to_apply_them_to() {
         "--port",
         &test_port(0).to_string(),
     ]);
+    let (code, stderr) = server.wait_for_exit(Duration::from_secs(20));
 
     assert_eq!(code, Some(2), "expected a usage error\nstderr: {stderr}");
     assert!(
@@ -135,8 +169,8 @@ fn serve_rejects_sim_args_with_no_simulation_to_apply_them_to() {
 /// is refused too rather than reaching the sim.
 #[test]
 fn serve_rejects_a_body_it_cannot_apply() {
-    let (code, stderr) =
-        run_expecting_exit(&["--body", "mars", "--port", &test_port(1).to_string()]);
+    let server = Server::spawn(&["--body", "mars", "--port", &test_port(1).to_string()]);
+    let (code, stderr) = server.wait_for_exit(Duration::from_secs(20));
 
     assert_eq!(code, Some(2), "expected a usage error\nstderr: {stderr}");
     assert!(
@@ -149,19 +183,16 @@ fn serve_rejects_a_body_it_cannot_apply() {
 /// documented no-argument invocation into an error.
 #[test]
 fn bare_serve_still_comes_up_idle() {
-    let (mut child, lines) = spawn_and_wait_for_startup(&["--port", &test_port(2).to_string()]);
-    child.kill().ok();
-    child.wait().ok();
+    let server = Server::spawn(&["--port", &test_port(2).to_string()]);
+    server.wait_for_startup();
+    let went_idle = server.wait_for(
+        "idle, waiting for start_simulation",
+        Duration::from_secs(15),
+    );
+    let stderr = server.shutdown();
 
-    let joined = lines.join("\n");
-    assert!(
-        joined.contains("Server listening on"),
-        "server did not start:\n{joined}"
-    );
-    assert!(
-        joined.contains("idle, waiting for start_simulation"),
-        "server should be idle:\n{joined}"
-    );
+    assert!(stderr.contains("Server listening on"), "{stderr}");
+    assert!(went_idle, "server should have gone idle:\n{stderr}");
 }
 
 /// With an orbit the args reach the simulation, so the server must accept
@@ -174,7 +205,7 @@ fn bare_serve_still_comes_up_idle() {
 #[tokio::test]
 async fn serve_with_an_orbit_honors_the_sim_args() {
     let port = test_port(3);
-    let (mut child, lines) = spawn_and_wait_for_startup(&[
+    let server = Server::spawn(&[
         "--sat",
         "altitude=400,id=argtest",
         "--dt",
@@ -184,15 +215,7 @@ async fn serve_with_an_orbit_honors_the_sim_args() {
         "--port",
         &port.to_string(),
     ]);
-    let joined = lines.join("\n");
-    assert!(
-        joined.contains("Server listening on"),
-        "server did not start:\n{joined}"
-    );
-    assert!(
-        !joined.contains("idle, waiting for start_simulation"),
-        "an explicit orbit must auto-start the simulation:\n{joined}"
-    );
+    server.wait_for_startup();
 
     let info = tokio::time::timeout(Duration::from_secs(20), async {
         let url = format!("ws://localhost:{port}/ws");
@@ -209,10 +232,9 @@ async fn serve_with_an_orbit_honors_the_sim_args() {
             .expect("info is not JSON")
     })
     .await;
-    child.kill().ok();
-    child.wait().ok();
+    let stderr = server.shutdown();
 
-    let info = info.expect("timed out waiting for the info message");
+    let info = info.unwrap_or_else(|_| panic!("timed out waiting for the info message:\n{stderr}"));
     assert_eq!(info["type"], "info");
     assert_eq!(info["dt"], 1.0, "--dt was not applied: {info}");
     assert_eq!(
@@ -222,5 +244,9 @@ async fn serve_with_an_orbit_honors_the_sim_args() {
     assert_eq!(
         info["satellites"][0]["id"], "/world/sat/argtest",
         "--sat was not applied: {info}"
+    );
+    assert!(
+        !stderr.contains("idle, waiting for start_simulation"),
+        "an explicit orbit must auto-start the simulation:\n{stderr}"
     );
 }


### PR DESCRIPTION
`orts serve` が黙って失敗する 3 件を直す。どれも警告だけ出して先へ進むので、viewer には正しい値が描かれているように見える。

## 前提: `serve` の履歴の持ち方

`serve` は各 step の state を `HistoryBuffer` に積む。memory に置ける上限が `capacity`（`serve` は 5000 件）で、そこに達すると古い側の半分を `/tmp/orts-<pid>/seg_0000.jsonl` のようなファイルに書き（`flush`）、memory から外す。このファイルを segment と呼ぶ。viewer が過去区間を要求したら `query_range` が segment を読み、memory に残っている分と合わせて返す。

これとは別に、viewer の全体表示用の overview を entity ごとに持つ。間引いた点列なので、segment に落ちた区間も含めて全期間をカバーし続ける。

以下の 2 件は segment への書き込みの話。

## `flush` が失敗すると、その回に書こうとした state が消える

`flush` は書き込む state を `self.states.drain(..)` で memory から抜き、そのあとで disk に書いていた。書き込みが失敗すると warning を出して `return` するので、抜いた state はそこで失われる。1 回の対象は buffer の古い側の半分（`states.len() / 2`）で、`capacity = 4` なら 2 件。

実測: 書き込めない `data_dir` を与えて capacity=4 の buffer に 5 push すると、`load_all()` が 3 件しか返さない。失敗時に `segment_count` を進めないので、次の書き出しが同じ index を上書きしてもいた。

書き込みが成功してから memory から外すようにした。これで 1 回の失敗の代償は「memory が `capacity` より多く抱える」だけになる。書き損じた segment ファイルは削除する。

長時間動く server で未書き出しの履歴が増え続けないよう、失敗が続く場合は `capacity * 8` を超えたところで古い順に捨て、何を捨てたかを warning に出す（overview が間引いた点列を別に持つので、捨てた区間も表示は続く）。リトライは buffer が `capacity` 件増えてから行うので、書き込めないディレクトリでも失敗書き込みは `capacity` push ごとに 1 回で済む。

## segment に加速度と RW momentum を書いていない

segment に書いていたのは position / velocity / quaternion / angular velocity の 4 つ。viewer は欠損を `?? 0` で埋めるので、**書き出し済みの区間だけ重力加速度が 0 として描かれる**（LEO なら実際は 8.7e-3 km/s²）。reaction wheel momentum も同じく消える。

segment の形式を `.rrd` から JSON-lines (`seg_NNNN.jsonl`) に変え、payload をそのまま書く。`.rrd` の `RrdRow` が持つのは固定列だけで、per-force acceleration の内訳（モデル定義キーの map）と reaction wheel momentum（wheel ごとに 1 要素）はそこに収まらない。segment を読むのは同じ pid の `serve` だけなので、rrd スキーマを広げずに済む形を選んだ。

state から計算して出す値（Keplerian 要素・高度・エネルギーなど）は、読み込み時に `make_history_state` で再計算する。in-memory の値を作ったのと同じ関数なので、disk から読んだ state は field 単位で一致する。

float は text として書く。`serde_json` は NaN と ±inf を `null` にし、既定の number parser は `0.03 + 2e-5` を 1 ulp ずらす。発散した run こそ読み返したいデータなので、値を字面のまま往復させる。

## `serve` が受理した引数をどこにも渡していない

orbit（`--sat` / `--tle` / `--omm` / `--norad-id`）も `--config` も与えない `serve` は idle で起動し、client の `start_simulation` が自分で `SimParams` を作る。コマンドラインの sim args はそこで捨てられる。実測では banner の後 `idle, waiting for start_simulation` を出して永久に serve し続ける。`--config` と併用した場合も同じで、`SimParams::from_config` が config だけから組み立てるため `--dt` が捨てられる。

反映先のない sim args を、名前を挙げて拒否する（exit 2）。

```
$ orts serve --dt 1 --output-interval 10
Error: --dt, --output-interval cannot be honored: without an orbit or a config,
`serve` comes up idle and takes its simulation parameters from the client's
start_simulation. Give it a simulation to apply them to (--sat altitude=400,
--tle, --omm, --norad-id, or --config), or drop them.

$ orts serve --config sim.toml --dt 1
Error: --dt cannot be honored: `serve --config sim.toml` builds its simulation
from the config alone. Set the value in the config instead, or drop the flag.
```

config の `[[command]]` timeline を拒否しているのと同じ方針。`SimParams::from_sim_args` が読む CLI-orbit 経路（`--sat` / `--tle` / `--omm` / `--norad-id`）はこれまで通り全て受け付ける。

判定は「flag なしのコマンドラインと意味が違うか」で行う。この層に届くのは値だけで、clap の `ArgMatches` は渡っていない。拾いたいのは値の意味が落ちる場合なので、`--dt 10`（既定と同じ値）と `dt` に等しい `--output-interval`（`from_sim_args` が選ぶ既定と同じ）は通す。`--plugin-backend` と `--plugin-backend-threshold` は `PluginBackendOverrides` が manager の全経路に適用するので、拒否対象から外してある。

**挙動の変更**: orbit も config もない `serve` に sim args を付けると、これまで idle server が立ち上がっていたところが usage error (exit 2) になる。引数なしの `orts serve`、`serve --config`、`serve --sat ...` はこれまで通り。リポジトリ内の `serve` 呼び出し（CI の viewer smoke test、serve 系 E2E 4 本）は全て orbit か config を伴う。

docs の getting-started は subcommand 化前の `--serve` 表記と、今回拒否される組み合わせを載せていたので `orts serve --sat ...` に直した。

## テスト

**書き出しの失敗** — 書き込めない `data_dir`（パスが既存の通常ファイル）で capacity+1 push しても `load_all()` が全件返し、`segment_count == 0` であること。drain を書き込み前に戻すと 3 件しか返らず落ちる。失敗が続いても in-memory が `capacity * 8` に収まり、最新側が残り、overview が捨てた区間をカバーし続けること。

**payload の往復** — 書き出しを挟んだ全 payload の一致を state 単位で固定（accelerations 3 keys + 4 wheel の RW momentum を含む）。さらに同じ states を、書き出さない buffer とほぼ全部書き出す buffer に流し、`query_range` の結果が payload まで一致すること。この 2 件は `SegmentRecord` から accelerations / rw_momentum を落とすと落ちる。既存の `flush_preserves_attitude` は落としても通る。

**非有限値** — NaN・±inf を含む行が残り、finite 値が bit 単位で戻ること。

**引数の拒否**（`cli/tests/serve_sim_args_e2e.rs`）— 拒否（exit 2 とメッセージ内容）、引数なし `serve` が idle で立ち上がり続けること、CLI-orbit 経路が WS の `info` で `dt = 1`, `output_interval = 10`, 衛星 id を返すこと。拒否系は deadline 付きで待つので、拒否をやめる回帰はテストが落ちる。

## 関連

viewer が欠損値を 0 で埋める（`?? 0`）点は、segment が全 payload を持つようになって実害は消えたが、欠損と 0 を区別する対応は別途必要。

`serve --config x.toml --body earth` のように既定と同じ値で明示された flag は引き続き黙って無視される。この層は値だけを受け取るので「書かれた」と「書かれていない」を区別できない。`run --config x.toml --dt 10` も同じで、flag が書かれたかどうかを parse 時点から渡す変更として別途扱う。

`--config` と orbit args の併用は、`--config` の help が「orbit 関連の引数は無視される」と明記しているので、この優先順位のまま残した。

`serve` は `--plugin-backend-async-mode` を今も無視する（`WasmPluginCache::new()` の Deterministic で建てる一方、CLI の既定は Throughput）。実行挙動の変更になるので別 PR で扱う。
