### PR TITLE
fix: reject config input the simulation cannot honor

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -194,6 +194,11 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   どの質量分布もこの値を持たない。([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
+- `[satellites.attitude]` や `[satellites.controller]` を一部の衛星にだけ書いた
+  config を、`orts config validate` と `orts serve --config` が bind 前に拒否する。
+  engine は元からこの fleet を拒否していたが、`orts serve` は engine を spawn した
+  manager の中で建てるので、config は valid と言われ banner も出た上で、渡した
+  config が走らないまま server が idle で待つ状態になっていた。([#351](https://github.com/sksat/orts/pull/351))
 - WebSocket の `add_satellite` が、実行中の fleet にいる衛星と同じ entity path
   (`/world/sat/<id>`) になる id を拒否する。従来は同じ path の 2 機を許し、
   `[[command]]` は後から追加した方にしか届かなかった。`id` 省略時の

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -217,7 +217,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   どのフィールドも読まないキーは、拒否せずキー名を warning として表示する。実行は
   続くので新しい `orts` 向けに書いた config も古い `orts` で実行でき、`duraton = 100`
   が黙って 1 周期分実行されることはなくなった。`orts config validate` は `warnings`
-  にキーのパスを出力し、`run` と `serve` は stderr に表示する。server は client の
+  にキーのパスを出力し、`run` と `serve` は `log::warn!` で報告する。server は client の
   `start_simulation` や `add_satellite` に含まれるものを表示する。`type` タグ付きの
   block (`[satellites.orbit]`、`[satellites.controller]`、reaction wheel、磁気トルカ)
   だけは拒否する。`serde_ignored` は internally tagged enum の内部を見られず報告

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -170,8 +170,10 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - config ファイル、`orts config validate`、WebSocket の `start_simulation`
   payload は、シミュレーションが honor できない入力を別の何かに解決せず拒否する:
   未知の `[integrator] type` / `atmosphere` (従来は dp45 / exponential
-  モデル)、id が 1 つの recording entity を指す 2 機 (id の文字列でなく entity で比較するので、下流と同じく `a` と `/a` は衝突する)
-  (従来は recording entity・CSV section・`[[command]]` の宛先を共有)、
+  モデル)、id が 1 つの recording entity を指す 2 機 (id の文字列でなく entity で
+  比較するので、recording と同じく `a` と `/a` は衝突する。従来は recording
+  entity と CSV section を共有し、id 文字列まで同じなら `[[command]]` の宛先も
+  共有していた)、
   剛体が持てない attitude ブロック (正定値でない、または主慣性モーメントで
   `I1 + I2 >= I3` を破る慣性テンソル、`mass <= 0`、正規化できない
   `initial_quaternion`)。config が受理する `integrator` / `atmosphere` の綴りは、

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -171,7 +171,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   payload は、シミュレーションが honor できない入力を別の何かに解決せず拒否する:
   未知の `[integrator] type` / `atmosphere` (従来は dp45 / exponential
   モデル)、config tree のどこかにある未知キー (従来は drop されるので
-  `duraton = 100` が 1 周期走った)、解決後の id が衝突する 2 機
+  `duraton = 100` が 1 周期走った)、id が 1 つの recording entity を指す 2 機 (id の文字列でなく entity で比較するので、下流と同じく `a` と `/a` は衝突する)
   (従来は recording entity・CSV section・`[[command]]` の宛先を共有)、
   剛体が持てない attitude ブロック (正定値でない、または主慣性モーメントで
   `I1 + I2 >= I3` を破る慣性テンソル、`mass <= 0`、正規化できない

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -30,6 +30,21 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - WIT v0 plugin interface に msg-io / stream-io チャネルを追加。([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
+- `SatelliteParams` が `SpacecraftShape` を optional で持ち、
+  `build_spacecraft_dynamics` がそれを見て等方面の `SolarRadiationPressure` /
+  `AtmosphericDrag` の代わりに `PanelSrp` / `PanelDrag` を install するように
+  した。機体の外形は一つなので、パネルは片方ではなく両方の力を担う。
+  `build_orbital_system` はどちらも install しない (パネルの力は姿勢を要求する)。
+  `SurfacePanel` に `with_cp_offset` を追加した。パネルの力を姿勢外乱にするのは
+  この offset である。([#386](https://github.com/sksat/orts/pull/386))
+- 外乱トルクの登録を `orts::setup` に集約し、どれを解くかを `SatelliteParams` の
+  `DisturbanceTorques` で選ぶようにした。`build_spacecraft_dynamics` がそれを見て
+  gravity gradient トルクを install する。`build_orbital_system` は install しない
+  (軌道のみの系にはトルクが作用する姿勢が無く、`torque_body` を捨てる)。
+  呼び出し側は環境モデルを登録しなくなった。CLI はこのトルクを 2 つの entry point
+  で同一行に書いていて、両者が食い違わない保証が無かった。actuator (RW, MTQ,
+  thruster) の登録は呼び出し側に残る。搭載する actuator は機体のハードウェア記述で
+  決まる。([#382](https://github.com/sksat/orts/pull/382))
 - `SurfacePanel` が lumped な `cr` の代わりに `optics: PanelOptics { specular,
   diffuse }` を持つようになった。吸収率は `1 - specular - diffuse` として導出する。
   単一係数は face-on の SRP 力の大きさを決めるだけで、斜入射での向きが決まらない
@@ -116,6 +131,22 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 ### `orts-cli` (Rust, crates.io, binary)
 
 #### Added
+- `[[satellites.panels]]` で衛星に平板の外形を与えられるようにした
+  (`area`, `normal`, `cd`, `specular`, `diffuse`, `cp_offset`)。パネルを書くと
+  SRP と大気抵抗が姿勢依存になり、圧力中心が重心から外れていればそれが姿勢外乱に
+  なる。等方面の `srp_area_to_mass` / `ballistic_coeff` では表せない部分である。
+  パネルは `attitude` を要求し、等方面のパラメータとの同時指定は reject する
+  (同じ力を二通りに述べることになる)。パネルが 0 枚のリストも reject する。
+  等方面で表すならキーを書かない。0 枚の外形は何も述べていない。パネルの加速度は wire 上では力の名前
+  (`drag`, `srp`) で報告する。あのチャネルはモデル単位ではなく物理力単位だから
+  である。どのモデルかは `perturbations` が述べ、姿勢を持つ衛星についてはこれを
+  軌道のみの系を組み直して読むのではなく、実際に伝播する dynamics から取るように
+  した。([#386](https://github.com/sksat/orts/pull/386))
+- `[satellites.disturbances]` で衛星がモデル化する環境外乱トルクを選べるように
+  した。`gravity_gradient` の既定は true で、姿勢伝播が従来から持っていた振る舞い。
+  `[satellites.attitude]` の中ではなく sibling の table にしたのは、前者が姿勢の
+  状態と機体特性を述べる場所であり、どの環境モデルを解くかは別の関心事だから。
+  `attitude` 不在での指定は reject する。([#382](https://github.com/sksat/orts/pull/382))
 - `orts run` の地上局コンタクトウィンドウ出力: `[[ground_station]]`
   (`name`、`latitude_deg`、`longitude_deg`、`altitude_km`、`min_elevation_deg`)
   で局を宣言。検出したウィンドウを AOS 順に stderr へ出力 (UTC 時刻、
@@ -158,6 +189,10 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   追加。よく使う・agent に関係する経路を端末内で発見できるようにした。([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
+- `orts run` の downlink log レコードの level を info/debug から debug/trace へ
+  下げた。衛星 × outbound message × control tick ごとに出るため、logger が
+  実際に動く状態では info だと fleet 規模の実行で他の診断が読めなくなり、
+  積分ループ内で stderr のロックを取る書き込みが増える。 ([#390](https://github.com/sksat/orts/pull/390))
 - `--tle` を再び TLE 専用 (2LE/3LE、`-` で stdin) とし、新規 `--omm` と
   対にした。要素セットのパースは削除した `orts::tle` でなく
   `arika::tle` / `arika::omm` を使用 (従来は `--tle` が OMM も自動受理)。([#87](https://github.com/sksat/orts/pull/87))
@@ -193,6 +228,15 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   client への error も無い状態になっていた。([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
+- `orts` が診断ログを stderr に出力するようになった。logger を初期化していな
+  かったため `log::` の呼び出しは全て破棄されており、stream-io stdio plug の
+  displaced、stream の socket error、`serve` 中のシミュレーション停止、
+  WASM plugin が WIT `host-env.log` 経由で出力した行が、どれも表示されなかった。
+  `.rrd` を書く際に rerun の crate が出す診断も同じ出力に含まれる。level は
+  `RUST_LOG` で選び、既定は `warn,orts=info` (orts は info、依存は warn)。
+  `NO_COLOR` 指定時と stderr が terminal でない場合は装飾を付けない。どちらも
+  `orts --help` に記載がある。stdout は従来どおりコマンドの出力 (CSV、`--json`
+  サマリ、`serve --stream-stdio` の protocol) だけ。 ([#390](https://github.com/sksat/orts/pull/390))
 - どの mode でも実行できない fleet を `orts config validate` と
   `orts serve --config` が拒否する。`[satellites.attitude]` や
   `[satellites.controller]` を一部の衛星にだけ書いた config と、全衛星に controller

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -168,44 +168,46 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - TLE epoch の day-of-year を (閏考慮の) 年日数で検証。不正値はそのまま別の
   年に繰り上がらず拒否される。([#87](https://github.com/sksat/orts/pull/87))
 - config ファイル、`orts config validate`、WebSocket の `start_simulation`
-  payload は、シミュレーションが honor できない入力を別の何かに解決せず拒否する:
+  payload は、シミュレーションが実行できない入力を別の値に読み替えず拒否する:
   未知の `[integrator] type` / `atmosphere` (従来は dp45 / exponential
   モデル)、id が 1 つの recording entity を指す 2 機 (id の文字列でなく entity で
   比較するので、recording と同じく `a` と `/a` は衝突する。従来は recording
   entity と CSV section を共有し、id 文字列まで同じなら `[[command]]` の宛先も
   共有していた)、
-  剛体が持てない attitude ブロック (正定値でない、または主慣性モーメントで
+  どの剛体もとりえない attitude ブロック (正定値でない、または主慣性モーメントで
   `I1 + I2 >= I3` を破る慣性テンソル、`mass <= 0`、正規化できない
   `initial_quaternion`)。config が受理する `integrator` / `atmosphere` の綴りは、
   対応する CLI フラグが受理する集合と厳密に一致する。
 
-  何も読まないキーは、拒否ではなく名前を出す。実行は続くので新しい `orts` 向けに
-  書いた config もここで動き、`duraton = 100` が黙って 1 周期走ることはなくなった。
-  `orts config validate` は `warnings` にパスを載せ、`run` と `serve` は表示し、
-  server は client の `start_simulation` や `add_satellite` に含まれるものを出す。
-  `type` タグ付きの block (`[satellites.orbit]`、`[satellites.controller]`、
-  reaction wheel、磁気トルカ) だけは拒否する。`serde_ignored` は internally tagged
-  enum の中を見られないので名前を出す手段が無く、`inclinaton = 51.6` が落ちると
-  軌道が赤道面のままになる。特異な慣性テンソルは従来
+  どのフィールドも読まないキーは、拒否せずキー名を warning として表示する。実行は
+  続くので新しい `orts` 向けに書いた config も古い `orts` で実行でき、`duraton = 100`
+  が黙って 1 周期分実行されることはなくなった。`orts config validate` は `warnings`
+  にキーのパスを出力し、`run` と `serve` は stderr に表示する。server は client の
+  `start_simulation` や `add_satellite` に含まれるものを表示する。`type` タグ付きの
+  block (`[satellites.orbit]`、`[satellites.controller]`、reaction wheel、磁気トルカ)
+  だけは拒否する。`serde_ignored` は internally tagged enum の内部を見られず報告
+  できないため、`inclinaton = 51.6` が無視されると軌道が赤道面のままになる。特異な
+  慣性テンソルは従来
   `SpacecraftDynamics::new` で panic し、`orts serve --config` では spawn された
   manager task の中で起きるため、server は listen したままシミュレーションも
   client への error も無い状態になっていた。([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
-- どの mode でも走らない fleet を `orts config validate` と `orts serve --config`
-  が拒否する。`[satellites.attitude]` や `[satellites.controller]` を一部の衛星に
-  だけ書いた config と、全衛星に controller があって attitude がどこにもない config。
-  engine は元からこれらを拒否していたが、`orts serve` は engine を spawn した
-  manager の中で建てるので、config は valid と言われ banner も出た上で、渡した
-  config が走らないまま server が idle で待つ状態になっていた。`serve` は listening を
-  告げる代わりにエラーで終了する。([#351](https://github.com/sksat/orts/pull/351))
-- WebSocket の `add_satellite` が、実行中の fleet にいる衛星と同じ entity path
-  (`/world/sat/<id>`) になる id を拒否する。従来は同じ path の 2 機を許し、
-  `[[command]]` は後から追加した方にしか届かなかった。`id` 省略時の
-  `sat-<現在の機数>` も同じように衝突する。([#351](https://github.com/sksat/orts/pull/351))
+- どの mode でも実行できない fleet を `orts config validate` と
+  `orts serve --config` が拒否する。`[satellites.attitude]` や
+  `[satellites.controller]` を一部の衛星にだけ書いた config と、全衛星に controller
+  があって attitude がどこにもない config。engine は元からこれらを拒否していたが、
+  `orts serve` は engine を spawn した manager task 内で構築するため、config は valid
+  と判定され banner も表示された上で、指定した config が実行されないまま server が
+  idle 状態で待機していた。`serve` は listening と表示せずエラー終了する。([#351](https://github.com/sksat/orts/pull/351))
+- WebSocket の `add_satellite` が、実行中の fleet の衛星と同じ entity path
+  (`/world/sat/<id>`) になる id を拒否する。従来は同じ path の 2 機を受理し、
+  `[[command]]` は後から追加した方にしか配送されなかった。`id` 省略時の
+  `sat-<現在の機数>` も同様に衝突する。([#351](https://github.com/sksat/orts/pull/351))
 - `orts serve` が、`ClientMessage` に deserialize できなかったメッセージに
-  `{"type":"error"}` を返す。従来は error を捨てていたので、client は来ない応答を
-  待ち続けた。失敗するのは `type` タグ付き block に未知のキーがある場合。([#351](https://github.com/sksat/orts/pull/351))
+  `{"type":"error"}` を返す。従来は error を破棄していたため、client は応答が
+  返らないまま待ち続けた。deserialize が失敗するのは `type` タグ付き block に未知の
+  キーがある場合。([#351](https://github.com/sksat/orts/pull/351))
 - `orts serve` が `Server listening` / `WebSocket endpoint` の banner を、
   `--config` ファイルを受理した後にだけ出すようになった。先に出していたため、
   banner を起動完了として待つ呼び出し側 (`cli/tests/ws_e2e.rs`、Playwright の

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -190,10 +190,6 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   `SpacecraftDynamics::new` で panic し、`orts serve --config` では spawn された
   manager task の中で起きるため、server は listen したままシミュレーションも
   client への error も無い状態になっていた。([#351](https://github.com/sksat/orts/pull/351))
-- orbit 引数なしで起動した `orts serve` の既定 fleet は、SSO 衛星に実現可能な
-  慣性テンソル `[83.3, 208.3, 208.3]` kg·m² (500 kg, 2x1x1 m box) を与える。
-  従来の `[100, 200, 50]` は主慣性モーメントの三角不等式を破っており、
-  どの質量分布もこの値を持たない。([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
 - どの mode でも走らない fleet を `orts config validate` と `orts serve --config`

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -237,6 +237,10 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   `NO_COLOR` 指定時と stderr が terminal でない場合は装飾を付けない。どちらも
   `orts --help` に記載がある。stdout は従来どおりコマンドの出力 (CSV、`--json`
   サマリ、`serve --stream-stdio` の protocol) だけ。 ([#390](https://github.com/sksat/orts/pull/390))
+- `tle` / `norad` 軌道を Earth 以外の中心天体で使う config を、
+  `orts config validate` と `orts serve --config` が拒否する。SGP4 は Earth 専用で、
+  `SimParams::from_config` はこの規則に panic 経由で到達していたため、config は valid
+  と判定された上で `orts run --config` が panic していた。([#351](https://github.com/sksat/orts/pull/351))
 - どの mode でも実行できない fleet を `orts config validate` と
   `orts serve --config` が拒否する。`[satellites.attitude]` や
   `[satellites.controller]` を一部の衛星にだけ書いた config と、全衛星に controller

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -170,13 +170,21 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - config ファイル、`orts config validate`、WebSocket の `start_simulation`
   payload は、シミュレーションが honor できない入力を別の何かに解決せず拒否する:
   未知の `[integrator] type` / `atmosphere` (従来は dp45 / exponential
-  モデル)、config tree のどこかにある未知キー (従来は drop されるので
-  `duraton = 100` が 1 周期走った)、id が 1 つの recording entity を指す 2 機 (id の文字列でなく entity で比較するので、下流と同じく `a` と `/a` は衝突する)
+  モデル)、id が 1 つの recording entity を指す 2 機 (id の文字列でなく entity で比較するので、下流と同じく `a` と `/a` は衝突する)
   (従来は recording entity・CSV section・`[[command]]` の宛先を共有)、
   剛体が持てない attitude ブロック (正定値でない、または主慣性モーメントで
   `I1 + I2 >= I3` を破る慣性テンソル、`mass <= 0`、正規化できない
   `initial_quaternion`)。config が受理する `integrator` / `atmosphere` の綴りは、
-  対応する CLI フラグが受理する集合と厳密に一致する。特異な慣性テンソルは従来
+  対応する CLI フラグが受理する集合と厳密に一致する。
+
+  何も読まないキーは、拒否ではなく名前を出す。実行は続くので新しい `orts` 向けに
+  書いた config もここで動き、`duraton = 100` が黙って 1 周期走ることはなくなった。
+  `orts config validate` は `warnings` にパスを載せ、`run` と `serve` は表示し、
+  server は client の `start_simulation` や `add_satellite` に含まれるものを出す。
+  `type` タグ付きの block (`[satellites.orbit]`、`[satellites.controller]`、
+  reaction wheel、磁気トルカ) だけは拒否する。`serde_ignored` は internally tagged
+  enum の中を見られないので名前を出す手段が無く、`inclinaton = 51.6` が落ちると
+  軌道が赤道面のままになる。特異な慣性テンソルは従来
   `SpacecraftDynamics::new` で panic し、`orts serve --config` では spawn された
   manager task の中で起きるため、server は listen したままシミュレーションも
   client への error も無い状態になっていた。([#351](https://github.com/sksat/orts/pull/351))

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -30,21 +30,6 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - WIT v0 plugin interface に msg-io / stream-io チャネルを追加。([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
-- `SatelliteParams` が `SpacecraftShape` を optional で持ち、
-  `build_spacecraft_dynamics` がそれを見て等方面の `SolarRadiationPressure` /
-  `AtmosphericDrag` の代わりに `PanelSrp` / `PanelDrag` を install するように
-  した。機体の外形は一つなので、パネルは片方ではなく両方の力を担う。
-  `build_orbital_system` はどちらも install しない (パネルの力は姿勢を要求する)。
-  `SurfacePanel` に `with_cp_offset` を追加した。パネルの力を姿勢外乱にするのは
-  この offset である。([#386](https://github.com/sksat/orts/pull/386))
-- 外乱トルクの登録を `orts::setup` に集約し、どれを解くかを `SatelliteParams` の
-  `DisturbanceTorques` で選ぶようにした。`build_spacecraft_dynamics` がそれを見て
-  gravity gradient トルクを install する。`build_orbital_system` は install しない
-  (軌道のみの系にはトルクが作用する姿勢が無く、`torque_body` を捨てる)。
-  呼び出し側は環境モデルを登録しなくなった。CLI はこのトルクを 2 つの entry point
-  で同一行に書いていて、両者が食い違わない保証が無かった。actuator (RW, MTQ,
-  thruster) の登録は呼び出し側に残る。搭載する actuator は機体のハードウェア記述で
-  決まる。([#382](https://github.com/sksat/orts/pull/382))
 - `SurfacePanel` が lumped な `cr` の代わりに `optics: PanelOptics { specular,
   diffuse }` を持つようになった。吸収率は `1 - specular - diffuse` として導出する。
   単一係数は face-on の SRP 力の大きさを決めるだけで、斜入射での向きが決まらない
@@ -131,22 +116,6 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 ### `orts-cli` (Rust, crates.io, binary)
 
 #### Added
-- `[[satellites.panels]]` で衛星に平板の外形を与えられるようにした
-  (`area`, `normal`, `cd`, `specular`, `diffuse`, `cp_offset`)。パネルを書くと
-  SRP と大気抵抗が姿勢依存になり、圧力中心が重心から外れていればそれが姿勢外乱に
-  なる。等方面の `srp_area_to_mass` / `ballistic_coeff` では表せない部分である。
-  パネルは `attitude` を要求し、等方面のパラメータとの同時指定は reject する
-  (同じ力を二通りに述べることになる)。パネルが 0 枚のリストも reject する。
-  等方面で表すならキーを書かない。0 枚の外形は何も述べていない。パネルの加速度は wire 上では力の名前
-  (`drag`, `srp`) で報告する。あのチャネルはモデル単位ではなく物理力単位だから
-  である。どのモデルかは `perturbations` が述べ、姿勢を持つ衛星についてはこれを
-  軌道のみの系を組み直して読むのではなく、実際に伝播する dynamics から取るように
-  した。([#386](https://github.com/sksat/orts/pull/386))
-- `[satellites.disturbances]` で衛星がモデル化する環境外乱トルクを選べるように
-  した。`gravity_gradient` の既定は true で、姿勢伝播が従来から持っていた振る舞い。
-  `[satellites.attitude]` の中ではなく sibling の table にしたのは、前者が姿勢の
-  状態と機体特性を述べる場所であり、どの環境モデルを解くかは別の関心事だから。
-  `attitude` 不在での指定は reject する。([#382](https://github.com/sksat/orts/pull/382))
 - `orts run` の地上局コンタクトウィンドウ出力: `[[ground_station]]`
   (`name`、`latitude_deg`、`longitude_deg`、`altitude_km`、`min_elevation_deg`)
   で局を宣言。検出したウィンドウを AOS 順に stderr へ出力 (UTC 時刻、
@@ -189,10 +158,6 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   追加。よく使う・agent に関係する経路を端末内で発見できるようにした。([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
-- `orts run` の downlink log レコードの level を info/debug から debug/trace へ
-  下げた。衛星 × outbound message × control tick ごとに出るため、logger が
-  実際に動く状態では info だと fleet 規模の実行で他の診断が読めなくなり、
-  積分ループ内で stderr のロックを取る書き込みが増える。 ([#390](https://github.com/sksat/orts/pull/390))
 - `--tle` を再び TLE 専用 (2LE/3LE、`-` で stdin) とし、新規 `--omm` と
   対にした。要素セットのパースは削除した `orts::tle` でなく
   `arika::tle` / `arika::omm` を使用 (従来は `--tle` が OMM も自動受理)。([#87](https://github.com/sksat/orts/pull/87))
@@ -221,15 +186,11 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   どの質量分布もこの値を持たない。([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
-- `orts` が診断ログを stderr に出力するようになった。logger を初期化していな
-  かったため `log::` の呼び出しは全て破棄されており、stream-io stdio plug の
-  displaced、stream の socket error、`serve` 中のシミュレーション停止、
-  WASM plugin が WIT `host-env.log` 経由で出力した行が、どれも表示されなかった。
-  `.rrd` を書く際に rerun の crate が出す診断も同じ出力に含まれる。level は
-  `RUST_LOG` で選び、既定は `warn,orts=info` (orts は info、依存は warn)。
-  `NO_COLOR` 指定時と stderr が terminal でない場合は装飾を付けない。どちらも
-  `orts --help` に記載がある。stdout は従来どおりコマンドの出力 (CSV、`--json`
-  サマリ、`serve --stream-stdio` の protocol) だけ。 ([#390](https://github.com/sksat/orts/pull/390))
+- `orts serve` が `Server listening` / `WebSocket endpoint` のバナーを、
+  `--config` ファイルを受理した後にだけ出すようになった。先に出していたため、
+  バナーを起動完了として待つ呼び出し側 (`cli/tests/ws_e2e.rs`、Playwright の
+  spec) には、拒否された config がエラーメッセージではなく接続失敗として
+  届いていた。([#351](https://github.com/sksat/orts/pull/351))
 - `orts run --format csv --output <path>` が CSV を `<path>` に書き込むように
   なった。従来は `--format csv` の実行が `--output` に関わらず常に stdout へ
   出力し、指定パスを黙って無視していた。([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -202,6 +202,23 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   は併用不可。`--tle-line1` / `--tle-line2` は両方指定が必須。([#87](https://github.com/sksat/orts/pull/87))
 - TLE epoch の day-of-year を (閏考慮の) 年日数で検証。不正値はそのまま別の
   年に繰り上がらず拒否される。([#87](https://github.com/sksat/orts/pull/87))
+- config ファイル、`orts config validate`、WebSocket の `start_simulation`
+  payload は、シミュレーションが honor できない入力を別の何かに解決せず拒否する:
+  未知の `[integrator] type` / `atmosphere` (従来は dp45 / exponential
+  モデル)、config tree のどこかにある未知キー (従来は drop されるので
+  `duraton = 100` が 1 周期走った)、解決後の id が衝突する 2 機
+  (従来は recording entity・CSV section・`[[command]]` の宛先を共有)、
+  剛体が持てない attitude ブロック (正定値でない、または主慣性モーメントで
+  `I1 + I2 >= I3` を破る慣性テンソル、`mass <= 0`、正規化できない
+  `initial_quaternion`)。config が受理する `integrator` / `atmosphere` の綴りは、
+  対応する CLI フラグが受理する集合と厳密に一致する。特異な慣性テンソルは従来
+  `SpacecraftDynamics::new` で panic し、`orts serve --config` では spawn された
+  manager task の中で起きるため、server は listen したままシミュレーションも
+  client への error も無い状態になっていた。([#351](https://github.com/sksat/orts/pull/351))
+- orbit 引数なしで起動した `orts serve` の既定 fleet は、SSO 衛星に実現可能な
+  慣性テンソル `[83.3, 208.3, 208.3]` kg·m² (500 kg, 2x1x1 m box) を与える。
+  従来の `[100, 200, 50]` は主慣性モーメントの三角不等式を破っており、
+  どの質量分布もこの値を持たない。([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
 - `orts` が診断ログを stderr に出力するようになった。logger を初期化していな

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -194,11 +194,13 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   どの質量分布もこの値を持たない。([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
-- `[satellites.attitude]` や `[satellites.controller]` を一部の衛星にだけ書いた
-  config を、`orts config validate` と `orts serve --config` が bind 前に拒否する。
-  engine は元からこの fleet を拒否していたが、`orts serve` は engine を spawn した
+- どの mode でも走らない fleet を `orts config validate` と `orts serve --config`
+  が拒否する。`[satellites.attitude]` や `[satellites.controller]` を一部の衛星に
+  だけ書いた config と、全衛星に controller があって attitude がどこにもない config。
+  engine は元からこれらを拒否していたが、`orts serve` は engine を spawn した
   manager の中で建てるので、config は valid と言われ banner も出た上で、渡した
-  config が走らないまま server が idle で待つ状態になっていた。([#351](https://github.com/sksat/orts/pull/351))
+  config が走らないまま server が idle で待つ状態になっていた。`serve` は listening を
+  告げる代わりにエラーで終了する。([#351](https://github.com/sksat/orts/pull/351))
 - WebSocket の `add_satellite` が、実行中の fleet にいる衛星と同じ entity path
   (`/world/sat/<id>`) になる id を拒否する。従来は同じ path の 2 機を許し、
   `[[command]]` は後から追加した方にしか届かなかった。`id` 省略時の

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -194,10 +194,17 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   どの質量分布もこの値を持たない。([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
-- `orts serve` が `Server listening` / `WebSocket endpoint` のバナーを、
+- WebSocket の `add_satellite` が、実行中の fleet にいる衛星と同じ entity path
+  (`/world/sat/<id>`) になる id を拒否する。従来は同じ path の 2 機を許し、
+  `[[command]]` は後から追加した方にしか届かなかった。`id` 省略時の
+  `sat-<現在の機数>` も同じように衝突する。([#351](https://github.com/sksat/orts/pull/351))
+- `orts serve` が、`ClientMessage` に deserialize できなかったメッセージに
+  `{"type":"error"}` を返す。従来は error を捨てていたので、client は来ない応答を
+  待ち続けた。失敗するのは `type` タグ付き block に未知のキーがある場合。([#351](https://github.com/sksat/orts/pull/351))
+- `orts serve` が `Server listening` / `WebSocket endpoint` の banner を、
   `--config` ファイルを受理した後にだけ出すようになった。先に出していたため、
-  バナーを起動完了として待つ呼び出し側 (`cli/tests/ws_e2e.rs`、Playwright の
-  spec) には、拒否された config がエラーメッセージではなく接続失敗として
+  banner を起動完了として待つ呼び出し側 (`cli/tests/ws_e2e.rs`、Playwright の
+  spec) には、拒否された config が error message ではなく接続失敗として
   届いていた。([#351](https://github.com/sksat/orts/pull/351))
 - `orts run --format csv --output <path>` が CSV を `<path>` に書き込むように
   なった。従来は `--format csv` の実行が `--output` に関わらず常に stdout へ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,10 +216,6 @@ section is subdivided by package.
   `SpacecraftDynamics::new`; under `orts serve --config` that happened inside
   the spawned manager task, leaving the server listening with no simulation and
   no error to the client. ([#351](https://github.com/sksat/orts/pull/351))
-- `orts serve`'s built-in default fleet (started with no orbit arguments) gives
-  the SSO satellite a realizable inertia tensor, `[83.3, 208.3, 208.3]` kg·m²
-  (500 kg, 2x1x1 m box). The previous `[100, 200, 50]` violates the triangle
-  inequality on principal moments, so no mass distribution has it. ([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
 - `orts config validate` and `orts serve --config` refuse a fleet no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,9 +195,9 @@ section is subdivided by package.
   something else: an unknown `[integrator] type` or `atmosphere` (previously
   dp45 / the exponential model), two
   satellites whose ids name one recording entity (previously one entity and one
-  CSV section for both, and for two spellings of one id string, one
-  `[[command]]` target too; compared on the entity, so `a` and `/a` collide as
-  they do in the recording), and an attitude block no
+  CSV section for both; compared on the entity, so `a` and `/a` collide as they
+  do in the recording, while the same id string twice shared its `[[command]]`
+  target as well), and an attitude block no
   rigid body could have — an inertia tensor that is not positive definite or
   violates `I1 + I2 >= I3` on its principal moments, `mass <= 0`, or an
   `initial_quaternion` that cannot be normalized. The `integrator` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,22 @@ section is subdivided by package.
 - WIT v0 plugin interface extended with the msg-io and stream-io channels. ([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
+- `SatelliteParams` carries an optional `SpacecraftShape`, and
+  `build_spacecraft_dynamics` installs `PanelSrp` and `PanelDrag` from it in
+  place of the isotropic `SolarRadiationPressure` and `AtmosphericDrag`. The
+  outer shape is one object, so panels drive both forces rather than one of
+  them. `build_orbital_system` installs neither: panel forces need an attitude.
+  `SurfacePanel` gains `with_cp_offset`, which is what turns a panel force into
+  an attitude disturbance. ([#386](https://github.com/sksat/orts/pull/386))
+- `orts::setup` registers disturbance torques, and `SatelliteParams` carries a
+  `DisturbanceTorques` selection to say which. `build_spacecraft_dynamics`
+  installs the gravity-gradient torque from it; `build_orbital_system` installs
+  none, since an orbit-only system has no orientation for a torque to act on and
+  discards `torque_body`. Callers no longer register environmental models
+  themselves — the CLI had been adding this torque on the same line in two entry
+  points, with nothing keeping the two in step. Actuators (RW, MTQ, thrusters)
+  stay with the caller, since they come from the spacecraft's own hardware
+  description. ([#382](https://github.com/sksat/orts/pull/382))
 - `SurfacePanel` carries `optics: PanelOptics { specular, diffuse }` in place of
   a lumped `cr`, with the absorbed fraction derived as `1 - specular - diffuse`.
   A single coefficient fixes the SRP force magnitude face-on but leaves its
@@ -134,6 +150,25 @@ section is subdivided by package.
 ### `orts-cli` (Rust, crates.io, binary)
 
 #### Added
+- `[[satellites.panels]]` gives a satellite a flat-panel outer surface, with
+  `area`, `normal`, `cd`, `specular`, `diffuse` and `cp_offset`. Writing panels
+  makes SRP and drag attitude-dependent, and an off-centre centre of pressure
+  turns them into attitude disturbances — which is what the isotropic
+  `srp_area_to_mass` / `ballistic_coeff` cannot express. Panels require
+  `attitude` and are rejected alongside those isotropic parameters, since both
+  would describe the same force. A list of zero panels is rejected too: omit
+  the key for an isotropic cross-section, since a surface of no panels
+  describes nothing. Panel accelerations report on the wire under
+  the name of the force (`drag`, `srp`), because that channel is per force
+  rather than per model; `perturbations` names the model, and for an attitude
+  satellite it now comes from the dynamics being propagated rather than from a
+  rebuilt orbit-only system. ([#386](https://github.com/sksat/orts/pull/386))
+- `[satellites.disturbances]` selects which environmental disturbance torques a
+  satellite models, `gravity_gradient` defaulting to true — the behaviour
+  attitude propagation has always had. A sibling of `[satellites.attitude]`
+  rather than a field inside it: that table states the attitude state and the
+  body's properties, this one selects which environment models get solved.
+  Specifying it without `attitude` is rejected. ([#382](https://github.com/sksat/orts/pull/382))
 - Ground-station contact-window reporting in `orts run`: declare stations with
   `[[ground_station]]` (`name`, `latitude_deg`, `longitude_deg`, `altitude_km`,
   `min_elevation_deg`); detected windows print to stderr ordered by AOS, with
@@ -181,6 +216,10 @@ section is subdivided by package.
   are discoverable without leaving the terminal. ([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
+- `orts run`'s downlink log records moved from info/debug to debug/trace. They
+  fire per satellite per outbound message per control tick, so with a backend
+  installed, info would bury every other diagnostic on a fleet-sized run and add
+  a locked stderr write inside the integration loop. ([#390](https://github.com/sksat/orts/pull/390))
 - `--tle` is TLE-only again (2LE/3LE; `-` for stdin) and pairs with the new
   `--omm`; element-set parsing is now backed by `arika::tle` / `arika::omm`
   instead of the removed `orts::tle`. (Previously `--tle` also auto-accepted OMM.) ([#87](https://github.com/sksat/orts/pull/87))
@@ -218,6 +257,15 @@ section is subdivided by package.
   no error to the client. ([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
+- `orts` now writes its diagnostics to stderr. With no `log` backend installed
+  every `log::` call was discarded, so a displaced stream-io stdio plug, a stream
+  socket error, a halted `serve` simulation, and every line a WASM plugin logged
+  through the WIT `host-env.log` import all went unreported. The diagnostics the
+  rerun crates emit while writing an `.rrd` now appear in the same output.
+  `RUST_LOG` selects the level — default `warn,orts=info`, ours at info and
+  dependencies at warn — and `NO_COLOR`, or a stderr that is not a terminal,
+  drops the styling; `orts --help` documents both. stdout is unchanged: the CSV,
+  the `--json` summary, or the `serve --stream-stdio` protocol and nothing else. ([#390](https://github.com/sksat/orts/pull/390))
 - `orts config validate` and `orts serve --config` refuse a fleet no
   simulation mode can run: `[satellites.attitude]` or
   `[satellites.controller]` on some satellites but not all, or a controller on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,22 +33,6 @@ section is subdivided by package.
 - WIT v0 plugin interface extended with the msg-io and stream-io channels. ([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
-- `SatelliteParams` carries an optional `SpacecraftShape`, and
-  `build_spacecraft_dynamics` installs `PanelSrp` and `PanelDrag` from it in
-  place of the isotropic `SolarRadiationPressure` and `AtmosphericDrag`. The
-  outer shape is one object, so panels drive both forces rather than one of
-  them. `build_orbital_system` installs neither: panel forces need an attitude.
-  `SurfacePanel` gains `with_cp_offset`, which is what turns a panel force into
-  an attitude disturbance. ([#386](https://github.com/sksat/orts/pull/386))
-- `orts::setup` registers disturbance torques, and `SatelliteParams` carries a
-  `DisturbanceTorques` selection to say which. `build_spacecraft_dynamics`
-  installs the gravity-gradient torque from it; `build_orbital_system` installs
-  none, since an orbit-only system has no orientation for a torque to act on and
-  discards `torque_body`. Callers no longer register environmental models
-  themselves — the CLI had been adding this torque on the same line in two entry
-  points, with nothing keeping the two in step. Actuators (RW, MTQ, thrusters)
-  stay with the caller, since they come from the spacecraft's own hardware
-  description. ([#382](https://github.com/sksat/orts/pull/382))
 - `SurfacePanel` carries `optics: PanelOptics { specular, diffuse }` in place of
   a lumped `cr`, with the absorbed fraction derived as `1 - specular - diffuse`.
   A single coefficient fixes the SRP force magnitude face-on but leaves its
@@ -150,25 +134,6 @@ section is subdivided by package.
 ### `orts-cli` (Rust, crates.io, binary)
 
 #### Added
-- `[[satellites.panels]]` gives a satellite a flat-panel outer surface, with
-  `area`, `normal`, `cd`, `specular`, `diffuse` and `cp_offset`. Writing panels
-  makes SRP and drag attitude-dependent, and an off-centre centre of pressure
-  turns them into attitude disturbances — which is what the isotropic
-  `srp_area_to_mass` / `ballistic_coeff` cannot express. Panels require
-  `attitude` and are rejected alongside those isotropic parameters, since both
-  would describe the same force. A list of zero panels is rejected too: omit
-  the key for an isotropic cross-section, since a surface of no panels
-  describes nothing. Panel accelerations report on the wire under
-  the name of the force (`drag`, `srp`), because that channel is per force
-  rather than per model; `perturbations` names the model, and for an attitude
-  satellite it now comes from the dynamics being propagated rather than from a
-  rebuilt orbit-only system. ([#386](https://github.com/sksat/orts/pull/386))
-- `[satellites.disturbances]` selects which environmental disturbance torques a
-  satellite models, `gravity_gradient` defaulting to true — the behaviour
-  attitude propagation has always had. A sibling of `[satellites.attitude]`
-  rather than a field inside it: that table states the attitude state and the
-  body's properties, this one selects which environment models get solved.
-  Specifying it without `attitude` is rejected. ([#382](https://github.com/sksat/orts/pull/382))
 - Ground-station contact-window reporting in `orts run`: declare stations with
   `[[ground_station]]` (`name`, `latitude_deg`, `longitude_deg`, `altitude_km`,
   `min_elevation_deg`); detected windows print to stderr ordered by AOS, with
@@ -216,10 +181,6 @@ section is subdivided by package.
   are discoverable without leaving the terminal. ([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
-- `orts run`'s downlink log records moved from info/debug to debug/trace. They
-  fire per satellite per outbound message per control tick, so with a backend
-  installed, info would bury every other diagnostic on a fleet-sized run and add
-  a locked stderr write inside the integration loop. ([#390](https://github.com/sksat/orts/pull/390))
 - `--tle` is TLE-only again (2LE/3LE; `-` for stdin) and pairs with the new
   `--omm`; element-set parsing is now backed by `arika::tle` / `arika::omm`
   instead of the removed `orts::tle`. (Previously `--tle` also auto-accepted OMM.) ([#87](https://github.com/sksat/orts/pull/87))
@@ -250,15 +211,11 @@ section is subdivided by package.
   inequality on principal moments, so no mass distribution has it. ([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
-- `orts` now writes its diagnostics to stderr. With no `log` backend installed
-  every `log::` call was discarded, so a displaced stream-io stdio plug, a stream
-  socket error, a halted `serve` simulation, and every line a WASM plugin logged
-  through the WIT `host-env.log` import all went unreported. The diagnostics the
-  rerun crates emit while writing an `.rrd` now appear in the same output.
-  `RUST_LOG` selects the level — default `warn,orts=info`, ours at info and
-  dependencies at warn — and `NO_COLOR`, or a stderr that is not a terminal,
-  drops the styling; `orts --help` documents both. stdout is unchanged: the CSV,
-  the `--json` summary, or the `serve --stream-stdio` protocol and nothing else. ([#390](https://github.com/sksat/orts/pull/390))
+- `orts serve` prints its `Server listening` / `WebSocket endpoint` banner only
+  after the `--config` file is accepted. Printing it first made a rejected
+  config reach a caller that waits on the banner — `cli/tests/ws_e2e.rs`, the
+  Playwright specs — as a refused connection rather than as its own error
+  message. ([#351](https://github.com/sksat/orts/pull/351))
 - `orts run --format csv --output <path>` now writes the CSV to `<path>`.
   Previously every `--format csv` run wrote to stdout regardless of `--output`,
   silently ignoring the given path. ([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,10 @@ section is subdivided by package.
   dependencies at warn — and `NO_COLOR`, or a stderr that is not a terminal,
   drops the styling; `orts --help` documents both. stdout is unchanged: the CSV,
   the `--json` summary, or the `serve --stream-stdio` protocol and nothing else. ([#390](https://github.com/sksat/orts/pull/390))
+- `orts config validate` and `orts serve --config` refuse a `tle` or `norad`
+  orbit about any body but Earth. SGP4 is Earth's, and `SimParams::from_config`
+  reached that rule through a panic, so such a config validated clean and then
+  took down `orts run --config`. ([#351](https://github.com/sksat/orts/pull/351))
 - `orts config validate` and `orts serve --config` refuse a fleet no
   simulation mode can run: `[satellites.attitude]` or
   `[satellites.controller]` on some satellites but not all, or a controller on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,12 @@ section is subdivided by package.
   inequality on principal moments, so no mass distribution has it. ([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
+- A config declaring `[satellites.attitude]` or `[satellites.controller]` on
+  some satellites but not all is refused by `orts config validate` and by
+  `orts serve --config` before it binds. The engine already refused such a
+  fleet, but `orts serve` builds it inside the spawned manager, so the config
+  validated clean, the banner printed, and the server sat idle with the given
+  config never running. ([#351](https://github.com/sksat/orts/pull/351))
 - The WebSocket `add_satellite` refuses an id whose entity path
   (`/world/sat/<id>`) already belongs to a satellite in the running fleet. Two
   satellites on one path meant `[[command]]` reached only the one added last. An

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,25 @@ section is subdivided by package.
   `--tle-line2`; and `--tle-line1` / `--tle-line2` must be given together. ([#87](https://github.com/sksat/orts/pull/87))
 - TLE epoch day-of-year is validated against the (leap-aware) year length, so a
   malformed field is rejected rather than rolling into another year. ([#87](https://github.com/sksat/orts/pull/87))
+- Config files, `orts config validate` and the WebSocket `start_simulation`
+  payload reject input the simulation cannot honor, instead of resolving it to
+  something else: an unknown `[integrator] type` or `atmosphere` (previously
+  dp45 / the exponential model), an unknown key anywhere in the config tree
+  (previously dropped, so `duraton = 100` ran for one orbital period), two
+  satellites whose resolved ids collide (previously one recording entity, one
+  CSV section and one `[[command]]` target for both), and an attitude block no
+  rigid body could have — an inertia tensor that is not positive definite or
+  violates `I1 + I2 >= I3` on its principal moments, `mass <= 0`, or an
+  `initial_quaternion` that cannot be normalized. The `integrator` /
+  `atmosphere` spellings a config accepts are now exactly the ones the
+  equivalent CLI flag accepts. A singular inertia tensor previously panicked in
+  `SpacecraftDynamics::new`; under `orts serve --config` that happened inside
+  the spawned manager task, leaving the server listening with no simulation and
+  no error to the client. ([#351](https://github.com/sksat/orts/pull/351))
+- `orts serve`'s built-in default fleet (started with no orbit arguments) gives
+  the SSO satellite a realizable inertia tensor, `[83.3, 208.3, 208.3]` kg·m²
+  (500 kg, 2x1x1 m box). The previous `[100, 200, 50]` violates the triangle
+  inequality on principal moments, so no mass distribution has it. ([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
 - `orts` now writes its diagnostics to stderr. With no `log` backend installed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,8 +246,8 @@ section is subdivided by package.
   A key nothing reads is named rather than refused: the run goes ahead, so a
   config written for a newer `orts` still works here, and `duraton = 100` no
   longer runs for one orbital period in silence. `orts config validate` carries
-  the paths in its `warnings`, `run` and `serve` print them, and the server names
-  the ones in a client's `start_simulation` or `add_satellite`. A `type`-tagged
+  the paths in its `warnings`, `run` and `serve` report them at warn level, and
+  the server names the ones in a client's `start_simulation` or `add_satellite`. A `type`-tagged
   block — `[satellites.orbit]`, `[satellites.controller]`, the reaction wheels
   and the magnetorquers — refuses instead: `serde_ignored` cannot see inside an
   internally tagged enum, so there is nothing to name there, and a dropped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,12 +221,14 @@ section is subdivided by package.
   inequality on principal moments, so no mass distribution has it. ([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
-- A config declaring `[satellites.attitude]` or `[satellites.controller]` on
-  some satellites but not all is refused by `orts config validate` and by
-  `orts serve --config` before it binds. The engine already refused such a
-  fleet, but `orts serve` builds it inside the spawned manager, so the config
-  validated clean, the banner printed, and the server sat idle with the given
-  config never running. ([#351](https://github.com/sksat/orts/pull/351))
+- `orts config validate` and `orts serve --config` refuse a fleet no
+  simulation mode can run: `[satellites.attitude]` or
+  `[satellites.controller]` on some satellites but not all, or a controller on
+  every satellite with attitude on none. The engine already refused these, but
+  `orts serve` builds it inside the spawned manager, so the config validated
+  clean, the startup banner printed, and the server sat idle with the given
+  config never running. `serve` now exits with the error instead of announcing
+  a listening server. ([#351](https://github.com/sksat/orts/pull/351))
 - The WebSocket `add_satellite` refuses an id whose entity path
   (`/world/sat/<id>`) already belongs to a satellite in the running fleet. Two
   satellites on one path meant `[[command]]` reached only the one added last. An

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,8 +195,9 @@ section is subdivided by package.
   something else: an unknown `[integrator] type` or `atmosphere` (previously
   dp45 / the exponential model), an unknown key anywhere in the config tree
   (previously dropped, so `duraton = 100` ran for one orbital period), two
-  satellites whose resolved ids collide (previously one recording entity, one
-  CSV section and one `[[command]]` target for both), and an attitude block no
+  satellites whose ids name one recording entity (previously one entity, one
+  CSV section and one `[[command]]` target for both; compared on the entity, so
+  `a` and `/a` collide as they do downstream), and an attitude block no
   rigid body could have — an inertia tensor that is not positive definite or
   violates `I1 + I2 >= I3` on its principal moments, `mass <= 0`, or an
   `initial_quaternion` that cannot be normalized. The `integrator` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,8 +193,7 @@ section is subdivided by package.
 - Config files, `orts config validate` and the WebSocket `start_simulation`
   payload reject input the simulation cannot honor, instead of resolving it to
   something else: an unknown `[integrator] type` or `atmosphere` (previously
-  dp45 / the exponential model), an unknown key anywhere in the config tree
-  (previously dropped, so `duraton = 100` ran for one orbital period), two
+  dp45 / the exponential model), two
   satellites whose ids name one recording entity (previously one entity, one
   CSV section and one `[[command]]` target for both; compared on the entity, so
   `a` and `/a` collide as they do downstream), and an attitude block no
@@ -202,7 +201,17 @@ section is subdivided by package.
   violates `I1 + I2 >= I3` on its principal moments, `mass <= 0`, or an
   `initial_quaternion` that cannot be normalized. The `integrator` /
   `atmosphere` spellings a config accepts are now exactly the ones the
-  equivalent CLI flag accepts. A singular inertia tensor previously panicked in
+  equivalent CLI flag accepts.
+
+  A key nothing reads is named rather than refused: the run goes ahead, so a
+  config written for a newer `orts` still works here, and `duraton = 100` no
+  longer runs for one orbital period in silence. `orts config validate` carries
+  the paths in its `warnings`, `run` and `serve` print them, and the server names
+  the ones in a client's `start_simulation` or `add_satellite`. A `type`-tagged
+  block — `[satellites.orbit]`, `[satellites.controller]`, the reaction wheels
+  and the magnetorquers — refuses instead: `serde_ignored` cannot see inside an
+  internally tagged enum, so there is nothing to name there, and a dropped
+  `inclinaton = 51.6` would leave the orbit equatorial. A singular inertia tensor previously panicked in
   `SpacecraftDynamics::new`; under `orts serve --config` that happened inside
   the spawned manager task, leaving the server listening with no simulation and
   no error to the client. ([#351](https://github.com/sksat/orts/pull/351))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,15 @@ section is subdivided by package.
   inequality on principal moments, so no mass distribution has it. ([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
+- The WebSocket `add_satellite` refuses an id whose entity path
+  (`/world/sat/<id>`) already belongs to a satellite in the running fleet. Two
+  satellites on one path meant `[[command]]` reached only the one added last. An
+  omitted `id` takes `sat-<current fleet size>`, which collides the same
+  way. ([#351](https://github.com/sksat/orts/pull/351))
+- `orts serve` answers a message that does not deserialize into `ClientMessage`
+  with a `{"type":"error"}` frame. The error used to be discarded, leaving the
+  client waiting for a response that never came. An unknown key in a
+  `type`-tagged block is what fails. ([#351](https://github.com/sksat/orts/pull/351))
 - `orts serve` prints its `Server listening` / `WebSocket endpoint` banner only
   after the `--config` file is accepted. Printing it first made a rejected
   config reach a caller that waits on the banner — `cli/tests/ws_e2e.rs`, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,9 +194,10 @@ section is subdivided by package.
   payload reject input the simulation cannot honor, instead of resolving it to
   something else: an unknown `[integrator] type` or `atmosphere` (previously
   dp45 / the exponential model), two
-  satellites whose ids name one recording entity (previously one entity, one
-  CSV section and one `[[command]]` target for both; compared on the entity, so
-  `a` and `/a` collide as they do downstream), and an attitude block no
+  satellites whose ids name one recording entity (previously one entity and one
+  CSV section for both, and for two spellings of one id string, one
+  `[[command]]` target too; compared on the entity, so `a` and `/a` collide as
+  they do in the recording), and an attitude block no
   rigid body could have — an inertia tensor that is not positive definite or
   violates `I1 + I2 >= I3` on its principal moments, `mass <= 0`, or an
   `initial_quaternion` that cannot be normalized. The `integrator` /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2881,6 +2881,7 @@ dependencies = [
  "rayon",
  "rust-embed",
  "serde",
+ "serde_ignored",
  "serde_json",
  "serde_yaml",
  "tempfile",
@@ -4322,6 +4323,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -54,6 +54,9 @@ ureq.workspace = true
 image.workspace = true
 toml.workspace = true
 serde_yaml.workspace = true
+# Collects the config keys a deserialize ignored, so an unknown one is a
+# warning naming its path rather than a rejected file.
+serde_ignored = "0.1.14"
 rust-embed = { workspace = true, optional = true }
 wasmtime = { workspace = true, optional = true }
 rayon = "1"

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -75,6 +75,10 @@ fn run_validate(path: &str, json: bool) {
             // A key nothing read is a warning, not a failure: a config written
             // for a newer `orts` still runs here. Naming the paths is what
             // makes a typo findable, since the value it carried is gone.
+            // The JSON form carries the key as it was written — a JSON string
+            // encodes a newline or an escape character itself. The line printed
+            // to a terminal goes through `printable_key`, like every other
+            // warning naming a key.
             let warnings: Vec<String> = loaded
                 .unread_keys
                 .iter()
@@ -88,8 +92,11 @@ fn run_validate(path: &str, json: bool) {
                     "warnings": warnings,
                 }));
             } else {
-                for warning in &warnings {
-                    eprintln!("Warning: {path}: {warning}");
+                for key in &loaded.unread_keys {
+                    eprintln!(
+                        "Warning: {path}: nothing reads `{}`; its value is ignored",
+                        crate::config::printable_key(key)
+                    );
                 }
                 eprintln!("OK: {path} is a valid orts config");
             }

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -93,8 +93,8 @@ fn run_validate(path: &str, json: bool) {
                 }));
             } else {
                 for key in &loaded.unread_keys {
-                    eprintln!(
-                        "Warning: {path}: nothing reads `{}`; its value is ignored",
+                    log::warn!(
+                        "{path}: nothing reads `{}`; its value is ignored",
                         crate::config::printable_key(key)
                     );
                 }

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -70,15 +70,27 @@ fn run_example(format: ConfigFormat) {
 }
 
 fn run_validate(path: &str, json: bool) {
-    match SimConfig::load(std::path::Path::new(path)) {
-        Ok(_) => {
+    match SimConfig::load_with_warnings(std::path::Path::new(path)) {
+        Ok(loaded) => {
+            // A key nothing read is a warning, not a failure: a config written
+            // for a newer `orts` still runs here. Naming the paths is what
+            // makes a typo findable, since the value it carried is gone.
+            let warnings: Vec<String> = loaded
+                .unread_keys
+                .iter()
+                .map(|key| format!("nothing reads `{key}`; its value is ignored"))
+                .collect();
             if json {
                 emit_verdict(serde_json::json!({
                     "schema": "orts.config-validate/v1",
                     "status": "ok",
                     "path": path,
+                    "warnings": warnings,
                 }));
             } else {
+                for warning in &warnings {
+                    eprintln!("Warning: {path}: {warning}");
+                }
                 eprintln!("OK: {path} is a valid orts config");
             }
         }

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -70,7 +70,9 @@ pub fn run_simulation_cmd(
             ));
         }
     };
-    // Holds for every path above: the `--sat` fleet has no per-entry validation.
+    // Every path above, config included. A config's own `validate` reaches this
+    // first and can name the offending `[[satellites]]` index; a `--sat` fleet has
+    // no per-entry validation at all, and here is where it gets one.
     crate::satellite::ensure_unique_ids(&params.satellites)?;
     // Resolve and validate the stdout/output contract before running the
     // (potentially long) simulation, so usage errors fail fast.

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -48,7 +48,8 @@ pub fn run_simulation_cmd(
     json: bool,
 ) -> Result<(), CmdError> {
     let mut params = if let Some(config_path) = &sim.config {
-        let config = crate::config::SimConfig::load(std::path::Path::new(config_path))?;
+        let config =
+            crate::config::load_config_reporting_unread_keys(std::path::Path::new(config_path))?;
         SimParams::from_config(&config)
     } else if sim.has_orbit_args() {
         // The direct-CLI path bypasses `SimConfig::validate`, so apply the
@@ -60,7 +61,7 @@ pub fn run_simulation_cmd(
         // Auto-detect orts.toml in the current directory
         let config_path = std::path::Path::new("orts.toml");
         if config_path.exists() {
-            let config = crate::config::SimConfig::load(config_path)?;
+            let config = crate::config::load_config_reporting_unread_keys(config_path)?;
             SimParams::from_config(&config)
         } else {
             return Err(CmdError::usage(

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -70,6 +70,8 @@ pub fn run_simulation_cmd(
             ));
         }
     };
+    // Holds for every path above: the `--sat` fleet has no per-entry validation.
+    crate::satellite::ensure_unique_ids(&params.satellites)?;
     // Resolve and validate the stdout/output contract before running the
     // (potentially long) simulation, so usage errors fail fast.
     let sink = resolve_data_sink(output, format);

--- a/cli/src/commands/serve/connection.rs
+++ b/cli/src/commands/serve/connection.rs
@@ -195,18 +195,13 @@ async fn main_loop(
                         // (nothing can report one there), and dropping the error
                         // left the client waiting on a reply that never came.
                         if let Err(e) = &parsed {
-                            let _ = ws_sender
-                                .send(Message::Text(
-                                    serde_json::to_string(&WsMessage::Error {
-                                        message: format!("could not read the message: {e}"),
-                                    })
-                                    .unwrap_or_else(|_| {
-                                        "{\"type\":\"error\",\"message\":\"could not read the message\"}"
-                                            .to_string()
-                                    })
-                                    .into(),
-                                ))
-                                .await;
+                            let json = serde_json::to_string(&WsMessage::Error {
+                                message: format!("could not read the message: {e}"),
+                            })
+                            .expect("failed to serialize error");
+                            if ws_sender.send(Message::Text(json.into())).await.is_err() {
+                                break;
+                            }
                         }
                         if let Ok(client_msg) = parsed {
                             let result = match client_msg {

--- a/cli/src/commands/serve/connection.rs
+++ b/cli/src/commands/serve/connection.rs
@@ -148,6 +148,37 @@ async fn dispatch_command<T>(
     }
 }
 
+/// How many characters of a parse error go back to the client.
+///
+/// 200 leaves room for the whole of every error this server produces from a
+/// message of its own shape.
+const ERROR_DETAIL_LIMIT: usize = 200;
+
+/// A parse error, cut to something bounded.
+///
+/// Serde names the field it could not read, and over `/ws` that name is the
+/// client's own text. Measured: a 100 KB unknown key inside an orbit block
+/// yields a 100 KB error, which would then be serialized and sent back — the
+/// inbound limit turned into an outbound allocation. The head of the message
+/// says which field and what was expected, which is the part anyone reads.
+///
+/// The position is appended when serde has one. On this path it does not: the
+/// error comes from replaying a buffered `type`-tagged block, so `line` and
+/// `column` are both 0 (measured), and a top-level syntax error carries its
+/// position in the text already, well inside the limit.
+fn client_error_detail(e: &serde_json::Error) -> String {
+    let text = e.to_string();
+    let Some((cut, _)) = text.char_indices().nth(ERROR_DETAIL_LIMIT) else {
+        return text;
+    };
+    let mut out = text[..cut].to_string();
+    out.push('…');
+    if e.line() != 0 {
+        out.push_str(&format!(" (line {}, column {})", e.line(), e.column()));
+    }
+    out
+}
+
 async fn main_loop(
     ws_sender: &mut WsSender,
     ws_receiver: &mut WsReceiver,
@@ -219,7 +250,10 @@ async fn main_loop(
                         // left the client waiting on a reply that never came.
                         if let Err(e) = &parsed {
                             let json = serde_json::to_string(&WsMessage::Error {
-                                message: format!("could not read the message: {e}"),
+                                message: format!(
+                                    "could not read the message: {}",
+                                    client_error_detail(e)
+                                ),
                             })
                             .expect("failed to serialize error");
                             if ws_sender.send(Message::Text(json.into())).await.is_err() {
@@ -287,5 +321,55 @@ async fn main_loop(
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The error a client gets back is bounded, however long its key was.
+    ///
+    /// Serde puts the field name in the message, and over `/ws` that name is
+    /// whatever the client sent. Measured before this was cut: a 100 KB unknown
+    /// key inside an orbit block produced a 100 KB error, which the server then
+    /// serialized and sent back.
+    #[test]
+    fn a_client_error_is_bounded_however_long_the_key() {
+        let key = "z".repeat(100_000);
+        let msg = format!(
+            "{{\"type\":\"start_simulation\",\"config\":{{\"satellites\":[{{\"id\":\"a\",\
+             \"orbit\":{{\"type\":\"circular\",\"altitude\":400,\"{key}\":1}}}}]}}}}"
+        );
+        let e = serde_json::from_str::<ClientMessage>(&msg)
+            .err()
+            .expect("an unknown key in a `type`-tagged block is refused");
+        assert!(
+            e.to_string().len() > 100_000,
+            "the raw error carries the whole key, which is what needs cutting"
+        );
+
+        let detail = client_error_detail(&e);
+        assert!(
+            detail.chars().count() <= ERROR_DETAIL_LIMIT + 40,
+            "bounded: {} chars",
+            detail.chars().count()
+        );
+        assert!(
+            detail.starts_with("unknown field"),
+            "the head still says what went wrong: {detail:.60}"
+        );
+        assert!(detail.ends_with('…'), "and says it was cut: {detail:.60}");
+    }
+
+    /// An error short enough to fit comes through whole, position and all.
+    #[test]
+    fn a_short_client_error_keeps_its_position() {
+        let e = serde_json::from_str::<ClientMessage>("{\"type\":\"query_range\",")
+            .err()
+            .expect("truncated JSON is refused");
+        let detail = client_error_detail(&e);
+        assert_eq!(detail, e.to_string());
+        assert!(detail.contains("line 1"), "serde's position: {detail}");
     }
 }

--- a/cli/src/commands/serve/connection.rs
+++ b/cli/src/commands/serve/connection.rs
@@ -189,7 +189,26 @@ async fn main_loop(
                                 "Warning: client message: nothing reads `{key}`; its value is ignored"
                             );
                         }
-                        if let Ok(client_msg) = serde_json::from_str::<ClientMessage>(&text) {
+                        let parsed = serde_json::from_str::<ClientMessage>(&text);
+                        // A message this server cannot read is answered, not
+                        // dropped. A `type`-tagged block refuses an unknown key
+                        // (nothing can report one there), and dropping the error
+                        // left the client waiting on a reply that never came.
+                        if let Err(e) = &parsed {
+                            let _ = ws_sender
+                                .send(Message::Text(
+                                    serde_json::to_string(&WsMessage::Error {
+                                        message: format!("could not read the message: {e}"),
+                                    })
+                                    .unwrap_or_else(|_| {
+                                        "{\"type\":\"error\",\"message\":\"could not read the message\"}"
+                                            .to_string()
+                                    })
+                                    .into(),
+                                ))
+                                .await;
+                        }
+                        if let Ok(client_msg) = parsed {
                             let result = match client_msg {
                                 ClientMessage::QueryRange { t_min, t_max, max_points, entity_path } => {
                                     let (resp_tx, resp_rx) = oneshot::channel();

--- a/cli/src/commands/serve/connection.rs
+++ b/cli/src/commands/serve/connection.rs
@@ -200,14 +200,14 @@ async fn main_loop(
                             {
                                 let unread = crate::config::unread_client_message_keys(&value);
                                 for key in &unread.named {
-                                    eprintln!(
-                                        "Warning: client message: nothing reads `{}`; its value is ignored",
+                                    log::warn!(
+                                        "client message: nothing reads `{}`; its value is ignored",
                                         crate::config::printable_key(key)
                                     );
                                 }
                                 if unread.unnamed > 0 {
-                                    eprintln!(
-                                        "Warning: client message: and {} more keys nothing reads",
+                                    log::warn!(
+                                        "client message: and {} more keys nothing reads",
                                         unread.unnamed
                                     );
                                 }

--- a/cli/src/commands/serve/connection.rs
+++ b/cli/src/commands/serve/connection.rs
@@ -184,11 +184,20 @@ async fn main_loop(
                         // working here, and an operator can see what was
                         // dropped. `start_simulation` carries a whole config, so
                         // a typo there would otherwise be silent.
-                        // One parse for both: the warning pass reads the tree
-                        // and `ClientMessage` then consumes it, so a frame is
-                        // not parsed twice on the way in.
-                        let parsed = serde_json::from_str::<serde_json::Value>(&text).and_then(
-                            |value| {
+                        //
+                        // The message is read from the text, not from a
+                        // `serde_json::Value`: a `Value`'s map keeps the last of
+                        // two members with one name, so
+                        // `{…,"config":{"dt":1},"config":{"dt":99}}` would run
+                        // with 99 and no word about it, where serde refuses a
+                        // duplicate field outright. The tree for the warning
+                        // pass is then built only for a message that was read,
+                        // and `MAX_CONTROL_MESSAGE_BYTES` bounds what that costs.
+                        let parsed = serde_json::from_str::<ClientMessage>(&text);
+                        if parsed.is_ok()
+                            && let Ok(value) = serde_json::from_str::<serde_json::Value>(&text)
+                        {
+                            {
                                 let unread = crate::config::unread_client_message_keys(&value);
                                 for key in &unread.named {
                                     eprintln!(
@@ -202,9 +211,8 @@ async fn main_loop(
                                         unread.unnamed
                                     );
                                 }
-                                serde_json::from_value::<ClientMessage>(value)
-                            },
-                        );
+                            }
+                        }
                         // A message this server cannot read is answered, not
                         // dropped. A `type`-tagged block refuses an unknown key
                         // (nothing can report one there), and dropping the error

--- a/cli/src/commands/serve/connection.rs
+++ b/cli/src/commands/serve/connection.rs
@@ -186,7 +186,8 @@ async fn main_loop(
                         // a typo there would otherwise be silent.
                         for key in crate::config::unread_client_message_keys(&text) {
                             eprintln!(
-                                "Warning: client message: nothing reads `{key}`; its value is ignored"
+                                "Warning: client message: nothing reads `{}`; its value is ignored",
+                                crate::config::printable_key(&key)
                             );
                         }
                         let parsed = serde_json::from_str::<ClientMessage>(&text);

--- a/cli/src/commands/serve/connection.rs
+++ b/cli/src/commands/serve/connection.rs
@@ -184,13 +184,20 @@ async fn main_loop(
                         // working here, and an operator can see what was
                         // dropped. `start_simulation` carries a whole config, so
                         // a typo there would otherwise be silent.
-                        for key in crate::config::unread_client_message_keys(&text) {
-                            eprintln!(
-                                "Warning: client message: nothing reads `{}`; its value is ignored",
-                                crate::config::printable_key(&key)
-                            );
-                        }
-                        let parsed = serde_json::from_str::<ClientMessage>(&text);
+                        // One parse for both: the warning pass reads the tree
+                        // and `ClientMessage` then consumes it, so a frame is
+                        // not parsed twice on the way in.
+                        let parsed = serde_json::from_str::<serde_json::Value>(&text).and_then(
+                            |value| {
+                                for key in crate::config::unread_client_message_keys(&value) {
+                                    eprintln!(
+                                        "Warning: client message: nothing reads `{}`; its value is ignored",
+                                        crate::config::printable_key(&key)
+                                    );
+                                }
+                                serde_json::from_value::<ClientMessage>(value)
+                            },
+                        );
                         // A message this server cannot read is answered, not
                         // dropped. A `type`-tagged block refuses an unknown key
                         // (nothing can report one there), and dropping the error

--- a/cli/src/commands/serve/connection.rs
+++ b/cli/src/commands/serve/connection.rs
@@ -178,6 +178,17 @@ async fn main_loop(
             ws_msg = ws_receiver.next() => {
                 match ws_msg {
                     Some(Ok(Message::Text(text))) => {
+                        // A key nothing reads is named on the server's stderr
+                        // and the message still runs, the policy a config file
+                        // gets: a client built against a newer `orts` keeps
+                        // working here, and an operator can see what was
+                        // dropped. `start_simulation` carries a whole config, so
+                        // a typo there would otherwise be silent.
+                        for key in crate::config::unread_client_message_keys(&text) {
+                            eprintln!(
+                                "Warning: client message: nothing reads `{key}`; its value is ignored"
+                            );
+                        }
                         if let Ok(client_msg) = serde_json::from_str::<ClientMessage>(&text) {
                             let result = match client_msg {
                                 ClientMessage::QueryRange { t_min, t_max, max_points, entity_path } => {

--- a/cli/src/commands/serve/connection.rs
+++ b/cli/src/commands/serve/connection.rs
@@ -189,10 +189,17 @@ async fn main_loop(
                         // not parsed twice on the way in.
                         let parsed = serde_json::from_str::<serde_json::Value>(&text).and_then(
                             |value| {
-                                for key in crate::config::unread_client_message_keys(&value) {
+                                let unread = crate::config::unread_client_message_keys(&value);
+                                for key in &unread.named {
                                     eprintln!(
                                         "Warning: client message: nothing reads `{}`; its value is ignored",
-                                        crate::config::printable_key(&key)
+                                        crate::config::printable_key(key)
+                                    );
+                                }
+                                if unread.unnamed > 0 {
+                                    eprintln!(
+                                        "Warning: client message: and {} more keys nothing reads",
+                                        unread.unnamed
                                     );
                                 }
                                 serde_json::from_value::<ClientMessage>(value)

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -945,6 +945,35 @@ impl ServeEngine {
             );
         }
 
+        // The id has to name an entity of its own, and one no satellite in the
+        // running fleet already answers to. Both paths below resolve the id from
+        // `self.metas.len()`, so an entry with no `id` becomes `sat-<len>` —
+        // which the initial config may have already spelled out — and the two
+        // would share an entity path: commands reach whichever comes last and
+        // state lookups find the first. Same rules a config file gets, applied
+        // against the fleet as it stands rather than against one list.
+        let id = satellite.resolved_id(self.metas.len());
+        crate::satellite::validate_id(&id)?;
+        let entity = crate::satellite::entity_path_for_id(&id).to_string();
+        if let Some(taken) = self
+            .metas
+            .iter()
+            .find(|m| m.spec.entity_path().to_string() == entity)
+        {
+            return Err(format!(
+                "satellite id '{id}' names the same entity as '{}', which is already in \
+                 the simulation; ids must be unique{}",
+                taken.spec.id,
+                if satellite.id.is_none() {
+                    format!(
+                        " — this request has no `id`, so it defaults to '{id}'; give it an explicit id"
+                    )
+                } else {
+                    String::new()
+                }
+            ));
+        }
+
         // Branch on the running simulation mode. Controlled and spacecraft
         // paths are handled inline; the orbit-only path continues below.
         match &self.group {
@@ -1725,5 +1754,82 @@ streams = ["comlink"]
         assert_eq!(events.len(), 10);
         assert_eq!(events.front().unwrap(), "event-0");
         assert_eq!(events.back().unwrap(), "event-9");
+    }
+
+    /// `add_satellite` refuses an id that names a satellite already running.
+    ///
+    /// The entity path is the fleet's addressing scheme, so two satellites on
+    /// one path make commands reach whichever was pushed last and state lookups
+    /// find the first. A config file is checked for this; the live path was not.
+    #[test]
+    fn add_satellite_refuses_an_id_already_in_the_fleet() {
+        let mut init = engine_from_toml(ORBIT_ONLY).expect("engine builds");
+        let cfg: SatelliteConfig = serde_json::from_str(
+            r#"{
+                "id": "sat-a",
+                "orbit": { "type": "circular", "altitude": 700 }
+            }"#,
+        )
+        .expect("valid satellite config");
+        let err = init
+            .engine
+            .add_satellite(cfg)
+            .err()
+            .expect("an id already in the fleet must be refused");
+        assert!(err.contains("sat-a"), "the message names the id: {err}");
+        assert!(err.contains("unique"), "got: {err}");
+    }
+
+    /// The same collision, reached through an omitted id.
+    ///
+    /// A request with no `id` takes `sat-<fleet size>`, which the initial config
+    /// can already have spelled out. The error says so, because the request
+    /// itself carries no id to look at.
+    #[test]
+    fn add_satellite_refuses_a_default_id_the_config_took() {
+        // One satellite, explicitly named `sat-1`: the next default id.
+        let mut init = engine_from_toml(
+            r#"
+[[satellites]]
+id = "sat-1"
+orbit = { type = "circular", altitude = 500 }
+"#,
+        )
+        .expect("engine builds");
+        let cfg: SatelliteConfig =
+            serde_json::from_str(r#"{ "orbit": { "type": "circular", "altitude": 700 } }"#)
+                .expect("valid satellite config");
+        let err = init
+            .engine
+            .add_satellite(cfg)
+            .err()
+            .expect("a default id the config took must be refused");
+        assert!(err.contains("sat-1"), "the message names the id: {err}");
+        assert!(
+            err.contains("no `id`"),
+            "the message says the id was defaulted: {err}"
+        );
+    }
+
+    /// An id that names no entity of its own is refused here too.
+    ///
+    /// `/` contributes no path segment, so it collapses to the `/world/sat` root
+    /// the whole fleet shares.
+    #[test]
+    fn add_satellite_refuses_an_id_naming_no_entity() {
+        let mut init = engine_from_toml(ORBIT_ONLY).expect("engine builds");
+        let cfg: SatelliteConfig = serde_json::from_str(
+            r#"{
+                "id": "/",
+                "orbit": { "type": "circular", "altitude": 700 }
+            }"#,
+        )
+        .expect("valid satellite config");
+        let err = init
+            .engine
+            .add_satellite(cfg)
+            .err()
+            .expect("an id naming no entity must be refused");
+        assert!(err.contains("no path segment"), "got: {err}");
     }
 }

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -1832,4 +1832,34 @@ orbit = { type = "circular", altitude = 500 }
             .expect("an id naming no entity must be refused");
         assert!(err.contains("no path segment"), "got: {err}");
     }
+
+    /// Two id spellings that name one entity are a collision here too.
+    ///
+    /// `EntityPath` drops empty segments, so `a` and `/a` both parse to
+    /// `/world/sat/a`. Comparing the resolved paths catches that; comparing the
+    /// id strings would not.
+    #[test]
+    fn add_satellite_refuses_an_id_spelled_differently_for_one_entity() {
+        let mut init = engine_from_toml(
+            r#"
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 500 }
+"#,
+        )
+        .expect("engine builds");
+        let cfg: SatelliteConfig = serde_json::from_str(
+            r#"{
+                "id": "/a",
+                "orbit": { "type": "circular", "altitude": 700 }
+            }"#,
+        )
+        .expect("valid satellite config");
+        let err = init
+            .engine
+            .add_satellite(cfg)
+            .err()
+            .expect("an id naming an entity already in the fleet must be refused");
+        assert!(err.contains("unique"), "got: {err}");
+    }
 }

--- a/cli/src/commands/serve/mod.rs
+++ b/cli/src/commands/serve/mod.rs
@@ -128,9 +128,9 @@ async fn async_server(
     // Determine initial config: if CLI args specify simulation, auto-start.
     let initial_config = if has_explicit_sim_args(sim) {
         match sim.config.as_ref() {
-            Some(config_path) => Some(crate::config::SimConfig::load(std::path::Path::new(
-                config_path,
-            ))?),
+            Some(config_path) => Some(crate::config::load_config_reporting_unread_keys(
+                std::path::Path::new(config_path),
+            )?),
             None => None,
         }
     } else {

--- a/cli/src/commands/serve/mod.rs
+++ b/cli/src/commands/serve/mod.rs
@@ -180,6 +180,7 @@ async fn async_server(
         // Same reason as in `run`: this path skips `SimConfig::validate`.
         crate::commands::run::validate_sim_args(sim)?;
         let params = Arc::new(SimParams::from_sim_args(sim, true));
+        crate::satellite::ensure_unique_ids(&params.satellites)?;
         tokio::spawn(manager::simulation_manager_with_params(
             params,
             plugin_overrides,

--- a/cli/src/commands/serve/mod.rs
+++ b/cli/src/commands/serve/mod.rs
@@ -121,10 +121,6 @@ async fn async_server(
         .map_err(|e| CmdError::failure(format!("binding to {addr}: {e}")))?;
 
     let actual_port = listener.local_addr().unwrap().port();
-    eprintln!("Server listening on http://localhost:{actual_port}");
-    #[cfg(feature = "viewer")]
-    eprintln!("Viewer:             http://localhost:{actual_port}/");
-    eprintln!("WebSocket endpoint: ws://localhost:{actual_port}/ws");
 
     let (tx, _rx) = broadcast::channel::<String>(256);
     let (cmd_tx, cmd_rx) = mpsc::channel::<SimCommand>(16);
@@ -234,6 +230,16 @@ async fn async_server(
     let app = app.fallback(spa::spa_handler);
 
     let app = app.with_state(state);
+
+    // Announced only once every rejection above is behind us. This banner is
+    // what callers wait on to mean "the endpoint is up" — `cli/tests/ws_e2e.rs`
+    // matches the first line, the Playwright specs read the port out of the
+    // `ws://` one — so printing it before the config is loaded turned a
+    // rejected config into a connection that is refused with no explanation.
+    eprintln!("Server listening on http://localhost:{actual_port}");
+    #[cfg(feature = "viewer")]
+    eprintln!("Viewer:             http://localhost:{actual_port}/");
+    eprintln!("WebSocket endpoint: ws://localhost:{actual_port}/ws");
 
     match shutdown_rx {
         Some(rx) => {

--- a/cli/src/commands/serve/mod.rs
+++ b/cli/src/commands/serve/mod.rs
@@ -71,13 +71,27 @@ fn has_explicit_sim_args(sim: &SimArgs) -> bool {
     sim.config.is_some() || sim.has_orbit_args()
 }
 
+/// The largest control message `/ws` will read.
+///
+/// Every inbound frame is parsed into a `serde_json::Value` so the keys nothing
+/// reads can be named, and the tree costs several times the bytes on the wire.
+/// axum's default ceiling is 64 MiB per message, which is far past anything this
+/// endpoint has to carry: measured, a `start_simulation` runs about 256 bytes per
+/// satellite, so 250 KiB for a fleet of 1000 and 2.5 MiB for 10000. 8 MiB leaves
+/// room for a fleet larger than any this simulator runs while keeping what one
+/// unauthenticated client can make the server hold to something bounded.
+///
+/// Outbound messages are unaffected: this bounds what is read.
+const MAX_CONTROL_MESSAGE_BYTES: usize = 8 * 1024 * 1024;
+
 async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
     let rx = state.tx.subscribe();
     let cmd_tx = state.cmd_tx.clone();
-    ws.on_upgrade(move |socket| async move {
-        connection::handle_connection(socket, rx, cmd_tx).await;
-        eprintln!("Client disconnected");
-    })
+    ws.max_message_size(MAX_CONTROL_MESSAGE_BYTES)
+        .on_upgrade(move |socket| async move {
+            connection::handle_connection(socket, rx, cmd_tx).await;
+            eprintln!("Client disconnected");
+        })
 }
 
 /// Binary WS endpoint for a declared `stream-io` stream — the shape of a

--- a/cli/src/commands/serve/protocol.rs
+++ b/cli/src/commands/serve/protocol.rs
@@ -46,6 +46,28 @@ pub enum ClientMessage {
     TerminateSimulation,
 }
 
+/// The keys a variant reads beside the `type` tag, or `None` where there is
+/// nothing to compare against.
+///
+/// `serde_ignored` cannot see inside an internally tagged enum, so
+/// [`crate::config::unread_client_message_keys`] compares a message's own keys
+/// against this list to find the ones nothing reads. It lives here so that a
+/// field added to a variant above and not listed here is one line away rather
+/// than one file away — miss it and that field's typos go back to being
+/// dropped in silence.
+///
+/// `None` for `add_satellite`, whose whole envelope is the flattened
+/// `SatelliteConfig` that function inspects as a payload, and for a `type` no
+/// variant answers to, which fails to deserialize and is reported as an error.
+pub fn variant_envelope_keys(kind: &str) -> Option<&'static [&'static str]> {
+    match kind {
+        "query_range" => Some(&["t_min", "t_max", "max_points", "entity_path"]),
+        "start_simulation" => Some(&["config"]),
+        "pause_simulation" | "resume_simulation" | "terminate_simulation" => Some(&[]),
+        _ => None,
+    }
+}
+
 /// Server-to-client WebSocket message.
 #[derive(Serialize, Clone, Debug, TS)]
 #[serde(tag = "type")]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -851,6 +851,17 @@ pub struct UnreadClientKeys {
     pub unnamed: usize,
 }
 
+impl UnreadClientKeys {
+    /// Name a key while there is room for one, and count it after that.
+    fn push(&mut self, key: String) {
+        if self.named.len() < CLIENT_MESSAGE_KEY_LIMIT {
+            self.named.push(key);
+        } else {
+            self.unnamed += 1;
+        }
+    }
+}
+
 /// The keys of a client message that no field of it reads.
 ///
 /// `ClientMessage` is `#[serde(tag = "type")]`, and `serde_ignored` cannot see
@@ -860,8 +871,11 @@ pub struct UnreadClientKeys {
 /// past the tag — the same trick reaches `add_satellite`'s flattened
 /// `SatelliteConfig`, where `flatten` removes the unknown-field check outright.
 ///
-/// Paths are relative to the part inspected: `dtt` and `satellites.0.altitide`
-/// for `start_simulation`'s config.
+/// Two things are inspected: the message's own keys, against what the variant
+/// reads (`ClientMessage` ignores an unknown one), and the payload the variant
+/// carries. Paths are relative to whichever they came from, so an envelope
+/// `dtt` and a config `dtt` are both named `dtt` — the name is what finds the
+/// typo either way.
 ///
 /// Takes the message already parsed, so the caller can hand the same `Value` to
 /// `ClientMessage` rather than paying for a second parse of every frame.
@@ -871,13 +885,22 @@ pub fn unread_client_message_keys(value: &serde_json::Value) -> UnreadClientKeys
     };
 
     let mut keys = UnreadClientKeys::default();
-    let mut note = |path: serde_ignored::Path| {
-        if keys.named.len() < CLIENT_MESSAGE_KEY_LIMIT {
-            keys.named.push(path.to_string());
-        } else {
-            keys.unnamed += 1;
+
+    // The envelope, against the keys the variant reads. `ClientMessage` ignores
+    // an unknown one, so `{"type":"start_simulation","config":{…},"dtt":10}`
+    // used to start the simulation with `dtt` dropped in silence.
+    if let (Some(read), Some(object)) = (
+        crate::commands::serve::protocol::variant_envelope_keys(kind),
+        value.as_object(),
+    ) {
+        for key in object.keys() {
+            if key != "type" && !read.contains(&key.as_str()) {
+                keys.push(key.clone());
+            }
         }
-    };
+    }
+
+    let mut note = |path: serde_ignored::Path| keys.push(path.to_string());
     match kind {
         "start_simulation" => {
             if let Some(config) = value.get("config") {
@@ -4123,5 +4146,77 @@ orbit = { type = "circular", altitude = 600 }
         // on what gets said about it, not on what it may contain.
         serde_json::from_value::<crate::commands::serve::protocol::ClientMessage>(value)
             .expect("a message full of unknown keys still starts a simulation");
+    }
+
+    /// A key beside the variant's own is named too, not only one in the payload.
+    ///
+    /// `ClientMessage` ignores an envelope key it does not read, so
+    /// `{"type":"start_simulation","config":{…},"dtt":10}` started the
+    /// simulation with `dtt` dropped in silence. The same held for a typo in an
+    /// optional field of `query_range`, and for any key on a variant that reads
+    /// none — a typo in a required field fails to deserialize instead, which the
+    /// server answers with an error.
+    #[test]
+    fn a_key_beside_the_variants_own_is_named() {
+        let cases = [
+            (
+                "start_simulation",
+                "{\"type\":\"start_simulation\",\"dtt\":10,\"config\":{\"dt\":1.0,\
+                 \"satellites\":[{\"id\":\"a\",\"orbit\":\
+                 {\"type\":\"circular\",\"altitude\":400}}]}}",
+                "dtt",
+            ),
+            (
+                "query_range",
+                "{\"type\":\"query_range\",\"t_min\":0.0,\"t_max\":10.0,\"max_pointz\":100}",
+                "max_pointz",
+            ),
+            (
+                "pause_simulation",
+                "{\"type\":\"pause_simulation\",\"untl\":10.0}",
+                "untl",
+            ),
+        ];
+        for (label, msg, key) in cases {
+            let value: serde_json::Value =
+                serde_json::from_str(msg).unwrap_or_else(|e| panic!("{label}: valid JSON: {e}"));
+            // The message is still one the server runs; the key is a warning.
+            serde_json::from_value::<crate::commands::serve::protocol::ClientMessage>(
+                value.clone(),
+            )
+            .unwrap_or_else(|e| panic!("{label}: an unknown key must not stop the message: {e}"));
+            let unread = unread_client_message_keys(&value);
+            assert_eq!(
+                unread.named,
+                vec![key.to_string()],
+                "{label}: the key beside the variant's own"
+            );
+        }
+    }
+
+    /// The keys a variant does read are not reported.
+    ///
+    /// The list in `protocol::variant_envelope_keys` is written by hand, so a
+    /// wrong entry would name a field the message uses.
+    #[test]
+    fn the_keys_a_variant_reads_are_not_named() {
+        for msg in [
+            "{\"type\":\"query_range\",\"t_min\":0.0,\"t_max\":10.0,\"max_points\":100,\
+             \"entity_path\":\"/world/sat/a\"}",
+            "{\"type\":\"pause_simulation\"}",
+            "{\"type\":\"resume_simulation\"}",
+            "{\"type\":\"terminate_simulation\"}",
+        ] {
+            let value: serde_json::Value = serde_json::from_str(msg).expect("valid JSON");
+            serde_json::from_value::<crate::commands::serve::protocol::ClientMessage>(
+                value.clone(),
+            )
+            .unwrap_or_else(|e| panic!("{msg} must deserialize: {e}"));
+            assert_eq!(
+                unread_client_message_keys(&value),
+                UnreadClientKeys::default(),
+                "nothing to report for {msg}"
+            );
+        }
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1250,6 +1250,11 @@ impl SimConfig {
         let mut seen: HashMap<String, usize> = HashMap::with_capacity(self.satellites.len());
         for (i, sat) in self.satellites.iter().enumerate() {
             let id = sat.resolved_id(i);
+            // An id has to name an entity before two of them can be compared:
+            // one made only of separators contributes no segment and collapses
+            // to the `/world/sat` root the whole fleet shares, which a fleet of
+            // one reaches as readily as a fleet of many.
+            crate::satellite::validate_id(&id).map_err(|e| format!("satellites[{i}]: {e}"))?;
             let entity = crate::satellite::entity_path_for_id(&id).to_string();
             if let Some(first) = seen.insert(entity, i) {
                 return Err(format!(
@@ -3370,6 +3375,32 @@ altitude = 500.0
                 err.contains("duplicate satellite id"),
                 "ids {a:?} and {b:?}: {err}"
             );
+        }
+    }
+
+    /// An id naming no entity of its own is rejected, fleet of one included.
+    ///
+    /// A separator-only id contributes no path segment, so the recording entity
+    /// collapses to the `/world/sat` root the whole fleet shares. The `--sat`
+    /// path rejects it (`validate_id`); a config file accepted it, and a fleet
+    /// of one got there without any duplicate to notice.
+    #[test]
+    fn an_id_naming_no_entity_is_rejected() {
+        for id in ["/", "//"] {
+            let toml = format!(
+                r#"
+[[satellites]]
+id = "{id}"
+[satellites.orbit]
+type = "circular"
+altitude = 400.0
+"#
+            );
+            let config: SimConfig = toml::from_str(&toml).expect("parse");
+            let err = config
+                .validate()
+                .expect_err(&format!("id {id:?} names no entity"));
+            assert!(err.contains("no path segment"), "id {id:?}: {err}");
         }
     }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -297,6 +297,14 @@ impl Default for IntegratorConfig {
     }
 }
 
+/// How far a normalized `initial_quaternion` may sit from unit norm.
+///
+/// 1e-9 of unit-norm error scales a rotation by that much, ~2e-4 arcsec at
+/// 1 rad, three orders below the ~484 arcsec that separates the ECI frames this
+/// config chooses between. See [`AttitudeConfig::validate`] for the measurements
+/// this sits between.
+const QUATERNION_UNIT_TOLERANCE: f64 = 1e-9;
+
 /// Attitude dynamics configuration for a satellite.
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
 #[ts(export)]
@@ -490,12 +498,10 @@ impl AttitudeConfig {
     /// slack keeps a config that states the lamina case exactly from being
     /// rejected by the eigenvalue solver's last bits.
     ///
-    /// The WebSocket `add_satellite` path validates a built `SatelliteSpec`
-    /// instead, against a determinant threshold, so it neither rejects
-    /// everything this does nor accepts everything this accepts (a uniformly
-    /// tiny tensor has a determinant below the threshold while being perfectly
-    /// invertible). That check should delegate here so the two surfaces cannot
-    /// disagree about what a spacecraft is.
+    /// The WebSocket `add_satellite` path reaches the same rules:
+    /// [`crate::sim::mode::validate_satellite_spec`] takes a built
+    /// `SatelliteSpec` and delegates to this, so neither surface can accept a
+    /// spacecraft the other refuses.
     pub fn validate(&self) -> Result<(), String> {
         // Non-finite first: every comparison below is false for `NaN`, so a
         // `NaN` mass would pass `mass <= 0.0` and a `NaN` determinant would
@@ -520,20 +526,34 @@ impl AttitudeConfig {
         }
         // The quaternion need not be normalized — `AttitudeState::orientation`
         // normalizes on use and `OdeState::project` renormalizes after every
-        // step — but it has to be something those can normalize. Both divide by
-        // the sum of squares, so the test is that sum rather than the
-        // components: `[1e200, 0, 0, 0]` squares to infinity and drives every
-        // component to zero.
+        // step — but the normalization has to land on a unit quaternion. Ask
+        // that the way the dynamics do, by running the same call and looking at
+        // what comes out, rather than by putting a floor on the squared norm:
+        // a floor on the smallest normal rejects `[1e-154, 0, 0, 0]`, whose
+        // squared norm is subnormal yet normalizes exactly.
         //
-        // The floor is the smallest normal rather than `> 0.0` because a
-        // subnormal sum has already lost mantissa bits before the square root:
-        // `[1e-160, 0, 0, 0]` has a squared norm of 1e-320 and normalizes to
-        // 1.0000056, not 1.
-        let quat_norm_sq: f64 = self.initial_quaternion.iter().map(|q| q * q).sum();
-        if !quat_norm_sq.is_finite() || quat_norm_sq < f64::MIN_POSITIVE {
+        // Measured across the range: `[1e200, 0, 0, 0]` squares to infinity and
+        // normalizes to all zeros; `[1e-164, 0, 0, 0]` squares to zero and
+        // normalizes to infinity; a squared norm deep in the subnormal range
+        // has lost mantissa bits before the square root, so `[1e-160, 0, 0, 0]`
+        // normalizes to 1.0000056. The last accepted case, `[1e-157, 0, 0, 0]`,
+        // is off by 1.8e-11.
+        //
+        // `QUATERNION_UNIT_TOLERANCE` sits between those two.
+        let normalized = nalgebra::UnitQuaternion::from_quaternion(nalgebra::Quaternion::new(
+            self.initial_quaternion[0],
+            self.initial_quaternion[1],
+            self.initial_quaternion[2],
+            self.initial_quaternion[3],
+        ))
+        .into_inner()
+        .norm();
+        if !normalized.is_finite() || (normalized - 1.0).abs() > QUATERNION_UNIT_TOLERANCE {
+            let quat_norm_sq: f64 = self.initial_quaternion.iter().map(|q| q * q).sum();
             return Err(format!(
-                "`initial_quaternion` cannot be normalized (its components square to \
-                 {quat_norm_sq}); it names no attitude"
+                "`initial_quaternion` does not normalize to a unit quaternion (its \
+                 components square to {quat_norm_sq}, and normalizing gives a norm of \
+                 {normalized}); it names no attitude"
             ));
         }
         // Ask the inertia question the way the dynamics do: `SpacecraftDynamics::new`
@@ -3414,12 +3434,12 @@ altitude = 800
     /// every consumer reads it through `orientation()`, which normalizes it. So
     /// the config check is correct when it accepts a quaternion exactly when
     /// that normalization yields a finite unit quaternion. Cross-checked
-    /// against the real call rather than against a threshold, because the
-    /// interesting boundary is not where the arithmetic fails outright:
-    /// `[1e-160, 0, 0, 0]` looks harmless and does produce a finite result,
-    /// but its squared norm is subnormal, so the result has a norm of
-    /// 1.0000056 — which is why the check floors the squared norm at the
-    /// smallest normal instead of at zero.
+    /// against the real call rather than against a threshold on the input,
+    /// because the interesting boundary is not where the arithmetic fails
+    /// outright: `[1e-160, 0, 0, 0]` looks harmless and does produce a finite
+    /// result, but its squared norm is subnormal deeply enough that the result
+    /// has a norm of 1.0000056. A squared norm that is merely subnormal is fine,
+    /// which is why the bound is on the normalized result and not on that sum.
     #[test]
     fn accepted_quaternions_are_exactly_the_normalizable_ones() {
         for q in [
@@ -3428,8 +3448,15 @@ altitude = 800
             // Not unit norm, but normalization handles it — the config is
             // allowed to state a rotation without pre-normalizing it.
             [2.0, 0.0, 0.0, 0.0],
-            // Squared norm is subnormal, its square root is not.
+            // Squared norm is subnormal and normalizes exactly.
+            [1e-154, 0.0, 0.0, 0.0],
+            // Subnormal enough to lose bits, still inside the tolerance
+            // (1.8e-11).
+            [1e-157, 0.0, 0.0, 0.0],
+            // Subnormal enough to leave it (5.6e-6).
             [1e-160, 0.0, 0.0, 0.0],
+            // Squared norm underflows to zero, normalizing to infinity.
+            [1e-164, 0.0, 0.0, 0.0],
             // Squared norm underflows to zero.
             [1e-200, 0.0, 0.0, 0.0],
             // Squared norm overflows to infinity.
@@ -3446,7 +3473,7 @@ altitude = 800
             };
             let orientation = state.orientation();
             let usable = orientation.coords.iter().all(|c| c.is_finite())
-                && (orientation.coords.norm() - 1.0).abs() < 1e-12;
+                && (orientation.coords.norm() - 1.0).abs() <= QUATERNION_UNIT_TOLERANCE;
             assert_eq!(
                 att.validate().is_ok(),
                 usable,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -299,10 +299,13 @@ impl Default for IntegratorConfig {
 
 /// How far a normalized `initial_quaternion` may sit from unit norm.
 ///
-/// 1e-9 of unit-norm error scales a rotation by that much, ~2e-4 arcsec at
-/// 1 rad, three orders below the ~484 arcsec that separates the ECI frames this
-/// config chooses between. See [`AttitudeConfig::validate`] for the measurements
-/// this sits between.
+/// An empirical bound on the normalization residual, not a bound on attitude
+/// error: a quaternion's norm scales it radially in 4D and says nothing on its
+/// own about the rotation it names. It exists to separate a residual that is
+/// floating-point rounding from one that says the input lost its mantissa
+/// before the square root — see [`AttitudeConfig::validate`] for the measured
+/// cases it sits between, 1.8e-11 on the last accepted and 5.6e-6 on the first
+/// refused.
 const QUATERNION_UNIT_TOLERANCE: f64 = 1e-9;
 
 /// Attitude dynamics configuration for a satellite.
@@ -1426,6 +1429,28 @@ impl SimConfig {
                 arika::tle::parse(&format!("{line1}\n{line2}"))
                     .map_err(|e| format!("satellites[{i}]: invalid TLE: {e}"))?;
             }
+        }
+        // Which mode the fleet runs in is settled by the config, so a fleet no
+        // mode can serve is settled here too. `SatelliteSpec` carries these two
+        // as clones of the fields counted below, so the count the engine makes
+        // is this count.
+        if !self.satellites.is_empty() {
+            let fleet_size = self.satellites.len();
+            let with_attitude = self
+                .satellites
+                .iter()
+                .filter(|s| s.attitude.is_some())
+                .count();
+            let with_controller = self
+                .satellites
+                .iter()
+                .filter(|s| s.controller.is_some())
+                .count();
+            crate::sim::mode::ensure_fleet_declares_uniformly(
+                fleet_size,
+                with_attitude,
+                with_controller,
+            )?;
         }
         for (i, cmd) in self.commands.iter().enumerate() {
             // A non-finite or negative `t` would never satisfy the
@@ -3754,5 +3779,109 @@ altitude = 500.0
 "#;
         let config: SimConfig = toml::from_str(toml).expect("parse");
         config.validate().expect("two entities, two satellites");
+    }
+
+    /// A fleet no mode can serve is refused by the config, not by the engine.
+    ///
+    /// `orts serve --config` builds its engine inside a spawned manager, so a
+    /// mixed fleet used to validate clean, print the startup banner, and leave
+    /// the server idle with the caller's config never running.
+    #[test]
+    fn a_fleet_no_mode_can_serve_is_rejected() {
+        let mixed_attitude = r#"
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 500 }
+attitude = { inertia_diag = [10.0, 10.0, 10.0], mass = 100.0 }
+
+[[satellites]]
+id = "b"
+orbit = { type = "circular", altitude = 600 }
+"#;
+        let config: SimConfig = toml::from_str(mixed_attitude).expect("valid toml");
+        let err = config
+            .validate()
+            .expect_err("half a fleet with attitude runs in no mode");
+        assert!(err.contains("Mixed attitude config"), "msg: {err}");
+
+        let mixed_controller = r#"
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 500 }
+controller = { type = "wasm", path = "ctrl.wasm" }
+
+[[satellites]]
+id = "b"
+orbit = { type = "circular", altitude = 600 }
+"#;
+        let config: SimConfig = toml::from_str(mixed_controller).expect("valid toml");
+        let err = config
+            .validate()
+            .expect_err("half a fleet with a controller runs in no mode");
+        assert!(err.contains("Mixed controller config"), "msg: {err}");
+
+        // Both declared on every satellite, and on none, are the fleets that do
+        // pick a mode.
+        for toml in [
+            r#"
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 500 }
+attitude = { inertia_diag = [10.0, 10.0, 10.0], mass = 100.0 }
+
+[[satellites]]
+id = "b"
+orbit = { type = "circular", altitude = 600 }
+attitude = { inertia_diag = [10.0, 10.0, 10.0], mass = 100.0 }
+"#,
+            r#"
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 500 }
+
+[[satellites]]
+id = "b"
+orbit = { type = "circular", altitude = 600 }
+"#,
+        ] {
+            let config: SimConfig = toml::from_str(toml).expect("valid toml");
+            config.validate().expect("a uniform fleet picks a mode");
+        }
+    }
+
+    /// The config's count and the engine's count are the same count.
+    ///
+    /// `validate` counts `SatelliteConfig::attitude` / `controller` because
+    /// building specs would reach the network for a `norad_id` orbit, while
+    /// `select_sim_mode` counts the spec fields. They agree only as long as
+    /// `to_satellite_spec` keeps cloning them across unchanged.
+    #[test]
+    fn the_config_counts_what_the_engine_counts() {
+        let toml = r#"
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 500 }
+attitude = { inertia_diag = [10.0, 10.0, 10.0], mass = 100.0 }
+controller = { type = "wasm", path = "ctrl.wasm" }
+
+[[satellites]]
+id = "b"
+orbit = { type = "circular", altitude = 600 }
+"#;
+        let config: SimConfig = toml::from_str(toml).expect("valid toml");
+        let body = crate::satellite::try_parse_body(&config.body).expect("earth");
+        for (i, sat) in config.satellites.iter().enumerate() {
+            let spec = sat.to_satellite_spec(i, body, 398600.4418);
+            assert_eq!(
+                sat.attitude.is_some(),
+                spec.attitude_config.is_some(),
+                "satellites[{i}]: attitude"
+            );
+            assert_eq!(
+                sat.controller.is_some(),
+                spec.controller_config.is_some(),
+                "satellites[{i}]: controller"
+            );
+        }
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -943,8 +943,14 @@ impl SimConfig {
         let config: SimConfig = match ext.as_str() {
             "json" => {
                 let mut de = serde_json::Deserializer::from_str(&content);
-                serde_ignored::deserialize(&mut de, &mut note)
-                    .map_err(|e| format!("Failed to parse JSON config: {e}"))?
+                let config = serde_ignored::deserialize(&mut de, &mut note)
+                    .map_err(|e| format!("Failed to parse JSON config: {e}"))?;
+                // `serde_json::from_str` ends by checking that the input is
+                // spent; driving the `Deserializer` directly does not, so
+                // anything after the config would be dropped without a word.
+                de.end()
+                    .map_err(|e| format!("Failed to parse JSON config: {e}"))?;
+                config
             }
             "toml" => {
                 let de = toml::Deserializer::parse(&content)
@@ -3175,6 +3181,37 @@ altitude = 500
         std::fs::remove_dir_all(&dir).ok();
     }
 
+    /// A JSON file with anything after the config is refused.
+    ///
+    /// Reading the keys nothing reads means driving `serde_json`'s
+    /// `Deserializer` instead of calling `from_str`, and only `from_str` ends by
+    /// checking that the input is spent. A second object, or a truncated edit
+    /// that left the old text behind, would otherwise load as though the file
+    /// stopped where the config did.
+    #[test]
+    fn a_json_config_with_content_after_it_is_refused() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts-json-trailing-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let config =
+            r#"{"dt":1.0,"satellites":[{"id":"a","orbit":{"type":"circular","altitude":400}}]}"#;
+        let path = dir.join("sim.json");
+
+        std::fs::write(&path, config).expect("write config");
+        SimConfig::load_with_warnings(&path).expect("the config alone loads");
+
+        for trailing in ["{\"dt\":99.0}", "this is not json"] {
+            std::fs::write(&path, format!("{config}{trailing}")).expect("write config");
+            let err = SimConfig::load_with_warnings(&path)
+                .expect_err("content after the config must be refused");
+            assert!(err.contains("JSON"), "msg: {err}");
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
     /// Two satellites resolving to one id share the recording entity path and
     /// the CSV section, and `[[command]]` reaches only whichever one won the
     /// id → index map. Reject the fleet instead.
@@ -3429,11 +3466,14 @@ altitude = 800
         assert!(err.contains("initial_quaternion"), "msg: {err}");
     }
 
-    /// The quaternion bound must be exactly what the dynamics break on: `run`
-    /// and `serve` copy `initial_quaternion` into `AttitudeState` verbatim, and
-    /// every consumer reads it through `orientation()`, which normalizes it. So
-    /// the config check is correct when it accepts a quaternion exactly when
-    /// that normalization yields a finite unit quaternion. Cross-checked
+    /// The quaternion bound must be exactly what the dynamics break on. `run`
+    /// and `serve` divide by the norm once ([`normalized_initial_quaternion`],
+    /// which is the same normalization) before storing, and every consumer then
+    /// reads the state through `orientation()`, which normalizes again. So the
+    /// config check is correct when it accepts a quaternion exactly when that
+    /// normalization yields a finite unit quaternion — checked here by feeding
+    /// the raw components to `orientation()`, the one call whose result the
+    /// config cannot influence. Cross-checked
     /// against the real call rather than against a threshold on the input,
     /// because the interesting boundary is not where the arithmetic fails
     /// outright: `[1e-160, 0, 0, 0]` looks harmless and does produce a finite
@@ -3481,6 +3521,20 @@ altitude = 800
                 orientation.coords
             );
         }
+
+        // Where the bound itself sits, written out so that loosening
+        // `QUATERNION_UNIT_TOLERANCE` cannot take the oracle with it. Measured:
+        // these two normalize 1.8e-11 and 5.6e-6 off unit norm.
+        let mut accepted = attitude([10.0, 10.0, 10.0], [0.0; 3], 100.0);
+        accepted.initial_quaternion = [1e-157, 0.0, 0.0, 0.0];
+        accepted
+            .validate()
+            .expect("1e-157 normalizes close enough to unit norm");
+        let mut refused = attitude([10.0, 10.0, 10.0], [0.0; 3], 100.0);
+        refused.initial_quaternion = [1e-160, 0.0, 0.0, 0.0];
+        refused
+            .validate()
+            .expect_err("1e-160 normalizes to 1.0000056, too far to accept");
     }
 
     #[test]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -3139,6 +3139,19 @@ direction_body = [0.0, 0.0, 0.0]
                  \n[satellites.controller]\ntype = \"wasm\"\npath = \"p.wasm\"\npth = \"q.wasm\"\n",
                 "pth",
             ),
+            (
+                "reaction_wheels",
+                "[[satellites]]\n[satellites.orbit]\ntype = \"circular\"\naltitude = 500\n\
+                 \n[satellites.reaction_wheels]\ntype = \"three_axis\"\ninertia = 1e-4\n\
+                 max_momentum = 0.03\nmax_torqe = 0.001\n",
+                "max_torqe",
+            ),
+            (
+                "magnetorquers",
+                "[[satellites]]\n[satellites.orbit]\ntype = \"circular\"\naltitude = 500\n\
+                 \n[satellites.magnetorquers]\ntype = \"three_axis\"\nmax_momnet = 0.2\n",
+                "max_momnet",
+            ),
         ];
         for (label, toml_src, key) in cases {
             let err = toml::from_str::<SimConfig>(toml_src)
@@ -3910,5 +3923,86 @@ orbit = { type = "circular", altitude = 600 }
                 "satellites[{i}]: controller"
             );
         }
+    }
+
+    /// Every format the loader accepts names its unread keys the same way.
+    ///
+    /// The three go through different `serde_ignored` adapters — a `&mut`
+    /// `serde_json::Deserializer`, a `toml::Deserializer` by value, a
+    /// `serde_yaml::Deserializer` by value — so a change to one says nothing
+    /// about the others. The same two typos, at the top level and inside a
+    /// satellite, must come back as the same two paths from all three.
+    #[test]
+    fn every_format_names_the_same_unread_keys() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts-unread-formats-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+
+        let files = [
+            (
+                "sim.toml",
+                "dt = 1.0\nduraton = 100.0\n\n[[satellites]]\nid = \"a\"\naltitide = 400\n\
+                 [satellites.orbit]\ntype = \"circular\"\naltitude = 400\n"
+                    .to_string(),
+            ),
+            (
+                "sim.json",
+                r#"{"dt":1.0,"duraton":100.0,"satellites":[
+                    {"id":"a","altitide":400,
+                     "orbit":{"type":"circular","altitude":400}}]}"#
+                    .to_string(),
+            ),
+            (
+                "sim.yaml",
+                "dt: 1.0\nduraton: 100.0\nsatellites:\n  - id: a\n    altitide: 400\n    \
+                 orbit:\n      type: circular\n      altitude: 400\n"
+                    .to_string(),
+            ),
+        ];
+
+        for (name, body) in files {
+            let path = dir.join(name);
+            std::fs::write(&path, &body).expect("write config");
+            let loaded = SimConfig::load_with_warnings(&path)
+                .unwrap_or_else(|e| panic!("{name}: the file loads: {e}"));
+            assert_eq!(
+                loaded.unread_keys,
+                vec!["duraton", "satellites.0.altitide"],
+                "{name}: both paths, in order"
+            );
+            assert_eq!(loaded.config.dt, 1.0, "{name}: the read keys still land");
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A YAML file holding a second document is refused.
+    ///
+    /// `serde_yaml::from_str` refuses a multi-document stream; driving the
+    /// `Deserializer` to collect the unread keys has to keep doing so, or the
+    /// documents after the first would be dropped without a word — the JSON
+    /// trailing-input hole in a different format.
+    #[test]
+    fn a_yaml_config_with_a_second_document_is_refused() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts-yaml-multidoc-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("sim.yaml");
+        let one = "dt: 1.0\nsatellites:\n  - id: a\n    orbit:\n      type: circular\n      \
+                   altitude: 400\n";
+
+        std::fs::write(&path, one).expect("write config");
+        SimConfig::load_with_warnings(&path).expect("one document loads");
+
+        std::fs::write(&path, format!("{one}---\ndt: 99.0\n")).expect("write config");
+        let err =
+            SimConfig::load_with_warnings(&path).expect_err("a second document must be refused");
+        assert!(err.contains("YAML"), "msg: {err}");
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1518,6 +1518,16 @@ impl SimConfig {
                 arika::tle::parse(&format!("{line1}\n{line2}"))
                     .map_err(|e| format!("satellites[{i}]: invalid TLE: {e}"))?;
             }
+            // SGP4 is Earth's, and `SimParams::from_config` reaches this rule
+            // through an `unwrap_or_else(panic)`: a non-Earth TLE config
+            // validated clean and then took down `orts run --config`.
+            if matches!(
+                sat.orbit,
+                OrbitConfig::Tle { .. } | OrbitConfig::Norad { .. }
+            ) {
+                crate::sim::params::ensure_body_carries_omm(body)
+                    .map_err(|e| format!("satellites[{i}]: {e}"))?;
+            }
         }
         // Which mode the fleet runs in is settled by the config, so a fleet no
         // mode can serve is settled here too. `SatelliteSpec` carries these two
@@ -4281,5 +4291,40 @@ orbit = { type = "circular", altitude = 600 }
             err.to_string().contains("duplicate field"),
             "the error says which: {err}"
         );
+    }
+
+    /// A TLE or NORAD orbit about anything but Earth is refused by the config.
+    ///
+    /// SGP4 is Earth's, and `SimParams::from_config` reaches that rule through
+    /// an `unwrap_or_else(panic)`. Measured before this: `orts config validate`
+    /// called a Moon + TLE config valid and `orts run --config` panicked on it.
+    ///
+    /// The `norad` case is checked here rather than through a spec, because
+    /// building one fetches the element set over the network.
+    #[test]
+    fn a_tle_about_another_body_is_rejected() {
+        let tle = "[[satellites]]\nid = \"a\"\n[satellites.orbit]\ntype = \"tle\"\n\
+                   line1 = \"1 25544U 98067A   24079.50000000  .00016717  00000-0  \
+                   30000-4 0  9996\"\n\
+                   line2 = \"2 25544  51.6400 208.6520 0007417  35.3910 324.7580 \
+                   15.49561654480008\"\n";
+        let norad = "[[satellites]]\nid = \"a\"\n[satellites.orbit]\n\
+                     type = \"norad\"\nnorad_id = 25544\n";
+
+        for (label, orbit) in [("tle", tle), ("norad", norad)] {
+            let config: SimConfig = toml::from_str(&format!("body = \"moon\"\n{orbit}"))
+                .unwrap_or_else(|e| panic!("{label}: valid toml: {e}"));
+            let err = config
+                .validate()
+                .expect_err(&format!("{label}: SGP4 cannot propagate about the Moon"));
+            assert!(err.contains("Earth-centered"), "{label}: {err}");
+
+            // The same orbit about Earth is what the check must not refuse.
+            let config: SimConfig = toml::from_str(&format!("body = \"earth\"\n{orbit}"))
+                .unwrap_or_else(|e| panic!("{label}: valid toml: {e}"));
+            config
+                .validate()
+                .unwrap_or_else(|e| panic!("{label}: Earth is where SGP4 belongs: {e}"));
+        }
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -475,6 +475,17 @@ impl AttitudeConfig {
     /// orbit. An inertia scaled so far from the orbit that the gravity gradient
     /// alone overflows therefore passes here and stops at the first step with
     /// [`utsuroi::IntegrationError::NonFiniteState`].
+    /// Equality `I1 + I2 == I3` is accepted: that is the flat-plate (lamina)
+    /// limit, physically attainable and numerically well-posed. The relative
+    /// slack keeps a config that states the lamina case exactly from being
+    /// rejected by the eigenvalue solver's last bits.
+    ///
+    /// The WebSocket `add_satellite` path validates a built `SatelliteSpec`
+    /// instead, against a determinant threshold, so it neither rejects
+    /// everything this does nor accepts everything this accepts (a uniformly
+    /// tiny tensor has a determinant below the threshold while being perfectly
+    /// invertible). That check should delegate here so the two surfaces cannot
+    /// disagree about what a spacecraft is.
     pub fn validate(&self) -> Result<(), String> {
         // Non-finite first: every comparison below is false for `NaN`, so a
         // `NaN` mass would pass `mass <= 0.0` and a `NaN` determinant would
@@ -494,6 +505,32 @@ impl AttitudeConfig {
                 return Err(format!("non-finite `{name}` component: {bad}"));
             }
         }
+        if !self.mass.is_finite() || self.mass <= 0.0 {
+            return Err(format!(
+                "attitude.mass must be positive and finite (got {})",
+                self.mass
+            ));
+        }
+        // `AttitudeState::orientation()` normalizes whatever it is given, so a
+        // quaternion it cannot normalize becomes a NaN or non-unit attitude
+        // rather than an error. The condition is on the squared norm, because
+        // that is what the normalization divides by: zero (components small
+        // enough that the squares underflow) divides by zero, and infinity
+        // (components large enough that the squares overflow) drives every
+        // component to zero. The floor is the smallest normal rather than `> 0`
+        // because a subnormal squared norm has lost mantissa bits before the
+        // square root is taken: `[1e-160, 0, 0, 0]` normalizes to a norm of
+        // 1.0000056, not 1. `accepted_quaternions_are_exactly_the_normalizable_ones`
+        // pins the bound against that call.
+        let quat_norm_sq: f64 = self.initial_quaternion.iter().map(|q| q * q).sum();
+        if !quat_norm_sq.is_finite() || quat_norm_sq < f64::MIN_POSITIVE {
+            return Err(format!(
+                "attitude.initial_quaternion must have a usable norm (got {:?}): it is a \
+                 rotation (w, x, y, z), and the default (1, 0, 0, 0) is the identity",
+                self.initial_quaternion
+            ));
+        }
+
         // Ask the question the way the dynamics do: `SpacecraftDynamics::new`
         // takes `try_inverse().expect(…)`, so the test is whether that inverse
         // exists and is usable. A magnitude threshold on the determinant cannot
@@ -3012,7 +3049,7 @@ altitude = 800
         let err = attitude([0.0, 0.0, 0.0], [0.0; 3], 100.0)
             .validate()
             .expect_err("a zero inertia tensor must be rejected");
-        assert!(err.contains("positive definite"), "msg: {err}");
+        assert!(err.contains("inertia tensor"), "msg: {err}");
 
         // Singular through the off-diagonals only: [[1,1,0],[1,1,0],[0,0,1]]
         // has principal moments (0, 1, 2), which `inertia_diag` alone does not
@@ -3020,7 +3057,7 @@ altitude = 800
         let err = attitude([1.0, 1.0, 1.0], [1.0, 0.0, 0.0], 100.0)
             .validate()
             .expect_err("an off-diagonal singular tensor must be rejected");
-        assert!(err.contains("positive definite"), "msg: {err}");
+        assert!(err.contains("inertia tensor"), "msg: {err}");
     }
 
     /// An indefinite tensor is invertible — a determinant test passes it — but
@@ -3087,7 +3124,10 @@ altitude = 800
             let err = attitude([10.0, 10.0, 10.0], [0.0; 3], mass)
                 .validate()
                 .expect_err("non-positive mass must be rejected");
-            assert!(err.contains("attitude.mass"), "msg for {mass}: {err}");
+            assert!(
+                err.contains("mass") || err.contains("`mass`"),
+                "msg for {mass}: {err}"
+            );
         }
     }
 
@@ -3107,6 +3147,100 @@ altitude = 800
             .validate()
             .expect_err("a non-finite quaternion must be rejected");
         assert!(err.contains("initial_quaternion"), "msg: {err}");
+    }
+
+    /// Finite but absurd magnitudes must come back as an error, not as a
+    /// panic from the eigenvalue solver or a NaN slipping through.
+    #[test]
+    fn attitude_validate_rejects_unusable_magnitudes() {
+        let huge = attitude([f64::MAX, f64::MAX, f64::MAX], [f64::MAX, 0.0, 0.0], 100.0);
+        let err = huge
+            .validate()
+            .expect_err("an overflowing tensor must be rejected");
+        // The inverse check reaches it first: cofactors of `f64::MAX` overflow,
+        // so `I · I⁻¹` is nowhere near the identity. Either guard is a correct
+        // rejection; what matters is that it is an error and not a panic from
+        // the eigenvalue solver.
+        assert!(err.contains("inertia tensor"), "got: {err}");
+
+        // Finite principal moments whose determinant still overflows:
+        // `try_inverse` returns `Some` for a non-zero (infinite) determinant,
+        // so the inverse comes back unusable rather than absent.
+        let overflowing_det = attitude([1e308, 1e308, 1e308], [0.0; 3], 100.0);
+        let moments = overflowing_det.inertia_matrix().symmetric_eigenvalues();
+        assert!(
+            moments.iter().all(|m| m.is_finite()),
+            "fixture must pass the diagonalization guard: {moments:?}"
+        );
+        let err = overflowing_det
+            .validate()
+            .expect_err("an inverse full of non-finite entries must be rejected");
+        assert!(err.contains("cannot be inverted"), "msg: {err}");
+
+        // A quaternion whose squared norm overflows: normalization divides
+        // every component by infinity.
+        let mut huge_quat = attitude([10.0, 10.0, 10.0], [0.0; 3], 100.0);
+        huge_quat.initial_quaternion = [1e200, 1e200, 0.0, 0.0];
+        let err = huge_quat
+            .validate()
+            .expect_err("a quaternion whose squared norm overflows must be rejected");
+        assert!(err.contains("initial_quaternion"), "msg: {err}");
+
+        // Components small enough that the squared norm underflows to zero:
+        // `orientation()` would divide by it.
+        let mut denormal = attitude([10.0, 10.0, 10.0], [0.0; 3], 100.0);
+        denormal.initial_quaternion = [1e-200, 0.0, 0.0, 0.0];
+        let err = denormal
+            .validate()
+            .expect_err("a quaternion whose squared norm underflows must be rejected");
+        assert!(err.contains("initial_quaternion"), "msg: {err}");
+    }
+
+    /// The quaternion bound must be exactly what the dynamics break on: `run`
+    /// and `serve` copy `initial_quaternion` into `AttitudeState` verbatim, and
+    /// every consumer reads it through `orientation()`, which normalizes it. So
+    /// the config check is correct when it accepts a quaternion exactly when
+    /// that normalization yields a finite unit quaternion. Cross-checked
+    /// against the real call rather than against a threshold, because the
+    /// interesting boundary is not where the arithmetic fails outright:
+    /// `[1e-160, 0, 0, 0]` looks harmless and does produce a finite result,
+    /// but its squared norm is subnormal, so the result has a norm of
+    /// 1.0000056 — which is why the check floors the squared norm at the
+    /// smallest normal instead of at zero.
+    #[test]
+    fn accepted_quaternions_are_exactly_the_normalizable_ones() {
+        for q in [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.5, 0.5, 0.5, 0.5],
+            // Not unit norm, but normalization handles it — the config is
+            // allowed to state a rotation without pre-normalizing it.
+            [2.0, 0.0, 0.0, 0.0],
+            // Squared norm is subnormal, its square root is not.
+            [1e-160, 0.0, 0.0, 0.0],
+            // Squared norm underflows to zero.
+            [1e-200, 0.0, 0.0, 0.0],
+            // Squared norm overflows to infinity.
+            [1e200, 1e200, 0.0, 0.0],
+            [1e300, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+        ] {
+            let mut att = attitude([10.0, 10.0, 10.0], [0.0; 3], 100.0);
+            att.initial_quaternion = q;
+            // The construction `cli::sim::controlled` and `serve::engine` do.
+            let state = orts::attitude::AttitudeState {
+                quaternion: nalgebra::Vector4::from_row_slice(&q),
+                angular_velocity: nalgebra::Vector3::zeros(),
+            };
+            let orientation = state.orientation();
+            let usable = orientation.coords.iter().all(|c| c.is_finite())
+                && (orientation.coords.norm() - 1.0).abs() < 1e-12;
+            assert_eq!(
+                att.validate().is_ok(),
+                usable,
+                "validate() and orientation() disagree on {q:?}: normalized to {:?}",
+                orientation.coords
+            );
+        }
     }
 
     #[test]
@@ -3157,7 +3291,8 @@ mass = 100.0
         std::fs::write(&path, toml).unwrap();
         let err = SimConfig::load(&path).expect_err("a singular inertia tensor must be rejected");
         assert!(err.contains("satellites[0]"), "msg: {err}");
-        assert!(err.contains("positive definite"), "msg: {err}");
+        assert!(err.contains("attitude:"), "msg: {err}");
+        assert!(err.contains("inertia tensor"), "msg: {err}");
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -3196,5 +3331,14 @@ mass = 100.0
         let nested_typo = add.replace("\"mass\": 500.0", "\"mass\": 500.0, \"masss\": 1.0");
         serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(&nested_typo)
             .expect_err("a misspelled key inside `attitude` must be rejected");
+        // The gap that leaves: at the flattened level there is no unknown-field
+        // check to apply, so `ballistic_coef` (one `f` short of
+        // `ballistic_coeff`) is dropped and the satellite is added without
+        // drag. Closing it means hand-writing `Deserialize` for the message,
+        // i.e. a protocol change. Asserted rather than left unsaid, so the day
+        // it closes this test reports it instead of passing silently.
+        let flat_typo = add.replace("\"name\": \"Dyn\",", "\"ballistic_coef\": 100.0,");
+        serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(&flat_typo)
+            .expect("known gap: `flatten` drops unknown keys at the message level");
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -4253,4 +4253,36 @@ orbit = { type = "circular", altitude = 600 }
             );
         }
     }
+
+    /// A frame naming one field twice is refused, not resolved to the last one.
+    ///
+    /// `serde_json::Value` keeps the last of two members with one name, so
+    /// reading the message from a tree would run
+    /// `{…,"config":{"dt":1},"config":{"dt":99}}` with 99 and say nothing. The
+    /// server reads the text, where serde refuses a duplicate field.
+    #[test]
+    fn a_duplicate_field_is_refused() {
+        let one = "{\"dt\":1.0,\"satellites\":[{\"id\":\"a\",\"orbit\":\
+                   {\"type\":\"circular\",\"altitude\":400}}]}";
+        let msg = format!("{{\"type\":\"start_simulation\",\"config\":{one},\"config\":{one}}}");
+
+        // Through a tree: the duplicate is gone before anything can object.
+        let value: serde_json::Value = serde_json::from_str(&msg).expect("valid JSON");
+        assert_eq!(
+            value.as_object().expect("an object").len(),
+            2,
+            "the tree holds `type` and one `config`"
+        );
+        serde_json::from_value::<crate::commands::serve::protocol::ClientMessage>(value)
+            .expect("a tree cannot see the duplicate");
+
+        // From the text, which is what the server reads.
+        let err = serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(&msg)
+            .err()
+            .expect("a duplicate field must be refused");
+        assert!(
+            err.to_string().contains("duplicate field"),
+            "the error says which: {err}"
+        );
+    }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1241,11 +1241,17 @@ impl SimConfig {
         // therefore merge two satellites' rows under one path and route all
         // commands to whichever one won the map — silently. Note the collision
         // an explicit `id` can have with the `sat-{index}` default of an
-        // id-less entry, which is why this compares resolved ids.
+        // id-less entry, which is why this resolves the id first.
+        //
+        // Compared on the entity the id names, not on the id text: `EntityPath`
+        // drops empty segments, so `a` and `/a` (or `a/b` and `a//b`) are two id
+        // strings naming one entity. `ensure_unique_ids` compares the same way
+        // for fleets built from repeated `--sat`.
         let mut seen: HashMap<String, usize> = HashMap::with_capacity(self.satellites.len());
         for (i, sat) in self.satellites.iter().enumerate() {
             let id = sat.resolved_id(i);
-            if let Some(first) = seen.insert(id.clone(), i) {
+            let entity = crate::satellite::entity_path_for_id(&id).to_string();
+            if let Some(first) = seen.insert(entity, i) {
                 return Err(format!(
                     "satellites[{i}]: duplicate satellite id '{id}' (already used by \
                      satellites[{first}]); ids must be unique{}",
@@ -3329,5 +3335,64 @@ mass = 100.0
         let flat_typo = add.replace("\"name\": \"Dyn\",", "\"ballistic_coef\": 100.0,");
         serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(&flat_typo)
             .expect("known gap: `flatten` drops unknown keys at the message level");
+    }
+
+    /// Two ids naming one entity are a duplicate, whatever their text.
+    ///
+    /// `EntityPath` drops empty segments, so `a` and `/a` both name
+    /// `/world/sat/a`. Compared as text they looked distinct and the fleet was
+    /// accepted: measured, both entries resolved to `/world/sat/a` and
+    /// `validate` returned `Ok`. The `--sat` path compares on the entity
+    /// already (`ensure_unique_ids`).
+    #[test]
+    fn ids_naming_one_entity_are_a_duplicate() {
+        for (a, b) in [("a", "/a"), ("a/b", "a//b")] {
+            let toml = format!(
+                r#"
+[[satellites]]
+id = "{a}"
+[satellites.orbit]
+type = "circular"
+altitude = 400.0
+
+[[satellites]]
+id = "{b}"
+[satellites.orbit]
+type = "circular"
+altitude = 500.0
+"#
+            );
+            let config: SimConfig = toml::from_str(&toml).expect("parse");
+            let err = config
+                .validate()
+                .expect_err(&format!("ids {a:?} and {b:?} name one entity"));
+            assert!(
+                err.contains("duplicate satellite id"),
+                "ids {a:?} and {b:?}: {err}"
+            );
+        }
+    }
+
+    /// Ids that name entities of their own are accepted.
+    ///
+    /// The check above compares on the entity, so it must not read two distinct
+    /// ones as a collision.
+    #[test]
+    fn ids_naming_entities_of_their_own_are_accepted() {
+        let toml = r#"
+[[satellites]]
+id = "a"
+[satellites.orbit]
+type = "circular"
+altitude = 400.0
+
+[[satellites]]
+id = "a/b"
+[satellites.orbit]
+type = "circular"
+altitude = 500.0
+"#;
+        let config: SimConfig = toml::from_str(toml).expect("parse");
+        config.validate().expect("two entities, two satellites");
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -885,11 +885,27 @@ pub fn load_config_reporting_unread_keys(path: &Path) -> Result<SimConfig, Strin
     let loaded = SimConfig::load_with_warnings(path)?;
     for key in &loaded.unread_keys {
         eprintln!(
-            "Warning: {}: nothing reads `{key}`; its value is ignored",
-            path.display()
+            "Warning: {}: nothing reads `{}`; its value is ignored",
+            path.display(),
+            printable_key(key)
         );
     }
     Ok(loaded.config)
+}
+
+/// A key as it can be written to a terminal.
+///
+/// A key name is arbitrary text. Over the WebSocket it is whatever a client
+/// sent, and a `\n` in one would put a second `Warning:` line in the log while a
+/// terminal escape would move the cursor or repaint what is already there.
+/// Measured: `{"a\nWarning: forged line": 1}` in a `start_simulation` config
+/// comes back as a key holding that newline.
+///
+/// `escape_debug` leaves an ordinary key alone — what it rewrites is the
+/// characters no key needs. The JSON form of `orts config validate` needs none
+/// of this; a JSON string encodes them itself.
+pub fn printable_key(key: &str) -> std::str::EscapeDebug<'_> {
+    key.escape_debug()
 }
 
 /// A loaded config and the keys in its file that nothing read.
@@ -4004,5 +4020,44 @@ orbit = { type = "circular", altitude = 600 }
             SimConfig::load_with_warnings(&path).expect_err("a second document must be refused");
         assert!(err.contains("YAML"), "msg: {err}");
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A key a client chose cannot forge a line or move the cursor.
+    ///
+    /// The names come from the client's own JSON, and the server writes them to
+    /// its log. Measured before this was escaped: a `start_simulation` carrying
+    /// `"a\nWarning: forged line"` gave back a key with that newline in it, and
+    /// the warning printed as two lines, the second looking like the server's.
+    #[test]
+    fn a_key_reaches_the_log_on_one_line() {
+        let msg = "{\"type\":\"start_simulation\",\"config\":{\
+                   \"dt\":1.0,\
+                   \"a\\nWarning: forged line\":1,\
+                   \"b\\u001b[31m\":2,\
+                   \"satellites\":[{\"id\":\"a\",\"orbit\":\
+                   {\"type\":\"circular\",\"altitude\":400}}]}}";
+        let keys = unread_client_message_keys(msg);
+        assert_eq!(keys.len(), 2, "both keys are collected: {keys:?}");
+        assert!(
+            keys.iter().any(|k| k.contains('\n')),
+            "the raw key holds the newline, so the escaping is what removes it: {keys:?}"
+        );
+
+        for key in &keys {
+            let line = format!("{}", printable_key(key));
+            assert!(
+                !line.contains('\n') && !line.contains('\r'),
+                "no line break survives: {line:?}"
+            );
+            assert!(
+                !line.contains('\u{1b}'),
+                "no escape character survives: {line:?}"
+            );
+        }
+        // An ordinary key is untouched, so the escaping costs nothing to read.
+        assert_eq!(
+            format!("{}", printable_key("satellites.0.altitide")),
+            "satellites.0.altitide"
+        );
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -570,11 +570,18 @@ impl AttitudeConfig {
                 self.inertia_diag, self.inertia_off_diag
             ));
         }
-        // No mass distribution can violate `I1 + I2 >= I3`, so a tensor that
-        // does integrates attitude motion belonging to no spacecraft. Equality
-        // is the flat-plate (lamina) limit — attainable and well-posed — and the
-        // relative slack keeps a config that states it exactly from being
-        // rejected by the eigenvalue solver's last bits.
+        // No mass distribution can violate `I1 + I2 >= I3`: in principal axes
+        // `∫z² dm = (I1 + I2 − I3)/2`, so a tensor that violates it needs
+        // negative mass. Equality is the flat-plate (lamina) limit, attainable
+        // and well-posed, and a config on the physical side of the boundary is
+        // accepted however close it sits.
+        //
+        // The slack is relative because the moments carry kg·m² and an absolute
+        // tolerance would mean different things at different scales. `1e-9` is
+        // far looser than the eigenvalue solver needs — a few hundred
+        // `f64::EPSILON` would cover its rounding — and is set for hand-entered
+        // and rounded engineering figures, which can land just outside the
+        // boundary they were meant to state.
         const TRIANGLE_SLACK: f64 = 1e-9;
         if i1 + i2 < i3 * (1.0 - TRIANGLE_SLACK) {
             return Err(format!(

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -505,33 +505,28 @@ impl AttitudeConfig {
                 return Err(format!("non-finite `{name}` component: {bad}"));
             }
         }
-        if !self.mass.is_finite() || self.mass <= 0.0 {
-            return Err(format!(
-                "attitude.mass must be positive and finite (got {})",
-                self.mass
-            ));
+        if self.mass <= 0.0 {
+            return Err(format!("non-positive mass: {}", self.mass));
         }
-        // `AttitudeState::orientation()` normalizes whatever it is given, so a
-        // quaternion it cannot normalize becomes a NaN or non-unit attitude
-        // rather than an error. The condition is on the squared norm, because
-        // that is what the normalization divides by: zero (components small
-        // enough that the squares underflow) divides by zero, and infinity
-        // (components large enough that the squares overflow) drives every
-        // component to zero. The floor is the smallest normal rather than `> 0`
-        // because a subnormal squared norm has lost mantissa bits before the
-        // square root is taken: `[1e-160, 0, 0, 0]` normalizes to a norm of
-        // 1.0000056, not 1. `accepted_quaternions_are_exactly_the_normalizable_ones`
-        // pins the bound against that call.
+        // The quaternion need not be normalized — `AttitudeState::orientation`
+        // normalizes on use and `OdeState::project` renormalizes after every
+        // step — but it has to be something those can normalize. Both divide by
+        // the sum of squares, so the test is that sum rather than the
+        // components: `[1e200, 0, 0, 0]` squares to infinity and drives every
+        // component to zero.
+        //
+        // The floor is the smallest normal rather than `> 0.0` because a
+        // subnormal sum has already lost mantissa bits before the square root:
+        // `[1e-160, 0, 0, 0]` has a squared norm of 1e-320 and normalizes to
+        // 1.0000056, not 1.
         let quat_norm_sq: f64 = self.initial_quaternion.iter().map(|q| q * q).sum();
         if !quat_norm_sq.is_finite() || quat_norm_sq < f64::MIN_POSITIVE {
             return Err(format!(
-                "attitude.initial_quaternion must have a usable norm (got {:?}): it is a \
-                 rotation (w, x, y, z), and the default (1, 0, 0, 0) is the identity",
-                self.initial_quaternion
+                "`initial_quaternion` cannot be normalized (its components square to \
+                 {quat_norm_sq}); it names no attitude"
             ));
         }
-
-        // Ask the question the way the dynamics do: `SpacecraftDynamics::new`
+        // Ask the inertia question the way the dynamics do: `SpacecraftDynamics::new`
         // takes `try_inverse().expect(…)`, so the test is whether that inverse
         // exists and is usable. A magnitude threshold on the determinant cannot
         // answer it — the determinant carries the cube of the units, so
@@ -543,7 +538,7 @@ impl AttitudeConfig {
         // quieter failure too: nalgebra's 3x3 inverse divides cofactors by the
         // determinant, so `[1e154; 3]` — condition number 1 — overflows both to
         // give `Some(zero matrix)`. Every component is finite, and a spacecraft
-        // built on it would answer every torque with zero angular acceleration.
+        // built on it would answer every torque with no angular acceleration.
         // `I · I⁻¹` is dimensionless, so one tolerance holds at every scale.
         let inertia = self.inertia_matrix();
         let inverse = inertia.try_inverse().filter(|inv| {
@@ -556,25 +551,47 @@ impl AttitudeConfig {
                 self.inertia_diag, self.inertia_off_diag
             ));
         };
-        // The quaternion need not be normalized — `AttitudeState::orientation`
-        // normalizes on use and `OdeState::project` renormalizes after every
-        // step — but it has to be something those can normalize. Both divide by
-        // the sum of squares, so the test is that sum, not the components: an
-        // all-zero quaternion names no attitude, `[1e-200, 0, 0, 0]` squares to
-        // zero, and `[1e200, 0, 0, 0]` squares to infinity. Each leaves the
-        // orientation undefined even though the components themselves are
-        // finite and non-zero.
-        let quat_norm_sq: f64 = self.initial_quaternion.iter().map(|q| q * q).sum();
-        if !(quat_norm_sq > 0.0 && quat_norm_sq.is_finite()) {
+        // Numeric usability is not physical possibility, and these come before
+        // the derivative below: a tensor no mass distribution can produce should
+        // be reported as such rather than as whatever its derivative happens to
+        // do. State both constraints in terms of the principal moments
+        // `I1 <= I2 <= I3` — the eigenvalues, which equal `inertia_diag` only
+        // when `inertia_off_diag` is zero, so read them off the tensor.
+        let mut moments: Vec<f64> = inertia.symmetric_eigenvalues().iter().copied().collect();
+        moments.sort_by(|a, b| a.partial_cmp(b).expect("eigenvalues of a finite tensor"));
+        let (i1, i2, i3) = (moments[0], moments[1], moments[2]);
+        // A non-positive principal moment means zero or negative mass off that
+        // axis. `I1 == 0` is the singular case the inverse already refuses; a
+        // negative one can invert cleanly and still describe nothing.
+        if i1 <= 0.0 {
             return Err(format!(
-                "`initial_quaternion` cannot be normalized \
-                 (its components square to {quat_norm_sq}); it names no attitude"
+                "inertia tensor is not positive definite: smallest principal moment is \
+                 {i1} (diag {:?}, off-diag {:?})",
+                self.inertia_diag, self.inertia_off_diag
             ));
         }
-        // A usable inverse is not yet an integrable state: the torque-free Euler
-        // term `I⁻¹ (−ω × Iω)` can overflow on its own. `[1e-308, 1, 2]` with
-        // `ω = [1, 2, 2]` inverts cleanly and still starts at an infinite
-        // angular acceleration.
+        // No mass distribution can violate `I1 + I2 >= I3`, so a tensor that
+        // does integrates attitude motion belonging to no spacecraft. Equality
+        // is the flat-plate (lamina) limit — attainable and well-posed — and the
+        // relative slack keeps a config that states it exactly from being
+        // rejected by the eigenvalue solver's last bits.
+        const TRIANGLE_SLACK: f64 = 1e-9;
+        if i1 + i2 < i3 * (1.0 - TRIANGLE_SLACK) {
+            return Err(format!(
+                "inertia tensor violates the triangle inequality: principal moments \
+                 [{i1}, {i2}, {i3}] have I1 + I2 < I3, which no mass distribution can \
+                 produce (diag {:?}, off-diag {:?})",
+                self.inertia_diag, self.inertia_off_diag
+            ));
+        }
+        // A usable, physically possible tensor is still not an integrable state:
+        // the torque-free Euler term `I⁻¹ (−ω × Iω)` can overflow on the rate
+        // alone. `diag(1, 1, 2)` with `ω = 1e200` squares out of range in the
+        // cross product.
+        //
+        // The tensor cannot do it by itself once the inequality holds: in
+        // principal axes `α1 = ((I2 − I3)/I1) ω2 ω3`, and `|I2 − I3| <= I1`
+        // there, so the gain never exceeds 1.
         let omega = nalgebra::Vector3::from_row_slice(&self.initial_angular_velocity);
         let alpha = inverse * -omega.cross(&(inertia * omega));
         if !alpha.iter().all(|v| v.is_finite()) {
@@ -597,41 +614,6 @@ impl AttitudeConfig {
         // The bound holds of the partial sums too only because `q_dot` halves
         // `ω` before forming the products. Halving the sum afterwards instead
         // lets it overflow at twice the answer's magnitude.
-        if self.mass <= 0.0 {
-            return Err(format!("non-positive mass: {}", self.mass));
-        }
-        // Numeric usability is not physical possibility. State the two
-        // constraints every real inertia tensor satisfies in terms of its
-        // principal moments `I1 <= I2 <= I3` — the eigenvalues, which equal
-        // `inertia_diag` only when `inertia_off_diag` is zero, so read them off
-        // the tensor rather than the diagonal.
-        let mut moments: Vec<f64> = inertia.symmetric_eigenvalues().iter().copied().collect();
-        moments.sort_by(|a, b| a.partial_cmp(b).expect("eigenvalues of a finite tensor"));
-        let (i1, i2, i3) = (moments[0], moments[1], moments[2]);
-        // A non-positive principal moment means zero or negative mass off that
-        // axis. `I1 == 0` is the singular case the inverse above already
-        // refuses; a negative one can invert cleanly and still describe nothing.
-        if i1 <= 0.0 {
-            return Err(format!(
-                "inertia tensor is not positive definite: smallest principal moment is \
-                 {i1} (diag {:?}, off-diag {:?})",
-                self.inertia_diag, self.inertia_off_diag
-            ));
-        }
-        // No mass distribution can violate `I1 + I2 >= I3`, so a tensor that
-        // does integrates attitude motion belonging to no spacecraft. Equality
-        // is the flat-plate (lamina) limit — attainable and well-posed — and the
-        // relative slack keeps a config that states it exactly from being
-        // rejected by the eigenvalue solver's last bits.
-        const TRIANGLE_SLACK: f64 = 1e-9;
-        if i1 + i2 < i3 * (1.0 - TRIANGLE_SLACK) {
-            return Err(format!(
-                "inertia tensor violates the triangle inequality: principal moments \
-                 [{i1}, {i2}, {i3}] have I1 + I2 < I3, which no mass distribution can \
-                 produce (diag {:?}, off-diag {:?})",
-                self.inertia_diag, self.inertia_off_diag
-            ));
-        }
         Ok(())
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -843,10 +843,9 @@ pub enum OrbitConfig {
 ///
 /// Paths are relative to the part inspected: `dtt` and `satellites.0.altitide`
 /// for `start_simulation`'s config.
-pub fn unread_client_message_keys(text: &str) -> Vec<String> {
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(text) else {
-        return Vec::new();
-    };
+/// Takes the message already parsed, so the caller can hand the same `Value` to
+/// `ClientMessage` rather than paying for a second parse of every frame.
+pub fn unread_client_message_keys(value: &serde_json::Value) -> Vec<String> {
     let Some(kind) = value.get("type").and_then(|v| v.as_str()) else {
         return Vec::new();
     };
@@ -855,18 +854,25 @@ pub fn unread_client_message_keys(text: &str) -> Vec<String> {
     let mut note = |path: serde_ignored::Path| keys.push(path.to_string());
     match kind {
         "start_simulation" => {
-            if let Some(config) = value.get("config").cloned() {
+            if let Some(config) = value.get("config") {
+                // Borrowed, not cloned: the config subtree of a fleet-sized
+                // message is the largest thing here.
                 let _ = serde_ignored::deserialize::<_, _, SimConfig>(config, &mut note);
             }
         }
         "add_satellite" => {
             // The satellite is flattened next to the tag, so the tag itself is
             // the one key that belongs to the message rather than the satellite.
+            // Only the map is rebuilt, without the tag; the values it points at
+            // are borrowed.
             if let Some(object) = value.as_object() {
-                let mut object = object.clone();
-                object.remove("type");
+                let satellite: Vec<(&str, &serde_json::Value)> = object
+                    .iter()
+                    .filter(|(k, _)| k.as_str() != "type")
+                    .map(|(k, v)| (k.as_str(), v))
+                    .collect();
                 let _ = serde_ignored::deserialize::<_, _, SatelliteConfig>(
-                    serde_json::Value::Object(object),
+                    serde::de::value::MapDeserializer::new(satellite.into_iter()),
                     &mut note,
                 );
             }
@@ -1453,24 +1459,22 @@ impl SimConfig {
         // mode can serve is settled here too. `SatelliteSpec` carries these two
         // as clones of the fields counted below, so the count the engine makes
         // is this count.
-        if !self.satellites.is_empty() {
-            let fleet_size = self.satellites.len();
-            let with_attitude = self
-                .satellites
-                .iter()
-                .filter(|s| s.attitude.is_some())
-                .count();
-            let with_controller = self
-                .satellites
-                .iter()
-                .filter(|s| s.controller.is_some())
-                .count();
-            crate::sim::mode::ensure_fleet_declares_uniformly(
-                fleet_size,
-                with_attitude,
-                with_controller,
-            )?;
-        }
+        let fleet_size = self.satellites.len();
+        let with_attitude = self
+            .satellites
+            .iter()
+            .filter(|s| s.attitude.is_some())
+            .count();
+        let with_controller = self
+            .satellites
+            .iter()
+            .filter(|s| s.controller.is_some())
+            .count();
+        crate::sim::mode::ensure_fleet_declares_uniformly(
+            fleet_size,
+            with_attitude,
+            with_controller,
+        )?;
         for (i, cmd) in self.commands.iter().enumerate() {
             // A non-finite or negative `t` would never satisfy the
             // schedule's `t <= t_due`, silently dropping the command.
@@ -1508,6 +1512,16 @@ impl SimConfig {
 
 #[cfg(test)]
 mod tests {
+    /// The unread keys of a message, parsed the way `connection.rs` parses it.
+    ///
+    /// The collector takes the tree, since the server hands the same one to
+    /// `ClientMessage` rather than parsing each frame twice.
+    fn unread_keys_of(text: &str) -> Vec<String> {
+        let value: serde_json::Value =
+            serde_json::from_str(text).expect("the message is valid JSON");
+        unread_client_message_keys(&value)
+    }
+
     use super::*;
 
     #[test]
@@ -3669,7 +3683,7 @@ mass = 100.0
         }"#;
         serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(start)
             .expect("start_simulation must parse");
-        assert_eq!(unread_client_message_keys(start), Vec::<String>::new());
+        assert_eq!(unread_keys_of(start), Vec::<String>::new());
 
         // A struct-level key nothing reads, at two depths: the message still
         // starts a simulation, and both paths are named.
@@ -3679,10 +3693,7 @@ mass = 100.0
         );
         serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(&typo)
             .expect("an unknown key must not stop the message parsing");
-        assert_eq!(
-            unread_client_message_keys(&typo),
-            vec!["dtt", "satellites.0.altitide"]
-        );
+        assert_eq!(unread_keys_of(&typo), vec!["dtt", "satellites.0.altitide"]);
 
         // A typo inside the `type`-tagged orbit: refused, as in a file.
         let orbit_typo = start.replace(
@@ -3701,7 +3712,7 @@ mass = 100.0
         }"#;
         serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(add)
             .expect("add_satellite must still parse");
-        assert_eq!(unread_client_message_keys(add), Vec::<String>::new());
+        assert_eq!(unread_keys_of(add), Vec::<String>::new());
 
         // `add_satellite` flattens its satellite next to the tag, where
         // `flatten` removes the unknown-field check outright. Targeting the
@@ -3711,10 +3722,7 @@ mass = 100.0
         let flat_typo = add.replace("\"name\": \"Dyn\",", "\"ballistic_coef\": 100.0,");
         serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(&flat_typo)
             .expect("the message still adds the satellite");
-        assert_eq!(
-            unread_client_message_keys(&flat_typo),
-            vec!["ballistic_coef"]
-        );
+        assert_eq!(unread_keys_of(&flat_typo), vec!["ballistic_coef"]);
 
         // A key under a nested struct is named at its path too. An `Option`
         // field puts a `?` in that path, which is how the crate spells the
@@ -3722,10 +3730,7 @@ mass = 100.0
         let nested_typo = add.replace("\"mass\": 500.0", "\"mass\": 500.0, \"masss\": 1.0");
         serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(&nested_typo)
             .expect("the message still adds the satellite");
-        assert_eq!(
-            unread_client_message_keys(&nested_typo),
-            vec!["attitude.?.masss"]
-        );
+        assert_eq!(unread_keys_of(&nested_typo), vec!["attitude.?.masss"]);
     }
 
     /// Two ids naming one entity are a duplicate, whatever their text.
@@ -4036,7 +4041,7 @@ orbit = { type = "circular", altitude = 600 }
                    \"b\\u001b[31m\":2,\
                    \"satellites\":[{\"id\":\"a\",\"orbit\":\
                    {\"type\":\"circular\",\"altitude\":400}}]}}";
-        let keys = unread_client_message_keys(msg);
+        let keys = unread_keys_of(msg);
         assert_eq!(keys.len(), 2, "both keys are collected: {keys:?}");
         assert!(
             keys.iter().any(|k| k.contains('\n')),

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -55,12 +55,26 @@ fn de_atmosphere<'de, D: Deserializer<'de>>(de: D) -> Result<String, D::Error> {
 /// Also the payload of the `start_simulation` WebSocket message, so the
 /// whole tree derives [`TS`]. Fields the server defaults when absent are
 /// `#[ts(optional)]` so TypeScript clients may omit them too.
-// `deny_unknown_fields` here and on the rest of the config tree: a dropped key
-// is indistinguishable from a key that was never written, so `duraton = 100`
-// used to run with the default duration and report success. Kept out of the
-// doc comment because doc comments are copied into the generated TypeScript.
+// A key nothing reads is reported by `load_with_warnings`, not rejected: a
+// dropped key is indistinguishable from one never written, so `duraton = 100`
+// used to run with the default duration and report success in silence. Refusing
+// the file instead would stop an older `orts` reading a config written for a
+// newer one.
+//
+// The `#[serde(tag = "type")]` enums below keep `deny_unknown_fields` and refuse
+// instead. `serde_ignored`, which collects the paths, cannot see into an
+// internally tagged enum — serde buffers the variant's content and replays it,
+// so an unknown key there is dropped with nothing to report (measured: a typo
+// inside `[satellites.orbit]` yields no path, while one at the top level and one
+// in `[integrator]` both do). A silent `inclinaton = 51.6` leaves the orbit
+// equatorial, so those four reject rather than say nothing. The alternative,
+// external tagging, spells the orbit `[satellites.orbit.circular]` and gives the
+// same error for the same typo, changing the config format and the WebSocket
+// payload to buy nothing.
+//
+// Kept out of the doc comment because doc comments are copied into the generated
+// TypeScript.
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
-#[serde(deny_unknown_fields)]
 #[ts(export)]
 pub struct SimConfig {
     #[serde(default = "default_body")]
@@ -109,7 +123,6 @@ pub struct SimConfig {
 
 /// Ground station definition for visibility / contact window detection.
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
-#[serde(deny_unknown_fields)]
 #[ts(export)]
 pub struct GroundStationConfig {
     pub name: String,
@@ -152,7 +165,6 @@ impl GroundStationConfig {
 /// コントローラ(FSW)へ `kind` + `args`(key-value payload) を配送する。
 /// host が配送 tick を確定するので決定論的。
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
-#[serde(deny_unknown_fields)]
 #[ts(export)]
 pub struct CommandConfig {
     /// 配送するシミュレーション時刻 \[s\]。
@@ -248,7 +260,6 @@ fn default_ap() -> f64 {
 
 /// Integrator configuration within a config file.
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
-#[serde(deny_unknown_fields)]
 #[ts(export)]
 pub struct IntegratorConfig {
     #[serde(
@@ -288,7 +299,6 @@ impl Default for IntegratorConfig {
 
 /// Attitude dynamics configuration for a satellite.
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
-#[serde(deny_unknown_fields)]
 #[ts(export)]
 pub struct AttitudeConfig {
     /// Diagonal inertia tensor [Ixx, Iyy, Izz] kg·m².
@@ -689,7 +699,6 @@ pub enum MtqConfig {
 
 /// 推進器一機分の静的パラメータ。
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
-#[serde(deny_unknown_fields)]
 #[ts(export)]
 pub struct ThrusterSpecConfig {
     /// 最大推力 [N]。
@@ -709,7 +718,6 @@ pub struct ThrusterSpecConfig {
 /// `thrusters` に各推進器の静的パラメータを並べ、`dry_mass` で
 /// 推進剤枯渇時の停止閾値 (spacecraft total mass [kg]) を指定する。
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
-#[serde(deny_unknown_fields)]
 #[ts(export)]
 pub struct ThrusterConfig {
     /// 推進器一覧（空リストは reject）。
@@ -723,7 +731,6 @@ pub struct ThrusterConfig {
 
 /// Per-satellite configuration.
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
-#[serde(deny_unknown_fields)]
 #[ts(export)]
 pub struct SatelliteConfig {
     #[ts(optional)]
@@ -802,9 +809,103 @@ pub enum OrbitConfig {
     Norad { norad_id: u32 },
 }
 
+/// The keys of a client message that no field of it reads.
+///
+/// `ClientMessage` is `#[serde(tag = "type")]`, and `serde_ignored` cannot see
+/// inside an internally tagged enum: serde buffers the variant's content and
+/// replays it, so deserializing the message itself collects nothing. Reaching
+/// into the JSON for the part that is a config and targeting that directly gets
+/// past the tag — the same trick reaches `add_satellite`'s flattened
+/// `SatelliteConfig`, where `flatten` removes the unknown-field check outright.
+///
+/// Paths are relative to the part inspected: `dtt` and `satellites.0.altitide`
+/// for `start_simulation`'s config.
+pub fn unread_client_message_keys(text: &str) -> Vec<String> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(text) else {
+        return Vec::new();
+    };
+    let Some(kind) = value.get("type").and_then(|v| v.as_str()) else {
+        return Vec::new();
+    };
+
+    let mut keys = Vec::new();
+    let mut note = |path: serde_ignored::Path| keys.push(path.to_string());
+    match kind {
+        "start_simulation" => {
+            if let Some(config) = value.get("config").cloned() {
+                let _ = serde_ignored::deserialize::<_, _, SimConfig>(config, &mut note);
+            }
+        }
+        "add_satellite" => {
+            // The satellite is flattened next to the tag, so the tag itself is
+            // the one key that belongs to the message rather than the satellite.
+            if let Some(object) = value.as_object() {
+                let mut object = object.clone();
+                object.remove("type");
+                let _ = serde_ignored::deserialize::<_, _, SatelliteConfig>(
+                    serde_json::Value::Object(object),
+                    &mut note,
+                );
+            }
+        }
+        // The rest carry scalars the message's own fields all read.
+        _ => {}
+    }
+    keys
+}
+
+/// Load a config and report, on stderr, the keys nothing read.
+///
+/// For the paths that run a simulation. `orts config validate` renders them
+/// itself, since it also has a `--json` form to put them in.
+pub fn load_config_reporting_unread_keys(path: &Path) -> Result<SimConfig, String> {
+    let loaded = SimConfig::load_with_warnings(path)?;
+    for key in &loaded.unread_keys {
+        eprintln!(
+            "Warning: {}: nothing reads `{key}`; its value is ignored",
+            path.display()
+        );
+    }
+    Ok(loaded.config)
+}
+
+/// A loaded config and the keys in its file that nothing read.
+///
+/// The keys are paths as `serde_ignored` spells them — `satellites.0.disturbanses`
+/// rather than `satellites[0].disturbanses`.
+#[derive(Debug, Clone)]
+pub struct LoadedConfig {
+    pub config: SimConfig,
+    /// Paths of keys the file carried and no field claimed, in the order the
+    /// deserialize met them. Empty for a config whose every key was read.
+    pub unread_keys: Vec<String>,
+}
+
 impl SimConfig {
-    /// Load a config file, auto-detecting format by extension.
+    /// Load a config file, auto-detecting format by extension, and discard the
+    /// keys nothing read.
+    ///
+    /// For a caller with nowhere to report them. The paths that run a
+    /// simulation go through [`load_config_reporting_unread_keys`], and
+    /// `orts config validate` renders them itself.
+    #[cfg(test)]
     pub fn load(path: &Path) -> Result<Self, String> {
+        Ok(Self::load_with_warnings(path)?.config)
+    }
+
+    /// Load a config, and say which of its keys nothing read.
+    ///
+    /// An unknown key is a warning rather than an error so that a config
+    /// written for a newer `orts` still runs on an older one: rejecting the file
+    /// would make one added option enough to stop it being read at all. A known
+    /// key holding an unknown value stays an error — there the file names
+    /// something the simulation cannot do.
+    ///
+    /// The paths come back as a value rather than through `log::warn!`, which
+    /// the CLI initializes no logger for (see #387), so nothing would print
+    /// them. A caller decides where they go: `orts config validate --json` puts
+    /// them in `warnings`, and a test reads them without a logger.
+    pub fn load_with_warnings(path: &Path) -> Result<LoadedConfig, String> {
         let ext = path
             .extension()
             .and_then(|e| e.to_str())
@@ -814,14 +915,28 @@ impl SimConfig {
         let content = std::fs::read_to_string(path)
             .map_err(|e| format!("Failed to read config file '{}': {e}", path.display()))?;
 
+        // One funnel for all three formats, so the paths are collected the same
+        // way whichever one the file is in.
+        let mut unread_keys = Vec::new();
+        let mut note = |path: serde_ignored::Path| unread_keys.push(path.to_string());
+
         let config: SimConfig = match ext.as_str() {
-            "json" => serde_json::from_str(&content)
-                .map_err(|e| format!("Failed to parse JSON config: {e}"))?,
-            "toml" => {
-                toml::from_str(&content).map_err(|e| format!("Failed to parse TOML config: {e}"))?
+            "json" => {
+                let mut de = serde_json::Deserializer::from_str(&content);
+                serde_ignored::deserialize(&mut de, &mut note)
+                    .map_err(|e| format!("Failed to parse JSON config: {e}"))?
             }
-            "yaml" | "yml" => serde_yaml::from_str(&content)
-                .map_err(|e| format!("Failed to parse YAML config: {e}"))?,
+            "toml" => {
+                let de = toml::Deserializer::parse(&content)
+                    .map_err(|e| format!("Failed to parse TOML config: {e}"))?;
+                serde_ignored::deserialize(de, &mut note)
+                    .map_err(|e| format!("Failed to parse TOML config: {e}"))?
+            }
+            "yaml" | "yml" => {
+                let de = serde_yaml::Deserializer::from_str(&content);
+                serde_ignored::deserialize(de, &mut note)
+                    .map_err(|e| format!("Failed to parse YAML config: {e}"))?
+            }
             _ => {
                 return Err(format!(
                     "Unknown config file extension '.{ext}'. Supported: .json, .toml, .yaml, .yml"
@@ -831,7 +946,10 @@ impl SimConfig {
 
         config.validate()?;
 
-        Ok(config)
+        Ok(LoadedConfig {
+            config,
+            unread_keys,
+        })
     }
 
     /// The integrator selected by `[integrator] type`.
@@ -2898,20 +3016,19 @@ direction_body = [0.0, 0.0, 0.0]
         let _ = config.atmosphere_choice();
     }
 
-    /// An unknown key used to be dropped, which is indistinguishable from a key
-    /// the user never wrote: `duraton = 100` ran for one orbital period and
-    /// reported success.
+    /// A key nothing reads is named, at whatever depth it sits.
+    ///
+    /// Dropping it in silence is indistinguishable from never writing it:
+    /// `duraton = 100` ran for one orbital period and reported success. The file
+    /// still loads, so a config written for a newer `orts` runs here; what
+    /// changes is that the key is reported.
     #[test]
-    fn unknown_keys_are_rejected() {
+    fn unread_keys_are_named() {
         let cases = [
             ("top level", "duraton = 100.0\n"),
             (
                 "satellite",
                 "[[satellites]]\naltitide = 400\n[satellites.orbit]\ntype = \"circular\"\naltitude = 500\n",
-            ),
-            (
-                "orbit",
-                "[[satellites]]\n[satellites.orbit]\ntype = \"circular\"\naltitude = 500\ninclinaton = 51.6\n",
             ),
             ("integrator", "[integrator]\natoll = 1.0e-9\n"),
             (
@@ -2929,17 +3046,113 @@ direction_body = [0.0, 0.0, 0.0]
             ),
         ];
         for (label, toml) in cases {
-            let err = toml::from_str::<SimConfig>(toml)
+            let dir = std::env::temp_dir().join(format!(
+                "orts-unread-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            std::fs::create_dir_all(&dir).expect("temp dir");
+            let path = dir.join("sim.toml");
+            std::fs::write(&path, toml).expect("write config");
+
+            let loaded = SimConfig::load_with_warnings(&path)
+                .unwrap_or_else(|e| panic!("{label}: the file should still load: {e}"));
+            assert!(
+                !loaded.unread_keys.is_empty(),
+                "{label}: the unread key must be named"
+            );
+            std::fs::remove_dir_all(&dir).ok();
+        }
+    }
+
+    /// A `type`-tagged block refuses an unknown key rather than reporting it.
+    ///
+    /// `serde_ignored` cannot see inside an internally tagged enum, so there is
+    /// nothing to report there: serde buffers the variant's content and replays
+    /// it. A dropped `inclinaton = 51.6` leaves the orbit equatorial, so those
+    /// blocks reject instead of saying nothing.
+    #[test]
+    fn a_type_tagged_block_refuses_an_unknown_key() {
+        let cases = [
+            (
+                "orbit",
+                "[[satellites]]\n[satellites.orbit]\ntype = \"circular\"\naltitude = 500\ninclinaton = 51.6\n",
+                "inclinaton",
+            ),
+            (
+                "controller",
+                "[[satellites]]\n[satellites.orbit]\ntype = \"circular\"\naltitude = 500\n\
+                 \n[satellites.controller]\ntype = \"wasm\"\npath = \"p.wasm\"\npth = \"q.wasm\"\n",
+                "pth",
+            ),
+        ];
+        for (label, toml_src, key) in cases {
+            let err = toml::from_str::<SimConfig>(toml_src)
                 .map(|c| format!("{c:?}"))
-                .expect_err(&format!(
-                    "{label}: an unknown key must be rejected, not dropped"
-                ))
+                .expect_err(&format!("{label}: an unknown key here must be refused"))
                 .to_string();
             assert!(
-                err.contains("unknown field"),
-                "{label}: expected an unknown-field error, got {err}"
+                err.contains("unknown field") && err.contains(key),
+                "{label}: expected an unknown-field error naming `{key}`, got {err}"
             );
         }
+    }
+
+    /// The named path is the key's, so a typo can be found from it.
+    #[test]
+    fn an_unread_key_is_named_by_its_path() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts-unread-path-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("sim.toml");
+        std::fs::write(
+            &path,
+            "duraton = 100.0
+
+[[satellites]]
+altitide = 400
+             [satellites.orbit]
+type = \"circular\"
+altitude = 500
+",
+        )
+        .expect("write config");
+
+        let loaded = SimConfig::load_with_warnings(&path).expect("the file loads");
+        assert_eq!(loaded.unread_keys, vec!["duraton", "satellites.0.altitide"]);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A config whose every key is read reports nothing.
+    #[test]
+    fn a_config_read_whole_names_no_key() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts-unread-none-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("sim.toml");
+        std::fs::write(
+            &path,
+            "dt = 1.0
+duration = 100.0
+
+[[satellites]]
+id = \"a\"
+             [satellites.orbit]
+type = \"circular\"
+altitude = 500
+",
+        )
+        .expect("write config");
+
+        let loaded = SimConfig::load_with_warnings(&path).expect("the file loads");
+        assert_eq!(loaded.unread_keys, Vec::<String>::new());
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// Two satellites resolving to one id share the recording entity path and
@@ -3296,14 +3509,19 @@ mass = 100.0
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    /// The WebSocket surface: `start_simulation` nests the whole
-    /// `SimConfig`, so a misspelled key is rejected there like in a file;
-    /// `add_satellite` flattens a `SatelliteConfig` next to the message tag,
-    /// and serde disables the unknown-field check under `flatten` — the message
-    /// must keep parsing, and that path keeps dropping unknown keys until the
-    /// protocol stops flattening.
+    /// The WebSocket surface follows the config policy, and names what it drops.
+    ///
+    /// A message carrying a key no field reads still starts a simulation, so a
+    /// client built against a newer `orts` keeps working here — the same reason a
+    /// config file warns rather than refuses. Deserializing `ClientMessage`
+    /// collects nothing, since `#[serde(tag = "type")]` buffers the variant's
+    /// content; reaching into the JSON for the part that is a config gets past
+    /// the tag.
+    ///
+    /// A `type`-tagged block nested inside still refuses: nothing can report it,
+    /// and a dropped key there changes the orbit.
     #[test]
-    fn websocket_messages_agree_with_the_strict_config_tree() {
+    fn websocket_messages_agree_with_the_config_policy() {
         let start = r#"{
             "type": "start_simulation",
             "config": {
@@ -3313,9 +3531,28 @@ mass = 100.0
         }"#;
         serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(start)
             .expect("start_simulation must parse");
-        let typo = start.replace("\"dt\"", "\"dtt\"");
+        assert_eq!(unread_client_message_keys(start), Vec::<String>::new());
+
+        // A struct-level key nothing reads, at two depths: the message still
+        // starts a simulation, and both paths are named.
+        let typo = start.replace("\"dt\"", "\"dtt\"").replace(
+            "\"satellites\": [{",
+            "\"satellites\": [{ \"altitide\": 400,",
+        );
         serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(&typo)
-            .expect_err("a misspelled key in start_simulation must be rejected");
+            .expect("an unknown key must not stop the message parsing");
+        assert_eq!(
+            unread_client_message_keys(&typo),
+            vec!["dtt", "satellites.0.altitide"]
+        );
+
+        // A typo inside the `type`-tagged orbit: refused, as in a file.
+        let orbit_typo = start.replace(
+            "\"altitude\": 500.0",
+            "\"altitude\": 500.0, \"inclinaton\": 51.6",
+        );
+        serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(&orbit_typo)
+            .expect_err("a `type`-tagged block cannot report, so it refuses");
 
         let add = r#"{
             "type": "add_satellite",
@@ -3326,20 +3563,31 @@ mass = 100.0
         }"#;
         serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(add)
             .expect("add_satellite must still parse");
-        // Nested structs under the flattened one are still checked: only the
-        // flattened level loses it.
-        let nested_typo = add.replace("\"mass\": 500.0", "\"mass\": 500.0, \"masss\": 1.0");
-        serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(&nested_typo)
-            .expect_err("a misspelled key inside `attitude` must be rejected");
-        // The gap that leaves: at the flattened level there is no unknown-field
-        // check to apply, so `ballistic_coef` (one `f` short of
-        // `ballistic_coeff`) is dropped and the satellite is added without
-        // drag. Closing it means hand-writing `Deserialize` for the message,
-        // i.e. a protocol change. Asserted rather than left unsaid, so the day
-        // it closes this test reports it instead of passing silently.
+        assert_eq!(unread_client_message_keys(add), Vec::<String>::new());
+
+        // `add_satellite` flattens its satellite next to the tag, where
+        // `flatten` removes the unknown-field check outright. Targeting the
+        // satellite directly names the key anyway: `ballistic_coef`, one `f`
+        // short of `ballistic_coeff`, used to add the satellite without drag and
+        // without a word.
         let flat_typo = add.replace("\"name\": \"Dyn\",", "\"ballistic_coef\": 100.0,");
         serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(&flat_typo)
-            .expect("known gap: `flatten` drops unknown keys at the message level");
+            .expect("the message still adds the satellite");
+        assert_eq!(
+            unread_client_message_keys(&flat_typo),
+            vec!["ballistic_coef"]
+        );
+
+        // A key under a nested struct is named at its path too. An `Option`
+        // field puts a `?` in that path, which is how the crate spells the
+        // step through it.
+        let nested_typo = add.replace("\"mass\": 500.0", "\"mass\": 500.0, \"masss\": 1.0");
+        serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(&nested_typo)
+            .expect("the message still adds the satellite");
+        assert_eq!(
+            unread_client_message_keys(&nested_typo),
+            vec!["attitude.?.masss"]
+        );
     }
 
     /// Two ids naming one entity are a duplicate, whatever their text.

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -946,8 +946,8 @@ pub fn unread_client_message_keys(value: &serde_json::Value) -> UnreadClientKeys
 pub fn load_config_reporting_unread_keys(path: &Path) -> Result<SimConfig, String> {
     let loaded = SimConfig::load_with_warnings(path)?;
     for key in &loaded.unread_keys {
-        eprintln!(
-            "Warning: {}: nothing reads `{}`; its value is ignored",
+        log::warn!(
+            "{}: nothing reads `{}`; its value is ignored",
             path.display(),
             printable_key(key)
         );
@@ -1015,11 +1015,8 @@ impl SimConfig {
     ///
     /// The paths come back as a value so that each caller decides where they
     /// go: `orts config validate --json` puts them in `warnings`, `run` and
-    /// `serve` print them, and a test reads them. The printing ones use
-    /// `eprintln!`, which is what every other line addressed to whoever wrote
-    /// the config uses (`Warning: satellite 'a': sensors declared without …`).
-    /// `log::` in this crate carries diagnostics about the machinery instead,
-    /// and reaches nobody until a backend is installed (#387, #390).
+    /// `serve` report them through `log::warn!`, and a test reads them without
+    /// a logger installed.
     pub fn load_with_warnings(path: &Path) -> Result<LoadedConfig, String> {
         let ext = path
             .extension()

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -924,10 +924,13 @@ impl SimConfig {
     /// key holding an unknown value stays an error — there the file names
     /// something the simulation cannot do.
     ///
-    /// The paths come back as a value rather than through `log::warn!`, which
-    /// the CLI initializes no logger for (see #387), so nothing would print
-    /// them. A caller decides where they go: `orts config validate --json` puts
-    /// them in `warnings`, and a test reads them without a logger.
+    /// The paths come back as a value so that each caller decides where they
+    /// go: `orts config validate --json` puts them in `warnings`, `run` and
+    /// `serve` print them, and a test reads them. The printing ones use
+    /// `eprintln!`, which is what every other line addressed to whoever wrote
+    /// the config uses (`Warning: satellite 'a': sensors declared without …`).
+    /// `log::` in this crate carries diagnostics about the machinery instead,
+    /// and reaches nobody until a backend is installed (#387, #390).
     pub fn load_with_warnings(path: &Path) -> Result<LoadedConfig, String> {
         let ext = path
             .extension()
@@ -3819,6 +3822,30 @@ orbit = { type = "circular", altitude = 600 }
             .validate()
             .expect_err("half a fleet with a controller runs in no mode");
         assert!(err.contains("Mixed controller config"), "msg: {err}");
+
+        // A uniform controlled fleet with no attitude anywhere. The mode comes
+        // out `Controlled`, and `build_controlled_satellite` then refuses every
+        // satellite for want of an attitude state — under `orts serve --config`
+        // that refusal arrives after the startup banner.
+        let controller_without_attitude = r#"
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 500 }
+controller = { type = "wasm", path = "ctrl.wasm" }
+
+[[satellites]]
+id = "b"
+orbit = { type = "circular", altitude = 600 }
+controller = { type = "wasm", path = "ctrl.wasm" }
+"#;
+        let config: SimConfig = toml::from_str(controller_without_attitude).expect("valid toml");
+        let err = config
+            .validate()
+            .expect_err("a controller has no attitude state to command");
+        assert!(
+            err.contains("without `[satellites.attitude]`"),
+            "msg: {err}"
+        );
 
         // Both declared on every satellite, and on none, are the fleets that do
         // pick a mode.

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -832,6 +832,25 @@ pub enum OrbitConfig {
     Norad { norad_id: u32 },
 }
 
+/// How many of a client message's unread keys are named before the rest are
+/// only counted.
+///
+/// `/ws` takes messages from whoever reaches the port, and each named key costs
+/// one synchronous `eprintln!` on the connection task — stderr is unbuffered, so
+/// that is a write syscall each. One frame of `{"a":1,"b":2,…}` is cheap to send
+/// and would otherwise become as many writes as it has keys. Twenty is well past
+/// what anyone reads to find a typo.
+const CLIENT_MESSAGE_KEY_LIMIT: usize = 20;
+
+/// The unread keys of a client message, and how many did not fit.
+#[derive(Default, Debug, PartialEq, Eq)]
+pub struct UnreadClientKeys {
+    /// At most [`CLIENT_MESSAGE_KEY_LIMIT`] paths.
+    pub named: Vec<String>,
+    /// How many more keys nothing read, past the ones named.
+    pub unnamed: usize,
+}
+
 /// The keys of a client message that no field of it reads.
 ///
 /// `ClientMessage` is `#[serde(tag = "type")]`, and `serde_ignored` cannot see
@@ -843,15 +862,22 @@ pub enum OrbitConfig {
 ///
 /// Paths are relative to the part inspected: `dtt` and `satellites.0.altitide`
 /// for `start_simulation`'s config.
+///
 /// Takes the message already parsed, so the caller can hand the same `Value` to
 /// `ClientMessage` rather than paying for a second parse of every frame.
-pub fn unread_client_message_keys(value: &serde_json::Value) -> Vec<String> {
+pub fn unread_client_message_keys(value: &serde_json::Value) -> UnreadClientKeys {
     let Some(kind) = value.get("type").and_then(|v| v.as_str()) else {
-        return Vec::new();
+        return UnreadClientKeys::default();
     };
 
-    let mut keys = Vec::new();
-    let mut note = |path: serde_ignored::Path| keys.push(path.to_string());
+    let mut keys = UnreadClientKeys::default();
+    let mut note = |path: serde_ignored::Path| {
+        if keys.named.len() < CLIENT_MESSAGE_KEY_LIMIT {
+            keys.named.push(path.to_string());
+        } else {
+            keys.unnamed += 1;
+        }
+    };
     match kind {
         "start_simulation" => {
             if let Some(config) = value.get("config") {
@@ -1519,7 +1545,12 @@ mod tests {
     fn unread_keys_of(text: &str) -> Vec<String> {
         let value: serde_json::Value =
             serde_json::from_str(text).expect("the message is valid JSON");
-        unread_client_message_keys(&value)
+        let unread = unread_client_message_keys(&value);
+        assert_eq!(
+            unread.unnamed, 0,
+            "these messages hold fewer keys than the limit"
+        );
+        unread.named
     }
 
     use super::*;
@@ -4064,5 +4095,33 @@ orbit = { type = "circular", altitude = 600 }
             format!("{}", printable_key("satellites.0.altitide")),
             "satellites.0.altitide"
         );
+    }
+
+    /// A client message names at most `CLIENT_MESSAGE_KEY_LIMIT` keys.
+    ///
+    /// Each named key is one unbuffered `eprintln!` on the connection task, and
+    /// `/ws` takes messages from whoever reaches the port, so one frame must not
+    /// decide how many writes the server makes. The rest are counted.
+    #[test]
+    fn a_client_message_names_at_most_the_limit() {
+        let extra = 7;
+        let typos: String = (0..CLIENT_MESSAGE_KEY_LIMIT + extra)
+            .map(|i| format!("\"typo{i}\":{i},"))
+            .collect();
+        let msg = format!(
+            "{{\"type\":\"start_simulation\",\"config\":{{{typos}\
+             \"satellites\":[{{\"id\":\"a\",\"orbit\":\
+             {{\"type\":\"circular\",\"altitude\":400}}}}]}}}}"
+        );
+        let value: serde_json::Value =
+            serde_json::from_str(&msg).expect("the message is valid JSON");
+
+        let unread = unread_client_message_keys(&value);
+        assert_eq!(unread.named.len(), CLIENT_MESSAGE_KEY_LIMIT);
+        assert_eq!(unread.unnamed, extra, "the rest are counted, not dropped");
+        // The message still parses into something the server runs: the limit is
+        // on what gets said about it, not on what it may contain.
+        serde_json::from_value::<crate::commands::serve::protocol::ClientMessage>(value)
+            .expect("a message full of unknown keys still starts a simulation");
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
 use std::path::Path;
 
-use serde::{Deserialize, Serialize};
+use clap::ValueEnum;
+use serde::{Deserialize, Deserializer, Serialize};
 use ts_rs::TS;
 
 use crate::cli::{AtmosphereChoice, IntegratorChoice};
@@ -11,12 +13,54 @@ use orts::plugin::{Message, NamedValue, NodeId, Payload, Value};
 use orts::setup::DisturbanceTorques;
 use orts::spacecraft::{PanelOptics, SpacecraftShape, SurfacePanel};
 
+/// Resolve a config string through the [`ValueEnum`] impl the matching CLI
+/// flag uses, so `--atmosphere x` and `atmosphere = "x"` accept exactly the
+/// same set by construction: there is one list of spellings, clap's.
+///
+/// The config transport keeps these fields as `String` (the TypeScript clients
+/// of `start_simulation` send strings), so this is where the string becomes a
+/// model choice — and where an unknown spelling has to be rejected rather than
+/// silently resolved to some default model.
+fn parse_choice<T: ValueEnum>(field: &str, value: &str) -> Result<T, String> {
+    <T as ValueEnum>::from_str(value, false).map_err(|_| {
+        let allowed = T::value_variants()
+            .iter()
+            .filter_map(|v| v.to_possible_value())
+            .map(|p| p.get_name().to_string())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        format!("unknown {field} '{value}' (expected one of: {allowed})")
+    })
+}
+
+/// Reject an unknown `[integrator] type` at deserialization time, so every
+/// entry point (file, `orts config validate`, the `start_simulation`
+/// WebSocket payload) fails on a typo instead of running a different method.
+fn de_integrator_kind<'de, D: Deserializer<'de>>(de: D) -> Result<String, D::Error> {
+    let s = String::deserialize(de)?;
+    parse_choice::<IntegratorChoice>("integrator.type", &s).map_err(serde::de::Error::custom)?;
+    Ok(s)
+}
+
+/// Reject an unknown `atmosphere` at deserialization time. A typo used to fall
+/// back to the exponential model, i.e. quietly integrate different physics.
+fn de_atmosphere<'de, D: Deserializer<'de>>(de: D) -> Result<String, D::Error> {
+    let s = String::deserialize(de)?;
+    parse_choice::<AtmosphereChoice>("atmosphere", &s).map_err(serde::de::Error::custom)?;
+    Ok(s)
+}
+
 /// JSON/TOML/YAML simulation configuration.
 ///
 /// Also the payload of the `start_simulation` WebSocket message, so the
 /// whole tree derives [`TS`]. Fields the server defaults when absent are
 /// `#[ts(optional)]` so TypeScript clients may omit them too.
+// `deny_unknown_fields` here and on the rest of the config tree: a dropped key
+// is indistinguishable from a key that was never written, so `duraton = 100`
+// used to run with the default duration and report success. Kept out of the
+// doc comment because doc comments are copied into the generated TypeScript.
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
+#[serde(deny_unknown_fields)]
 #[ts(export)]
 pub struct SimConfig {
     #[serde(default = "default_body")]
@@ -34,7 +78,7 @@ pub struct SimConfig {
     #[serde(default)]
     #[ts(as = "Option<_>", optional)]
     pub integrator: IntegratorConfig,
-    #[serde(default = "default_atmosphere")]
+    #[serde(default = "default_atmosphere", deserialize_with = "de_atmosphere")]
     #[ts(as = "Option<_>", optional)]
     pub atmosphere: String,
     #[serde(default = "default_f107")]
@@ -65,6 +109,7 @@ pub struct SimConfig {
 
 /// Ground station definition for visibility / contact window detection.
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
+#[serde(deny_unknown_fields)]
 #[ts(export)]
 pub struct GroundStationConfig {
     pub name: String,
@@ -107,6 +152,7 @@ impl GroundStationConfig {
 /// コントローラ(FSW)へ `kind` + `args`(key-value payload) を配送する。
 /// host が配送 tick を確定するので決定論的。
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
+#[serde(deny_unknown_fields)]
 #[ts(export)]
 pub struct CommandConfig {
     /// 配送するシミュレーション時刻 \[s\]。
@@ -202,9 +248,14 @@ fn default_ap() -> f64 {
 
 /// Integrator configuration within a config file.
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
+#[serde(deny_unknown_fields)]
 #[ts(export)]
 pub struct IntegratorConfig {
-    #[serde(rename = "type", default = "default_integrator")]
+    #[serde(
+        rename = "type",
+        default = "default_integrator",
+        deserialize_with = "de_integrator_kind"
+    )]
     #[ts(as = "Option<_>", optional)]
     pub kind: String,
     #[serde(default = "default_atol")]
@@ -237,6 +288,7 @@ impl Default for IntegratorConfig {
 
 /// Attitude dynamics configuration for a satellite.
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
+#[serde(deny_unknown_fields)]
 #[ts(export)]
 pub struct AttitudeConfig {
     /// Diagonal inertia tensor [Ixx, Iyy, Izz] kg·m².
@@ -511,13 +563,45 @@ impl AttitudeConfig {
         if self.mass <= 0.0 {
             return Err(format!("non-positive mass: {}", self.mass));
         }
+        // Numeric usability is not physical possibility. State the two
+        // constraints every real inertia tensor satisfies in terms of its
+        // principal moments `I1 <= I2 <= I3` — the eigenvalues, which equal
+        // `inertia_diag` only when `inertia_off_diag` is zero, so read them off
+        // the tensor rather than the diagonal.
+        let mut moments: Vec<f64> = inertia.symmetric_eigenvalues().iter().copied().collect();
+        moments.sort_by(|a, b| a.partial_cmp(b).expect("eigenvalues of a finite tensor"));
+        let (i1, i2, i3) = (moments[0], moments[1], moments[2]);
+        // A non-positive principal moment means zero or negative mass off that
+        // axis. `I1 == 0` is the singular case the inverse above already
+        // refuses; a negative one can invert cleanly and still describe nothing.
+        if i1 <= 0.0 {
+            return Err(format!(
+                "inertia tensor is not positive definite: smallest principal moment is \
+                 {i1} (diag {:?}, off-diag {:?})",
+                self.inertia_diag, self.inertia_off_diag
+            ));
+        }
+        // No mass distribution can violate `I1 + I2 >= I3`, so a tensor that
+        // does integrates attitude motion belonging to no spacecraft. Equality
+        // is the flat-plate (lamina) limit — attainable and well-posed — and the
+        // relative slack keeps a config that states it exactly from being
+        // rejected by the eigenvalue solver's last bits.
+        const TRIANGLE_SLACK: f64 = 1e-9;
+        if i1 + i2 < i3 * (1.0 - TRIANGLE_SLACK) {
+            return Err(format!(
+                "inertia tensor violates the triangle inequality: principal moments \
+                 [{i1}, {i2}, {i3}] have I1 + I2 < I3, which no mass distribution can \
+                 produce (diag {:?}, off-diag {:?})",
+                self.inertia_diag, self.inertia_off_diag
+            ));
+        }
         Ok(())
     }
 }
 
 /// コントローラ設定。
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
-#[serde(tag = "type")]
+#[serde(tag = "type", deny_unknown_fields)]
 #[ts(export)]
 pub enum ControllerConfig {
     /// WASM Component ゲストプラグイン。
@@ -545,7 +629,7 @@ pub enum SensorChoice {
 
 /// リアクションホイール設定。
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
-#[serde(tag = "type")]
+#[serde(tag = "type", deny_unknown_fields)]
 #[ts(export)]
 pub enum ReactionWheelConfig {
     /// 直交 3 軸配置。
@@ -566,7 +650,7 @@ pub enum ReactionWheelConfig {
 
 /// MTQ (磁気トルカ) 設定。
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
-#[serde(tag = "type")]
+#[serde(tag = "type", deny_unknown_fields)]
 #[ts(export)]
 pub enum MtqConfig {
     /// 直交 3 軸配置。
@@ -579,6 +663,7 @@ pub enum MtqConfig {
 
 /// 推進器一機分の静的パラメータ。
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
+#[serde(deny_unknown_fields)]
 #[ts(export)]
 pub struct ThrusterSpecConfig {
     /// 最大推力 [N]。
@@ -598,6 +683,7 @@ pub struct ThrusterSpecConfig {
 /// `thrusters` に各推進器の静的パラメータを並べ、`dry_mass` で
 /// 推進剤枯渇時の停止閾値 (spacecraft total mass [kg]) を指定する。
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
+#[serde(deny_unknown_fields)]
 #[ts(export)]
 pub struct ThrusterConfig {
     /// 推進器一覧（空リストは reject）。
@@ -611,6 +697,7 @@ pub struct ThrusterConfig {
 
 /// Per-satellite configuration.
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
+#[serde(deny_unknown_fields)]
 #[ts(export)]
 pub struct SatelliteConfig {
     #[ts(optional)]
@@ -665,7 +752,7 @@ pub struct SatelliteConfig {
 
 /// Orbit specification in config files.
 #[derive(Deserialize, Serialize, Clone, Debug, TS)]
-#[serde(tag = "type")]
+#[serde(tag = "type", deny_unknown_fields)]
 #[ts(export)]
 pub enum OrbitConfig {
     /// Circular orbit at given altitude.
@@ -721,22 +808,35 @@ impl SimConfig {
         Ok(config)
     }
 
-    /// Parse the integrator choice from the config string.
+    /// The integrator selected by `[integrator] type`.
+    ///
+    /// # Panics
+    /// If the string is not one of the [`IntegratorChoice`] spellings. Both
+    /// `Deserialize` and [`validate`](Self::validate) reject those, so this is
+    /// only reachable for a hand-built `SimConfig`; the previous fallback to
+    /// `dp45` meant a typo integrated with a different method and exited 0.
     pub fn integrator_choice(&self) -> IntegratorChoice {
-        match self.integrator.kind.as_str() {
-            "rk4" => IntegratorChoice::Rk4,
-            "dop853" => IntegratorChoice::Dop853,
-            _ => IntegratorChoice::Dp45,
-        }
+        self.try_integrator_choice()
+            .unwrap_or_else(|e| panic!("{e}"))
     }
 
-    /// Parse the atmosphere choice from the config string.
+    /// The atmosphere model selected by `atmosphere`.
+    ///
+    /// # Panics
+    /// As [`integrator_choice`](Self::integrator_choice), for the same reason:
+    /// falling back to the exponential model would silently substitute the
+    /// physics the user asked for.
     pub fn atmosphere_choice(&self) -> AtmosphereChoice {
-        match self.atmosphere.as_str() {
-            "harris-priester" => AtmosphereChoice::HarrisPriester,
-            "nrlmsise00" => AtmosphereChoice::Nrlmsise00,
-            _ => AtmosphereChoice::Exponential,
-        }
+        self.try_atmosphere_choice()
+            .unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    fn try_integrator_choice(&self) -> Result<IntegratorChoice, String> {
+        parse_choice("integrator.type", &self.integrator.kind)
+    }
+
+    fn try_atmosphere_choice(&self) -> Result<AtmosphereChoice, String> {
+        parse_choice("atmosphere", &self.atmosphere)
     }
 
     /// Parse the central body from the config string.
@@ -746,9 +846,20 @@ impl SimConfig {
 }
 
 impl SatelliteConfig {
+    /// The id this satellite is known by downstream: the recording entity
+    /// path, the CSV section, the `[[command]]` target and the WebSocket
+    /// messages. An omitted `id` becomes `sat-{index}`.
+    ///
+    /// Single source of the default so validation and
+    /// [`to_satellite_spec`](Self::to_satellite_spec) cannot disagree about
+    /// which ids a fleet actually resolves to.
+    pub fn resolved_id(&self, index: usize) -> String {
+        self.id.clone().unwrap_or_else(|| format!("sat-{index}"))
+    }
+
     /// Convert a SatelliteConfig to a SatelliteSpec.
     pub fn to_satellite_spec(&self, index: usize, body: KnownBody, mu: f64) -> SatelliteSpec {
-        let id = self.id.clone().unwrap_or_else(|| format!("sat-{index}"));
+        let id = self.resolved_id(index);
 
         let (orbit, period, derived_name) = match &self.orbit {
             OrbitConfig::Circular {
@@ -1070,17 +1181,18 @@ impl SimConfig {
     /// not resolve `norad` orbits — that requires a network fetch and is left
     /// to run time.
     pub fn validate(&self) -> Result<(), String> {
+        // Resolve the model choices first: a deserialized config cannot carry
+        // an unknown spelling, but a hand-built one can, and every later step
+        // (tolerances, drag) depends on which model was actually selected.
+        let integrator = self.try_integrator_choice()?;
+        self.try_atmosphere_choice()?;
         validate_time_params(
             self.dt,
             self.output_interval,
             self.stream_interval,
             self.duration,
         )?;
-        validate_tolerances(
-            self.integrator_choice(),
-            self.integrator.atol,
-            self.integrator.rtol,
-        )?;
+        validate_tolerances(integrator, self.integrator.atol, self.integrator.rtol)?;
         if crate::satellite::try_parse_body(&self.body).is_none() {
             return Err(format!(
                 "unknown body '{}' (expected one of: sun, mercury, venus, earth, \
@@ -1097,6 +1209,31 @@ impl SimConfig {
         }
         let body = crate::satellite::try_parse_body(&self.body)
             .expect("body was validated as parseable above");
+        // Resolved ids must be unique: they are the recording entity path, the
+        // CSV section header and the `[[command]]` target, and every consumer
+        // resolves an id by first match or by `HashMap` insert. Duplicates
+        // therefore merge two satellites' rows under one path and route all
+        // commands to whichever one won the map — silently. Note the collision
+        // an explicit `id` can have with the `sat-{index}` default of an
+        // id-less entry, which is why this compares resolved ids.
+        let mut seen: HashMap<String, usize> = HashMap::with_capacity(self.satellites.len());
+        for (i, sat) in self.satellites.iter().enumerate() {
+            let id = sat.resolved_id(i);
+            if let Some(first) = seen.insert(id.clone(), i) {
+                return Err(format!(
+                    "satellites[{i}]: duplicate satellite id '{id}' (already used by \
+                     satellites[{first}]); ids must be unique{}",
+                    if sat.id.is_none() {
+                        format!(
+                            " — this entry has no `id`, so it defaults to '{id}'; \
+                             give it an explicit id"
+                        )
+                    } else {
+                        String::new()
+                    }
+                ));
+            }
+        }
         for (i, sat) in self.satellites.iter().enumerate() {
             sat.validate()
                 .map_err(|e| format!("satellites[{i}]: {e}"))?;
@@ -2624,5 +2761,440 @@ direction_body = [0.0, 0.0, 0.0]
         let err = SimConfig::load(&path).unwrap_err();
         assert!(err.contains("direction_body"), "msg: {err}");
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The name clap shows for a `ValueEnum` variant — the exact spelling a
+    /// `--integrator` / `--atmosphere` flag accepts.
+    fn choice_name<T: ValueEnum>(v: &T) -> String {
+        v.to_possible_value()
+            .expect("no choice variant is skipped")
+            .get_name()
+            .to_string()
+    }
+
+    /// A config file must accept exactly the spellings the equivalent CLI flag
+    /// accepts, and resolve each to the same model. The reverse inclusion holds
+    /// by construction (both sides go through the one `ValueEnum` impl); this
+    /// pins it, so adding a variant to only one side fails here.
+    #[test]
+    fn config_accepts_exactly_the_cli_choice_sets() {
+        for variant in IntegratorChoice::value_variants() {
+            let name = choice_name(variant);
+            let config = config_with(&format!("[integrator]\ntype = \"{name}\""));
+            assert_eq!(
+                choice_name(&config.integrator_choice()),
+                name,
+                "config resolved integrator '{name}' to a different method"
+            );
+            config.validate().unwrap_or_else(|e| {
+                panic!("integrator '{name}' is a CLI value but config rejects it: {e}")
+            });
+        }
+        for variant in AtmosphereChoice::value_variants() {
+            let name = choice_name(variant);
+            let config = config_with(&format!("atmosphere = \"{name}\""));
+            assert_eq!(
+                choice_name(&config.atmosphere_choice()),
+                name,
+                "config resolved atmosphere '{name}' to a different model"
+            );
+            config.validate().unwrap_or_else(|e| {
+                panic!("atmosphere '{name}' is a CLI value but config rejects it: {e}")
+            });
+        }
+    }
+
+    /// `--integrator dop835` is rejected by clap; the config spelling used to
+    /// fall back to dp45 and exit 0, integrating with a different method than
+    /// the one written down.
+    #[test]
+    fn unknown_integrator_type_is_rejected() {
+        let err = toml::from_str::<SimConfig>("[integrator]\ntype = \"dop835\"\n")
+            .expect_err("an unknown integrator must not deserialize")
+            .to_string();
+        assert!(err.contains("dop835"), "error should name the typo: {err}");
+        assert!(
+            err.contains("dop853"),
+            "error should list the legal spellings: {err}"
+        );
+    }
+
+    /// The same for `atmosphere`, where the old fallback to the exponential
+    /// model substituted the drag physics silently — nothing in the run
+    /// summary echoes the atmosphere model.
+    #[test]
+    fn unknown_atmosphere_is_rejected() {
+        for typo in ["nrlmsise0", "harris_priester", "NRLMSISE00", ""] {
+            let err = toml::from_str::<SimConfig>(&format!("atmosphere = \"{typo}\"\n"))
+                .expect_err("an unknown atmosphere must not deserialize")
+                .to_string();
+            assert!(
+                err.contains("harris-priester"),
+                "error should list the legal spellings: {err}"
+            );
+        }
+    }
+
+    /// A hand-built config (no deserialization) is caught by `validate`
+    /// instead, so `run`/`serve` cannot reach the model resolution with an
+    /// unknown spelling.
+    #[test]
+    fn validate_rejects_an_unknown_model_on_a_hand_built_config() {
+        let mut config = config_with("");
+        config.atmosphere = "nrlmsise0".into();
+        let err = config.validate().expect_err("unknown atmosphere");
+        assert!(err.contains("nrlmsise0"), "msg: {err}");
+
+        let mut config = config_with("");
+        config.integrator.kind = "dop835".into();
+        let err = config.validate().expect_err("unknown integrator");
+        assert!(err.contains("dop835"), "msg: {err}");
+    }
+
+    /// The resolution itself has no fallback arm any more: a model that was
+    /// never validated aborts loudly rather than quietly becoming another one.
+    #[test]
+    #[should_panic(expected = "unknown atmosphere 'nrlmsise0'")]
+    fn atmosphere_choice_has_no_silent_fallback() {
+        let mut config = config_with("");
+        config.atmosphere = "nrlmsise0".into();
+        let _ = config.atmosphere_choice();
+    }
+
+    /// An unknown key used to be dropped, which is indistinguishable from a key
+    /// the user never wrote: `duraton = 100` ran for one orbital period and
+    /// reported success.
+    #[test]
+    fn unknown_keys_are_rejected() {
+        let cases = [
+            ("top level", "duraton = 100.0\n"),
+            (
+                "satellite",
+                "[[satellites]]\naltitide = 400\n[satellites.orbit]\ntype = \"circular\"\naltitude = 500\n",
+            ),
+            (
+                "orbit",
+                "[[satellites]]\n[satellites.orbit]\ntype = \"circular\"\naltitude = 500\ninclinaton = 51.6\n",
+            ),
+            ("integrator", "[integrator]\natoll = 1.0e-9\n"),
+            (
+                "attitude",
+                "[[satellites]]\n[satellites.orbit]\ntype = \"circular\"\naltitude = 500\n\
+                 \n[satellites.attitude]\ninertia_diag = [10, 10, 10]\nmass = 100\nmas = 50\n",
+            ),
+            (
+                "ground station",
+                "[[ground_station]]\nname = \"gs\"\nlatitude_deg = 35.0\nlongitude_deg = 139.0\nelevation_deg = 5.0\n",
+            ),
+            (
+                "command",
+                "[[command]]\nt = 1.0\nsat = \"a\"\nkind = \"x\"\nargs = {}\nkid = \"y\"\n",
+            ),
+        ];
+        for (label, toml) in cases {
+            let err = toml::from_str::<SimConfig>(toml)
+                .map(|c| format!("{c:?}"))
+                .expect_err(&format!(
+                    "{label}: an unknown key must be rejected, not dropped"
+                ))
+                .to_string();
+            assert!(
+                err.contains("unknown field"),
+                "{label}: expected an unknown-field error, got {err}"
+            );
+        }
+    }
+
+    /// Two satellites resolving to one id share the recording entity path and
+    /// the CSV section, and `[[command]]` reaches only whichever one won the
+    /// id → index map. Reject the fleet instead.
+    #[test]
+    fn validate_rejects_duplicate_satellite_ids() {
+        let toml = r#"
+[[satellites]]
+id = "a"
+[satellites.orbit]
+type = "circular"
+altitude = 500
+
+[[satellites]]
+id = "a"
+[satellites.orbit]
+type = "circular"
+altitude = 800
+"#;
+        let config: SimConfig = toml::from_str(toml).unwrap();
+        let err = config
+            .validate()
+            .expect_err("a duplicate satellite id must be rejected");
+        assert!(err.contains("duplicate satellite id 'a'"), "msg: {err}");
+        assert!(
+            err.contains("satellites[1]") && err.contains("satellites[0]"),
+            "error should name both entries: {err}"
+        );
+    }
+
+    /// The collision an explicit id can have with the `sat-{index}` default of
+    /// an id-less entry: neither id is written twice, so it is invisible in the
+    /// config file.
+    #[test]
+    fn validate_rejects_an_id_colliding_with_the_auto_default() {
+        let toml = r#"
+[[satellites]]
+id = "sat-1"
+[satellites.orbit]
+type = "circular"
+altitude = 500
+
+[[satellites]]
+[satellites.orbit]
+type = "circular"
+altitude = 800
+"#;
+        let config: SimConfig = toml::from_str(toml).unwrap();
+        let err = config
+            .validate()
+            .expect_err("an id colliding with the auto default must be rejected");
+        assert!(err.contains("duplicate satellite id 'sat-1'"), "msg: {err}");
+        assert!(
+            err.contains("no `id`"),
+            "error should point at the defaulted entry: {err}"
+        );
+    }
+
+    /// The ordinary multi-satellite fleet stays valid, including the all-auto
+    /// case (`sat-0`, `sat-1`, …).
+    #[test]
+    fn validate_accepts_distinct_satellite_ids() {
+        let toml = r#"
+[[satellites]]
+id = "iss"
+[satellites.orbit]
+type = "circular"
+altitude = 400
+
+[[satellites]]
+[satellites.orbit]
+type = "circular"
+altitude = 500
+
+[[satellites]]
+[satellites.orbit]
+type = "circular"
+altitude = 800
+"#;
+        let config: SimConfig = toml::from_str(toml).unwrap();
+        config.validate().expect("distinct ids must be accepted");
+        let ids: Vec<String> = config
+            .satellites
+            .iter()
+            .enumerate()
+            .map(|(i, s)| s.resolved_id(i))
+            .collect();
+        assert_eq!(ids, ["iss", "sat-1", "sat-2"]);
+    }
+
+    fn attitude(inertia_diag: [f64; 3], inertia_off_diag: [f64; 3], mass: f64) -> AttitudeConfig {
+        AttitudeConfig {
+            inertia_diag,
+            inertia_off_diag,
+            mass,
+            initial_quaternion: default_identity_quat(),
+            initial_angular_velocity: [0.0; 3],
+        }
+    }
+
+    /// `SpacecraftDynamics::new` inverts the inertia tensor with
+    /// `try_inverse().expect(...)`, so a singular tensor used to abort the
+    /// process (exit 101) instead of being reported as bad input.
+    #[test]
+    fn attitude_validate_rejects_singular_inertia() {
+        let err = attitude([0.0, 0.0, 0.0], [0.0; 3], 100.0)
+            .validate()
+            .expect_err("a zero inertia tensor must be rejected");
+        assert!(err.contains("positive definite"), "msg: {err}");
+
+        // Singular through the off-diagonals only: [[1,1,0],[1,1,0],[0,0,1]]
+        // has principal moments (0, 1, 2), which `inertia_diag` alone does not
+        // show.
+        let err = attitude([1.0, 1.0, 1.0], [1.0, 0.0, 0.0], 100.0)
+            .validate()
+            .expect_err("an off-diagonal singular tensor must be rejected");
+        assert!(err.contains("positive definite"), "msg: {err}");
+    }
+
+    /// An indefinite tensor is invertible — a determinant test passes it — but
+    /// a negative principal moment is negative mass off that axis.
+    #[test]
+    fn attitude_validate_rejects_indefinite_inertia() {
+        let indefinite = attitude([1.0, 1.0, 1.0], [2.0, 0.0, 0.0], 100.0);
+        assert!(
+            indefinite.inertia_matrix().try_inverse().is_some(),
+            "this tensor is invertible: only the eigenvalues expose it"
+        );
+        let err = indefinite
+            .validate()
+            .expect_err("an indefinite tensor must be rejected");
+        assert!(err.contains("positive definite"), "msg: {err}");
+    }
+
+    /// `I1 + I2 >= I3` holds for every mass distribution, so a config that
+    /// breaks it describes no spacecraft. Checked on the principal moments,
+    /// not on `inertia_diag`: here the diagonal alone satisfies the inequality
+    /// while the tensor's eigenvalues (1, 1, 5) do not.
+    #[test]
+    fn attitude_validate_rejects_triangle_inequality_violation() {
+        let err = attitude([1.0, 1.0, 5.0], [0.0; 3], 100.0)
+            .validate()
+            .expect_err("I1 + I2 < I3 must be rejected");
+        assert!(err.contains("triangle inequality"), "msg: {err}");
+
+        let off_diag = attitude([3.0, 3.0, 1.0], [2.0, 0.0, 0.0], 100.0);
+        let mut moments: Vec<f64> = off_diag
+            .inertia_matrix()
+            .symmetric_eigenvalues()
+            .iter()
+            .copied()
+            .collect();
+        moments.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert!(
+            (moments[2] - 5.0).abs() < 1e-9 && moments[0] + moments[1] < moments[2],
+            "test fixture should violate the inequality only through the off-diagonals: {moments:?}"
+        );
+        let err = off_diag
+            .validate()
+            .expect_err("an off-diagonal triangle violation must be rejected");
+        assert!(err.contains("triangle inequality"), "msg: {err}");
+    }
+
+    /// Equality is the flat-plate (lamina) limit: physically attainable, and
+    /// the tensor is still invertible, so it stays accepted.
+    #[test]
+    fn attitude_validate_accepts_the_lamina_boundary() {
+        attitude([1.0, 2.0, 3.0], [0.0; 3], 100.0)
+            .validate()
+            .expect("I1 + I2 == I3 is a flat plate, not an impossible body");
+        // Scale-invariant: the slack is relative, so a large plate is accepted
+        // too.
+        attitude([1e8, 2e8, 3e8], [0.0; 3], 100.0)
+            .validate()
+            .expect("the triangle slack must be relative, not absolute");
+    }
+
+    #[test]
+    fn attitude_validate_rejects_non_positive_mass() {
+        for mass in [0.0, -1.0, f64::NAN] {
+            let err = attitude([10.0, 10.0, 10.0], [0.0; 3], mass)
+                .validate()
+                .expect_err("non-positive mass must be rejected");
+            assert!(err.contains("attitude.mass"), "msg for {mass}: {err}");
+        }
+    }
+
+    /// A zero quaternion normalizes to NaN in `AttitudeState::orientation()`,
+    /// so the attitude is NaN from the first step with no error anywhere.
+    #[test]
+    fn attitude_validate_rejects_a_zero_or_non_finite_quaternion() {
+        let mut att = attitude([10.0, 10.0, 10.0], [0.0; 3], 100.0);
+        att.initial_quaternion = [0.0; 4];
+        let err = att
+            .validate()
+            .expect_err("a zero quaternion must be rejected");
+        assert!(err.contains("initial_quaternion"), "msg: {err}");
+
+        att.initial_quaternion = [1.0, f64::NAN, 0.0, 0.0];
+        let err = att
+            .validate()
+            .expect_err("a non-finite quaternion must be rejected");
+        assert!(err.contains("initial_quaternion"), "msg: {err}");
+    }
+
+    #[test]
+    fn attitude_validate_rejects_non_finite_inertia() {
+        let mut att = attitude([10.0, 10.0, f64::INFINITY], [0.0; 3], 100.0);
+        let err = att.validate().expect_err("infinite inertia");
+        assert!(err.contains("inertia_diag"), "msg: {err}");
+
+        att = attitude([10.0, 10.0, 10.0], [f64::NAN, 0.0, 0.0], 100.0);
+        let err = att.validate().expect_err("NaN off-diagonal");
+        assert!(err.contains("inertia_off_diag"), "msg: {err}");
+    }
+
+    /// The realistic tensors the repo ships in examples and presets stay valid.
+    #[test]
+    fn attitude_validate_accepts_realistic_tensors() {
+        for diag in [
+            [10.0, 10.0, 10.0],
+            [100.0, 100.0, 50.0],
+            // ISS, approximately [kg·m²]
+            [128_913_000.0, 107_321_000.0, 201_433_000.0],
+        ] {
+            attitude(diag, [0.0; 3], 420_000.0)
+                .validate()
+                .unwrap_or_else(|e| panic!("{diag:?} should be valid: {e}"));
+        }
+    }
+
+    /// End to end through the loader: the error names the satellite and the
+    /// field, where `orts run` used to reach the panic in
+    /// `SpacecraftDynamics::new`.
+    #[test]
+    fn config_load_rejects_singular_inertia() {
+        let toml = r#"
+[[satellites]]
+id = "a"
+[satellites.orbit]
+type = "circular"
+altitude = 500
+
+[satellites.attitude]
+inertia_diag = [0.0, 0.0, 0.0]
+mass = 100.0
+"#;
+        let dir = std::env::temp_dir().join(format!("orts_config_att_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("singular.toml");
+        std::fs::write(&path, toml).unwrap();
+        let err = SimConfig::load(&path).expect_err("a singular inertia tensor must be rejected");
+        assert!(err.contains("satellites[0]"), "msg: {err}");
+        assert!(err.contains("positive definite"), "msg: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The WebSocket surface: `start_simulation` nests the whole
+    /// `SimConfig`, so a misspelled key is rejected there like in a file;
+    /// `add_satellite` flattens a `SatelliteConfig` next to the message tag,
+    /// and serde disables the unknown-field check under `flatten` — the message
+    /// must keep parsing, and that path keeps dropping unknown keys until the
+    /// protocol stops flattening.
+    #[test]
+    fn websocket_messages_agree_with_the_strict_config_tree() {
+        let start = r#"{
+            "type": "start_simulation",
+            "config": {
+                "dt": 10.0,
+                "satellites": [{ "orbit": { "type": "circular", "altitude": 500.0 } }]
+            }
+        }"#;
+        serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(start)
+            .expect("start_simulation must parse");
+        let typo = start.replace("\"dt\"", "\"dtt\"");
+        serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(&typo)
+            .expect_err("a misspelled key in start_simulation must be rejected");
+
+        let add = r#"{
+            "type": "add_satellite",
+            "id": "dynamic-sat",
+            "name": "Dyn",
+            "orbit": { "type": "circular", "altitude": 500.0 },
+            "attitude": { "inertia_diag": [10.0, 10.0, 10.0], "mass": 500.0 }
+        }"#;
+        serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(add)
+            .expect("add_satellite must still parse");
+        // Nested structs under the flattened one are still checked: only the
+        // flattened level loses it.
+        let nested_typo = add.replace("\"mass\": 500.0", "\"mass\": 500.0, \"masss\": 1.0");
+        serde_json::from_str::<crate::commands::serve::protocol::ClientMessage>(&nested_typo)
+            .expect_err("a misspelled key inside `attitude` must be rejected");
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -842,6 +842,13 @@ pub enum OrbitConfig {
 /// what anyone reads to find a typo.
 const CLIENT_MESSAGE_KEY_LIMIT: usize = 20;
 
+/// How many characters of one key reach the log.
+///
+/// The key-count limit says nothing about how long each is, and a key over `/ws`
+/// is as long as its sender cares to make it. A config key that anyone typed
+/// fits in far less than this.
+const PRINTED_KEY_LIMIT: usize = 128;
+
 /// The unread keys of a client message, and how many did not fit.
 #[derive(Default, Debug, PartialEq, Eq)]
 pub struct UnreadClientKeys {
@@ -959,8 +966,19 @@ pub fn load_config_reporting_unread_keys(path: &Path) -> Result<SimConfig, Strin
 /// `escape_debug` leaves an ordinary key alone — what it rewrites is the
 /// characters no key needs. The JSON form of `orts config validate` needs none
 /// of this; a JSON string encodes them itself.
-pub fn printable_key(key: &str) -> std::str::EscapeDebug<'_> {
-    key.escape_debug()
+///
+/// The length is bounded too: a key is as long as its sender cares to make it,
+/// and escaping can turn one character into six (`\u{1b}`). Counting the escaped
+/// characters bounds the line whatever the input expands to. What is left out is
+/// the middle of a name nobody was going to read to the end; the byte count says
+/// how much.
+pub fn printable_key(key: &str) -> String {
+    let mut escaped = key.escape_debug();
+    let mut out: String = escaped.by_ref().take(PRINTED_KEY_LIMIT).collect();
+    if escaped.next().is_some() {
+        out.push_str(&format!("… ({} bytes in all)", key.len()));
+    }
+    out
 }
 
 /// A loaded config and the keys in its file that nothing read.
@@ -4115,9 +4133,25 @@ orbit = { type = "circular", altitude = 600 }
         }
         // An ordinary key is untouched, so the escaping costs nothing to read.
         assert_eq!(
-            format!("{}", printable_key("satellites.0.altitide")),
+            printable_key("satellites.0.altitide"),
             "satellites.0.altitide"
         );
+
+        // A key is as long as its sender chose, and escaping expands each
+        // character up to six, so the rendered line is bounded and says what it
+        // left out.
+        let long = "\u{1b}".repeat(10_000);
+        let rendered = printable_key(&long);
+        assert!(
+            rendered.chars().count() < PRINTED_KEY_LIMIT + 40,
+            "bounded whatever the escaping does to it: {} chars",
+            rendered.chars().count()
+        );
+        assert!(
+            rendered.contains("10000 bytes in all"),
+            "and says how long the key was: {rendered}"
+        );
+        assert!(!rendered.contains('\u{1b}'), "still escaped: {rendered:?}");
     }
 
     /// A client message names at most `CLIENT_MESSAGE_KEY_LIMIT` keys.

--- a/cli/src/satellite.rs
+++ b/cli/src/satellite.rs
@@ -147,8 +147,15 @@ impl SatelliteSpec {
     }
 
     pub fn entity_path(&self) -> EntityPath {
-        EntityPath::parse(&format!("/world/sat/{}", self.id))
+        entity_path_for_id(&self.id)
     }
+}
+
+/// The recording entity a satellite id names. Shared with config validation,
+/// which checks id uniqueness before any [`SatelliteSpec`] exists (resolving
+/// one can require a network fetch).
+pub fn entity_path_for_id(id: &str) -> EntityPath {
+    EntityPath::parse(&format!("/world/sat/{id}"))
 }
 
 /// Reject a fleet whose ids are not unique.
@@ -162,16 +169,35 @@ impl SatelliteSpec {
 /// `SimConfig::validate` catches this for config files, where it can name the
 /// offending `[[satellites]]` index; this covers the fleets built outside a
 /// config file (repeated `--sat id=…`), where the specs only exist as a list.
+/// Compared on the resolved [`EntityPath`], not on the id text: `EntityPath`
+/// drops empty segments, so `a` and `/a` (or `a/b` and `a//b`) are two id
+/// strings naming one entity.
 pub fn ensure_unique_ids(specs: &[SatelliteSpec]) -> Result<(), String> {
-    let mut seen: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    let mut seen: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
     for (i, spec) in specs.iter().enumerate() {
-        if let Some(first) = seen.insert(&spec.id, i) {
+        validate_id(&spec.id).map_err(|e| format!("satellite #{i}: {e}"))?;
+        if let Some(first) = seen.insert(spec.entity_path().to_string(), i) {
             return Err(format!(
                 "duplicate satellite id '{}': satellites #{first} and #{i} would share \
                  one recording entity and one command target; ids must be unique",
                 spec.id
             ));
         }
+    }
+    Ok(())
+}
+
+/// Reject an id that cannot name an entity of its own.
+///
+/// The id is appended to `/world/sat/`, and [`EntityPath::parse`] drops empty
+/// segments, so an id that is empty or only separators/whitespace resolves to
+/// the `/world/sat` root shared by every satellite.
+pub fn validate_id(id: &str) -> Result<(), String> {
+    if id.split('/').all(|segment| segment.is_empty()) {
+        return Err(format!(
+            "satellite id '{id}' contributes no path segment, so the recording entity \
+             collapses to the '/world/sat' root shared by the whole fleet"
+        ));
     }
     Ok(())
 }

--- a/cli/src/satellite.rs
+++ b/cli/src/satellite.rs
@@ -189,9 +189,10 @@ pub fn ensure_unique_ids(specs: &[SatelliteSpec]) -> Result<(), String> {
 
 /// Reject an id that cannot name an entity of its own.
 ///
-/// The id is appended to `/world/sat/`, and [`EntityPath::parse`] drops empty
-/// segments, so an id that is empty or only separators/whitespace resolves to
-/// the `/world/sat` root shared by every satellite.
+/// The id is appended to `/world/sat/`, and [`EntityPath::parse`] keeps every
+/// segment that is not empty — nothing else, no trimming — so an id built only
+/// out of separators resolves to the `/world/sat` root that the whole fleet
+/// shares. The condition here mirrors that filter.
 pub fn validate_id(id: &str) -> Result<(), String> {
     if id.split('/').all(|segment| segment.is_empty()) {
         return Err(format!(

--- a/cli/src/satellite.rs
+++ b/cli/src/satellite.rs
@@ -179,7 +179,7 @@ pub fn ensure_unique_ids(specs: &[SatelliteSpec]) -> Result<(), String> {
         if let Some(first) = seen.insert(spec.entity_path().to_string(), i) {
             return Err(format!(
                 "duplicate satellite id '{}': satellites #{first} and #{i} would share \
-                 one recording entity and one command target; ids must be unique",
+                 one recording entity, and one CSV section with it; ids must be unique",
                 spec.id
             ));
         }

--- a/cli/src/satellite.rs
+++ b/cli/src/satellite.rs
@@ -151,6 +151,31 @@ impl SatelliteSpec {
     }
 }
 
+/// Reject a fleet whose ids are not unique.
+///
+/// The id is the fleet's addressing scheme: [`SatelliteSpec::entity_path`]
+/// derives the recording entity from it, the CSV writer sections by it, and
+/// the command / lookup paths resolve it through a first match or a `HashMap`
+/// insert. Two satellites sharing an id therefore write into one entity and
+/// only one of them can be addressed — with no error anywhere.
+///
+/// `SimConfig::validate` catches this for config files, where it can name the
+/// offending `[[satellites]]` index; this covers the fleets built outside a
+/// config file (repeated `--sat id=…`), where the specs only exist as a list.
+pub fn ensure_unique_ids(specs: &[SatelliteSpec]) -> Result<(), String> {
+    let mut seen: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for (i, spec) in specs.iter().enumerate() {
+        if let Some(first) = seen.insert(&spec.id, i) {
+            return Err(format!(
+                "duplicate satellite id '{}': satellites #{first} and #{i} would share \
+                 one recording entity and one command target; ids must be unique",
+                spec.id
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Satellite info sent in the WebSocket info message.
 #[derive(Serialize, Clone, Debug, ts_rs::TS)]
 #[ts(export)]
@@ -469,5 +494,31 @@ mod tests {
         let spec = parse_sat_spec("altitude=400,id=my-sat", KnownBody::Earth);
         let path = spec.entity_path();
         assert_eq!(path.to_string(), "/world/sat/my-sat");
+    }
+
+    /// Two `--sat` flags with the same id resolve to one entity path, so the
+    /// fleet has to be rejected as a whole — no single flag is wrong.
+    #[test]
+    fn ensure_unique_ids_rejects_a_repeated_id() {
+        let specs = [
+            parse_sat_spec("altitude=400,id=a", KnownBody::Earth),
+            parse_sat_spec("altitude=800,id=a", KnownBody::Earth),
+        ];
+        assert_eq!(
+            specs[0].entity_path().to_string(),
+            specs[1].entity_path().to_string(),
+            "the collision this guards is the shared entity path"
+        );
+        let err = ensure_unique_ids(&specs).expect_err("a repeated id must be rejected");
+        assert!(err.contains("duplicate satellite id 'a'"), "msg: {err}");
+    }
+
+    #[test]
+    fn ensure_unique_ids_accepts_distinct_ids() {
+        let specs = [
+            parse_sat_spec("altitude=400,id=a", KnownBody::Earth),
+            parse_sat_spec("altitude=800,id=b", KnownBody::Earth),
+        ];
+        ensure_unique_ids(&specs).expect("distinct ids must be accepted");
     }
 }

--- a/cli/src/sim/mode.rs
+++ b/cli/src/sim/mode.rs
@@ -68,6 +68,9 @@ pub fn select_sim_mode(satellites: &[SatelliteSpec]) -> Result<SimMode, String> 
 /// `orts serve` builds inside the spawned manager: a mixed fleet validated
 /// clean, `orts serve --config` printed its banner, and the config the caller
 /// passed never ran — the server sat idle waiting for a `start_simulation`.
+///
+/// An empty fleet meets every rule here: `serve` starts with no satellites and
+/// grows by `add_satellite`, and [`select_sim_mode`] calls that `OrbitOnly`.
 pub fn ensure_fleet_declares_uniformly(
     fleet_size: usize,
     with_attitude: usize,
@@ -93,7 +96,7 @@ pub fn ensure_fleet_declares_uniformly(
     // takes until the engine is built, which under `orts serve --config` is
     // after the startup banner: the fleet is uniform, the mode comes out
     // `Controlled`, and the server then sits idle.
-    if with_controller == fleet_size && with_attitude == 0 {
+    if fleet_size != 0 && with_controller == fleet_size && with_attitude == 0 {
         return Err(
             "`[satellites.controller]` without `[satellites.attitude]`: a controller \
              commands the satellite's attitude, so a controlled fleet propagates attitude \
@@ -251,6 +254,10 @@ orbit = { type = "circular", altitude = 400 }
     #[test]
     fn empty_fleet_is_orbit_only() {
         assert_eq!(select_sim_mode(&[]), Ok(SimMode::OrbitOnly));
+        // Held at the shared rule too, not only by the caller's early return:
+        // `serve` starts empty and grows by `add_satellite`, and zero
+        // controllers on zero satellites is not "controllers without attitude".
+        assert_eq!(ensure_fleet_declares_uniformly(0, 0, 0), Ok(()));
     }
 
     /// One attitude config with `attitude` filled in from `fields`.

--- a/cli/src/sim/mode.rs
+++ b/cli/src/sim/mode.rs
@@ -345,14 +345,21 @@ orbit = {{ type = "circular", altitude = 400 }}
     /// Euler term can overflow from the inertia and the rate alone.
     #[test]
     fn an_initial_state_that_starts_at_infinite_acceleration_is_rejected() {
+        // The rate, not the inertia, is what carries it out of range here. A
+        // tensor lopsided enough to overflow `I⁻¹` on its own — `[1e-308, 1, 2]`
+        // — is refused earlier for violating the triangle inequality, and the
+        // inequality is also what keeps the lopsided case from reaching this
+        // term: a tiny `I1` forces `I2 ≈ I3`, which shrinks the first component
+        // of `ω × Iω` by as much as `I⁻¹` magnifies it.
         let err = validate_satellite_spec(&attitude_spec(
-            "inertia_diag = [1e-308, 1, 2]\nmass = 500\ninitial_angular_velocity = [1, 2, 2]",
+            "inertia_diag = [1, 1, 2]\nmass = 500\n\
+             initial_angular_velocity = [1e200, 1e200, 1e200]",
         ))
         .expect_err("an infinite initial angular acceleration should be rejected");
         assert!(err.contains("angular acceleration"), "got {err}");
 
         // The same inertia at rest has nothing to diverge.
-        validate_satellite_spec(&attitude_spec("inertia_diag = [1e-308, 1, 2]\nmass = 500"))
+        validate_satellite_spec(&attitude_spec("inertia_diag = [1, 1, 2]\nmass = 500"))
             .expect("a resting spacecraft integrates whatever its inertia");
     }
 

--- a/cli/src/sim/mode.rs
+++ b/cli/src/sim/mode.rs
@@ -40,37 +40,55 @@ pub fn select_sim_mode(satellites: &[SatelliteSpec]) -> Result<SimMode, String> 
     if satellites.is_empty() {
         return Ok(SimMode::OrbitOnly);
     }
-    let n = satellites.len();
+    let fleet_size = satellites.len();
     let with_attitude = satellites
         .iter()
         .filter(|s| s.attitude_config.is_some())
         .count();
-    if with_attitude != 0 && with_attitude != n {
+    let with_controller = satellites
+        .iter()
+        .filter(|s| s.controller_config.is_some())
+        .count();
+    ensure_fleet_declares_uniformly(fleet_size, with_attitude, with_controller)?;
+
+    if with_controller == fleet_size {
+        return Ok(SimMode::Controlled);
+    }
+    if with_attitude == fleet_size {
+        return Ok(SimMode::Spacecraft);
+    }
+    Ok(SimMode::OrbitOnly)
+}
+
+/// The part of [`select_sim_mode`]'s rule that a config settles on its own:
+/// attitude and controller are declared fleet-wide or not at all.
+///
+/// Shared with [`crate::config::SimConfig::validate`] so a config file meets it
+/// before anything runs. It used to be reached only from the engine, which
+/// `orts serve` builds inside the spawned manager: a mixed fleet validated
+/// clean, `orts serve --config` printed its banner, and the config the caller
+/// passed never ran — the server sat idle waiting for a `start_simulation`.
+pub fn ensure_fleet_declares_uniformly(
+    fleet_size: usize,
+    with_attitude: usize,
+    with_controller: usize,
+) -> Result<(), String> {
+    if with_attitude != 0 && with_attitude != fleet_size {
         return Err(
             "Mixed attitude config: some satellites have attitude, some don't. \
              Specify attitude for all satellites or remove it from all."
                 .to_string(),
         );
     }
-    let with_controller = satellites
-        .iter()
-        .filter(|s| s.controller_config.is_some())
-        .count();
-    if with_controller != 0 && with_controller != n {
+    if with_controller != 0 && with_controller != fleet_size {
         return Err(format!(
-            "Mixed controller config: {with_controller} of {n} satellites have \
+            "Mixed controller config: {with_controller} of {fleet_size} satellites have \
              `[satellites.controller]`. The control loop steps the whole fleet or none of it, \
              so those controllers would never run. Specify a controller for all satellites \
              or remove it from all."
         ));
     }
-    if with_controller == n {
-        return Ok(SimMode::Controlled);
-    }
-    if with_attitude == n {
-        return Ok(SimMode::Spacecraft);
-    }
-    Ok(SimMode::OrbitOnly)
+    Ok(())
 }
 
 /// 選択されたモードでは効かない設定キーについての警告文。

--- a/cli/src/sim/mode.rs
+++ b/cli/src/sim/mode.rs
@@ -88,6 +88,20 @@ pub fn ensure_fleet_declares_uniformly(
              or remove it from all."
         ));
     }
+    // A controlled satellite is built on its attitude state, so
+    // `build_controlled_satellite` refuses one without it. Reaching that refusal
+    // takes until the engine is built, which under `orts serve --config` is
+    // after the startup banner: the fleet is uniform, the mode comes out
+    // `Controlled`, and the server then sits idle.
+    if with_controller == fleet_size && with_attitude == 0 {
+        return Err(
+            "`[satellites.controller]` without `[satellites.attitude]`: a controller \
+             commands the satellite's attitude, so a controlled fleet propagates attitude \
+             dynamics and needs the inertia and initial state to do it. Add \
+             `[satellites.attitude]` to every satellite or remove the controllers."
+                .to_string(),
+        );
+    }
     Ok(())
 }
 

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -442,6 +442,13 @@ impl SimParams {
     }
 
     /// Default satellites for `serve` with no orbit args: SSO 800km + ISS.
+    ///
+    /// No `serve` invocation reaches this any more. Idle mode took the branch:
+    /// `has_explicit_sim_args` gates the only call to
+    /// `from_sim_args(_, is_serve = true)`, and it is true only when a config or
+    /// an orbit argument is present — in which case the arms above build that
+    /// instead. `orts serve` with nothing else waits for a `start_simulation`.
+    /// See #393 for whether the fleet or the code should go.
     pub fn default_serve_satellites(body: KnownBody, mu: f64) -> Vec<SatelliteSpec> {
         let mut sats = Vec::new();
 

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -464,7 +464,12 @@ impl SimParams {
             disturbances: Default::default(),
             panels: None,
             attitude_config: Some(crate::config::AttitudeConfig {
-                inertia_diag: [100.0, 200.0, 50.0],
+                // 500 kg, 2 x 1 x 1 m box: I = m/12 * (b^2 + c^2) per axis.
+                // The previous [100, 200, 50] broke the triangle inequality
+                // (100 + 50 < 200), i.e. no mass distribution has it — and
+                // `AttitudeConfig::validate` now rejects the same numbers in a
+                // config file, so the shipped default has to be realizable.
+                inertia_diag: [83.3, 208.3, 208.3],
                 inertia_off_diag: [0.0, 0.0, 0.0],
                 mass: 500.0,
                 initial_quaternion: [1.0, 0.0, 0.0, 0.0],

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -123,17 +123,30 @@ pub(crate) fn validate_omm_body(
     body: KnownBody,
     satellites: &[SatelliteSpec],
 ) -> Result<(), String> {
-    if body != KnownBody::Earth
-        && satellites
-            .iter()
-            .any(|s| matches!(s.orbit, OrbitSpec::Omm { .. }))
+    if satellites
+        .iter()
+        .any(|s| matches!(s.orbit, OrbitSpec::Omm { .. }))
     {
-        return Err(format!(
-            "TLE/OMM orbits are Earth-centered (SGP4/TEME, WGS72) and cannot be \
-             propagated about {body:?}; use the Earth body or specify Keplerian elements"
-        ));
+        return ensure_body_carries_omm(body);
     }
     Ok(())
+}
+
+/// The half of [`validate_omm_body`] that a config settles on its own.
+///
+/// Shared with [`crate::config::SimConfig::validate`], which knows a satellite
+/// declares `tle` or `norad` without building the spec — building it would fetch
+/// a `norad_id` over the network. Reaching this only through `SimParams` meant
+/// `orts config validate` called a non-Earth TLE config valid and `orts run
+/// --config` then panicked on it.
+pub(crate) fn ensure_body_carries_omm(body: KnownBody) -> Result<(), String> {
+    if body == KnownBody::Earth {
+        return Ok(());
+    }
+    Err(format!(
+        "TLE/OMM orbits are Earth-centered (SGP4/TEME, WGS72) and cannot be \
+         propagated about {body:?}; use the Earth body or specify Keplerian elements"
+    ))
 }
 
 /// Simulation parameters derived from CLI arguments.

--- a/cli/tests/config_e2e.rs
+++ b/cli/tests/config_e2e.rs
@@ -278,12 +278,13 @@ fn test_config_validate_rejects_unintegrable_attitude() {
 #[test]
 fn serve_does_not_announce_a_port_for_a_rejected_config() {
     let dir = unique_dir("serve-reject");
-    let path = dir.join("unknown-key.json");
-    // `central_body` is not a config key (the key is `body`); before
-    // `deny_unknown_fields` it was dropped and the body silently defaulted.
+    let path = dir.join("unknown-value.json");
+    // A known key holding a value the simulation cannot honor: `atmosphere` is
+    // the model to use, and `none` names no model. (An unknown *key* is a
+    // warning, so it would not stop `serve` and could not test the ordering.)
     std::fs::write(
         &path,
-        br#"{"central_body":"earth","dt":1.0,"satellites":[{"id":"a","orbit":{"type":"circular","altitude":400}}]}"#,
+        br#"{"atmosphere":"none","dt":1.0,"satellites":[{"id":"a","orbit":{"type":"circular","altitude":400}}]}"#,
     )
     .unwrap();
 
@@ -315,8 +316,8 @@ fn serve_does_not_announce_a_port_for_a_rejected_config() {
 
     assert!(!status.success(), "serve accepted it: {stderr}");
     assert!(
-        stderr.contains("central_body"),
-        "the rejection should name the key: {stderr}"
+        stderr.contains("unknown atmosphere 'none'"),
+        "the rejection should name the value it cannot honor: {stderr}"
     );
     // Each banner line separately: the harnesses wait on different ones.
     for line in ["Server listening", "Viewer:", "WebSocket endpoint"] {

--- a/cli/tests/config_e2e.rs
+++ b/cli/tests/config_e2e.rs
@@ -362,8 +362,14 @@ fn config_validate_json_carries_the_unread_keys() {
     let warnings = verdict["warnings"]
         .as_array()
         .unwrap_or_else(|| panic!("a warnings array: {stdout}"));
-    let text: Vec<&str> = warnings.iter().filter_map(|w| w.as_str()).collect();
-    assert_eq!(text.len(), 2, "both keys: {text:?}");
+    assert_eq!(warnings.len(), 2, "both keys, and only those: {warnings:?}");
+    let text: Vec<&str> = warnings
+        .iter()
+        .map(|w| {
+            w.as_str()
+                .unwrap_or_else(|| panic!("every warning is a string: {warnings:?}"))
+        })
+        .collect();
     assert!(
         text.iter().any(|w| w.contains("`duraton`")),
         "the top-level key: {text:?}"

--- a/cli/tests/config_e2e.rs
+++ b/cli/tests/config_e2e.rs
@@ -273,7 +273,7 @@ fn test_config_validate_rejects_unintegrable_attitude() {
 /// every harness waits on: `cli/tests/ws_e2e.rs` matches `Server listening
 /// on`, the Playwright specs read the port out of the `WebSocket endpoint`
 /// line. Printing the banner ahead of the rejection left the caller connecting
-/// to a socket that was already closing, so an unknown key surfaced as a
+/// to a socket that was already closing, so a rejected value surfaced as a
 /// connection failure instead of as its own message.
 #[test]
 fn serve_does_not_announce_a_port_for_a_rejected_config() {
@@ -326,5 +326,52 @@ fn serve_does_not_announce_a_port_for_a_rejected_config() {
             "a rejected config printed the '{line}' banner line: {stderr}"
         );
     }
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// `config validate --json` carries the keys nothing read, and still says ok.
+///
+/// The lower-level loader tests cover the collection; this covers the shape a
+/// caller reads, which could otherwise disappear while they keep passing.
+#[test]
+fn config_validate_json_carries_the_unread_keys() {
+    let dir = unique_dir("validate-warnings");
+    let path = dir.join("typo.toml");
+    std::fs::write(
+        &path,
+        "dt = 1.0\nduraton = 100.0\n\n[[satellites]]\nid = \"a\"\naltitide = 400\n\
+         [satellites.orbit]\ntype = \"circular\"\naltitude = 400\n",
+    )
+    .unwrap();
+
+    let out = orts()
+        .args(["config", "validate", "--json"])
+        .arg(&path)
+        .output()
+        .expect("run config validate");
+
+    assert!(
+        out.status.success(),
+        "an unread key is a warning, so validate exits 0: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let verdict: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("json: {e}\n{stdout}"));
+    assert_eq!(verdict["status"], "ok");
+    let warnings = verdict["warnings"]
+        .as_array()
+        .unwrap_or_else(|| panic!("a warnings array: {stdout}"));
+    let text: Vec<&str> = warnings.iter().filter_map(|w| w.as_str()).collect();
+    assert_eq!(text.len(), 2, "both keys: {text:?}");
+    assert!(
+        text.iter().any(|w| w.contains("`duraton`")),
+        "the top-level key: {text:?}"
+    );
+    assert!(
+        text.iter().any(|w| w.contains("`satellites.0.altitide`")),
+        "the nested key, named by its path: {text:?}"
+    );
+
     std::fs::remove_dir_all(&dir).ok();
 }

--- a/cli/tests/config_e2e.rs
+++ b/cli/tests/config_e2e.rs
@@ -266,3 +266,64 @@ fn test_config_validate_rejects_unintegrable_attitude() {
         std::fs::remove_dir_all(&dir).ok();
     }
 }
+
+/// A rejected config must not be announced as a running server.
+///
+/// `serve` binds before it loads the config, and its startup banner is what
+/// every harness waits on: `cli/tests/ws_e2e.rs` matches `Server listening
+/// on`, the Playwright specs read the port out of the `WebSocket endpoint`
+/// line. Printing the banner ahead of the rejection left the caller connecting
+/// to a socket that was already closing, so an unknown key surfaced as a
+/// connection failure instead of as its own message.
+#[test]
+fn serve_does_not_announce_a_port_for_a_rejected_config() {
+    let dir = unique_dir("serve-reject");
+    let path = dir.join("unknown-key.json");
+    // `central_body` is not a config key (the key is `body`); before
+    // `deny_unknown_fields` it was dropped and the body silently defaulted.
+    std::fs::write(
+        &path,
+        br#"{"central_body":"earth","dt":1.0,"satellites":[{"id":"a","orbit":{"type":"circular","altitude":400}}]}"#,
+    )
+    .unwrap();
+
+    // Not `output()`: were the rejection itself to regress, `serve` would run
+    // forever and the test would hang rather than report which assertion broke.
+    let mut child = orts()
+        .args(["serve", "--port", "0", "--config", path.to_str().unwrap()])
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn serve with an unknown config key");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let status = loop {
+        match child.try_wait().expect("poll serve") {
+            Some(status) => break status,
+            None if std::time::Instant::now() >= deadline => {
+                child.kill().ok();
+                child.wait().ok();
+                std::fs::remove_dir_all(&dir).ok();
+                panic!("serve kept running for 30s on a config it should have rejected");
+            }
+            None => std::thread::sleep(std::time::Duration::from_millis(50)),
+        }
+    };
+
+    let mut stderr = String::new();
+    std::io::Read::read_to_string(&mut child.stderr.take().expect("piped stderr"), &mut stderr)
+        .expect("read serve stderr");
+
+    assert!(!status.success(), "serve accepted it: {stderr}");
+    assert!(
+        stderr.contains("central_body"),
+        "the rejection should name the key: {stderr}"
+    );
+    // Each banner line separately: the harnesses wait on different ones.
+    for line in ["Server listening", "Viewer:", "WebSocket endpoint"] {
+        assert!(
+            !stderr.contains(line),
+            "a rejected config printed the '{line}' banner line: {stderr}"
+        );
+    }
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -859,3 +859,160 @@ fn test_cli_json_and_data_stdout_conflict() {
         "error should mention the stdout conflict, got: {stderr}"
     );
 }
+
+/// Two satellites resolving to the same id used to run: both wrote rows under
+/// one recording entity path / CSV section, so the fleet silently became one
+/// mislabeled satellite. The second entry here has no `id`, so it defaults to
+/// `sat-1` and collides with the first entry's explicit id — the collision is
+/// invisible in the file.
+#[test]
+fn test_cli_config_rejects_duplicate_satellite_ids() {
+    let dir = std::env::temp_dir().join(format!("orts-e2e-dup-id-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let config_path = dir.join("dup.toml");
+    std::fs::write(
+        &config_path,
+        "dt = 10.0\nduration = 60.0\n\n\
+         [[satellites]]\nid = \"sat-1\"\n[satellites.orbit]\ntype = \"circular\"\naltitude = 400\n\n\
+         [[satellites]]\n[satellites.orbit]\ntype = \"circular\"\naltitude = 800\n",
+    )
+    .unwrap();
+
+    let output = run_cli_with_config(config_path.to_str().unwrap());
+    assert!(
+        !output.status.success(),
+        "duplicate satellite ids must fail the run, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("duplicate satellite id 'sat-1'"),
+        "error should name the colliding id, got: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// An inertia tensor that cannot be inverted reached
+/// `SpacecraftDynamics::new`, which aborts the process (`expect`) once the
+/// attitude config is honored. It is an input error, so it must be reported as
+/// one, with the satellite named.
+#[test]
+fn test_cli_config_rejects_singular_inertia() {
+    let dir = std::env::temp_dir().join(format!("orts-e2e-inertia-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let config_path = dir.join("singular.toml");
+    std::fs::write(
+        &config_path,
+        "dt = 10.0\nduration = 60.0\n\n\
+         [[satellites]]\nid = \"sat-a\"\n[satellites.orbit]\ntype = \"circular\"\naltitude = 400\n\n\
+         [satellites.attitude]\ninertia_diag = [0.0, 0.0, 0.0]\nmass = 100.0\n",
+    )
+    .unwrap();
+
+    let output = run_cli_with_config(config_path.to_str().unwrap());
+    assert!(
+        !output.status.success(),
+        "a singular inertia tensor must fail the run"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "bad input is a reported failure (`CmdError::failure`), not a panic (101): stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("satellites[0]") && stderr.contains("positive definite"),
+        "error should name the entry and the constraint, got: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// `--atmosphere nrlmsise0` is rejected by clap; the same typo in a config
+/// file used to run the exponential model instead, with nothing in the output
+/// naming the model that was actually integrated.
+#[test]
+fn test_cli_config_rejects_unknown_atmosphere() {
+    let dir = std::env::temp_dir().join(format!("orts-e2e-atmo-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let config_path = dir.join("atmo.toml");
+    std::fs::write(
+        &config_path,
+        "dt = 10.0\nduration = 60.0\natmosphere = \"nrlmsise0\"\n\n\
+         [[satellites]]\nid = \"a\"\nballistic_coeff = 0.01\n\
+         [satellites.orbit]\ntype = \"circular\"\naltitude = 300\n",
+    )
+    .unwrap();
+
+    let output = run_cli_with_config(config_path.to_str().unwrap());
+    assert!(
+        !output.status.success(),
+        "an unknown atmosphere model must fail the run"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("nrlmsise0") && stderr.contains("nrlmsise00"),
+        "error should name the typo and the legal spelling, got: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// A misspelled key was dropped, which is indistinguishable from a key that
+/// was never written: `duraton = 60` ran for one full orbital period.
+#[test]
+fn test_cli_config_rejects_unknown_key() {
+    let dir = std::env::temp_dir().join(format!("orts-e2e-unknown-key-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let config_path = dir.join("typo.toml");
+    std::fs::write(
+        &config_path,
+        "dt = 10.0\nduraton = 60.0\n\n\
+         [[satellites]]\nid = \"a\"\n[satellites.orbit]\ntype = \"circular\"\naltitude = 400\n",
+    )
+    .unwrap();
+
+    let output = run_cli_with_config(config_path.to_str().unwrap());
+    assert!(
+        !output.status.success(),
+        "an unknown config key must fail the run"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("duraton"),
+        "error should name the unknown key, got: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// The same collision from the CLI side: `--sat id=a` twice built a two-entry
+/// fleet whose entries shared one entity path and one command target.
+#[test]
+fn test_cli_repeated_sat_id_is_rejected() {
+    let binary = env!("CARGO_BIN_EXE_orts");
+    let output = Command::new(binary)
+        .args([
+            "run",
+            "--sat",
+            "altitude=400,id=a",
+            "--sat",
+            "altitude=800,id=a",
+            "--duration",
+            "60",
+            "--output",
+            "-",
+            "--format",
+            "csv",
+        ])
+        .output()
+        .expect("failed to execute orts");
+    assert!(
+        !output.status.success(),
+        "a repeated --sat id must fail the run, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("duplicate satellite id 'a'"),
+        "error should name the repeated id, got: {stderr}"
+    );
+}

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -922,8 +922,10 @@ fn test_cli_config_rejects_singular_inertia() {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("satellites[0]") && stderr.contains("positive definite"),
-        "error should name the entry and the constraint, got: {stderr}"
+        stderr.contains("satellites[0]")
+            && stderr.contains("attitude:")
+            && stderr.contains("inertia tensor"),
+        "error should name the entry, the block and the constraint, got: {stderr}"
     );
     std::fs::remove_dir_all(&dir).ok();
 }

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -959,10 +959,12 @@ fn test_cli_config_rejects_unknown_atmosphere() {
     std::fs::remove_dir_all(&dir).ok();
 }
 
-/// A misspelled key was dropped, which is indistinguishable from a key that
-/// was never written: `duraton = 60` ran for one full orbital period.
+/// A misspelled key was dropped without a word, which is indistinguishable from
+/// a key that was never written: `duraton = 60` ran for one full orbital period
+/// and reported success. The run still goes ahead — that is what lets a config
+/// written for a newer `orts` work here — but the key is named.
 #[test]
-fn test_cli_config_rejects_unknown_key() {
+fn test_cli_config_names_an_unread_key() {
     let dir = std::env::temp_dir().join(format!("orts-e2e-unknown-key-{}", std::process::id()));
     std::fs::create_dir_all(&dir).unwrap();
     let config_path = dir.join("typo.toml");
@@ -974,14 +976,14 @@ fn test_cli_config_rejects_unknown_key() {
     .unwrap();
 
     let output = run_cli_with_config(config_path.to_str().unwrap());
-    assert!(
-        !output.status.success(),
-        "an unknown config key must fail the run"
-    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
+        output.status.success(),
+        "the run goes ahead, ignoring the key: {stderr}"
+    );
+    assert!(
         stderr.contains("duraton"),
-        "error should name the unknown key, got: {stderr}"
+        "the warning should name the unread key, got: {stderr}"
     );
     std::fs::remove_dir_all(&dir).ok();
 }

--- a/cli/tests/run_mode_e2e.rs
+++ b/cli/tests/run_mode_e2e.rs
@@ -126,13 +126,21 @@ max_torque = 0.5
 /// The propagated quaternion is a real integration result, not a logged
 /// constant: with an asymmetric inertia tensor the coupled gravity-gradient
 /// torque spins the body up, and the quaternion stays a unit quaternion.
+///
+/// `diag(10, 40, 45)` satisfies `I1 + I2 >= I3` with 11% to spare, so it is a
+/// tensor some mass distribution has. The initial 45° about y puts the body's
+/// radial direction at `(1/√2, 0, 1/√2)`, where the difference between `Ix` and
+/// `Iz` produces the largest gravity-gradient torque: `|τy| = 6.7e-5 N·m` and
+/// `|ω̇y| = 1.7e-6 rad/s²` at `t = 0`. The span is short on purpose — the
+/// thresholds below are cleared within the first hundred seconds, and a longer
+/// run would fold the nonlinear response into the same assertion.
 #[test]
 fn spacecraft_mode_integrates_attitude() {
     let config = r#"
 body = "earth"
 dt = 1.0
-duration = 3000.0
-output_interval = 100.0
+duration = 200.0
+output_interval = 10.0
 
 [[satellites]]
 id = "sat-1"
@@ -142,7 +150,7 @@ type = "circular"
 altitude = 400
 
 [satellites.attitude]
-inertia_diag = [10.0, 40.0, 80.0]
+inertia_diag = [10.0, 40.0, 45.0]
 mass = 500
 initial_quaternion = [0.9238795325112867, 0.0, 0.3826834323650898, 0.0]
 initial_angular_velocity = [0.0, 0.0, 0.0]

--- a/cli/tests/ws_e2e.rs
+++ b/cli/tests/ws_e2e.rs
@@ -1054,3 +1054,79 @@ async fn test_websocket_add_satellite() {
     server.kill();
     result.expect("test timed out after 30 seconds");
 }
+
+/// A `start_simulation` the server cannot read is answered, and the socket lives.
+///
+/// A `type`-tagged block still refuses an unknown key, so this message fails to
+/// deserialize. Dropping that error left the client waiting on a reply that
+/// never arrives.
+#[tokio::test]
+async fn test_websocket_unreadable_message_is_answered() {
+    let port = test_port() + 22;
+    let mut server = Server::spawn_idle(port);
+
+    let result = tokio::time::timeout(Duration::from_secs(30), async {
+        let url = format!("ws://localhost:{port}/ws");
+        let (ws, _) = connect_async(&url).await.expect("failed to connect");
+        let (mut write, mut read) = ws.split();
+
+        let status = next_json(&mut read).await;
+        assert_eq!(status["state"], "idle");
+
+        // `inclinaton` is a typo for `inclination`, inside the `type`-tagged
+        // orbit block, which is the one place an unknown key is refused.
+        let typo = serde_json::json!({
+            "type": "start_simulation",
+            "config": {
+                "dt": 10.0,
+                "satellites": [
+                    { "id": "test", "orbit": {
+                        "type": "circular", "altitude": 400.0, "inclinaton": 51.6
+                    } }
+                ]
+            }
+        });
+        write
+            .send(tokio_tungstenite::tungstenite::Message::Text(
+                typo.to_string().into(),
+            ))
+            .await
+            .expect("failed to send start_simulation");
+
+        let (error, _) = read_until_type(&mut read, "error", 10).await;
+        let message = error["message"].as_str().expect("an error message");
+        assert!(
+            message.contains("inclinaton"),
+            "the message names the key it could not read: {message}"
+        );
+
+        // The same connection still serves a message the server can read.
+        let good = serde_json::json!({
+            "type": "start_simulation",
+            "config": {
+                "dt": 10.0,
+                "satellites": [
+                    { "id": "test", "orbit": { "type": "circular", "altitude": 400.0 } }
+                ]
+            }
+        });
+        write
+            .send(tokio_tungstenite::tungstenite::Message::Text(
+                good.to_string().into(),
+            ))
+            .await
+            .expect("failed to send start_simulation");
+
+        let (info, _) = read_until_type(&mut read, "info", 10).await;
+        assert!(
+            !info["satellites"]
+                .as_array()
+                .expect("satellites")
+                .is_empty()
+        );
+    })
+    .await;
+
+    server.kill();
+    result.expect("test timed out after 30 seconds");
+}

--- a/plugin-sdk/examples/constellation-phasing/gen_bench_config.py
+++ b/plugin-sdk/examples/constellation-phasing/gen_bench_config.py
@@ -30,13 +30,15 @@ WASM_PATH = str(
 
 
 def header() -> str:
+    # No `atmosphere`: it selects the model, not whether drag is on, and these
+    # satellites have no `ballistic_coeff`, so nothing applies drag to them.
+    # `atmosphere = "none"` was never a way to disable it and is now refused.
     return textwrap.dedent(f"""\
         body = "earth"
         dt = {DT}
         output_interval = {OUTPUT_INTERVAL}
         duration = {SIM_DURATION_S}
         epoch = "2024-01-01T00:00:00Z"
-        atmosphere = "none"
         """)
 
 

--- a/plugin-sdk/examples/constellation-phasing/gen_bench_config.py
+++ b/plugin-sdk/examples/constellation-phasing/gen_bench_config.py
@@ -30,8 +30,10 @@ WASM_PATH = str(
 
 
 def header() -> str:
-    # No `atmosphere`: it selects the model, not whether drag is on, and these
-    # satellites have no `ballistic_coeff`, so nothing applies drag to them.
+    # No `atmosphere`: it selects the model, not whether drag is on. Drag comes
+    # from `ballistic_coeff`, from `panels` (which carry their own areas and
+    # drag coefficients), or from a TLE/OMM whose B* is not effectively zero,
+    # and these satellites have none of the three.
     # `atmosphere = "none"` was never a way to disable it and is now refused.
     return textwrap.dedent(f"""\
         body = "earth"

--- a/plugin-sdk/examples/constellation-phasing/orts.toml
+++ b/plugin-sdk/examples/constellation-phasing/orts.toml
@@ -6,7 +6,8 @@ dt = 1.0
 output_interval = 60.0
 duration = 120000.0
 epoch = "2024-01-01T00:00:00Z"
-# Demo では drag の影響を排除して純粋な 2-body の phasing を見せる。
+# Demo では drag を掛けずに phasing を見せる（zonal 重力と、epoch があるので
+# Sun / Moon の第三体重力は入る）。
 # drag が入るのは ballistic_coeff を持つ衛星と、B* が実質ゼロでない TLE/OMM 軌道
 # (`has_bstar_drag`)。この例はどちらでもないので drag は掛からない
 # (`atmosphere` は drag の on/off ではなく、使う大気モデルの選択)。

--- a/plugin-sdk/examples/constellation-phasing/orts.toml
+++ b/plugin-sdk/examples/constellation-phasing/orts.toml
@@ -8,8 +8,9 @@ duration = 120000.0
 epoch = "2024-01-01T00:00:00Z"
 # Demo では drag を掛けずに phasing を見せる（zonal 重力と、epoch があるので
 # Sun / Moon の第三体重力は入る）。
-# drag が入るのは ballistic_coeff を持つ衛星と、B* が実質ゼロでない TLE/OMM 軌道
-# (`has_bstar_drag`)。この例はどちらでもないので drag は掛からない
+# drag が入るのは ballistic_coeff を持つ衛星、panels を持つ衛星 (面ごとの面積と
+# 抗力係数を自分で持つので PanelDrag になる)、B* が実質ゼロでない TLE/OMM 軌道
+# (`has_bstar_drag`) の 3 つ。この例はどれでもないので drag は掛からない
 # (`atmosphere` は drag の on/off ではなく、使う大気モデルの選択)。
 
 # In-plane constellation phasing demo。

--- a/plugin-sdk/examples/constellation-phasing/orts.toml
+++ b/plugin-sdk/examples/constellation-phasing/orts.toml
@@ -6,8 +6,9 @@ dt = 1.0
 output_interval = 60.0
 duration = 120000.0
 epoch = "2024-01-01T00:00:00Z"
-# Demo では drag の影響を排除して純粋な 2-body の phasing を見せる
-atmosphere = "none"
+# Demo では drag の影響を排除して純粋な 2-body の phasing を見せる。
+# drag が入るのは ballistic_coeff を持つ衛星だけなので、指定しないことで切っている
+# (`atmosphere` は drag の on/off ではなく、使う大気モデルの選択)。
 
 # In-plane constellation phasing demo。
 #

--- a/plugin-sdk/examples/constellation-phasing/orts.toml
+++ b/plugin-sdk/examples/constellation-phasing/orts.toml
@@ -7,7 +7,8 @@ output_interval = 60.0
 duration = 120000.0
 epoch = "2024-01-01T00:00:00Z"
 # Demo では drag の影響を排除して純粋な 2-body の phasing を見せる。
-# drag が入るのは ballistic_coeff を持つ衛星だけなので、指定しないことで切っている
+# drag が入るのは ballistic_coeff を持つ衛星と、B* が実質ゼロでない TLE/OMM 軌道
+# (`has_bstar_drag`)。この例はどちらでもないので drag は掛からない
 # (`atmosphere` は drag の on/off ではなく、使う大気モデルの選択)。
 
 # In-plane constellation phasing demo。

--- a/plugin-sdk/examples/transfer-burn-with-tcm/README.md
+++ b/plugin-sdk/examples/transfer-burn-with-tcm/README.md
@@ -77,7 +77,7 @@ cargo build -p orts-example-plugin-transfer-burn-with-tcm --target wasm32-wasip2
 ## シミュレーション実行
 
 付属の [`orts.toml`](orts.toml) には **500 km → 2000 km (高度 4 倍)** の
-Hohmann 遷移 demo が入っている。2-body only (atmosphere=none)、sim 7000 s。
+Hohmann 遷移 demo が入っている。2-body only (drag なし)、sim 7000 s。
 
 ```sh
 cd plugin-sdk/examples/transfer-burn-with-tcm

--- a/plugin-sdk/examples/transfer-burn-with-tcm/README.md
+++ b/plugin-sdk/examples/transfer-burn-with-tcm/README.md
@@ -77,7 +77,7 @@ cargo build -p orts-example-plugin-transfer-burn-with-tcm --target wasm32-wasip2
 ## シミュレーション実行
 
 付属の [`orts.toml`](orts.toml) には **500 km → 2000 km (高度 4 倍)** の
-Hohmann 遷移 demo が入っている。2-body only (drag なし)、sim 7000 s。
+Hohmann 遷移 demo が入っている。drag なし、sim 7000 s。
 
 ```sh
 cd plugin-sdk/examples/transfer-burn-with-tcm

--- a/plugin-sdk/examples/transfer-burn-with-tcm/orts.toml
+++ b/plugin-sdk/examples/transfer-burn-with-tcm/orts.toml
@@ -5,8 +5,9 @@ duration = 7000.0
 epoch = "2024-01-01T00:00:00Z"
 # Demo では drag を掛けずに Hohmann 遷移を見せる（zonal 重力と、epoch があるので
 # Sun / Moon の第三体重力は入る）。
-# drag が入るのは ballistic_coeff を持つ衛星と、B* が実質ゼロでない TLE/OMM 軌道
-# (`has_bstar_drag`)。この例はどちらでもないので drag は掛からない
+# drag が入るのは ballistic_coeff を持つ衛星、panels を持つ衛星 (面ごとの面積と
+# 抗力係数を自分で持つので PanelDrag になる)、B* が実質ゼロでない TLE/OMM 軌道
+# (`has_bstar_drag`) の 3 つ。この例はどれでもないので drag は掛からない
 # (`atmosphere` は drag の on/off ではなく、使う大気モデルの選択)。
 
 # 円軌道 500 km → 2000 km の Hohmann 遷移 (高度 4 倍) + 到達後の TCM デモ。

--- a/plugin-sdk/examples/transfer-burn-with-tcm/orts.toml
+++ b/plugin-sdk/examples/transfer-burn-with-tcm/orts.toml
@@ -3,7 +3,8 @@ dt = 0.1
 output_interval = 10.0
 duration = 7000.0
 epoch = "2024-01-01T00:00:00Z"
-# Demo では drag の影響を排除して純粋な 2-body の Hohmann 遷移を見せる。
+# Demo では drag を掛けずに Hohmann 遷移を見せる（zonal 重力と、epoch があるので
+# Sun / Moon の第三体重力は入る）。
 # drag が入るのは ballistic_coeff を持つ衛星と、B* が実質ゼロでない TLE/OMM 軌道
 # (`has_bstar_drag`)。この例はどちらでもないので drag は掛からない
 # (`atmosphere` は drag の on/off ではなく、使う大気モデルの選択)。

--- a/plugin-sdk/examples/transfer-burn-with-tcm/orts.toml
+++ b/plugin-sdk/examples/transfer-burn-with-tcm/orts.toml
@@ -4,7 +4,8 @@ output_interval = 10.0
 duration = 7000.0
 epoch = "2024-01-01T00:00:00Z"
 # Demo では drag の影響を排除して純粋な 2-body の Hohmann 遷移を見せる。
-# drag が入るのは ballistic_coeff を持つ衛星だけなので、指定しないことで切っている
+# drag が入るのは ballistic_coeff を持つ衛星と、B* が実質ゼロでない TLE/OMM 軌道
+# (`has_bstar_drag`)。この例はどちらでもないので drag は掛からない
 # (`atmosphere` は drag の on/off ではなく、使う大気モデルの選択)。
 
 # 円軌道 500 km → 2000 km の Hohmann 遷移 (高度 4 倍) + 到達後の TCM デモ。

--- a/plugin-sdk/examples/transfer-burn-with-tcm/orts.toml
+++ b/plugin-sdk/examples/transfer-burn-with-tcm/orts.toml
@@ -3,8 +3,9 @@ dt = 0.1
 output_interval = 10.0
 duration = 7000.0
 epoch = "2024-01-01T00:00:00Z"
-# Demo では drag の影響を排除して純粋な 2-body の Hohmann 遷移を見せる
-atmosphere = "none"
+# Demo では drag の影響を排除して純粋な 2-body の Hohmann 遷移を見せる。
+# drag が入るのは ballistic_coeff を持つ衛星だけなので、指定しないことで切っている
+# (`atmosphere` は drag の on/off ではなく、使う大気モデルの選択)。
 
 # 円軌道 500 km → 2000 km の Hohmann 遷移 (高度 4 倍) + 到達後の TCM デモ。
 # Plugin が **RW による姿勢追従** と **thruster throttle** を 1 つに合わせて

--- a/viewer/tests/attitude-data.spec.ts
+++ b/viewer/tests/attitude-data.spec.ts
@@ -18,7 +18,7 @@ test.beforeAll(async () => {
 
   // Write a temp config with attitude enabled
   const config = {
-    central_body: "earth",
+    body: "earth",
     dt: 1.0,
     output_interval: 10,
     satellites: [

--- a/viewer/tests/attitude-rendering.spec.ts
+++ b/viewer/tests/attitude-rendering.spec.ts
@@ -87,7 +87,7 @@ function spawnServer(configFile: string): Promise<{ child: ChildProcess; port: n
 test.beforeAll(async () => {
   // +90° rotation about the inertial Z axis, body-to-inertial, scalar-first [w,x,y,z].
   const config = {
-    central_body: "earth",
+    body: "earth",
     dt: 1.0,
     output_interval: 10,
     satellites: [


### PR DESCRIPTION
config の綴りを間違えると、そのキーや値が黙って捨てられ、指定したものと違う設定でシミュレーションが実行されていた。

`orts run --config`、自動検出の `orts.toml`、`orts serve --config`、`orts config validate`、WebSocket の `start_simulation` / `add_satellite` はすべて同じ tree を読むので、5 経路まとめて入力時点で拒否する。

## 未知の値は error

```toml
atmosphere = "nrlmsise0"   # nrlmsise00 の 0 が 1 つ足りない
```

従来は exponential 大気で完走した。`[integrator] type = "dop835"` なら dp45 で積分された。同じ値を `--atmosphere nrlmsise0` で渡せば clap が拒否するのに、config では通っていた。

```
$ orts config validate sim.toml
Error: sim.toml is not a valid orts config: Failed to parse TOML config:
unknown atmosphere 'nrlmsise0' (expected one of: exponential | harris-priester | nrlmsise00)
```

対応する CLI flag が使う `ValueEnum` を `deserialize_with` で通すようにした。綴りの一覧が 1 箇所になるので、flag と config が同じ集合を受理する。

## 未知のキーは warning

```toml
duraton = 100.0   # duration の i が抜けている
```

従来は 1 周期（400 km 円軌道で 5553 s）実行され、なぜ 100 s で終わらなかったのかは出力から分からなかった。

```
$ orts run --config sim.toml --format csv --output out.csv
2026-09-01T15:34:21.298745Z  WARN orts::config: sim.toml: nothing reads `duraton`; its value is ignored
Saved to out.csv
```

拒否しないのは、選択肢が 1 つ増えた config を古い orts が読めなくなるため。収集は `serde_ignored`。3 形式が通る箇所は `SimConfig::load` の 1 つなので、包む場所も 1 つ。`config validate --json` は `warnings` 配列に、`run` と `serve` は `log::warn!` で報告する（#390 が入れた backend が拾うので `RUST_LOG` で選別できる）。

JSON だけ `Deserializer` を直接回すので `end()` を明示的に呼ぶ。呼ばないと `{...config...}{"dt":99.0}` が config だけ取って残りを捨てる。

## `type` タグ付きの block だけは error

```toml
[satellites.orbit]
type = "circular"
altitude = 500
inclinaton = 51.6   # inclination の i が抜けている
```

無視されると軌道が赤道面のままになる。しかし `serde_ignored` は internally tagged enum の内部を見られないので（serde が variant の中身をバッファして再生するため）、報告する手段が無い。実測でも `[satellites.orbit]` の typo は keys=[] になる。そこで報告できない 4 つ（orbit、controller、reaction wheel、磁気トルカ）だけ拒否する。

```
$ orts config validate sim.toml
Error: ... unknown field `inclinaton`, expected one of `altitude`, `inclination`, `raan`
```

外部タグ（`[satellites.orbit.circular]`）にすれば報告できるが、config の形式と WebSocket payload と TS 型が変わる割に、得られる結果は同じ。

## 実行できない fleet を拒否する

attitude や controller を一部の衛星にだけ書いた config、全衛星に controller があって attitude が無い config は、engine が拒否する。しかし `orts serve` は engine を manager task 内で構築するので、banner を出した後に idle 待機していた（指定した config は実行されない）。規則を `ensure_fleet_declares_uniformly` に集めて config 検査と共有した。

```
$ orts serve --config sim.toml
Error: Mixed attitude config: some satellites have attitude, some don't. ...
```

## 重複する satellite id を拒否する

```toml
[[satellites]]
id = "sat-1"
...
[[satellites]]     # id 無し → 既定で sat-1
...
```

従来は CSV が 2 ブロックとも `sat-1`、`[[command]]` は後勝ち、状態参照は first match になった。

```
$ orts config validate sim.toml
Error: ... satellites[1]: duplicate satellite id 'sat-1' (already used by satellites[0]);
ids must be unique — this entry has no `id`, so it defaults to 'sat-1'; give it an explicit id
```

解決後の id を entity path にして比較する。`EntityPath` は空 segment を捨てるので `a` と `/a` は同じ entity を指す。`/` だけの id は `/world/sat` に潰れるので拒否する。WebSocket の `add_satellite` は id を一切検査していなかったので、mode 分岐の前に同じ検査を通した。

## 剛体がとりえない attitude を拒否する

```toml
[satellites.attitude]
inertia_diag = [0.0, 0.0, 0.0]
```

従来は manager task が panic し、server は listen したまま client に error を返さなかった。

```
$ orts config validate sim.toml
Error: ... satellites[0]: attitude: inertia tensor cannot be inverted:
[0.0, 0.0, 0.0] with off-diagonal [0.0, 0.0, 0.0]
```

正定値でない慣性テンソル、`I1 + I2 >= I3` を破るもの、`mass <= 0` が対象。quaternion は dynamics と同じ normalization を通した結果が unit norm から 1e-9 以内かで判定する。squared norm に floor を置くと、subnormal でも誤差 0 で正規化される `[1e-154, 0, 0, 0]` を落とすため。

## WebSocket

`ClientMessage` も `#[serde(tag = "type")]` なので、JSON から config 部分を取り出して直接対象にする。`add_satellite` では `flatten` が未知フィールド検査を無効にするため、`ballistic_coef`（`f` が 1 つ足りない）が黙って落ち、drag 無しで衛星が追加されていた。

variant の兄弟位置にあるキーは `protocol::variant_envelope_keys` と比較して検出する。

```json
{"type":"start_simulation","config":{"dt":1.0,...},"dtt":10}
```
```
WARN orts::commands::serve::connection: client message: nothing reads `dtt`; its value is ignored
```

deserialize 自体が失敗するメッセージには `{"type":"error"}` を返す。従来は error を破棄していたので、client は応答が返らないまま待ち続けた。

メッセージは text から読む。`Value` 経由では重複キーが最後の値で潰れ、serde が拒否するはずの `"config"` 2 つが通ってしまう。

`/ws` は誰でも到達できるので、報告する側にも上限を置いた。キーは 20 件、1 キーの表示は escape 後 128 文字、inbound メッセージは 8 MiB（実測で `start_simulation` は衛星 1 機あたり約 256 バイト、10000 機で 2.5 MiB）。

## banner

`Server listening on` / `WebSocket endpoint` を `axum::serve` の直前に移した。呼び出し側は banner を起動完了として待つ（`ws_e2e.rs` は前者、Playwright は後者から port を読む）ので、従来は拒否された config が接続失敗として届いていた。

bind は config 読み込みより前に起きるので、保証するのは listening と表示しないことで、何も bind しないことではない。

## テスト

orts-cli 297 件、`config_e2e` 10 件、`e2e` 22 件、`ws_e2e` 14 件 pass。

固定したもの: 3 形式で同じ typo が同じパスで報告されること、`type` タグ付き block 4 つすべての拒否、JSON の trailing data と YAML の 2 文書目と重複キーの拒否、`config validate --json` の `warnings`、WS の envelope と payload 両方でのキー名指し、`add_satellite` の id 4 ケース。

error 応答は `ws_e2e` で確認した。fix 無しだと client が 30 s 待って落ちる。

`serde_ignored` は `MIT OR Apache-2.0`。`cli/about.toml` の `accepted` に含まれ、`orts --license-notice` に載る。
