### PR TITLE
feat(orts)!: make the attitude target and star-tracker reading frame-typed (#332)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,6 +2880,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tobari",
  "tokio",
+ "trybuild",
  "utsuroi",
  "wasmtime",
  "wasmtime-wasi",

--- a/arika/src/frame.rs
+++ b/arika/src/frame.rs
@@ -469,8 +469,26 @@ impl<F> core::ops::SubAssign for Vec3<F> {
 ///
 /// Hamilton クォータニオンベース。`transform` でベクトルの
 /// フレーム変換を型安全に行う。
-#[derive(Clone, Copy, PartialEq)]
-pub struct Rotation<From, To>(UnitQuaternion<f64>, PhantomData<(From, To)>);
+///
+/// phantom は `fn() -> (From, To)` — frame tag は値として保持されないので、
+/// `Clone` / `Copy` / `PartialEq` / `Send` / `Sync` は tag に依存せず成立する。
+/// これにより frame-generic な struct が `Rotation<A, F>` をフィールドに持つ際、
+/// `F: Copy + Send + Sync` を全ての impl に伝播させる必要がなくなる
+/// (variance は tuple 版と同じく共変)。
+pub struct Rotation<From, To>(UnitQuaternion<f64>, PhantomData<fn() -> (From, To)>);
+
+// tag に依存しない手書き impl (derive は `From: Copy` 等の bound を付けてしまう)。
+impl<From, To> Clone for Rotation<From, To> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<From, To> Copy for Rotation<From, To> {}
+impl<From, To> PartialEq for Rotation<From, To> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
 
 impl<From, To> Rotation<From, To> {
     /// 生の `UnitQuaternion` から構築。

--- a/arika/src/frame.rs
+++ b/arika/src/frame.rs
@@ -131,9 +131,16 @@ mod sealed {
 /// Top-level frame trait. Implemented by every concrete frame marker.
 ///
 /// Provides `NAME` and `DESCRIPTOR` for runtime identification. Sealed: new
-/// frames can only be added inside arika. No `Copy` / `'static` bound —
-/// marker structs derive them themselves.
-pub trait Frame: sealed::Sealed {
+/// frames can only be added inside arika.
+///
+/// Every frame is a ZST marker, so the trait requires the auto/derivable traits
+/// that fact implies. Stating them once here is what lets the frame-tagged
+/// types ([`Vec3`], [`Rotation`]) and everything generic over a frame simply
+/// derive `Clone` / `Copy` / `PartialEq` and pick up `Send` / `Sync`, instead of
+/// each working around the phantom parameter on its own.
+pub trait Frame:
+    sealed::Sealed + core::fmt::Debug + Copy + PartialEq + Eq + Send + Sync + 'static
+{
     const NAME: &'static str;
     const DESCRIPTOR: FrameDescriptor;
 }
@@ -470,25 +477,12 @@ impl<F> core::ops::SubAssign for Vec3<F> {
 /// Hamilton クォータニオンベース。`transform` でベクトルの
 /// フレーム変換を型安全に行う。
 ///
-/// phantom は `fn() -> (From, To)` — frame tag は値として保持されないので、
-/// `Clone` / `Copy` / `PartialEq` / `Send` / `Sync` は tag に依存せず成立する。
-/// これにより frame-generic な struct が `Rotation<A, F>` をフィールドに持つ際、
-/// `F: Copy + Send + Sync` を全ての impl に伝播させる必要がなくなる
-/// (variance は tuple 版と同じく共変)。
-pub struct Rotation<From, To>(UnitQuaternion<f64>, PhantomData<fn() -> (From, To)>);
-
-// tag に依存しない手書き impl (derive は `From: Copy` 等の bound を付けてしまう)。
-impl<From, To> Clone for Rotation<From, To> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<From, To> Copy for Rotation<From, To> {}
-impl<From, To> PartialEq for Rotation<From, To> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
+/// `PhantomData<(From, To)>` はゼロサイズなのでメモリレイアウトは
+/// `UnitQuaternion<f64>` と同一。derive が要求する `From: Copy` 等の bound は
+/// [`Frame`] が保証するので、`Rotation<A, F>` をフィールドに持つ frame-generic
+/// な struct 側でも derive がそのまま通る。
+#[derive(Clone, Copy, PartialEq)]
+pub struct Rotation<From, To>(UnitQuaternion<f64>, PhantomData<(From, To)>);
 
 impl<From, To> Rotation<From, To> {
     /// 生の `UnitQuaternion` から構築。
@@ -662,17 +656,9 @@ impl Rotation<SimpleEcef, SimpleEci> {
     }
 }
 
-impl<From, To> core::fmt::Debug for Rotation<From, To> {
+impl<From: Frame, To: Frame> core::fmt::Debug for Rotation<From, To> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let from = core::any::type_name::<From>()
-            .rsplit("::")
-            .next()
-            .unwrap_or("?");
-        let to = core::any::type_name::<To>()
-            .rsplit("::")
-            .next()
-            .unwrap_or("?");
-        write!(f, "Rotation<{from}, {to}>({:?})", self.0)
+        write!(f, "Rotation<{}, {}>({:?})", From::NAME, To::NAME, self.0)
     }
 }
 

--- a/orts/Cargo.toml
+++ b/orts/Cargo.toml
@@ -70,6 +70,7 @@ required-features = ["plugin-wasm"]
 
 [dev-dependencies]
 proptest = "1.10.0"
+trybuild = "1.0.116"
 serde_json.workspace = true
 criterion = { version = "0.8", features = ["html_reports"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync", "time"] }

--- a/orts/benches/fiber_overhead.rs
+++ b/orts/benches/fiber_overhead.rs
@@ -41,7 +41,7 @@ fn dummy_spacecraft() -> SpacecraftState {
 }
 
 fn dummy_sensors() -> Sensors {
-    use arika::frame::{Body, Vec3};
+    use arika::frame::{Body, Rotation, Vec3};
     use orts::plugin::tick_input::{
         AngularVelocityBody, AttitudeBodyToInertial, MagneticFieldBody,
     };
@@ -50,8 +50,8 @@ fn dummy_sensors() -> Sensors {
         gyroscopes: vec![AngularVelocityBody::new(Vec3::<Body>::new(
             0.1, 0.05, -0.03,
         ))],
-        star_trackers: vec![AttitudeBodyToInertial::new(Vector4::new(
-            1.0, 0.0, 0.0, 0.0,
+        star_trackers: vec![AttitudeBodyToInertial::new(Rotation::from_raw(
+            nalgebra::UnitQuaternion::identity(),
         ))],
         sun_sensors: vec![],
     }

--- a/orts/src/attitude/control/bdot.rs
+++ b/orts/src/attitude/control/bdot.rs
@@ -124,9 +124,8 @@ impl<
         }
 
         // 2. Transform to body frame
-        let b_body = att
-            .rotation_tagged_as::<Fr>()
-            .inverse()
+        let b_body = state
+            .attitude_from_inertial()
             .transform(&b_inertial)
             .into_inner();
 

--- a/orts/src/attitude/control/bdot.rs
+++ b/orts/src/attitude/control/bdot.rs
@@ -9,7 +9,7 @@ use crate::attitude::AttitudeState;
 use crate::control::DiscreteController;
 use crate::magnetic;
 use crate::model::ExternalLoads;
-use crate::model::{HasAttitude, HasOrbit, Model};
+use crate::model::{HasAttitude, HasFrame, HasOrbit, Model};
 use crate::spacecraft::MtqAssemblyCore;
 
 /// B-dot detumbling controller using cross-product dB/dt estimation.
@@ -95,8 +95,11 @@ impl<F: MagneticFieldModel, Fr: EarthFixedTransform> BdotCross<F, Fr> {
 // via `magnetic::field_inertial` and rotated to the body frame with the matching
 // `Fr → Body` rotation. A frame without an `EarthFixedTransform` impl is
 // rejected at compile time. See #151.
-impl<F: MagneticFieldModel, Fr: EarthFixedTransform, S: HasAttitude + HasOrbit<Frame = Fr>>
-    Model<S, Fr> for BdotCross<F, Fr>
+impl<
+    F: MagneticFieldModel,
+    Fr: EarthFixedTransform,
+    S: HasFrame<Frame = Fr> + HasAttitude + HasOrbit,
+> Model<S, Fr> for BdotCross<F, Fr>
 {
     fn name(&self) -> &str {
         "bdot"
@@ -122,7 +125,8 @@ impl<F: MagneticFieldModel, Fr: EarthFixedTransform, S: HasAttitude + HasOrbit<F
 
         // 2. Transform to body frame
         let b_body = att
-            .rotation_from_inertial::<Fr>()
+            .rotation_tagged_as::<Fr>()
+            .inverse()
             .transform(&b_inertial)
             .into_inner();
 
@@ -182,8 +186,11 @@ impl<F: MagneticFieldModel, Fr: EarthFixedTransform> CommandedMagnetorquer<F, Fr
 }
 
 // Frame-generic, as `BdotCross` above.
-impl<F: MagneticFieldModel, Fr: EarthFixedTransform, S: HasAttitude + HasOrbit<Frame = Fr>>
-    Model<S, Fr> for CommandedMagnetorquer<F, Fr>
+impl<
+    F: MagneticFieldModel,
+    Fr: EarthFixedTransform,
+    S: HasFrame<Frame = Fr> + HasAttitude + HasOrbit,
+> Model<S, Fr> for CommandedMagnetorquer<F, Fr>
 {
     fn name(&self) -> &str {
         "magnetorquer"
@@ -202,8 +209,7 @@ impl<F: MagneticFieldModel, Fr: EarthFixedTransform, S: HasAttitude + HasOrbit<F
             return ExternalLoads::zeros();
         }
         let b_body = state
-            .attitude()
-            .rotation_from_inertial::<Fr>()
+            .attitude_from_inertial()
             .transform(&b_inertial)
             .into_inner();
         ExternalLoads::torque(self.commanded_moment.cross(&b_body))
@@ -326,7 +332,8 @@ impl<F: MagneticFieldModel, Fr: EarthFixedTransform> DiscreteController<Fr>
             return Vector3::zeros();
         }
         let b_body = attitude
-            .rotation_from_inertial::<Fr>()
+            .rotation_tagged_as::<Fr>()
+            .inverse()
             .transform(&b_inertial)
             .into_inner();
 
@@ -376,9 +383,11 @@ mod tests {
         }
     }
 
-    impl HasOrbit for TestState {
+    impl HasFrame for TestState {
         type Frame = arika::frame::SimpleEci;
+    }
 
+    impl HasOrbit for TestState {
         fn orbit(&self) -> &OrbitalState<arika::frame::SimpleEci> {
             &self.orbit
         }
@@ -550,8 +559,11 @@ mod tests {
                 &self.attitude
             }
         }
-        impl HasOrbit for GcrsState {
+        impl HasFrame for GcrsState {
             type Frame = frame::Gcrs;
+        }
+
+        impl HasOrbit for GcrsState {
             fn orbit(&self) -> &OrbitalState<frame::Gcrs> {
                 &self.orbit
             }
@@ -585,8 +597,7 @@ mod tests {
             &EarthOrientation::new(epoch, &zero_eop()),
         );
         let b_body = state
-            .attitude
-            .rotation_from_inertial::<frame::Gcrs>()
+            .attitude_from_inertial()
             .transform(&b_gcrs)
             .into_inner();
         let desired = gain * state.attitude.angular_velocity.cross(&b_body);

--- a/orts/src/attitude/control/pd_controller.rs
+++ b/orts/src/attitude/control/pd_controller.rs
@@ -111,6 +111,10 @@ impl<F: arika::frame::Eci, S: HasAttitude + HasOrbit<Frame = F>, R: AttitudeRefe
     fn eval(&self, t: f64, state: &S, epoch: Option<&Epoch>) -> ExternalLoads<F> {
         let att = state.attitude();
         let (q_target, omega_target) = self.reference.target(t, state.orbit(), epoch);
+        // The target's frame tag has done its job: it had to match the state's
+        // integration frame `F` for this call to type-check. Everything below
+        // is body-frame error algebra, so the tag is dropped here.
+        let q_target = q_target.into_inner();
 
         let q_current = att.orientation();
 
@@ -315,6 +319,7 @@ mod tests {
     // Characterization for the frame-typed attitude target (#332)
 
     use crate::attitude::control::InertialPointing;
+    use arika::frame::{Body, Rotation};
 
     /// A target orientation with all four components distinct and non-zero.
     fn nontrivial_target() -> UnitQuaternion<f64> {
@@ -343,7 +348,7 @@ mod tests {
             1.0,
             2.0,
             InertialPointing {
-                target_q: nontrivial_target(),
+                target_q: Rotation::<Body, arika::frame::SimpleEci>::from_raw(nontrivial_target()),
             },
         );
         let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
@@ -386,7 +391,13 @@ mod tests {
             q_err.w
         );
 
-        let ctrl = TrackingPdController::diagonal(1.0, 2.0, InertialPointing { target_q });
+        let ctrl = TrackingPdController::diagonal(
+            1.0,
+            2.0,
+            InertialPointing {
+                target_q: Rotation::<Body, arika::frame::SimpleEci>::from_raw(target_q),
+            },
+        );
         let got = ctrl.eval(0.0, &state, None).torque_body.into_inner();
         let expected = Vector3::new(
             -0.09532998610353678,
@@ -427,7 +438,9 @@ mod tests {
                 1.0,
                 2.0,
                 InertialPointing {
-                    target_q: nontrivial_target(),
+                    target_q: Rotation::<Body, arika::frame::SimpleEci>::from_raw(
+                        nontrivial_target(),
+                    ),
                 },
             );
             let tau = inertial.eval(0.0, &state, None).torque_body.into_inner();

--- a/orts/src/attitude/control/pd_controller.rs
+++ b/orts/src/attitude/control/pd_controller.rs
@@ -445,17 +445,21 @@ mod tests {
                     ),
                 },
             );
+            // The claim is that a non-finite state produces a non-finite
+            // command rather than a plausible-looking one. Whether a given
+            // component lands on NaN or ±inf depends on the quaternion
+            // normalization inside, which is not this controller's contract.
             let tau = inertial.eval(0.0, &state, None).torque_body.into_inner();
             assert!(
-                tau.iter().all(|c| c.is_nan()),
-                "expected an all-NaN torque for {bad}, got {tau:?}"
+                tau.iter().any(|c| !c.is_finite()),
+                "expected a non-finite torque for {bad}, got {tau:?}"
             );
 
             let nadir = TrackingPdController::diagonal(1.0, 2.0, NadirPointing);
             let tau = nadir.eval(0.0, &state, None).torque_body.into_inner();
             assert!(
-                tau.iter().all(|c| c.is_nan()),
-                "expected an all-NaN nadir torque for {bad}, got {tau:?}"
+                tau.iter().any(|c| !c.is_finite()),
+                "expected a non-finite nadir torque for {bad}, got {tau:?}"
             );
         }
     }

--- a/orts/src/attitude/control/pd_controller.rs
+++ b/orts/src/attitude/control/pd_controller.rs
@@ -111,9 +111,11 @@ impl<F: arika::frame::Eci, S: HasAttitude + HasOrbit<Frame = F>, R: AttitudeRefe
     fn eval(&self, t: f64, state: &S, epoch: Option<&Epoch>) -> ExternalLoads<F> {
         let att = state.attitude();
         let (q_target, omega_target) = self.reference.target(t, state.orbit(), epoch);
-        // The target's frame tag has done its job: it had to match the state's
-        // integration frame `F` for this call to type-check. Everything below
-        // is body-frame error algebra, so the tag is dropped here.
+        // The target's frame tag has done its job: it had to match the frame
+        // of the state's *orbit* (`HasOrbit<Frame = F>`) for this call to
+        // type-check. `q_current` below is still an untyped `AttitudeState`
+        // quaternion, so that is as far as the check reaches today. Everything
+        // below is body-frame error algebra, so the tag is dropped here.
         let q_target = q_target.into_inner();
 
         let q_current = att.orientation();

--- a/orts/src/attitude/control/pd_controller.rs
+++ b/orts/src/attitude/control/pd_controller.rs
@@ -2,7 +2,7 @@ use arika::epoch::Epoch;
 use nalgebra::{Matrix3, UnitQuaternion, Vector3};
 
 use crate::model::ExternalLoads;
-use crate::model::{HasAttitude, HasOrbit, Model};
+use crate::model::{HasAttitude, HasFrame, HasOrbit, Model};
 
 use super::reference::AttitudeReference;
 
@@ -38,7 +38,7 @@ impl InertialPdController {
     }
 }
 
-impl<S: HasAttitude> Model<S> for InertialPdController {
+impl<S: HasFrame<Frame = arika::frame::SimpleEci> + HasAttitude> Model<S> for InertialPdController {
     fn name(&self) -> &str {
         "pd_inertial"
     }
@@ -101,8 +101,11 @@ impl<R> TrackingPdController<R> {
 // Frame-generic: the reference is asked for its target in the state's own
 // inertial frame `F` (see #151). The torque itself is body-frame, so the
 // returned `ExternalLoads<F>` carries a zero acceleration in that same frame.
-impl<F: arika::frame::Eci, S: HasAttitude + HasOrbit<Frame = F>, R: AttitudeReference<F> + 'static>
-    Model<S, F> for TrackingPdController<R>
+impl<
+    F: arika::frame::Eci,
+    S: HasFrame<Frame = F> + HasAttitude + HasOrbit,
+    R: AttitudeReference<F> + 'static,
+> Model<S, F> for TrackingPdController<R>
 {
     fn name(&self) -> &str {
         "pd_tracking"
@@ -112,7 +115,7 @@ impl<F: arika::frame::Eci, S: HasAttitude + HasOrbit<Frame = F>, R: AttitudeRefe
         let att = state.attitude();
         let (q_target, omega_target) = self.reference.target(t, state.orbit(), epoch);
         // The target's frame tag has done its job: it had to match the frame
-        // of the state's *orbit* (`HasOrbit<Frame = F>`) for this call to
+        // of the state's *orbit* (`HasFrame<Frame = F> + HasOrbit`) for this call to
         // type-check. `q_current` below is still an untyped `AttitudeState`
         // quaternion, so that is as far as the check reaches today. Everything
         // below is body-frame error algebra, so the tag is dropped here.
@@ -274,8 +277,11 @@ mod tests {
         }
     }
 
-    impl HasOrbit for TestState {
+    impl HasFrame for TestState {
         type Frame = arika::frame::SimpleEci;
+    }
+
+    impl HasOrbit for TestState {
         fn orbit(&self) -> &OrbitalState {
             &self.orbit
         }

--- a/orts/src/attitude/control/pd_controller.rs
+++ b/orts/src/attitude/control/pd_controller.rs
@@ -312,6 +312,139 @@ mod tests {
         );
     }
 
+    // Characterization for the frame-typed attitude target (#332)
+
+    use crate::attitude::control::InertialPointing;
+
+    /// A target orientation with all four components distinct and non-zero.
+    fn nontrivial_target() -> UnitQuaternion<f64> {
+        UnitQuaternion::from_axis_angle(
+            &nalgebra::Unit::new_normalize(Vector3::new(-0.2, 0.7, 0.4)),
+            1.1,
+        )
+    }
+
+    fn state_with(q: UnitQuaternion<f64>, omega: Vector3<f64>) -> TestState {
+        TestState {
+            attitude: AttitudeState::new(q, omega),
+            orbit: OrbitalState::new(
+                Vector3::new(4000.0, -5000.0, 2500.0),
+                Vector3::new(1.0, 2.0, 7.0),
+            ),
+        }
+    }
+
+    /// Characterization: pinned `SimpleEci` tracking torque against an
+    /// `InertialPointing` reference, so typing the target by its inertial frame
+    /// cannot change it.
+    #[test]
+    fn tracking_pd_inertial_pointing_torque_snapshot() {
+        let ctrl = TrackingPdController::diagonal(
+            1.0,
+            2.0,
+            InertialPointing {
+                target_q: nontrivial_target(),
+            },
+        );
+        let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
+        let state = state_with(
+            UnitQuaternion::from_axis_angle(
+                &nalgebra::Unit::new_normalize(Vector3::new(0.3, -0.5, 0.8)),
+                0.7,
+            ),
+            Vector3::new(0.01, -0.02, 0.03),
+        );
+        let got = ctrl
+            .eval(0.0, &state, Some(&epoch))
+            .torque_body
+            .into_inner();
+        let expected = Vector3::new(-0.10232165152129191, 1.2848812683428932, -0.107551192649679);
+        assert!(
+            (got - expected).magnitude() <= 1e-12 * expected.magnitude(),
+            "InertialPointing tracking PD torque changed: {got:?}"
+        );
+    }
+
+    /// Characterization of the hemisphere-selection predicate (`q_err.w < 0`)
+    /// on the tracking path: the current attitude is nearly the negation of the
+    /// target, so the branch fires and the torque must follow the short path.
+    #[test]
+    fn tracking_pd_hemisphere_selection_snapshot() {
+        let target_q = nontrivial_target();
+        // 1.1 rad + 1.9π about the same axis: same axis, opposite hemisphere.
+        let current = UnitQuaternion::from_axis_angle(
+            &nalgebra::Unit::new_normalize(Vector3::new(-0.2, 0.7, 0.4)),
+            1.1 + PI * 1.9,
+        );
+        let state = state_with(current, Vector3::new(0.01, -0.02, 0.03));
+
+        // The branch under test: q_err.w is genuinely negative here.
+        let q_err = target_q.inverse() * state.attitude.orientation();
+        assert!(
+            q_err.w < -0.5,
+            "fixture must exercise the hemisphere flip, got q_err.w = {}",
+            q_err.w
+        );
+
+        let ctrl = TrackingPdController::diagonal(1.0, 2.0, InertialPointing { target_q });
+        let got = ctrl.eval(0.0, &state, None).torque_body.into_inner();
+        let expected = Vector3::new(
+            -0.09532998610353678,
+            0.30365495136237847,
+            0.09065997220707345,
+        );
+        assert!(
+            (got - expected).magnitude() <= 1e-12 * expected.magnitude(),
+            "hemisphere-selected tracking PD torque changed: {got:?}"
+        );
+        // Short path: without the flip the proportional term would point the
+        // other way (θ_err ≈ 2·q_err_vec with q_err.w < 0).
+        let unflipped_theta = 2.0 * Vector3::new(q_err.i, q_err.j, q_err.k);
+        assert!(
+            got.dot(&unflipped_theta) > 0.0,
+            "expected the flipped (short-path) sign, got {got:?}"
+        );
+    }
+
+    /// Characterization: a non-finite attitude reaches the hemisphere predicate
+    /// (`NaN < 0.0` is `false`, so no flip) and yields a non-finite torque
+    /// instead of panicking. Pins `NaN` and `±∞` for both references.
+    #[test]
+    fn tracking_pd_non_finite_attitude_yields_non_finite_torque() {
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let state = TestState {
+                attitude: AttitudeState {
+                    quaternion: Vector4::new(bad, 0.0, 0.0, 1.0),
+                    angular_velocity: Vector3::new(0.01, 0.0, 0.0),
+                },
+                orbit: OrbitalState::new(
+                    Vector3::new(4000.0, -5000.0, 2500.0),
+                    Vector3::new(1.0, 2.0, 7.0),
+                ),
+            };
+
+            let inertial = TrackingPdController::diagonal(
+                1.0,
+                2.0,
+                InertialPointing {
+                    target_q: nontrivial_target(),
+                },
+            );
+            let tau = inertial.eval(0.0, &state, None).torque_body.into_inner();
+            assert!(
+                tau.iter().all(|c| c.is_nan()),
+                "expected an all-NaN torque for {bad}, got {tau:?}"
+            );
+
+            let nadir = TrackingPdController::diagonal(1.0, 2.0, NadirPointing);
+            let tau = nadir.eval(0.0, &state, None).torque_body.into_inner();
+            assert!(
+                tau.iter().all(|c| c.is_nan()),
+                "expected an all-NaN nadir torque for {bad}, got {tau:?}"
+            );
+        }
+    }
+
     #[test]
     fn inertial_pd_no_acceleration_or_mass_rate() {
         let ctrl = InertialPdController::diagonal(1.0, 1.0, UnitQuaternion::identity());

--- a/orts/src/attitude/control/reference.rs
+++ b/orts/src/attitude/control/reference.rs
@@ -1,6 +1,6 @@
 use crate::OrbitalState;
 use arika::epoch::Epoch;
-use arika::frame;
+use arika::frame::{self, Body, Rotation};
 use nalgebra::{Matrix3, UnitQuaternion, Vector3};
 
 /// A target attitude reference that provides desired orientation and angular velocity.
@@ -8,43 +8,51 @@ use nalgebra::{Matrix3, UnitQuaternion, Vector3};
 /// Implementations define different pointing strategies (inertial hold, nadir pointing, etc.).
 ///
 /// The type parameter `F` is the inertial frame of the observed orbital state
-/// (default `SimpleEci`). A reference whose geometry is defined by the state
-/// vectors alone (inertial hold, nadir pointing) implements it for every `F`;
-/// one that needs an external direction (a Sun-pointing or ground-target
-/// reference) would implement it only for the frames it can express that
-/// direction in.
+/// (default `SimpleEci`). A reference whose geometry is built from the state
+/// vectors alone ([`NadirPointing`]) implements it for every `F`. One that
+/// holds a direction of its own carries that direction's frame in its type and
+/// implements the trait only for that frame — [`InertialPointing<F>`](InertialPointing) holds a
+/// [`Rotation<Body, F>`](Rotation); a Sun-pointing or ground-target reference
+/// would work the same way.
 pub trait AttitudeReference<F: frame::Eci = frame::SimpleEci>: Send + Sync {
     /// Compute the target orientation and angular velocity at time `t`.
     ///
     /// Returns `(q_target, omega_target)` where:
-    /// - `q_target` is the desired body-to-`F` quaternion
-    /// - `omega_target` is the desired angular velocity in the target body frame [rad/s]
+    /// - `q_target` is the desired body→`F` rotation. The frame is part of the
+    ///   type: the same physical attitude has different quaternion components
+    ///   in different inertial frames, so an untagged quaternion could not say
+    ///   which one it meant.
+    /// - `omega_target` is the desired angular velocity in the *target* body
+    ///   frame [rad/s] — a frame of its own, distinct from the spacecraft's
+    ///   current body frame, so it is left untagged here.
     fn target(
         &self,
         t: f64,
         orbit: &OrbitalState<F>,
         epoch: Option<&Epoch>,
-    ) -> (UnitQuaternion<f64>, Vector3<f64>);
+    ) -> (Rotation<Body, F>, Vector3<f64>);
 }
 
-/// Inertial pointing: hold a fixed orientation in the inertial frame.
-pub struct InertialPointing {
-    pub target_q: UnitQuaternion<f64>,
+/// Inertial pointing: hold a fixed orientation in the inertial frame `F`.
+///
+/// The target is a [`Rotation<Body, F>`](Rotation), so the frame it was
+/// expressed in travels with it: the same `InertialPointing` value cannot be
+/// used to steer a system integrated in another inertial frame, where those
+/// quaternion components would denote a different physical attitude (the frames
+/// differ by precession/nutation, ~0.1° at the pole by 2024).
+pub struct InertialPointing<F = frame::SimpleEci> {
+    pub target_q: Rotation<Body, F>,
 }
 
-// Deliberately `SimpleEci`-only, not blanket over every `F`. `target_q` is a
-// bare quaternion, so it carries no record of the frame it was expressed in:
-// with a blanket impl the same `InertialPointing` value handed to a `Gcrs`
-// system would denote a different physical attitude (the two frames differ by
-// precession/nutation, ~0.1° at the pole by 2024) with nothing to catch it.
-// Widen this once the target can be typed as `Rotation<Body, F>`.
-impl AttitudeReference<frame::SimpleEci> for InertialPointing {
+// Frame-generic now that the target names its own frame: the impl is only
+// reachable for the `F` the target was built in.
+impl<F: frame::Eci> AttitudeReference<F> for InertialPointing<F> {
     fn target(
         &self,
         _t: f64,
-        _orbit: &OrbitalState<frame::SimpleEci>,
+        _orbit: &OrbitalState<F>,
         _epoch: Option<&Epoch>,
-    ) -> (UnitQuaternion<f64>, Vector3<f64>) {
+    ) -> (Rotation<Body, F>, Vector3<f64>) {
         (self.target_q, Vector3::zeros())
     }
 }
@@ -68,7 +76,7 @@ impl<F: frame::Eci> AttitudeReference<F> for NadirPointing {
         _t: f64,
         orbit: &OrbitalState<F>,
         _epoch: Option<&Epoch>,
-    ) -> (UnitQuaternion<f64>, Vector3<f64>) {
+    ) -> (Rotation<Body, F>, Vector3<f64>) {
         let r = *orbit.position();
         let v = *orbit.velocity();
         let r_mag = r.magnitude();
@@ -94,7 +102,7 @@ impl<F: frame::Eci> AttitudeReference<F> for NadirPointing {
         // Angular velocity of LVLH frame in LVLH body frame: [0, -n, 0]
         let omega_target = Vector3::new(0.0, -n, 0.0);
 
-        (q_target, omega_target)
+        (Rotation::<Body, F>::from_raw(q_target), omega_target)
     }
 }
 
@@ -126,8 +134,11 @@ mod tests {
     #[test]
     fn inertial_pointing_target_components_snapshot() {
         let q = nontrivial_target();
-        let ref_point = InertialPointing { target_q: q };
+        let ref_point = InertialPointing {
+            target_q: Rotation::<Body, frame::SimpleEci>::from_raw(q),
+        };
         let (q_out, omega_out) = ref_point.target(0.0, &snapshot_orbit(), None);
+        let q_out = q_out.into_inner();
 
         // (w, x, y, z), Hamilton scalar-first.
         let expected = nalgebra::Vector4::new(
@@ -151,6 +162,7 @@ mod tests {
     #[test]
     fn nadir_pointing_target_components_snapshot() {
         let (q_out, omega_out) = NadirPointing.target(0.0, &snapshot_orbit(), None);
+        let q_out = q_out.into_inner();
         let got = nalgebra::Vector4::new(q_out.w, q_out.i, q_out.j, q_out.k);
 
         // Sign of a quaternion is a gauge freedom; compare through the
@@ -192,8 +204,11 @@ mod tests {
         for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
             // Inertial hold: a non-finite target normalizes to NaN.
             let q = UnitQuaternion::from_quaternion(nalgebra::Quaternion::new(bad, 0.0, 0.0, 1.0));
-            let (q_out, omega_out) =
-                InertialPointing { target_q: q }.target(0.0, &snapshot_orbit(), None);
+            let (q_out, omega_out) = InertialPointing {
+                target_q: Rotation::<Body, frame::SimpleEci>::from_raw(q),
+            }
+            .target(0.0, &snapshot_orbit(), None);
+            let q_out = q_out.into_inner();
             assert!(q_out.w.is_nan(), "expected NaN scalar part for {bad}");
             assert_eq!(omega_out, Vector3::zeros());
 
@@ -203,6 +218,7 @@ mod tests {
                 Vector3::new(1.0, 2.0, 7.0),
             );
             let (q_nadir, omega_nadir) = NadirPointing.target(0.0, &orbit, None);
+            let q_nadir = q_nadir.into_inner();
             assert!(
                 !q_nadir.w.is_finite()
                     || !q_nadir.i.is_finite()
@@ -221,12 +237,14 @@ mod tests {
     fn inertial_pointing_returns_fixed_target() {
         let axis = nalgebra::Unit::new_normalize(Vector3::new(0.0, 0.0, 1.0));
         let q = UnitQuaternion::from_axis_angle(&axis, PI / 4.0);
-        let ref_point = InertialPointing { target_q: q };
+        let ref_point = InertialPointing {
+            target_q: Rotation::<Body, frame::SimpleEci>::from_raw(q),
+        };
 
         let orbit = OrbitalState::new(Vector3::new(7000.0, 0.0, 0.0), Vector3::new(0.0, 7.5, 0.0));
 
         let (q_out, omega_out) = ref_point.target(0.0, &orbit, None);
-        assert!((q_out.angle() - PI / 4.0).abs() < 1e-14);
+        assert!((q_out.into_inner().angle() - PI / 4.0).abs() < 1e-14);
         assert!(omega_out.magnitude() < 1e-15);
     }
 
@@ -238,7 +256,7 @@ mod tests {
         let (q_target, _omega) = nadir.target(0.0, &orbit, None);
 
         // The body Z-axis in inertial frame should point nadir (toward -r)
-        let r_mat = q_target.to_rotation_matrix();
+        let r_mat = q_target.into_inner().to_rotation_matrix();
         let z_body_inertial = r_mat * Vector3::new(0.0, 0.0, 1.0);
 
         let r_hat = orbit.position().normalize();
@@ -295,7 +313,7 @@ mod tests {
         let (q_target, _) = nadir.target(0.0, &orbit, None);
 
         // The rotation matrix should be orthonormal
-        let r_mat = q_target.to_rotation_matrix();
+        let r_mat = q_target.into_inner().to_rotation_matrix();
         let m = r_mat.matrix();
         let identity = m.transpose() * m;
 

--- a/orts/src/attitude/control/reference.rs
+++ b/orts/src/attitude/control/reference.rs
@@ -157,43 +157,43 @@ mod tests {
         assert_eq!(omega_out, Vector3::zeros());
     }
 
-    /// Characterization: `NadirPointing` in `SimpleEci`, pinned component-wise
-    /// on an eccentric, out-of-plane state (so every component is non-zero).
+    /// Characterization: the `NadirPointing` target in `SimpleEci`, pinned
+    /// against literals computed outside the implementation (no re-derivation
+    /// of `|h|/r²` or of the LVLH triad from the state, which would just mirror
+    /// the code). The fixture is eccentric and out-of-plane, so every axis
+    /// component is non-zero.
     #[test]
-    fn nadir_pointing_target_components_snapshot() {
+    fn nadir_pointing_target_axes_and_rate_snapshot() {
         let (q_out, omega_out) = NadirPointing.target(0.0, &snapshot_orbit(), None);
-        let q_out = q_out.into_inner();
-        let got = nalgebra::Vector4::new(q_out.w, q_out.i, q_out.j, q_out.k);
+        let m = q_out.into_inner().to_rotation_matrix();
 
-        // Sign of a quaternion is a gauge freedom; compare through the
-        // rotation it denotes by pinning the LVLH axes instead.
-        let m = q_out.to_rotation_matrix();
-        let r = snapshot_orbit();
-        let z_body = m * Vector3::new(0.0, 0.0, 1.0);
-        let expected_z = -r.position().normalize();
-        assert!(
-            (z_body - expected_z).magnitude() <= 1e-12 * expected_z.magnitude(),
-            "nadir axis changed: {z_body:?}"
-        );
-        let h = r.position().cross(r.velocity());
-        let y_body = m * Vector3::new(0.0, 1.0, 0.0);
-        let expected_y = -h.normalize();
-        assert!(
-            (y_body - expected_y).magnitude() <= 1e-12 * expected_y.magnitude(),
-            "orbit-normal axis changed: {y_body:?}"
-        );
-        // The rate is the instantaneous |h|/r², non-zero for this state.
-        let n = h.magnitude() / r.position().magnitude_squared();
-        assert!(
-            n > 1e-4,
-            "fixture must produce a non-zero rate, got {n:.3e}"
-        );
-        let expected_omega = Vector3::new(0.0, -n, 0.0);
+        // Sign of a quaternion is a gauge freedom, so pin the rotation it
+        // denotes: the three body axes in `SimpleEci`.
+        let expected_axes = [
+            Vector3::new(
+                0.003697164137472425,
+                0.44957515911664725,
+                0.8932348556133385,
+            ),
+            Vector3::new(0.8132416567988889, 0.5184415562092917, -0.2643035384596389),
+            Vector3::new(-0.5819143739626463, 0.727392967453308, -0.363696483726654),
+        ];
+        for (i, expected) in expected_axes.iter().enumerate() {
+            let mut body = Vector3::zeros();
+            body[i] = 1.0;
+            let got = m * body;
+            assert!(
+                (got - expected).magnitude() <= 1e-12 * expected.magnitude(),
+                "LVLH axis {i} changed: {got:?}"
+            );
+        }
+
+        // Rate: [0, -n, 0] with n = |h|/r² — pinned as a literal.
+        let expected_omega = Vector3::new(0.0, -0.0010409708350321229, 0.0);
         assert!(
             (omega_out - expected_omega).magnitude() <= 1e-12 * expected_omega.magnitude(),
             "nadir rate changed: {omega_out:?}"
         );
-        assert!(got.iter().all(|c| c.is_finite()));
     }
 
     /// Characterization: a non-finite attitude target is passed through rather

--- a/orts/src/attitude/control/reference.rs
+++ b/orts/src/attitude/control/reference.rs
@@ -103,6 +103,120 @@ mod tests {
     use super::*;
     use std::f64::consts::PI;
 
+    /// A target orientation with all four components distinct and non-zero, so
+    /// a component-wise snapshot cannot pass by symmetry.
+    fn nontrivial_target() -> UnitQuaternion<f64> {
+        UnitQuaternion::from_axis_angle(
+            &nalgebra::Unit::new_normalize(Vector3::new(-0.2, 0.7, 0.4)),
+            1.1,
+        )
+    }
+
+    fn snapshot_orbit() -> OrbitalState {
+        OrbitalState::new(
+            Vector3::new(4000.0, -5000.0, 2500.0),
+            Vector3::new(1.0, 2.0, 7.0),
+        )
+    }
+
+    /// Characterization: the `InertialPointing` target is handed back
+    /// component-for-component (no renormalization, no frame rotation), and the
+    /// target rate is exactly zero. Pins the values so that typing the target
+    /// by its inertial frame cannot change them.
+    #[test]
+    fn inertial_pointing_target_components_snapshot() {
+        let q = nontrivial_target();
+        let ref_point = InertialPointing { target_q: q };
+        let (q_out, omega_out) = ref_point.target(0.0, &snapshot_orbit(), None);
+
+        // (w, x, y, z), Hamilton scalar-first.
+        let expected = nalgebra::Vector4::new(
+            0.8525245220595057,
+            -0.12584829590370833,
+            0.44046903566297907,
+            0.25169659180741666,
+        );
+        let got = nalgebra::Vector4::new(q_out.w, q_out.i, q_out.j, q_out.k);
+        assert!(
+            (got - expected).magnitude() <= 1e-12 * expected.magnitude(),
+            "InertialPointing target changed: {got:?}"
+        );
+        // A rate of exactly zero is the definition of an inertial hold, not a
+        // near-zero numerical outcome, so assert it exactly.
+        assert_eq!(omega_out, Vector3::zeros());
+    }
+
+    /// Characterization: `NadirPointing` in `SimpleEci`, pinned component-wise
+    /// on an eccentric, out-of-plane state (so every component is non-zero).
+    #[test]
+    fn nadir_pointing_target_components_snapshot() {
+        let (q_out, omega_out) = NadirPointing.target(0.0, &snapshot_orbit(), None);
+        let got = nalgebra::Vector4::new(q_out.w, q_out.i, q_out.j, q_out.k);
+
+        // Sign of a quaternion is a gauge freedom; compare through the
+        // rotation it denotes by pinning the LVLH axes instead.
+        let m = q_out.to_rotation_matrix();
+        let r = snapshot_orbit();
+        let z_body = m * Vector3::new(0.0, 0.0, 1.0);
+        let expected_z = -r.position().normalize();
+        assert!(
+            (z_body - expected_z).magnitude() <= 1e-12 * expected_z.magnitude(),
+            "nadir axis changed: {z_body:?}"
+        );
+        let h = r.position().cross(r.velocity());
+        let y_body = m * Vector3::new(0.0, 1.0, 0.0);
+        let expected_y = -h.normalize();
+        assert!(
+            (y_body - expected_y).magnitude() <= 1e-12 * expected_y.magnitude(),
+            "orbit-normal axis changed: {y_body:?}"
+        );
+        // The rate is the instantaneous |h|/r², non-zero for this state.
+        let n = h.magnitude() / r.position().magnitude_squared();
+        assert!(
+            n > 1e-4,
+            "fixture must produce a non-zero rate, got {n:.3e}"
+        );
+        let expected_omega = Vector3::new(0.0, -n, 0.0);
+        assert!(
+            (omega_out - expected_omega).magnitude() <= 1e-12 * expected_omega.magnitude(),
+            "nadir rate changed: {omega_out:?}"
+        );
+        assert!(got.iter().all(|c| c.is_finite()));
+    }
+
+    /// Characterization: a non-finite attitude target is passed through rather
+    /// than sanitized or panicked on. Pins the behavior of the (predicate-free)
+    /// reference path for `NaN` / `±∞` inputs.
+    #[test]
+    fn non_finite_states_do_not_panic() {
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            // Inertial hold: a non-finite target normalizes to NaN.
+            let q = UnitQuaternion::from_quaternion(nalgebra::Quaternion::new(bad, 0.0, 0.0, 1.0));
+            let (q_out, omega_out) =
+                InertialPointing { target_q: q }.target(0.0, &snapshot_orbit(), None);
+            assert!(q_out.w.is_nan(), "expected NaN scalar part for {bad}");
+            assert_eq!(omega_out, Vector3::zeros());
+
+            // Nadir pointing: a non-finite state propagates to a NaN target.
+            let orbit = OrbitalState::new(
+                Vector3::new(bad, -5000.0, 2500.0),
+                Vector3::new(1.0, 2.0, 7.0),
+            );
+            let (q_nadir, omega_nadir) = NadirPointing.target(0.0, &orbit, None);
+            assert!(
+                !q_nadir.w.is_finite()
+                    || !q_nadir.i.is_finite()
+                    || !q_nadir.j.is_finite()
+                    || !q_nadir.k.is_finite(),
+                "expected a non-finite nadir target for {bad}, got {q_nadir:?}"
+            );
+            assert!(
+                omega_nadir[1].is_nan(),
+                "expected NaN rate for {bad}, got {omega_nadir:?}"
+            );
+        }
+    }
+
     #[test]
     fn inertial_pointing_returns_fixed_target() {
         let axis = nalgebra::Unit::new_normalize(Vector3::new(0.0, 0.0, 1.0));

--- a/orts/src/attitude/decoupled.rs
+++ b/orts/src/attitude/decoupled.rs
@@ -5,7 +5,7 @@ use utsuroi::DynamicalSystem;
 use crate::OrbitalState;
 use crate::attitude::AttitudeState;
 use crate::model::ExternalLoads;
-use crate::model::{HasAttitude, HasMass, HasOrbit, Model};
+use crate::model::{HasAttitude, HasFrame, HasMass, HasOrbit, Model};
 
 /// Combined state providing attitude, orbit, and mass for decoupled models.
 ///
@@ -23,9 +23,11 @@ impl HasAttitude for DecoupledContext {
     }
 }
 
-impl HasOrbit for DecoupledContext {
+impl HasFrame for DecoupledContext {
     type Frame = arika::frame::SimpleEci;
+}
 
+impl HasOrbit for DecoupledContext {
     fn orbit(&self) -> &OrbitalState<arika::frame::SimpleEci> {
         &self.orbit
     }

--- a/orts/src/attitude/gravity_gradient.rs
+++ b/orts/src/attitude/gravity_gradient.rs
@@ -3,7 +3,7 @@ use arika::frame::{self, Vec3};
 use nalgebra::{Matrix3, Vector3};
 
 use crate::model::ExternalLoads;
-use crate::model::{HasAttitude, HasOrbit, Model};
+use crate::model::{HasAttitude, HasFrame, HasOrbit, Model};
 
 use super::state::AttitudeState;
 
@@ -59,7 +59,7 @@ pub(crate) fn gravity_gradient_torque_vector(
     mu: f64,
     inertia: &Matrix3<f64>,
     r_eci: &Vector3<f64>,
-    attitude: &AttitudeState,
+    inertial_to_body: arika::frame::Rotation<frame::SimpleEci, arika::frame::Body>,
 ) -> Vector3<f64> {
     let r_mag = r_eci.magnitude();
     if r_mag < 1e-10 {
@@ -67,8 +67,7 @@ pub(crate) fn gravity_gradient_torque_vector(
     }
 
     // Transform position to body frame: r_body = R_bi * r_eci
-    let r_body = attitude
-        .rotation_to_body()
+    let r_body = inertial_to_body
         .transform(&Vec3::<frame::SimpleEci>::from_raw(*r_eci))
         .into_inner();
 
@@ -82,7 +81,12 @@ impl GravityGradientTorque {
     /// Compute gravity gradient torque in body frame (decoupled: position from closure).
     pub(crate) fn torque(&self, t: f64, state: &AttitudeState) -> Vector3<f64> {
         let r_eci = (self.position_fn)(t);
-        gravity_gradient_torque_vector(self.mu, &self.inertia, &r_eci, state)
+        gravity_gradient_torque_vector(
+            self.mu,
+            &self.inertia,
+            &r_eci,
+            state.attitude_from_inertial(),
+        )
     }
 }
 
@@ -102,7 +106,9 @@ impl CoupledGravityGradient {
     }
 }
 
-impl<S: HasAttitude + HasOrbit> Model<S> for CoupledGravityGradient {
+impl<S: HasFrame<Frame = arika::frame::SimpleEci> + HasAttitude + HasOrbit> Model<S>
+    for CoupledGravityGradient
+{
     fn name(&self) -> &str {
         "gravity_gradient"
     }
@@ -112,13 +118,15 @@ impl<S: HasAttitude + HasOrbit> Model<S> for CoupledGravityGradient {
             self.mu,
             &self.inertia,
             state.orbit().position(),
-            state.attitude(),
+            state.attitude_from_inertial(),
         );
         ExternalLoads::torque(torque)
     }
 }
 
-impl<S: HasAttitude> Model<S> for GravityGradientTorque {
+impl<S: HasFrame<Frame = arika::frame::SimpleEci> + HasAttitude> Model<S>
+    for GravityGradientTorque
+{
     fn name(&self) -> &str {
         "gravity_gradient"
     }
@@ -277,7 +285,12 @@ mod tests {
 
         // Coupled version via shared function
         let r_eci = Vector3::new(r, 0.0, 0.0);
-        let tau_coupled = gravity_gradient_torque_vector(mu, &inertia, &r_eci, &attitude);
+        let tau_coupled = gravity_gradient_torque_vector(
+            mu,
+            &inertia,
+            &r_eci,
+            attitude.rotation_tagged_as::<frame::SimpleEci>().inverse(),
+        );
 
         assert!(
             (tau_decoupled - tau_coupled).magnitude() < 1e-15,

--- a/orts/src/attitude/state.rs
+++ b/orts/src/attitude/state.rs
@@ -2,7 +2,7 @@ use arika::frame::{self, Rotation};
 use nalgebra::{UnitQuaternion, Vector3, Vector4};
 use utsuroi::{OdeState, Tolerances};
 
-use crate::model::HasAttitude;
+use crate::model::{HasAttitude, HasFrame};
 
 /// Attitude state: unit quaternion (orientation) + angular velocity in body frame.
 ///
@@ -45,34 +45,21 @@ impl AttitudeState {
         UnitQuaternion::from_quaternion(q)
     }
 
-    /// Typed rotation: body frame → ECI (inertial).
-    pub fn rotation_to_eci(&self) -> Rotation<frame::Body, frame::SimpleEci> {
-        self.rotation_to_inertial()
-    }
-
-    /// Typed rotation: body frame → inertial frame `F`.
+    /// Rotation body → `F`, **tagging** the stored quaternion as being expressed
+    /// against `F` rather than converting it.
     ///
-    /// This **asserts** a frame, it does not convert one: the stored
-    /// quaternion is copied and only the phantom tag changes. That lets models
-    /// produce `ExternalLoads<F>` in any propagation frame without
-    /// `AttitudeState` needing a type parameter — but the caller is
-    /// responsible for `F` being the frame the state is actually propagated
-    /// in. Quaternion components are frame-dependent (`SimpleEci` and `Gcrs`
-    /// differ by ~484 arcsec at 2024), so naming the wrong `F` here silently
-    /// re-interprets the attitude. Typing `AttitudeState` itself would remove
-    /// the obligation.
-    pub fn rotation_to_inertial<F: frame::Eci>(&self) -> Rotation<frame::Body, F> {
+    /// The primitive behind [`HasAttitude::attitude_to_inertial`], and the only
+    /// way to name a frame by hand. Prefer the trait method: it reads `F` from
+    /// the state's own type, so it cannot disagree with the frame the state is
+    /// propagated in. Reach for this one only where no such state exists — the
+    /// attitude-only propagation path, and tests that build an `AttitudeState`
+    /// directly.
+    ///
+    /// Quaternion components are frame-dependent (`SimpleEci` and `Gcrs` differ
+    /// by ~484 arcsec at 2024), so naming the wrong `F` silently re-interprets
+    /// the attitude.
+    pub fn rotation_tagged_as<F: frame::Eci>(&self) -> Rotation<frame::Body, F> {
         Rotation::from_raw(self.orientation())
-    }
-
-    /// Typed rotation: ECI (inertial) → body frame.
-    pub fn rotation_to_body(&self) -> Rotation<frame::SimpleEci, frame::Body> {
-        self.rotation_from_inertial()
-    }
-
-    /// Typed rotation: inertial frame `F` → body frame.
-    pub fn rotation_from_inertial<F: frame::Eci>(&self) -> Rotation<F, frame::Body> {
-        self.rotation_to_inertial::<F>().inverse()
     }
 
     /// Quaternion kinematic equation: dq/dt = 0.5 * q ⊗ (0, ω).
@@ -111,6 +98,13 @@ impl AttitudeState {
             angular_velocity: angular_acceleration,
         }
     }
+}
+
+// The attitude-only propagation path has no orbit and therefore no other frame
+// in play, so simple-ECI is the frame by construction. Stating it here is the one
+// place this path names a frame, instead of every caller doing so.
+impl HasFrame for AttitudeState {
+    type Frame = frame::SimpleEci;
 }
 
 impl HasAttitude for AttitudeState {

--- a/orts/src/attitude/state.rs
+++ b/orts/src/attitude/state.rs
@@ -52,10 +52,15 @@ impl AttitudeState {
 
     /// Typed rotation: body frame → inertial frame `F`.
     ///
-    /// The quaternion data is frame-independent — only the phantom type
-    /// tag changes. This allows models to produce `ExternalLoads<F>` in
-    /// any propagation frame without `AttitudeState` needing a type
-    /// parameter.
+    /// This **asserts** a frame, it does not convert one: the stored
+    /// quaternion is copied and only the phantom tag changes. That lets models
+    /// produce `ExternalLoads<F>` in any propagation frame without
+    /// `AttitudeState` needing a type parameter — but the caller is
+    /// responsible for `F` being the frame the state is actually propagated
+    /// in. Quaternion components are frame-dependent (`SimpleEci` and `Gcrs`
+    /// differ by ~484 arcsec at 2024), so naming the wrong `F` here silently
+    /// re-interprets the attitude. Typing `AttitudeState` itself would remove
+    /// the obligation.
     pub fn rotation_to_inertial<F: frame::Eci>(&self) -> Rotation<frame::Body, F> {
         Rotation::from_raw(self.orientation())
     }

--- a/orts/src/model.rs
+++ b/orts/src/model.rs
@@ -61,6 +61,7 @@ pub trait HasMass {
 /// Parameterized by the inertial frame `F` (default `SimpleEci`).
 /// - acceleration: inertial frame [km/s²] (for translational EOM)
 /// - torque: body frame [N·m] (for rotational EOM)
+#[derive(Debug, Clone, PartialEq)]
 pub struct ExternalLoads<F: frame::Eci = frame::SimpleEci> {
     /// Translational acceleration in inertial frame [km/s²].
     pub acceleration_inertial: Vec3<F>,
@@ -68,33 +69,6 @@ pub struct ExternalLoads<F: frame::Eci = frame::SimpleEci> {
     pub torque_body: Vec3<Body>,
     /// Mass rate [kg/s] (negative for depletion, e.g. propellant consumption).
     pub mass_rate: f64,
-}
-
-// Manual impls to avoid F bounds from derive.
-impl<F: frame::Eci> std::fmt::Debug for ExternalLoads<F> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ExternalLoads")
-            .field("acceleration_inertial", &self.acceleration_inertial)
-            .field("torque_body", &self.torque_body)
-            .field("mass_rate", &self.mass_rate)
-            .finish()
-    }
-}
-impl<F: frame::Eci> Clone for ExternalLoads<F> {
-    fn clone(&self) -> Self {
-        Self {
-            acceleration_inertial: Vec3::from_raw(*self.acceleration_inertial.inner()),
-            torque_body: Vec3::from_raw(*self.torque_body.inner()),
-            mass_rate: self.mass_rate,
-        }
-    }
-}
-impl<F: frame::Eci> PartialEq for ExternalLoads<F> {
-    fn eq(&self, other: &Self) -> bool {
-        self.acceleration_inertial.inner() == other.acceleration_inertial.inner()
-            && self.torque_body.inner() == other.torque_body.inner()
-            && self.mass_rate == other.mass_rate
-    }
 }
 
 impl<F: frame::Eci> ExternalLoads<F> {

--- a/orts/src/model.rs
+++ b/orts/src/model.rs
@@ -16,7 +16,7 @@ use std::ops::{Add, AddAssign};
 use arika::epoch::Epoch;
 #[cfg(test)]
 use arika::frame::SimpleEci;
-use arika::frame::{self, Body, Vec3};
+use arika::frame::{self, Body, Rotation, Vec3};
 use nalgebra::Vector3;
 
 use crate::OrbitalState;
@@ -24,26 +24,52 @@ use crate::attitude::AttitudeState;
 
 // Capability traits
 
+/// The inertial frame a state is propagated in.
+///
+/// Both the orbit and the attitude of a given state are expressed against this
+/// one frame, so it is declared once here rather than separately on
+/// [`HasOrbit`] and [`HasAttitude`] — a state cannot claim its orbit is in
+/// `Gcrs` while its attitude is in `SimpleEci`.
+///
+/// This is what drives frame-generic model dispatch: a model is written as
+/// `impl<F: Cap, S: HasFrame<Frame = F> + HasOrbit> Model<S, F>`, bounded on the
+/// minimal capability `Cap` it needs from the frame (e.g.
+/// `EarthRotationPole`, `EarthFixedTransform`, `EphemerisFrameBridge`), so a
+/// frame that cannot supply it is a compile error rather than a silent mislabel.
+/// The frame the state is read in and the frame the model emits loads in are the
+/// same type parameter, which is what keeps a model from reading a quaternion in
+/// one frame and reporting the result in another (`SimpleEci` and `Gcrs` differ
+/// by ~484 arcsec at 2024).
+///
+/// TODO: `Eci` bound は地心慣性系に限定している。月周回や深宇宙では
+/// より general な `Frame` bound が必要になる (別 milestone)。
+pub trait HasFrame {
+    /// Inertial frame of this state.
+    type Frame: arika::frame::Eci;
+}
+
 /// State type that provides attitude information (quaternion + angular velocity).
-pub trait HasAttitude {
+pub trait HasAttitude: HasFrame {
     fn attitude(&self) -> &AttitudeState;
+
+    /// Rotation body → [`HasFrame::Frame`].
+    ///
+    /// Prefer this over [`AttitudeState::rotation_tagged_as`]: the frame comes
+    /// from the state's own type rather than from a caller-supplied parameter.
+    fn attitude_to_inertial(&self) -> Rotation<Body, Self::Frame> {
+        self.attitude().rotation_tagged_as()
+    }
+
+    /// Rotation [`HasFrame::Frame`] → body.
+    fn attitude_from_inertial(&self) -> Rotation<Self::Frame, Body> {
+        self.attitude()
+            .rotation_tagged_as::<Self::Frame>()
+            .inverse()
+    }
 }
 
 /// State type that provides orbital information (position + velocity).
-pub trait HasOrbit {
-    /// Inertial frame of the orbital state.
-    ///
-    /// This is what drives frame-generic model dispatch: a model is written as
-    /// `impl<F: Cap, S: HasOrbit<Frame = F>> Model<S, F>`, bounded on the
-    /// minimal capability `Cap` it needs from the frame (e.g.
-    /// `EarthRotationPole`, `EarthFixedTransform`, `EphemerisFrameBridge`), so a
-    /// frame that cannot supply it is a compile error rather than a silent
-    /// mislabel.
-    ///
-    /// TODO: `Eci` bound は地心慣性系に限定している。月周回や深宇宙では
-    /// より general な `Frame` bound が必要になる (別 milestone)。
-    type Frame: arika::frame::Eci;
-
+pub trait HasOrbit: HasFrame {
     fn orbit(&self) -> &OrbitalState<Self::Frame>;
 }
 

--- a/orts/src/orbital/state.rs
+++ b/orts/src/orbital/state.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::marker::PhantomData;
 
 use arika::frame::{Eci, SimpleEci, Vec3};
@@ -11,24 +10,8 @@ use crate::model::HasOrbit;
 ///
 /// Parameterized by frame `F` (default `SimpleEci`). The internal
 /// representation is a raw `State<3, 2>` — the frame is phantom.
+#[derive(Debug, Clone, PartialEq)]
 pub struct OrbitalState<F: Eci = SimpleEci>(pub State<3, 2>, PhantomData<F>);
-
-// Manual impls to avoid requiring F: Debug/Clone/PartialEq.
-impl<F: Eci> fmt::Debug for OrbitalState<F> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("OrbitalState").field(&self.0).finish()
-    }
-}
-impl<F: Eci> Clone for OrbitalState<F> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone(), PhantomData)
-    }
-}
-impl<F: Eci> PartialEq for OrbitalState<F> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
 
 impl<F: Eci> OrbitalState<F> {
     /// Wrap an existing `State<3, 2>` in the given frame.

--- a/orts/src/orbital/state.rs
+++ b/orts/src/orbital/state.rs
@@ -4,7 +4,7 @@ use arika::frame::{Eci, SimpleEci, Vec3};
 use nalgebra::Vector3;
 use utsuroi::{OdeState, State, Tolerances};
 
-use crate::model::HasOrbit;
+use crate::model::{HasFrame, HasOrbit};
 
 /// Orbital state: position and velocity in an inertial frame.
 ///
@@ -122,9 +122,11 @@ mod tests {
     }
 }
 
-impl<F: Eci> HasOrbit for OrbitalState<F> {
+impl<F: Eci> HasFrame for OrbitalState<F> {
     type Frame = F;
+}
 
+impl<F: Eci> HasOrbit for OrbitalState<F> {
     fn orbit(&self) -> &OrbitalState<F> {
         self
     }

--- a/orts/src/orbital/system.rs
+++ b/orts/src/orbital/system.rs
@@ -25,11 +25,6 @@ pub struct OrbitalSystem<F: Eci = SimpleEci> {
     _frame: PhantomData<F>,
 }
 
-// Manual Send + Sync: all fields are Send + Sync, PhantomData<F> is fine
-// because F is a ZST frame marker.
-unsafe impl<F: Eci> Send for OrbitalSystem<F> {}
-unsafe impl<F: Eci> Sync for OrbitalSystem<F> {}
-
 impl<F: Eci> OrbitalSystem<F> {
     pub fn new(mu: f64, gravity: Box<dyn GravityField>) -> Self {
         Self {

--- a/orts/src/perturbations/drag.rs
+++ b/orts/src/perturbations/drag.rs
@@ -8,7 +8,7 @@ use nalgebra::Vector3;
 use tobari::{AtmosphereInput, AtmosphereModel, Exponential};
 
 use crate::model::ExternalLoads;
-use crate::model::{HasOrbit, Model};
+use crate::model::{HasFrame, HasOrbit, Model};
 use crate::orbital::OrbitalState;
 use arika::earth::{EarthFixedTransform, EarthOrientation};
 
@@ -195,7 +195,7 @@ impl<F: EarthFixedTransform> AtmosphericDrag<F> {
     }
 }
 
-impl<F: EarthFixedTransform, S: HasOrbit<Frame = F>> Model<S, F> for AtmosphericDrag<F> {
+impl<F: EarthFixedTransform, S: HasFrame<Frame = F> + HasOrbit> Model<S, F> for AtmosphericDrag<F> {
     fn name(&self) -> &str {
         "drag"
     }

--- a/orts/src/perturbations/srp.rs
+++ b/orts/src/perturbations/srp.rs
@@ -7,7 +7,7 @@ use arika::earth::R as R_EARTH;
 use arika::earth::transform::EphemerisFrameBridge;
 
 use crate::model::ExternalLoads;
-use crate::model::{HasOrbit, Model};
+use crate::model::{HasFrame, HasOrbit, Model};
 
 /// Solar radiation pressure at 1 AU (N/m²).
 /// P/c = 1361 W/m² / 299792458 m/s ≈ 4.5396e-6 N/m²
@@ -156,7 +156,9 @@ impl SolarRadiationPressure {
 // Identity for GCRS-aligned `SimpleEci` / `Gcrs` (historical behavior preserved
 // exactly); `Cirs` applies the precession/nutation rotation. A frame without an
 // `EphemerisFrameBridge` impl (e.g. `Teme`) is rejected at compile time. See #191.
-impl<F: EphemerisFrameBridge, S: HasOrbit<Frame = F>> Model<S, F> for SolarRadiationPressure {
+impl<F: EphemerisFrameBridge, S: HasFrame<Frame = F> + HasOrbit> Model<S, F>
+    for SolarRadiationPressure
+{
     fn name(&self) -> &str {
         "srp"
     }

--- a/orts/src/perturbations/third_body.rs
+++ b/orts/src/perturbations/third_body.rs
@@ -6,7 +6,7 @@ use arika::frame::{self, Vec3};
 use nalgebra::Vector3;
 
 use crate::model::ExternalLoads;
-use crate::model::{HasOrbit, Model};
+use crate::model::{HasFrame, HasOrbit, Model};
 
 /// Type alias for a body-position function: `Epoch<Tdb> -> ECI position [km]`.
 ///
@@ -152,7 +152,7 @@ impl ThirdBodyGravity {
 // exactly); `Cirs` applies the precession/nutation rotation. A frame with no
 // `EphemerisFrameBridge` impl (e.g. `Teme`) is rejected at compile time rather
 // than silently mistreated. See #191.
-impl<F: EphemerisFrameBridge, S: HasOrbit<Frame = F>> Model<S, F> for ThirdBodyGravity {
+impl<F: EphemerisFrameBridge, S: HasFrame<Frame = F> + HasOrbit> Model<S, F> for ThirdBodyGravity {
     fn name(&self) -> &str {
         self.name
     }

--- a/orts/src/perturbations/zonal_gravity.rs
+++ b/orts/src/perturbations/zonal_gravity.rs
@@ -23,7 +23,7 @@ use arika::epoch::{Epoch, Utc};
 use nalgebra::Vector3;
 
 use crate::model::ExternalLoads;
-use crate::model::{HasOrbit, Model};
+use crate::model::{HasFrame, HasOrbit, Model};
 use arika::earth::EarthRotationPole;
 
 /// Zonal harmonics (J2, optional J3/J4) gravity perturbation about the
@@ -106,7 +106,7 @@ impl<F: EarthRotationPole> ZonalGravity<F> {
     }
 }
 
-impl<F: EarthRotationPole, S: HasOrbit<Frame = F>> Model<S, F> for ZonalGravity<F> {
+impl<F: EarthRotationPole, S: HasFrame<Frame = F> + HasOrbit> Model<S, F> for ZonalGravity<F> {
     fn name(&self) -> &str {
         "zonal_gravity"
     }

--- a/orts/src/plugin/tick_input.rs
+++ b/orts/src/plugin/tick_input.rs
@@ -5,8 +5,6 @@
 //! readings, and (optionally) the true spacecraft state for
 //! debugging.
 
-use core::fmt;
-
 use arika::epoch::Epoch;
 use arika::frame::{Body, Eci, Rotation, SimpleEci, Vec3};
 
@@ -61,6 +59,7 @@ impl AngularVelocityBody {
 /// `Vector4` cannot say what it means. `F` defaults to
 /// [`SimpleEci`](arika::frame::SimpleEci), the frame the plugin path
 /// propagates in.
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AttitudeBodyToInertial<F: Eci = SimpleEci>(Rotation<Body, F>);
 
 impl<F: Eci> AttitudeBodyToInertial<F> {
@@ -98,27 +97,6 @@ impl AttitudeBodyToInertial<SimpleEci> {
     }
 }
 
-// Manual impls to avoid requiring `F: Debug/Clone/Copy/PartialEq`
-// (the frame is a phantom tag, never a value).
-impl<F: Eci> fmt::Debug for AttitudeBodyToInertial<F> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("AttitudeBodyToInertial")
-            .field(&self.0)
-            .finish()
-    }
-}
-impl<F: Eci> Clone for AttitudeBodyToInertial<F> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<F: Eci> Copy for AttitudeBodyToInertial<F> {}
-impl<F: Eci> PartialEq for AttitudeBodyToInertial<F> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
 // sensor readings
 
 /// Sensor readings evaluated at the current tick instant.
@@ -136,6 +114,7 @@ impl<F: Eci> PartialEq for AttitudeBodyToInertial<F> {
 /// [`SimpleEci`](arika::frame::SimpleEci), which is what [`TickInput`] accepts:
 /// a bundle evaluated in another frame cannot be handed to a plugin, because
 /// the v0 plugin contract is defined in simple-ECI.
+#[derive(Debug, Clone)]
 pub struct Sensors<F: Eci = SimpleEci> {
     /// Magnetometer readings. Pre-evaluated once per tick.
     pub magnetometers: Vec<MagneticFieldBody>,
@@ -152,34 +131,13 @@ pub struct Sensors<F: Eci = SimpleEci> {
 
 impl<F: Eci> Sensors<F> {
     /// Construct an empty set of readings (no sensors configured).
+    ///
+    /// The only constructor: there is no `Default` impl. `derive(Default)` would
+    /// demand `F: Default`, and a frame marker has no default — "the default
+    /// frame" is exactly the implicit choice this frame tagging exists to
+    /// prevent — while a hand-written one would just be a second name for
+    /// `empty()`.
     pub fn empty() -> Self {
-        Self::default()
-    }
-}
-
-// Manual impls to avoid requiring `F: Debug/Clone/Default`.
-impl<F: Eci> fmt::Debug for Sensors<F> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Sensors")
-            .field("magnetometers", &self.magnetometers)
-            .field("gyroscopes", &self.gyroscopes)
-            .field("star_trackers", &self.star_trackers)
-            .field("sun_sensors", &self.sun_sensors)
-            .finish()
-    }
-}
-impl<F: Eci> Clone for Sensors<F> {
-    fn clone(&self) -> Self {
-        Self {
-            magnetometers: self.magnetometers.clone(),
-            gyroscopes: self.gyroscopes.clone(),
-            star_trackers: self.star_trackers.clone(),
-            sun_sensors: self.sun_sensors.clone(),
-        }
-    }
-}
-impl<F: Eci> Default for Sensors<F> {
-    fn default() -> Self {
         Self {
             magnetometers: Vec::new(),
             gyroscopes: Vec::new(),

--- a/orts/src/plugin/tick_input.rs
+++ b/orts/src/plugin/tick_input.rs
@@ -8,8 +8,7 @@
 use core::fmt;
 
 use arika::epoch::Epoch;
-use arika::frame::{Body, Rotation, SimpleEci, Vec3};
-use nalgebra::Vector4;
+use arika::frame::{Body, Eci, Rotation, SimpleEci, Vec3};
 
 use crate::SpacecraftState;
 
@@ -62,9 +61,9 @@ impl AngularVelocityBody {
 /// `Vector4` cannot say what it means. `F` defaults to
 /// [`SimpleEci`](arika::frame::SimpleEci), the frame the plugin path
 /// propagates in.
-pub struct AttitudeBodyToInertial<F = SimpleEci>(Rotation<Body, F>);
+pub struct AttitudeBodyToInertial<F: Eci = SimpleEci>(Rotation<Body, F>);
 
-impl<F> AttitudeBodyToInertial<F> {
+impl<F: Eci> AttitudeBodyToInertial<F> {
     /// Wrap a body→`F` rotation as an attitude reading in `F`.
     pub fn new(rotation: Rotation<Body, F>) -> Self {
         Self(rotation)
@@ -80,40 +79,41 @@ impl<F> AttitudeBodyToInertial<F> {
 }
 
 impl AttitudeBodyToInertial<SimpleEci> {
-    /// Drop the frame tag for the **v0 plugin WIT boundary**: the four
-    /// components `(w, x, y, z)` of the body→simple-ECI quaternion, Hamilton
-    /// convention, scalar-first.
+    /// Drop the frame tag for the **v0 plugin WIT boundary**: the components
+    /// `(w, x, y, z)` of the body→simple-ECI quaternion, Hamilton convention.
     ///
-    /// The v0 `attitude-body-to-inertial` record in
-    /// [`wit/v0/orts.wit`](https://github.com/sksat/orts/blob/main/orts/wit/v0/orts.wit)
+    /// The v0 `attitude-body-to-inertial` record in `orts/wit/v0/orts.wit`
     /// carries four bare floats whose frame is *defined* by the contract to be
-    /// simple-ECI. Guests therefore cannot be handed a reading from any other
-    /// frame, and this — the only sanctioned way across that boundary — exists
+    /// simple-ECI. This is the named crossing for that boundary, and it exists
     /// only for `SimpleEci`: shipping a `Gcrs` attitude to a guest is a compile
-    /// error, not silent nonsense. Widening the contract means a new WIT
+    /// error rather than silent nonsense. Widening the contract means a new WIT
     /// version that names the frame in the payload.
-    pub fn to_wit_v0_simple_eci_quat(&self) -> Vector4<f64> {
+    ///
+    /// `inner()` still hands out the rotation in any frame — the guarantee is
+    /// that the *boundary* operation names its frame, not that the components
+    /// are unreachable.
+    pub fn to_wit_v0_simple_eci_quat(&self) -> (f64, f64, f64, f64) {
         let q = self.0.inner();
-        Vector4::new(q.w, q.i, q.j, q.k)
+        (q.w, q.i, q.j, q.k)
     }
 }
 
 // Manual impls to avoid requiring `F: Debug/Clone/Copy/PartialEq`
 // (the frame is a phantom tag, never a value).
-impl<F> fmt::Debug for AttitudeBodyToInertial<F> {
+impl<F: Eci> fmt::Debug for AttitudeBodyToInertial<F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("AttitudeBodyToInertial")
             .field(&self.0)
             .finish()
     }
 }
-impl<F> Clone for AttitudeBodyToInertial<F> {
+impl<F: Eci> Clone for AttitudeBodyToInertial<F> {
     fn clone(&self) -> Self {
         *self
     }
 }
-impl<F> Copy for AttitudeBodyToInertial<F> {}
-impl<F> PartialEq for AttitudeBodyToInertial<F> {
+impl<F: Eci> Copy for AttitudeBodyToInertial<F> {}
+impl<F: Eci> PartialEq for AttitudeBodyToInertial<F> {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }
@@ -128,12 +128,15 @@ impl<F> PartialEq for AttitudeBodyToInertial<F> {
 /// does not change during a simulation run.
 ///
 /// `F` is the inertial frame the state was propagated in, carried by the
-/// frame-dependent readings ([`AttitudeBodyToInertial`]); the body-frame ones
-/// are frame-independent. It defaults to
+/// attitude readings ([`AttitudeBodyToInertial`]), whose components depend on
+/// it. The body-frame readings are unaffected to the precision that matters —
+/// the gyro's ω is the rate relative to `F`, but two inertial frames differ
+/// only by their relative rotation rate (~8e-12 rad/s for
+/// `SimpleEci` ↔ `Gcrs`). `F` defaults to
 /// [`SimpleEci`](arika::frame::SimpleEci), which is what [`TickInput`] accepts:
 /// a bundle evaluated in another frame cannot be handed to a plugin, because
 /// the v0 plugin contract is defined in simple-ECI.
-pub struct Sensors<F = SimpleEci> {
+pub struct Sensors<F: Eci = SimpleEci> {
     /// Magnetometer readings. Pre-evaluated once per tick.
     pub magnetometers: Vec<MagneticFieldBody>,
 
@@ -147,7 +150,7 @@ pub struct Sensors<F = SimpleEci> {
     pub sun_sensors: Vec<SunSensorOutput>,
 }
 
-impl<F> Sensors<F> {
+impl<F: Eci> Sensors<F> {
     /// Construct an empty set of readings (no sensors configured).
     pub fn empty() -> Self {
         Self::default()
@@ -155,7 +158,7 @@ impl<F> Sensors<F> {
 }
 
 // Manual impls to avoid requiring `F: Debug/Clone/Default`.
-impl<F> fmt::Debug for Sensors<F> {
+impl<F: Eci> fmt::Debug for Sensors<F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Sensors")
             .field("magnetometers", &self.magnetometers)
@@ -165,7 +168,7 @@ impl<F> fmt::Debug for Sensors<F> {
             .finish()
     }
 }
-impl<F> Clone for Sensors<F> {
+impl<F: Eci> Clone for Sensors<F> {
     fn clone(&self) -> Self {
         Self {
             magnetometers: self.magnetometers.clone(),
@@ -175,7 +178,7 @@ impl<F> Clone for Sensors<F> {
         }
     }
 }
-impl<F> Default for Sensors<F> {
+impl<F: Eci> Default for Sensors<F> {
     fn default() -> Self {
         Self {
             magnetometers: Vec::new(),

--- a/orts/src/plugin/tick_input.rs
+++ b/orts/src/plugin/tick_input.rs
@@ -5,8 +5,10 @@
 //! readings, and (optionally) the true spacecraft state for
 //! debugging.
 
+use core::fmt;
+
 use arika::epoch::Epoch;
-use arika::frame::{Body, Vec3};
+use arika::frame::{Body, Rotation, SimpleEci, Vec3};
 use nalgebra::Vector4;
 
 use crate::SpacecraftState;
@@ -51,21 +53,69 @@ impl AngularVelocityBody {
     }
 }
 
-/// Attitude quaternion representing the rotation from the body frame
-/// to the inertial (ECI) frame. Hamilton convention, scalar-first
-/// `[w, x, y, z]`.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct AttitudeBodyToInertial(Vector4<f64>);
+/// Attitude: the rotation from the body frame to the inertial frame `F`.
+///
+/// The frame is part of the type. A quaternion's components depend on the
+/// frame it is expressed against — the same physical attitude has different
+/// components in `SimpleEci` and in `Gcrs` (the two differ by
+/// precession/nutation, ~0.1° at the pole by 2024) — so an untagged
+/// `Vector4` cannot say what it means. `F` defaults to
+/// [`SimpleEci`](arika::frame::SimpleEci), the frame the plugin path
+/// propagates in.
+pub struct AttitudeBodyToInertial<F = SimpleEci>(Rotation<Body, F>);
 
-impl AttitudeBodyToInertial {
-    pub fn new(v: Vector4<f64>) -> Self {
-        Self(v)
+impl<F> AttitudeBodyToInertial<F> {
+    /// Wrap a body→`F` rotation as an attitude reading in `F`.
+    pub fn new(rotation: Rotation<Body, F>) -> Self {
+        Self(rotation)
     }
-    pub fn inner(&self) -> &Vector4<f64> {
+    /// Borrow the inner rotation.
+    pub fn inner(&self) -> &Rotation<Body, F> {
         &self.0
     }
-    pub fn into_inner(self) -> Vector4<f64> {
+    /// Consume and return the inner rotation.
+    pub fn into_inner(self) -> Rotation<Body, F> {
         self.0
+    }
+}
+
+impl AttitudeBodyToInertial<SimpleEci> {
+    /// Drop the frame tag for the **v0 plugin WIT boundary**: the four
+    /// components `(w, x, y, z)` of the body→simple-ECI quaternion, Hamilton
+    /// convention, scalar-first.
+    ///
+    /// The v0 `attitude-body-to-inertial` record in
+    /// [`wit/v0/orts.wit`](https://github.com/sksat/orts/blob/main/orts/wit/v0/orts.wit)
+    /// carries four bare floats whose frame is *defined* by the contract to be
+    /// simple-ECI. Guests therefore cannot be handed a reading from any other
+    /// frame, and this — the only sanctioned way across that boundary — exists
+    /// only for `SimpleEci`: shipping a `Gcrs` attitude to a guest is a compile
+    /// error, not silent nonsense. Widening the contract means a new WIT
+    /// version that names the frame in the payload.
+    pub fn to_wit_v0_simple_eci_quat(&self) -> Vector4<f64> {
+        let q = self.0.inner();
+        Vector4::new(q.w, q.i, q.j, q.k)
+    }
+}
+
+// Manual impls to avoid requiring `F: Debug/Clone/Copy/PartialEq`
+// (the frame is a phantom tag, never a value).
+impl<F> fmt::Debug for AttitudeBodyToInertial<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("AttitudeBodyToInertial")
+            .field(&self.0)
+            .finish()
+    }
+}
+impl<F> Clone for AttitudeBodyToInertial<F> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<F> Copy for AttitudeBodyToInertial<F> {}
+impl<F> PartialEq for AttitudeBodyToInertial<F> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
     }
 }
 
@@ -76,25 +126,63 @@ impl AttitudeBodyToInertial {
 /// Each field is a `Vec` — empty means no sensor of that type is
 /// configured. Index order is stable (config definition order) and
 /// does not change during a simulation run.
-#[derive(Debug, Clone, Default)]
-pub struct Sensors {
+///
+/// `F` is the inertial frame the state was propagated in, carried by the
+/// frame-dependent readings ([`AttitudeBodyToInertial`]); the body-frame ones
+/// are frame-independent. It defaults to
+/// [`SimpleEci`](arika::frame::SimpleEci), which is what [`TickInput`] accepts:
+/// a bundle evaluated in another frame cannot be handed to a plugin, because
+/// the v0 plugin contract is defined in simple-ECI.
+pub struct Sensors<F = SimpleEci> {
     /// Magnetometer readings. Pre-evaluated once per tick.
     pub magnetometers: Vec<MagneticFieldBody>,
 
     /// Gyroscope readings.
     pub gyroscopes: Vec<AngularVelocityBody>,
 
-    /// Star tracker readings.
-    pub star_trackers: Vec<AttitudeBodyToInertial>,
+    /// Star tracker readings, expressed against `F`.
+    pub star_trackers: Vec<AttitudeBodyToInertial<F>>,
 
     /// Sun sensor outputs.
     pub sun_sensors: Vec<SunSensorOutput>,
 }
 
-impl Sensors {
+impl<F> Sensors<F> {
     /// Construct an empty set of readings (no sensors configured).
     pub fn empty() -> Self {
         Self::default()
+    }
+}
+
+// Manual impls to avoid requiring `F: Debug/Clone/Default`.
+impl<F> fmt::Debug for Sensors<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Sensors")
+            .field("magnetometers", &self.magnetometers)
+            .field("gyroscopes", &self.gyroscopes)
+            .field("star_trackers", &self.star_trackers)
+            .field("sun_sensors", &self.sun_sensors)
+            .finish()
+    }
+}
+impl<F> Clone for Sensors<F> {
+    fn clone(&self) -> Self {
+        Self {
+            magnetometers: self.magnetometers.clone(),
+            gyroscopes: self.gyroscopes.clone(),
+            star_trackers: self.star_trackers.clone(),
+            sun_sensors: self.sun_sensors.clone(),
+        }
+    }
+}
+impl<F> Default for Sensors<F> {
+    fn default() -> Self {
+        Self {
+            magnetometers: Vec::new(),
+            gyroscopes: Vec::new(),
+            star_trackers: Vec::new(),
+            sun_sensors: Vec::new(),
+        }
     }
 }
 
@@ -181,6 +269,10 @@ pub struct TickInput<'a> {
     pub epoch: Option<&'a Epoch>,
     /// Sensor readings evaluated at this tick. May contain noise;
     /// use `spacecraft` for ground-truth.
+    ///
+    /// Simple-ECI, like `spacecraft`: that is what the v0 plugin contract
+    /// defines, so a bundle evaluated in another inertial frame does not fit
+    /// here (see [`Sensors`]).
     pub sensors: &'a Sensors,
     /// Actuator telemetry (e.g. RW momentum/speed) at this tick.
     pub actuators: &'a ActuatorTelemetry,

--- a/orts/src/plugin/wasm/convert.rs
+++ b/orts/src/plugin/wasm/convert.rs
@@ -126,7 +126,10 @@ macro_rules! impl_convert {
                     .star_trackers
                     .iter()
                     .map(|a| {
-                        let q = a.into_inner();
+                        // Frame-checked crossing: the v0 payload is defined as
+                        // body→simple-ECI, and this named operation exists only
+                        // for a `SimpleEci`-tagged reading.
+                        let q = a.to_wit_v0_simple_eci_quat();
                         wit::AttitudeBodyToInertial {
                             w: q[0],
                             x: q[1],
@@ -317,14 +320,14 @@ pub mod sync {
             use crate::plugin::tick_input::{
                 AngularVelocityBody, AttitudeBodyToInertial, MagneticFieldBody,
             };
-            use arika::frame::{Body, Vec3};
+            use arika::frame::{Body, Rotation, Vec3};
             let sensors = Sensors {
                 magnetometers: vec![MagneticFieldBody::new(Vec3::<Body>::new(1e-5, 2e-5, -3e-5))],
                 gyroscopes: vec![AngularVelocityBody::new(Vec3::<Body>::new(
                     0.1, 0.05, -0.03,
                 ))],
-                star_trackers: vec![AttitudeBodyToInertial::new(Vector4::new(
-                    1.0, 0.0, 0.0, 0.0,
+                star_trackers: vec![AttitudeBodyToInertial::new(Rotation::from_raw(
+                    nalgebra::UnitQuaternion::identity(),
                 ))],
                 sun_sensors: vec![],
             };
@@ -366,9 +369,9 @@ pub mod sync {
                 0.7,
             );
             let sensors = Sensors {
-                star_trackers: vec![AttitudeBodyToInertial::new(Vector4::new(
-                    q.w, q.i, q.j, q.k,
-                ))],
+                star_trackers: vec![AttitudeBodyToInertial::new(
+                    arika::frame::Rotation::from_raw(q),
+                )],
                 ..Sensors::empty()
             };
             let actuators = ActuatorTelemetry::default();

--- a/orts/src/plugin/wasm/convert.rs
+++ b/orts/src/plugin/wasm/convert.rs
@@ -353,6 +353,51 @@ pub mod sync {
             assert_eq!(wit_obs.sensors.star_trackers[0].w, 1.0);
         }
 
+        /// Characterization: the v0 WIT attitude payload carries the four
+        /// quaternion components in `(w, x, y, z)` order. Pinned with four
+        /// distinct non-zero components, which the identity quaternion of
+        /// `observation_roundtrip_preserves_values` cannot discriminate.
+        #[test]
+        fn star_tracker_wit_payload_component_order() {
+            use crate::plugin::tick_input::AttitudeBodyToInertial;
+            let spacecraft = make_spacecraft();
+            let q = nalgebra::UnitQuaternion::from_axis_angle(
+                &nalgebra::Unit::new_normalize(Vector3::new(0.3, -0.5, 0.8)),
+                0.7,
+            );
+            let sensors = Sensors {
+                star_trackers: vec![AttitudeBodyToInertial::new(Vector4::new(
+                    q.w, q.i, q.j, q.k,
+                ))],
+                ..Sensors::empty()
+            };
+            let actuators = ActuatorTelemetry::default();
+            let obs = TickInput {
+                t: 0.0,
+                epoch: None,
+                sensors: &sensors,
+                actuators: &actuators,
+                spacecraft: &spacecraft,
+            };
+            let wit_obs = tick_input_to_wit(&obs);
+            let got = &wit_obs.sensors.star_trackers[0];
+            // The boundary is a pure copy, so the order is pinned exactly.
+            assert_eq!([got.w, got.x, got.y, got.z], [q.w, q.i, q.j, q.k]);
+            // Pinned literals so a re-ordering of `q`'s own components would
+            // still be caught (relative: the fixture goes through libm trig).
+            let expected = Vector4::new(
+                0.9393727128473789,
+                0.10391372781674944,
+                -0.17318954636124906,
+                0.27710327417799857,
+            );
+            let actual = Vector4::new(got.w, got.x, got.y, got.z);
+            assert!(
+                (actual - expected).magnitude() <= 1e-12 * expected.magnitude(),
+                "v0 WIT attitude payload changed: {actual:?}"
+            );
+        }
+
         #[test]
         fn observation_empty_sensors() {
             let spacecraft = make_spacecraft();

--- a/orts/src/plugin/wasm/convert.rs
+++ b/orts/src/plugin/wasm/convert.rs
@@ -129,13 +129,8 @@ macro_rules! impl_convert {
                         // Frame-checked crossing: the v0 payload is defined as
                         // body→simple-ECI, and this named operation exists only
                         // for a `SimpleEci`-tagged reading.
-                        let q = a.to_wit_v0_simple_eci_quat();
-                        wit::AttitudeBodyToInertial {
-                            w: q[0],
-                            x: q[1],
-                            y: q[2],
-                            z: q[3],
-                        }
+                        let (w, x, y, z) = a.to_wit_v0_simple_eci_quat();
+                        wit::AttitudeBodyToInertial { w, x, y, z }
                     })
                     .collect(),
                 sun_sensors: s

--- a/orts/src/sensor/magnetometer.rs
+++ b/orts/src/sensor/magnetometer.rs
@@ -14,6 +14,7 @@ use tobari::magnetic::MagneticFieldModel;
 use super::noise::NoiseModel;
 use crate::SpacecraftState;
 use crate::magnetic;
+use crate::model::HasAttitude;
 use crate::plugin::tick_input::MagneticFieldBody;
 
 /// Three-axis magnetometer.
@@ -79,10 +80,7 @@ impl Magnetometer {
             &state.orbit.position_vec(),
             orientation,
         );
-        let b_body_typed = state
-            .attitude
-            .rotation_from_inertial::<F>()
-            .transform(&b_inertial);
+        let b_body_typed = state.attitude_from_inertial().transform(&b_inertial);
         let mut b_body = b_body_typed.into_inner();
         for n in &mut self.noise {
             b_body = n.apply(b_body);
@@ -202,8 +200,7 @@ mod tests {
             &EarthOrientation::new(epoch, &zero_eop()),
         );
         let expected = state
-            .attitude
-            .rotation_from_inertial::<frame::Gcrs>()
+            .attitude_from_inertial()
             .transform(&b_gcrs)
             .into_inner();
         assert!(

--- a/orts/src/sensor/mod.rs
+++ b/orts/src/sensor/mod.rs
@@ -184,6 +184,44 @@ mod tests {
         assert!(readings.star_trackers.is_empty());
     }
 
+    /// The bundle's frame parameter is the one the state was propagated in:
+    /// `evaluate_in_frame::<Gcrs>` yields `Sensors<Gcrs>` (the annotation is
+    /// the assertion), whose star-tracker readings are `Gcrs`-tagged. The
+    /// components are the state quaternion's either way — which is why the tag
+    /// has to travel with them.
+    #[test]
+    fn evaluate_in_frame_tags_the_readings_with_that_frame() {
+        use crate::test_support::zero_eop;
+
+        let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
+        let simple = make_state();
+        let state = SpacecraftState::<frame::Gcrs> {
+            orbit: OrbitalState::<frame::Gcrs>::new_in_frame(
+                *simple.orbit.position(),
+                *simple.orbit.velocity(),
+            ),
+            attitude: simple.attitude.clone(),
+            mass: simple.mass,
+        };
+
+        let mut bundle = SensorBundle {
+            magnetometers: Vec::new(),
+            gyroscopes: Vec::new(),
+            star_trackers: vec![StarTracker::new()],
+            sun_sensors: Vec::new(),
+        };
+        let readings: Sensors<frame::Gcrs> = bundle
+            .evaluate_in_frame::<frame::Gcrs>(&state, &EarthOrientation::new(epoch, &zero_eop()));
+
+        assert_eq!(readings.star_trackers.len(), 1);
+        let q = readings.star_trackers[0].inner().inner();
+        assert_eq!(
+            Vector4::new(q.w, q.i, q.j, q.k),
+            state.attitude.quaternion,
+            "the reading is the state quaternion, re-tagged as Gcrs"
+        );
+    }
+
     #[test]
     fn multiple_gyroscopes() {
         let mut bundle = SensorBundle {

--- a/orts/src/sensor/mod.rs
+++ b/orts/src/sensor/mod.rs
@@ -95,11 +95,15 @@ impl SensorBundle {
     /// magnetometers; evaluate those sensors with their own
     /// `measure_in_frame` instead. Split this into per-capability entry points
     /// if a caller needs the bundle in such a frame.
+    ///
+    /// The returned [`Sensors<F>`](Sensors) carries `F`, so a bundle evaluated
+    /// in one inertial frame cannot be consumed as another — nor handed to a
+    /// plugin, whose v0 contract is simple-ECI.
     pub fn evaluate_in_frame<F: EarthFixedTransform + EphemerisFrameBridge>(
         &mut self,
         state: &SpacecraftState<F>,
         orientation: &EarthOrientation<'_, F>,
-    ) -> Sensors {
+    ) -> Sensors<F> {
         // The non-magnetometer sensors need only the instant.
         let epoch = orientation.utc();
         Sensors {

--- a/orts/src/sensor/star_tracker.rs
+++ b/orts/src/sensor/star_tracker.rs
@@ -277,10 +277,16 @@ mod tests {
                 },
                 mass: 50.0,
             };
+            // The claim is that the non-finite input propagates rather than
+            // being swallowed into a plausible-looking attitude. Which
+            // components come out NaN and which ±inf depends on how
+            // `UnitQuaternion::from_quaternion` normalizes, so pinning
+            // all-NaN would be a claim about nalgebra's internals, not about
+            // this sensor.
             let ideal = components(&StarTracker::new().measure(&state, &epoch));
             assert!(
-                ideal.iter().all(|c| c.is_nan()),
-                "expected an all-NaN ideal reading for {bad}, got {ideal:?}"
+                ideal.iter().any(|c| !c.is_finite()),
+                "expected a non-finite ideal reading for {bad}, got {ideal:?}"
             );
             let noisy = components(
                 &StarTracker::new()
@@ -288,8 +294,8 @@ mod tests {
                     .measure(&state, &epoch),
             );
             assert!(
-                noisy.iter().all(|c| c.is_nan()),
-                "expected an all-NaN noisy reading for {bad}, got {noisy:?}"
+                noisy.iter().any(|c| !c.is_finite()),
+                "expected a non-finite noisy reading for {bad}, got {noisy:?}"
             );
         }
     }

--- a/orts/src/sensor/star_tracker.rs
+++ b/orts/src/sensor/star_tracker.rs
@@ -142,6 +142,147 @@ mod tests {
         assert_eq!(s1.measure(&state, &epoch), s2.measure(&state, &epoch));
     }
 
+    // Characterization for the frame-typed attitude reading (#332)
+
+    /// A state whose attitude has four distinct, non-zero quaternion
+    /// components, so a component-wise snapshot cannot pass by symmetry.
+    fn nontrivial_state() -> SpacecraftState {
+        SpacecraftState {
+            orbit: OrbitalState::new(
+                Vector3::new(4000.0, -5000.0, 2500.0),
+                Vector3::new(1.0, 2.0, 7.0),
+            ),
+            attitude: AttitudeState::new(
+                UnitQuaternion::from_axis_angle(
+                    &nalgebra::Unit::new_normalize(Vector3::new(0.3, -0.5, 0.8)),
+                    0.7,
+                ),
+                Vector3::new(0.01, -0.02, 0.03),
+            ),
+            mass: 50.0,
+        }
+    }
+
+    fn assert_close(got: Vector4<f64>, expected: Vector4<f64>, what: &str) {
+        assert!(
+            (got - expected).magnitude() <= 1e-12 * expected.magnitude(),
+            "{what} changed: {got:?}"
+        );
+    }
+
+    /// Characterization: the ideal reading is the state quaternion, component
+    /// for component, in `[w, x, y, z]` order.
+    #[test]
+    fn ideal_measurement_components_snapshot() {
+        let mut stt = StarTracker::new();
+        let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
+        let got = stt.measure(&nontrivial_state(), &epoch).into_inner();
+        assert_close(
+            got,
+            Vector4::new(
+                0.9393727128473789,
+                0.10391372781674944,
+                -0.17318954636124906,
+                0.27710327417799857,
+            ),
+            "ideal star tracker reading",
+        );
+    }
+
+    /// Characterization: the noise draw itself — RNG stream, per-axis σ order,
+    /// and the `q_true * δq` composition order — is pinned numerically, for
+    /// both the isotropic and the anisotropic constructor.
+    #[test]
+    fn noisy_measurement_components_snapshot() {
+        let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
+
+        let mut isotropic = StarTracker::new().with_pointing_noise_isotropic(5e-5, 42);
+        assert_close(
+            isotropic.measure(&nontrivial_state(), &epoch).into_inner(),
+            Vector4::new(
+                0.9393712890258086,
+                0.10391330045435347,
+                -0.17318662555980863,
+                0.277110086553847,
+            ),
+            "isotropic noisy star tracker reading",
+        );
+
+        let mut anisotropic =
+            StarTracker::new().with_pointing_noise(Vector3::new(1e-5, 5e-5, 2e-4), 7);
+        assert_close(
+            anisotropic
+                .measure(&nontrivial_state(), &epoch)
+                .into_inner(),
+            Vector4::new(
+                0.939390464493437,
+                0.10392513965336554,
+                -0.1731971454146844,
+                0.2770340581716219,
+            ),
+            "anisotropic noisy star tracker reading",
+        );
+    }
+
+    /// Characterization: `measure_in_frame` is a pure re-tag — the components
+    /// are the state quaternion's, whatever inertial frame is named, because
+    /// [`AttitudeState`] stores an untyped quaternion. This is precisely why the
+    /// reading must carry its frame in the type: the numbers alone say nothing.
+    #[test]
+    fn measurement_components_are_identical_in_every_frame() {
+        let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
+        let state = nontrivial_state();
+
+        let simple = StarTracker::new()
+            .measure_in_frame::<arika::frame::SimpleEci>(&state, &epoch)
+            .into_inner();
+        let gcrs_state = SpacecraftState::<arika::frame::Gcrs> {
+            orbit: OrbitalState::<arika::frame::Gcrs>::new_in_frame(
+                Vector3::new(4000.0, -5000.0, 2500.0),
+                Vector3::new(1.0, 2.0, 7.0),
+            ),
+            attitude: state.attitude.clone(),
+            mass: state.mass,
+        };
+        let gcrs = StarTracker::new()
+            .measure_in_frame::<arika::frame::Gcrs>(&gcrs_state, &epoch)
+            .into_inner();
+        assert_eq!(simple, gcrs);
+    }
+
+    /// Characterization: a non-finite attitude yields a non-finite reading
+    /// rather than a panic, on both the ideal and the noisy path.
+    #[test]
+    fn non_finite_attitude_yields_non_finite_reading() {
+        let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let state = SpacecraftState {
+                orbit: OrbitalState::new(
+                    Vector3::new(7000.0, 0.0, 0.0),
+                    Vector3::new(0.0, 7.5, 0.0),
+                ),
+                attitude: AttitudeState {
+                    quaternion: Vector4::new(bad, 0.0, 0.0, 1.0),
+                    angular_velocity: Vector3::zeros(),
+                },
+                mass: 50.0,
+            };
+            let ideal = StarTracker::new().measure(&state, &epoch).into_inner();
+            assert!(
+                ideal.iter().all(|c| c.is_nan()),
+                "expected an all-NaN ideal reading for {bad}, got {ideal:?}"
+            );
+            let noisy = StarTracker::new()
+                .with_pointing_noise_isotropic(5e-5, 42)
+                .measure(&state, &epoch)
+                .into_inner();
+            assert!(
+                noisy.iter().all(|c| c.is_nan()),
+                "expected an all-NaN noisy reading for {bad}, got {noisy:?}"
+            );
+        }
+    }
+
     #[test]
     fn noise_magnitude_is_reasonable() {
         let sigma = 1e-4; // ~20 arcsec

--- a/orts/src/sensor/star_tracker.rs
+++ b/orts/src/sensor/star_tracker.rs
@@ -5,7 +5,8 @@
 //! rotation perturbation to model pointing error.
 
 use arika::epoch::Epoch;
-use nalgebra::{UnitQuaternion, Vector3, Vector4};
+use arika::frame::{Body, Rotation};
+use nalgebra::{UnitQuaternion, Vector3};
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 use rand_distr::Normal;
@@ -58,17 +59,19 @@ impl StarTracker {
     ///
     /// The reading is the body→`F` rotation, and its components depend on `F`:
     /// the same physical attitude has different quaternion components in
-    /// `SimpleEci` and in `Gcrs`. [`AttitudeBodyToInertial`] does not record
-    /// which frame it came from, so a caller must interpret the value in the
-    /// frame the state was propagated in — nothing here can catch a `Gcrs`
-    /// reading being consumed as `SimpleEci`. Closing that hole needs a
-    /// frame-typed attitude output (`Rotation<Body, F>`), which also reaches the
-    /// plugin WIT payload; it is tracked separately.
+    /// `SimpleEci` and in `Gcrs`. The returned
+    /// [`AttitudeBodyToInertial<F>`](AttitudeBodyToInertial) carries that frame
+    /// in its type, so a `Gcrs` reading cannot be consumed as `SimpleEci`.
+    ///
+    /// The *components* are the same either way — [`crate::attitude::AttitudeState`]
+    /// stores an untyped quaternion, and this re-tags it with the frame the
+    /// state was propagated in. That is exactly why the tag has to travel with
+    /// the value: the numbers alone do not say which frame they belong to.
     pub fn measure_in_frame<F: arika::frame::Eci>(
         &mut self,
         state: &SpacecraftState<F>,
         _epoch: &Epoch,
-    ) -> AttitudeBodyToInertial {
+    ) -> AttitudeBodyToInertial<F> {
         let q_true = UnitQuaternion::from_quaternion(state.attitude.orientation().into_inner());
 
         let q_measured = match &mut self.sigma {
@@ -82,8 +85,7 @@ impl StarTracker {
             None => q_true,
         };
 
-        let q = q_measured.into_inner();
-        AttitudeBodyToInertial::new(Vector4::new(q.w, q.i, q.j, q.k))
+        AttitudeBodyToInertial::new(Rotation::<Body, F>::from_raw(q_measured))
     }
 }
 
@@ -98,6 +100,16 @@ mod tests {
     use super::*;
     use crate::attitude::AttitudeState;
     use crate::orbital::OrbitalState;
+    use nalgebra::Vector4;
+
+    /// The four components `(w, x, y, z)` of a reading, for value assertions.
+    /// Available in any frame: the point of the frame tag is that the caller
+    /// must name a frame to *interpret* these numbers, not that it cannot read
+    /// them.
+    fn components<F>(a: &AttitudeBodyToInertial<F>) -> Vector4<f64> {
+        let q = a.inner().inner();
+        Vector4::new(q.w, q.i, q.j, q.k)
+    }
 
     fn make_state() -> SpacecraftState {
         SpacecraftState {
@@ -116,7 +128,7 @@ mod tests {
         let state = make_state();
         let epoch = Epoch::j2000();
         let q = stt.measure(&state, &epoch);
-        assert_eq!(q.into_inner(), state.attitude.quaternion);
+        assert_eq!(components(&q), state.attitude.quaternion);
     }
 
     #[test]
@@ -126,9 +138,9 @@ mod tests {
         let state = make_state();
         let epoch = Epoch::j2000();
         let q = stt.measure(&state, &epoch);
-        assert_ne!(q.into_inner(), state.attitude.quaternion);
+        assert_ne!(components(&q), state.attitude.quaternion);
         // Should still be close to unit quaternion.
-        let q = q.into_inner();
+        let q = components(&q);
         let norm = (q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]).sqrt();
         assert!((norm - 1.0).abs() < 1e-10);
     }
@@ -176,7 +188,7 @@ mod tests {
     fn ideal_measurement_components_snapshot() {
         let mut stt = StarTracker::new();
         let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
-        let got = stt.measure(&nontrivial_state(), &epoch).into_inner();
+        let got = components(&stt.measure(&nontrivial_state(), &epoch));
         assert_close(
             got,
             Vector4::new(
@@ -198,7 +210,7 @@ mod tests {
 
         let mut isotropic = StarTracker::new().with_pointing_noise_isotropic(5e-5, 42);
         assert_close(
-            isotropic.measure(&nontrivial_state(), &epoch).into_inner(),
+            components(&isotropic.measure(&nontrivial_state(), &epoch)),
             Vector4::new(
                 0.9393712890258086,
                 0.10391330045435347,
@@ -211,9 +223,7 @@ mod tests {
         let mut anisotropic =
             StarTracker::new().with_pointing_noise(Vector3::new(1e-5, 5e-5, 2e-4), 7);
         assert_close(
-            anisotropic
-                .measure(&nontrivial_state(), &epoch)
-                .into_inner(),
+            components(&anisotropic.measure(&nontrivial_state(), &epoch)),
             Vector4::new(
                 0.939390464493437,
                 0.10392513965336554,
@@ -233,9 +243,9 @@ mod tests {
         let epoch = Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0);
         let state = nontrivial_state();
 
-        let simple = StarTracker::new()
-            .measure_in_frame::<arika::frame::SimpleEci>(&state, &epoch)
-            .into_inner();
+        let simple = components(
+            &StarTracker::new().measure_in_frame::<arika::frame::SimpleEci>(&state, &epoch),
+        );
         let gcrs_state = SpacecraftState::<arika::frame::Gcrs> {
             orbit: OrbitalState::<arika::frame::Gcrs>::new_in_frame(
                 Vector3::new(4000.0, -5000.0, 2500.0),
@@ -244,9 +254,9 @@ mod tests {
             attitude: state.attitude.clone(),
             mass: state.mass,
         };
-        let gcrs = StarTracker::new()
-            .measure_in_frame::<arika::frame::Gcrs>(&gcrs_state, &epoch)
-            .into_inner();
+        let gcrs = components(
+            &StarTracker::new().measure_in_frame::<arika::frame::Gcrs>(&gcrs_state, &epoch),
+        );
         assert_eq!(simple, gcrs);
     }
 
@@ -267,15 +277,16 @@ mod tests {
                 },
                 mass: 50.0,
             };
-            let ideal = StarTracker::new().measure(&state, &epoch).into_inner();
+            let ideal = components(&StarTracker::new().measure(&state, &epoch));
             assert!(
                 ideal.iter().all(|c| c.is_nan()),
                 "expected an all-NaN ideal reading for {bad}, got {ideal:?}"
             );
-            let noisy = StarTracker::new()
-                .with_pointing_noise_isotropic(5e-5, 42)
-                .measure(&state, &epoch)
-                .into_inner();
+            let noisy = components(
+                &StarTracker::new()
+                    .with_pointing_noise_isotropic(5e-5, 42)
+                    .measure(&state, &epoch),
+            );
             assert!(
                 noisy.iter().all(|c| c.is_nan()),
                 "expected an all-NaN noisy reading for {bad}, got {noisy:?}"
@@ -292,7 +303,7 @@ mod tests {
         let n_samples = 1000;
         let mut max_angle = 0.0_f64;
         for _ in 0..n_samples {
-            let q_meas = stt.measure(&state, &epoch).into_inner();
+            let q_meas = components(&stt.measure(&state, &epoch));
             let q_true = &state.attitude.quaternion;
             // Angular distance: 2 * arccos(|q_true · q_meas|)
             let dot = (q_true[0] * q_meas[0]

--- a/orts/src/sensor/star_tracker.rs
+++ b/orts/src/sensor/star_tracker.rs
@@ -106,7 +106,7 @@ mod tests {
     /// Available in any frame: the point of the frame tag is that the caller
     /// must name a frame to *interpret* these numbers, not that it cannot read
     /// them.
-    fn components<F>(a: &AttitudeBodyToInertial<F>) -> Vector4<f64> {
+    fn components<F: arika::frame::Eci>(a: &AttitudeBodyToInertial<F>) -> Vector4<f64> {
         let q = a.inner().inner();
         Vector4::new(q.w, q.i, q.j, q.k)
     }

--- a/orts/src/sensor/sun_sensor.rs
+++ b/orts/src/sensor/sun_sensor.rs
@@ -12,6 +12,7 @@ use arika::sun::sun_position_eci;
 
 use super::noise::NoiseModel;
 use crate::SpacecraftState;
+use crate::model::HasAttitude;
 use crate::plugin::tick_input::{SunDirectionBody, SunSensorOutput};
 
 /// Sun sensor that measures the sun direction in the body frame.
@@ -132,10 +133,7 @@ impl SunSensor {
 
         // Rotate to body frame
         let dir_eci_typed = Vec3::<F>::from_raw(dir_eci);
-        let dir_body = state
-            .attitude
-            .rotation_from_inertial::<F>()
-            .transform(&dir_eci_typed);
+        let dir_body = state.attitude_from_inertial().transform(&dir_eci_typed);
         let mut d = dir_body.into_inner();
 
         for n in &mut self.noise {
@@ -294,8 +292,7 @@ mod tests {
         let sun_cirs = Rotation::<Gcrs, Cirs>::iau2006_model(&epoch.to_tt()).transform(&sun_gcrs);
         let dir_cirs = (sun_cirs.into_inner() - pos).normalize();
         let expected = state
-            .attitude
-            .rotation_from_inertial::<Cirs>()
+            .attitude_from_inertial()
             .transform(&Vec3::<Cirs>::from_raw(dir_cirs))
             .into_inner();
         assert!(

--- a/orts/src/spacecraft/dynamics.rs
+++ b/orts/src/spacecraft/dynamics.rs
@@ -42,11 +42,6 @@ pub struct SpacecraftDynamics<G: GravityField, F: Eci = SimpleEci> {
     _frame: PhantomData<F>,
 }
 
-// Manual Send + Sync: all fields are Send + Sync, PhantomData<F> is fine
-// because F is a ZST frame marker.
-unsafe impl<G: GravityField, F: Eci> Send for SpacecraftDynamics<G, F> {}
-unsafe impl<G: GravityField, F: Eci> Sync for SpacecraftDynamics<G, F> {}
-
 impl<G: GravityField, F: Eci + 'static> SpacecraftDynamics<G, F> {
     /// Create with gravitational parameter, gravity model, and inertia tensor.
     ///

--- a/orts/src/spacecraft/dynamics.rs
+++ b/orts/src/spacecraft/dynamics.rs
@@ -815,7 +815,7 @@ mod tests {
     // `rotation_to_inertial::<F>`). This makes the old SimpleEci→`F`
     // mislabel unrepresentable.
 
-    use crate::model::HasAttitude;
+    use crate::model::{HasAttitude, HasFrame};
     use arika::frame::{Body, Gcrs, Vec3 as FrameVec3};
 
     /// Translational mock: contributes a constant acceleration already
@@ -850,7 +850,7 @@ mod tests {
         accel_body: Vector3<f64>,
     }
 
-    impl<S: HasAttitude, F: Eci> StateEffector<S, F> for BodyThrustEffector {
+    impl<S: HasFrame<Frame = F> + HasAttitude, F: Eci> StateEffector<S, F> for BodyThrustEffector {
         fn name(&self) -> &str {
             "body_thrust"
         }
@@ -866,10 +866,7 @@ mod tests {
             _epoch: Option<&Epoch>,
         ) -> ExternalLoads<F> {
             let a_body = FrameVec3::<Body>::from_raw(self.accel_body);
-            let a_inertial = state
-                .attitude()
-                .rotation_to_inertial::<F>()
-                .transform(&a_body);
+            let a_inertial = state.attitude_to_inertial().transform(&a_body);
             ExternalLoads {
                 acceleration_inertial: a_inertial,
                 torque_body: FrameVec3::zeros(),

--- a/orts/src/spacecraft/dynamics.rs
+++ b/orts/src/spacecraft/dynamics.rs
@@ -812,8 +812,9 @@ mod tests {
     // no coordinate re-tag. Torque-only effectors work on any `F`; a
     // translational effector produces its inertial acceleration in `F`
     // itself (e.g. by rotating a body-frame thrust via
-    // `rotation_to_inertial::<F>`). This makes the old SimpleEci→`F`
-    // mislabel unrepresentable.
+    // `attitude_to_inertial()`, whose `F` comes from the state's
+    // `HasFrame::Frame`). This makes the old SimpleEci→`F` mislabel
+    // unrepresentable.
 
     use crate::model::{HasAttitude, HasFrame};
     use arika::frame::{Body, Gcrs, Vec3 as FrameVec3};
@@ -938,7 +939,7 @@ mod tests {
     #[test]
     fn body_thrust_effector_rotates_into_gcrs() {
         // Regression guard for #103: a body-frame thrust is rotated into the
-        // host frame `F = Gcrs` via rotation_to_inertial::<F>, not re-tagged.
+        // host frame `F = Gcrs` via `attitude_to_inertial()`, not re-tagged.
         // 90° about +Z: body +X thrust → inertial +Y acceleration.
         let half = std::f64::consts::FRAC_PI_2 / 2.0;
         let attitude = AttitudeState {

--- a/orts/src/spacecraft/mtq.rs
+++ b/orts/src/spacecraft/mtq.rs
@@ -15,7 +15,7 @@ use nalgebra::Vector3;
 use tobari::magnetic::MagneticFieldModel;
 
 use crate::magnetic;
-use crate::model::{ExternalLoads, HasAttitude, HasOrbit, Model};
+use crate::model::{ExternalLoads, HasAttitude, HasFrame, HasOrbit, Model};
 
 /// A single magnetic torquer with physical limits.
 #[derive(Debug, Clone)]
@@ -265,8 +265,11 @@ impl<F: MagneticFieldModel, Fr: EarthFixedTransform> MtqAssembly<F, Fr> {
 // `SimpleEci`, the IAU 2006 chain for `Gcrs`), and rotated to the body frame
 // with the matching `Fr → Body` rotation. A frame without an
 // `EarthFixedTransform` impl is rejected at compile time. See #151.
-impl<F: MagneticFieldModel, Fr: EarthFixedTransform, S: HasAttitude + HasOrbit<Frame = Fr>>
-    Model<S, Fr> for MtqAssembly<F, Fr>
+impl<
+    F: MagneticFieldModel,
+    Fr: EarthFixedTransform,
+    S: HasFrame<Frame = Fr> + HasAttitude + HasOrbit,
+> Model<S, Fr> for MtqAssembly<F, Fr>
 {
     fn name(&self) -> &str {
         "mtq_assembly"
@@ -285,8 +288,7 @@ impl<F: MagneticFieldModel, Fr: EarthFixedTransform, S: HasAttitude + HasOrbit<F
             return ExternalLoads::zeros();
         }
         let b_body = state
-            .attitude()
-            .rotation_from_inertial::<Fr>()
+            .attitude_from_inertial()
             .transform(&b_inertial)
             .into_inner();
         let moments = self.resolved_moments();
@@ -319,8 +321,11 @@ mod tests {
         }
     }
 
-    impl HasOrbit for TestState {
+    impl HasFrame for TestState {
         type Frame = frame::SimpleEci;
+    }
+
+    impl HasOrbit for TestState {
         fn orbit(&self) -> &OrbitalState<frame::SimpleEci> {
             &self.orbit
         }
@@ -577,8 +582,7 @@ mod tests {
         )
         .into_inner();
         let b_body = state
-            .attitude
-            .rotation_to_body()
+            .attitude_from_inertial()
             .transform(&FrameVec3::<frame::SimpleEci>::from_raw(b_eci))
             .into_inner();
         let expected = assembly.core.torque(&[0.5, 0.0, 0.0], &b_body);
@@ -707,8 +711,11 @@ mod tests {
                 &self.attitude
             }
         }
-        impl HasOrbit for GcrsState {
+        impl HasFrame for GcrsState {
             type Frame = frame::Gcrs;
+        }
+
+        impl HasOrbit for GcrsState {
             fn orbit(&self) -> &OrbitalState<frame::Gcrs> {
                 &self.orbit
             }
@@ -738,8 +745,7 @@ mod tests {
             &EarthOrientation::new(epoch, &zero_eop()),
         );
         let b_body = state
-            .attitude
-            .rotation_from_inertial::<frame::Gcrs>()
+            .attitude_from_inertial()
             .transform(&b_gcrs)
             .into_inner();
         let expected = assembly.core.torque(&[0.7, -0.3, 0.2], &b_body);

--- a/orts/src/spacecraft/panel_srp.rs
+++ b/orts/src/spacecraft/panel_srp.rs
@@ -7,7 +7,7 @@ use crate::perturbations::SOLAR_RADIATION_PRESSURE;
 use arika::earth::R as R_EARTH;
 use arika::earth::transform::EphemerisFrameBridge;
 
-use crate::model::{HasAttitude, HasMass, HasOrbit, Model};
+use crate::model::{HasAttitude, HasFrame, HasMass, HasOrbit, Model};
 
 use super::{ExternalLoads, SpacecraftShape};
 
@@ -83,7 +83,7 @@ impl PanelSrp {
     pub(crate) fn loads_from_state<F: EphemerisFrameBridge>(
         &self,
         orbit: &crate::OrbitalState<F>,
-        attitude: &crate::attitude::AttitudeState,
+        body_to_inertial: arika::frame::Rotation<arika::frame::Body, F>,
         mass: f64,
         epoch: Option<&Epoch>,
     ) -> ExternalLoads<F> {
@@ -134,8 +134,8 @@ impl PanelSrp {
             }
             SpacecraftShape::Panels(panels) => {
                 // Transform Sun direction to body frame
-                let s_body = attitude
-                    .rotation_from_inertial::<F>()
+                let s_body = body_to_inertial
+                    .inverse()
                     .transform(&arika::frame::Vec3::<F>::from_raw(s_hat))
                     .into_inner();
 
@@ -159,7 +159,7 @@ impl PanelSrp {
 
                 // a_body [m/s²] → a_inertial [km/s²]
                 let a_body = arika::frame::Vec3::from_raw(total_force_body / mass);
-                let a_inertial = attitude.rotation_to_inertial::<F>().transform(&a_body) / 1000.0;
+                let a_inertial = body_to_inertial.transform(&a_body) / 1000.0;
 
                 ExternalLoads {
                     acceleration_inertial: a_inertial,
@@ -177,7 +177,7 @@ impl PanelSrp {
 // the body frame — so panel SRP is valid for any such frame (identity for
 // GCRS-aligned `SimpleEci`/`Gcrs`). A frame without an `EphemerisFrameBridge`
 // impl (e.g. `Teme`) is rejected at compile time. See #191.
-impl<F: EphemerisFrameBridge, S: HasAttitude + HasOrbit<Frame = F> + HasMass> Model<S, F>
+impl<F: EphemerisFrameBridge, S: HasFrame<Frame = F> + HasAttitude + HasOrbit + HasMass> Model<S, F>
     for PanelSrp
 {
     fn name(&self) -> &str {
@@ -185,7 +185,12 @@ impl<F: EphemerisFrameBridge, S: HasAttitude + HasOrbit<Frame = F> + HasMass> Mo
     }
 
     fn eval(&self, _t: f64, state: &S, epoch: Option<&Epoch>) -> ExternalLoads<F> {
-        self.loads_from_state(state.orbit(), state.attitude(), state.mass(), epoch)
+        self.loads_from_state(
+            state.orbit(),
+            state.attitude_to_inertial(),
+            state.mass(),
+            epoch,
+        )
     }
 }
 
@@ -557,7 +562,7 @@ mod tests {
         let att = AttitudeState::identity();
 
         let a_cirs = *srp
-            .loads_from_state(&orbit, &att, 1000.0, Some(&epoch))
+            .loads_from_state(&orbit, att.rotation_tagged_as(), 1000.0, Some(&epoch))
             .acceleration_inertial
             .inner();
 
@@ -599,11 +604,11 @@ mod tests {
         let cirs = OrbitalState::<Cirs>::new_in_frame(sat, vector![0.0, 7.5, 0.0]);
         let simple = OrbitalState::new(sat, vector![0.0, 7.5, 0.0]); // SimpleEci
         let a_cirs = *srp
-            .loads_from_state(&cirs, &att, 1000.0, Some(&epoch))
+            .loads_from_state(&cirs, att.rotation_tagged_as(), 1000.0, Some(&epoch))
             .acceleration_inertial
             .inner();
         let a_simple = *srp
-            .loads_from_state(&simple, &att, 1000.0, Some(&epoch))
+            .loads_from_state(&simple, att.rotation_tagged_as(), 1000.0, Some(&epoch))
             .acceleration_inertial
             .inner();
 

--- a/orts/src/spacecraft/state.rs
+++ b/orts/src/spacecraft/state.rs
@@ -3,7 +3,7 @@ use nalgebra::{Vector3, Vector4};
 use utsuroi::{OdeState, Tolerances};
 
 use crate::attitude::AttitudeState;
-use crate::model::{HasAttitude, HasMass, HasOrbit};
+use crate::model::{HasAttitude, HasFrame, HasMass, HasOrbit};
 use crate::orbital::OrbitalState;
 
 /// Combined spacecraft state: orbital (6D) + attitude (7D) + mass (1D).
@@ -52,9 +52,11 @@ impl SpacecraftState<SimpleEci> {
     }
 }
 
-impl<F: Eci> HasOrbit for SpacecraftState<F> {
+impl<F: Eci> HasFrame for SpacecraftState<F> {
     type Frame = F;
+}
 
+impl<F: Eci> HasOrbit for SpacecraftState<F> {
     fn orbit(&self) -> &OrbitalState<F> {
         &self.orbit
     }
@@ -75,9 +77,11 @@ impl<F: Eci> HasMass for SpacecraftState<F> {
 // Delegate capability traits for AugmentedState<SpacecraftState<F>>.
 use crate::effector::AugmentedState;
 
-impl<F: Eci> HasOrbit for AugmentedState<SpacecraftState<F>> {
+impl<F: Eci> HasFrame for AugmentedState<SpacecraftState<F>> {
     type Frame = F;
+}
 
+impl<F: Eci> HasOrbit for AugmentedState<SpacecraftState<F>> {
     fn orbit(&self) -> &OrbitalState<F> {
         &self.plant.orbit
     }

--- a/orts/src/spacecraft/state.rs
+++ b/orts/src/spacecraft/state.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use arika::frame::{Eci, SimpleEci};
 use nalgebra::{Vector3, Vector4};
 use utsuroi::{OdeState, Tolerances};
@@ -13,35 +11,11 @@ use crate::orbital::OrbitalState;
 /// Parameterized by the inertial frame `F` (default `SimpleEci`).
 /// Used as the ODE state vector for coupled orbit-attitude propagation.
 /// Mass is included for thrust modeling (mass depletion).
+#[derive(Debug, Clone, PartialEq)]
 pub struct SpacecraftState<F: Eci = SimpleEci> {
     pub orbit: OrbitalState<F>,
     pub attitude: AttitudeState,
     pub mass: f64,
-}
-
-// Manual impls to avoid requiring F: Debug/Clone/PartialEq.
-impl<F: Eci> fmt::Debug for SpacecraftState<F> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SpacecraftState")
-            .field("orbit", &self.orbit)
-            .field("attitude", &self.attitude)
-            .field("mass", &self.mass)
-            .finish()
-    }
-}
-impl<F: Eci> Clone for SpacecraftState<F> {
-    fn clone(&self) -> Self {
-        Self {
-            orbit: self.orbit.clone(),
-            attitude: self.attitude.clone(),
-            mass: self.mass,
-        }
-    }
-}
-impl<F: Eci> PartialEq for SpacecraftState<F> {
-    fn eq(&self, other: &Self) -> bool {
-        self.orbit == other.orbit && self.attitude == other.attitude && self.mass == other.mass
-    }
 }
 
 impl<F: Eci> SpacecraftState<F> {

--- a/orts/src/spacecraft/surface.rs
+++ b/orts/src/spacecraft/surface.rs
@@ -1,4 +1,4 @@
-use crate::model::{HasAttitude, HasMass, HasOrbit, Model};
+use crate::model::{HasAttitude, HasFrame, HasMass, HasOrbit, Model};
 use crate::perturbations::OMEGA_EARTH;
 use arika::body::KnownBody;
 use arika::earth::R as R_EARTH;
@@ -248,7 +248,7 @@ impl<F: EarthFixedTransform> PanelDrag<F> {
     pub(crate) fn loads_from_state(
         &self,
         orbit: &crate::OrbitalState<F>,
-        attitude: &crate::attitude::AttitudeState,
+        body_to_inertial: arika::frame::Rotation<arika::frame::Body, F>,
         mass: f64,
         epoch: Option<&Epoch<arika::epoch::Utc>>,
     ) -> ExternalLoads<F> {
@@ -294,8 +294,8 @@ impl<F: EarthFixedTransform> PanelDrag<F> {
             }
             SpacecraftShape::Panels(panels) => {
                 // Transform flow direction to body frame
-                let v_body = attitude
-                    .rotation_from_inertial::<F>()
+                let v_body = body_to_inertial
+                    .inverse()
                     .transform(&arika::frame::Vec3::<F>::from_raw(v_rel))
                     .into_inner(); // km/s in body frame
                 let v_body_m = v_body * 1000.0; // m/s
@@ -324,7 +324,7 @@ impl<F: EarthFixedTransform> PanelDrag<F> {
 
                 // a_body [m/s²] → a_inertial [km/s²]
                 let a_body = arika::frame::Vec3::from_raw(total_force_body / mass);
-                let a_inertial = attitude.rotation_to_inertial::<F>().transform(&a_body) / 1000.0;
+                let a_inertial = body_to_inertial.transform(&a_body) / 1000.0;
 
                 ExternalLoads {
                     acceleration_inertial: a_inertial,
@@ -340,7 +340,7 @@ impl<F: EarthFixedTransform> PanelDrag<F> {
 // `EarthFixedTransform` and the co-rotation about `EarthRotationPole`, so the
 // model is valid in any inertial frame that provides them (a frame without the
 // impl is a compile error). See #151.
-impl<F: EarthFixedTransform, S: HasAttitude + HasOrbit<Frame = F> + HasMass> Model<S, F>
+impl<F: EarthFixedTransform, S: HasFrame<Frame = F> + HasAttitude + HasOrbit + HasMass> Model<S, F>
     for PanelDrag<F>
 {
     fn name(&self) -> &str {
@@ -348,7 +348,12 @@ impl<F: EarthFixedTransform, S: HasAttitude + HasOrbit<Frame = F> + HasMass> Mod
     }
 
     fn eval(&self, _t: f64, state: &S, epoch: Option<&Epoch>) -> ExternalLoads<F> {
-        self.loads_from_state(state.orbit(), state.attitude(), state.mass(), epoch)
+        self.loads_from_state(
+            state.orbit(),
+            state.attitude_to_inertial(),
+            state.mass(),
+            epoch,
+        )
     }
 }
 
@@ -760,7 +765,8 @@ mod tests {
         assert!(rho > 0.0, "expected non-zero density");
 
         let v_body_m = attitude
-            .rotation_from_inertial::<frame::Gcrs>()
+            .rotation_tagged_as::<frame::Gcrs>()
+            .inverse()
             .transform(&Vec3::<frame::Gcrs>::from_raw(v_rel))
             .into_inner()
             * 1000.0;
@@ -781,7 +787,7 @@ mod tests {
             torque_body += panel.cp_offset.cross(&force);
         }
         let expected_a = attitude
-            .rotation_to_inertial::<frame::Gcrs>()
+            .rotation_tagged_as::<frame::Gcrs>()
             .transform(&Vec3::from_raw(force_body / simple.mass))
             .into_inner()
             / 1000.0;

--- a/orts/src/spacecraft/surface.rs
+++ b/orts/src/spacecraft/surface.rs
@@ -722,9 +722,9 @@ mod tests {
     }
 
     /// The sphere branch never touches the body frame, so it cannot cover the
-    /// two rotations this change made frame-generic
-    /// (`rotation_from_inertial::<F>` on the way in,
-    /// `rotation_to_inertial::<F>` on the way out). Exercise the panel branch in
+    /// two rotations this change made frame-generic (the `body_to_inertial`
+    /// rotation the model is handed: inverted on the way in, applied as-is on
+    /// the way out). Exercise the panel branch in
     /// `Gcrs` at a non-identity attitude with an asymmetric fixture, and
     /// reconstruct both outputs: the inertial acceleration, which round-trips
     /// through the body frame, and the body torque, which stays there.

--- a/orts/src/spacecraft/thruster.rs
+++ b/orts/src/spacecraft/thruster.rs
@@ -236,13 +236,8 @@ impl Thruster {
     }
 }
 
-impl<
-    S: HasFrame<Frame = arika::frame::SimpleEci>
-        + HasAttitude
-        + HasFrame<Frame = arika::frame::SimpleEci>
-        + HasOrbit
-        + HasMass,
-> Model<S> for Thruster
+impl<S: HasFrame<Frame = arika::frame::SimpleEci> + HasAttitude + HasOrbit + HasMass> Model<S>
+    for Thruster
 {
     fn name(&self) -> &str {
         "thruster"
@@ -341,13 +336,8 @@ impl ThrusterAssembly {
     }
 }
 
-impl<
-    S: HasFrame<Frame = arika::frame::SimpleEci>
-        + HasAttitude
-        + HasFrame<Frame = arika::frame::SimpleEci>
-        + HasOrbit
-        + HasMass,
-> Model<S> for ThrusterAssembly
+impl<S: HasFrame<Frame = arika::frame::SimpleEci> + HasAttitude + HasOrbit + HasMass> Model<S>
+    for ThrusterAssembly
 {
     fn name(&self) -> &str {
         "thruster_assembly"

--- a/orts/src/spacecraft/thruster.rs
+++ b/orts/src/spacecraft/thruster.rs
@@ -1,7 +1,7 @@
 use arika::epoch::Epoch;
 use nalgebra::Vector3;
 
-use crate::model::{HasAttitude, HasMass, HasOrbit, Model};
+use crate::model::{HasAttitude, HasFrame, HasMass, HasOrbit, Model};
 
 use super::{ExternalLoads, SpacecraftState};
 
@@ -155,7 +155,7 @@ impl ThrusterSpec {
         // Acceleration: body → inertial [km/s²]
         // F [N] / mass [kg] = [m/s²], / 1000 = [km/s²]
         let a_body = arika::frame::Vec3::from_raw(f_body_n / state.mass / 1000.0);
-        let a_inertial = state.attitude.rotation_to_eci().transform(&a_body);
+        let a_inertial = state.attitude_to_inertial().transform(&a_body);
 
         // Mass flow rate [kg/s]
         let mass_rate = -(self.thrust_n * throttle) / (self.isp_s * G0);
@@ -236,7 +236,14 @@ impl Thruster {
     }
 }
 
-impl<S: HasAttitude + HasOrbit<Frame = arika::frame::SimpleEci> + HasMass> Model<S> for Thruster {
+impl<
+    S: HasFrame<Frame = arika::frame::SimpleEci>
+        + HasAttitude
+        + HasFrame<Frame = arika::frame::SimpleEci>
+        + HasOrbit
+        + HasMass,
+> Model<S> for Thruster
+{
     fn name(&self) -> &str {
         "thruster"
     }
@@ -334,8 +341,13 @@ impl ThrusterAssembly {
     }
 }
 
-impl<S: HasAttitude + HasOrbit<Frame = arika::frame::SimpleEci> + HasMass> Model<S>
-    for ThrusterAssembly
+impl<
+    S: HasFrame<Frame = arika::frame::SimpleEci>
+        + HasAttitude
+        + HasFrame<Frame = arika::frame::SimpleEci>
+        + HasOrbit
+        + HasMass,
+> Model<S> for ThrusterAssembly
 {
     fn name(&self) -> &str {
         "thruster_assembly"

--- a/orts/tests/frame_typed_attitude.rs
+++ b/orts/tests/frame_typed_attitude.rs
@@ -18,7 +18,7 @@ use arika::epoch::Epoch;
 use arika::frame::{Body, Gcrs, Rotation, SimpleEci, Teme};
 use nalgebra::{UnitQuaternion, Vector3};
 use orts::attitude::{AttitudeState, InertialPointing, TrackingPdController};
-use orts::model::{HasAttitude, HasOrbit, Model};
+use orts::model::{HasAttitude, HasFrame, HasOrbit, Model};
 use orts::orbital::OrbitalState;
 use orts::plugin::tick_input::AttitudeBodyToInertial;
 
@@ -126,8 +126,11 @@ impl<F: arika::frame::Eci> HasAttitude for TestState<F> {
     }
 }
 
-impl<F: arika::frame::Eci> HasOrbit for TestState<F> {
+impl<F: arika::frame::Eci> HasFrame for TestState<F> {
     type Frame = F;
+}
+
+impl<F: arika::frame::Eci> HasOrbit for TestState<F> {
     fn orbit(&self) -> &OrbitalState<F> {
         &self.orbit
     }

--- a/orts/tests/frame_typed_attitude.rs
+++ b/orts/tests/frame_typed_attitude.rs
@@ -1,0 +1,156 @@
+//! Why the attitude surfaces carry their frame in the type (#332).
+//!
+//! A quaternion's components depend on the frame it is expressed against. These
+//! tests show that the difference is real and operationally large — not a
+//! rounding-level concern — for one physical attitude expressed against two
+//! inertial frames the simulator actually supports. The compile-fail companions
+//! in `tests/trybuild/` pin the type-level side: that such a value cannot be
+//! consumed as the wrong frame.
+//!
+//! The two frames are reached from a common third frame, TEME, because `arika`
+//! deliberately provides no direct `SimpleEci` ↔ `Gcrs` conversion (the point of
+//! the distinction is that the approximate and the precise frame are not
+//! interchangeable). `Rotation<Teme, Gcrs>` (IAU-76/FK5 reduction) and
+//! `Rotation<Teme, SimpleEci>` (GMST-aligned z-rotation) give the same physical
+//! orientation its components in each.
+
+use arika::epoch::Epoch;
+use arika::frame::{Body, Gcrs, Rotation, SimpleEci, Teme};
+use nalgebra::{UnitQuaternion, Vector3};
+use orts::attitude::{AttitudeState, InertialPointing, TrackingPdController};
+use orts::model::{HasAttitude, HasOrbit, Model};
+use orts::orbital::OrbitalState;
+use orts::plugin::tick_input::AttitudeBodyToInertial;
+
+/// 2024-03-20T12:00:00 UTC — 24 years of precession/nutation past J2000.
+fn epoch() -> Epoch {
+    Epoch::from_gregorian(2024, 3, 20, 12, 0, 0.0)
+}
+
+/// One physical spacecraft orientation, expressed as body→TEME.
+fn body_to_teme() -> Rotation<Body, Teme> {
+    Rotation::from_raw(UnitQuaternion::from_axis_angle(
+        &nalgebra::Unit::new_normalize(Vector3::new(0.3, -0.5, 0.8)),
+        0.7,
+    ))
+}
+
+fn body_to_gcrs() -> Rotation<Body, Gcrs> {
+    body_to_teme().then(&Rotation::<Teme, Gcrs>::teme_to_gcrs(&epoch().to_tt()))
+}
+
+fn body_to_simple_eci() -> Rotation<Body, SimpleEci> {
+    body_to_teme().then(&Rotation::<Teme, SimpleEci>::teme_to_simple_eci(
+        &epoch().to_ut1_naive(),
+    ))
+}
+
+/// The angle [rad] between two rotations of the same physical orientation,
+/// compared through their raw components — i.e. the error someone would commit
+/// by reading one frame's numbers as if they were the other's.
+fn component_angle(a: &UnitQuaternion<f64>, b: &UnitQuaternion<f64>) -> f64 {
+    (a.inverse() * b).angle()
+}
+
+#[test]
+fn the_same_attitude_has_different_components_in_gcrs_and_simple_eci() {
+    let gcrs = AttitudeBodyToInertial::new(body_to_gcrs());
+    let simple = AttitudeBodyToInertial::new(body_to_simple_eci());
+
+    let angle = component_angle(gcrs.inner().inner(), simple.inner().inner());
+    let arcsec = angle.to_degrees() * 3600.0;
+
+    // ~484 arcsec at this epoch: an order of magnitude above a good star
+    // tracker's accuracy (1–30 arcsec), so mistaking one frame for the other is
+    // a pointing error, not a rounding difference.
+    assert!(
+        arcsec > 300.0,
+        "the frames must differ operationally, got {arcsec:.1} arcsec"
+    );
+    let expected_deg = 0.13436522507125545;
+    let got_deg = angle.to_degrees();
+    assert!(
+        (got_deg - expected_deg).abs() <= 1e-12 * expected_deg,
+        "GCRS/simple-ECI attitude difference changed: {got_deg} deg"
+    );
+}
+
+struct TestState<F: arika::frame::Eci> {
+    attitude: AttitudeState,
+    orbit: OrbitalState<F>,
+}
+
+impl<F: arika::frame::Eci> HasAttitude for TestState<F> {
+    fn attitude(&self) -> &AttitudeState {
+        &self.attitude
+    }
+}
+
+impl<F: arika::frame::Eci> HasOrbit for TestState<F> {
+    type Frame = F;
+    fn orbit(&self) -> &OrbitalState<F> {
+        &self.orbit
+    }
+}
+
+fn test_state<F: arika::frame::Eci>() -> TestState<F> {
+    TestState {
+        attitude: AttitudeState::new(
+            UnitQuaternion::from_axis_angle(
+                &nalgebra::Unit::new_normalize(Vector3::new(0.1, 0.2, -0.4)),
+                0.3,
+            ),
+            Vector3::new(0.01, -0.02, 0.03),
+        ),
+        orbit: OrbitalState::<F>::new_in_frame(
+            Vector3::new(4000.0, -5000.0, 2500.0),
+            Vector3::new(1.0, 2.0, 7.0),
+        ),
+    }
+}
+
+/// The frame of an inertial-hold target changes the commanded torque, so
+/// carrying it in the type is load-bearing rather than decorative: the same
+/// physical target, tagged with the two frames, steers the spacecraft
+/// differently.
+#[test]
+fn an_inertial_hold_target_commands_a_different_torque_per_frame() {
+    let epoch = epoch();
+
+    let in_gcrs = TrackingPdController::diagonal(
+        1.0,
+        2.0,
+        InertialPointing {
+            target_q: body_to_gcrs(),
+        },
+    )
+    .eval(0.0, &test_state::<Gcrs>(), Some(&epoch))
+    .torque_body
+    .into_inner();
+
+    let in_simple = TrackingPdController::diagonal(
+        1.0,
+        2.0,
+        InertialPointing {
+            target_q: body_to_simple_eci(),
+        },
+    )
+    .eval(0.0, &test_state::<SimpleEci>(), Some(&epoch))
+    .torque_body
+    .into_inner();
+
+    // Both are real commands of order 1 N·m, and they disagree by ~2e-3 N·m —
+    // the proportional term's response to the ~484 arcsec frame difference.
+    assert!(in_simple.magnitude() > 0.1, "fixture must command a torque");
+    let diff = (in_gcrs - in_simple).magnitude();
+    assert!(
+        diff > 1e-3,
+        "the frame of the target must change the command, got {diff:.3e} N·m"
+    );
+    // Pinned: the difference is the frame difference, not an unrelated change.
+    let expected = 2.2670773348014944e-3;
+    assert!(
+        (diff - expected).abs() <= 1e-9 * expected,
+        "torque difference between frames changed: {diff:e} N·m"
+    );
+}

--- a/orts/tests/frame_typed_attitude.rs
+++ b/orts/tests/frame_typed_attitude.rs
@@ -52,10 +52,50 @@ fn component_angle(a: &UnitQuaternion<f64>, b: &UnitQuaternion<f64>) -> f64 {
     (a.inverse() * b).angle()
 }
 
+/// The four components `(w, x, y, z)` of a reading.
+fn components<F: arika::frame::Eci>(a: &AttitudeBodyToInertial<F>) -> nalgebra::Vector4<f64> {
+    let q = a.inner().inner();
+    nalgebra::Vector4::new(q.w, q.i, q.j, q.k)
+}
+
 #[test]
 fn the_same_attitude_has_different_components_in_gcrs_and_simple_eci() {
     let gcrs = AttitudeBodyToInertial::new(body_to_gcrs());
     let simple = AttitudeBodyToInertial::new(body_to_simple_eci());
+
+    // The components themselves, pinned: these are what a consumer reads, and
+    // they differ in every element. (The *angle* below is invariant under the
+    // body attitude — it is a property of the two frames — so pin the
+    // components too, which do depend on the spacecraft's orientation.)
+    let expected_gcrs = nalgebra::Vector4::new(
+        0.9403243276970059,
+        0.10374803626483178,
+        -0.1723626627136923,
+        0.2744405513305407,
+    );
+    let expected_simple = nalgebra::Vector4::new(
+        0.9401196045021765,
+        0.10344438721235631,
+        -0.17347028723054797,
+        0.27455864115536865,
+    );
+    assert!(
+        (components(&gcrs) - expected_gcrs).magnitude() <= 1e-12 * expected_gcrs.magnitude(),
+        "body→GCRS components changed: {:?}",
+        components(&gcrs)
+    );
+    assert!(
+        (components(&simple) - expected_simple).magnitude() <= 1e-12 * expected_simple.magnitude(),
+        "body→simple-ECI components changed: {:?}",
+        components(&simple)
+    );
+    for i in 0..4 {
+        let d = (components(&gcrs)[i] - components(&simple)[i]).abs();
+        assert!(
+            d > 1e-6,
+            "component {i} must differ between the frames, differs by {d:.3e}"
+        );
+    }
 
     let angle = component_angle(gcrs.inner().inner(), simple.inner().inner());
     let arcsec = angle.to_degrees() * 3600.0;

--- a/orts/tests/oracle_attitude.rs
+++ b/orts/tests/oracle_attitude.rs
@@ -25,7 +25,7 @@ fn rotational_energy(state: &AttitudeState, inertia: &Matrix3<f64>) -> f64 {
 fn angular_momentum_inertial(state: &AttitudeState, inertia: &Matrix3<f64>) -> Vector3<f64> {
     let l_body = inertia * state.angular_velocity;
     state
-        .rotation_to_eci()
+        .rotation_tagged_as::<arika::frame::SimpleEci>()
         .transform(&arika::frame::Vec3::from_raw(l_body))
         .into_inner()
 }

--- a/orts/tests/oracle_discrete_bdot.rs
+++ b/orts/tests/oracle_discrete_bdot.rs
@@ -203,7 +203,8 @@ fn commanded_magnetorquer_torque_is_m_cross_b() {
     );
     let b_body = state
         .attitude
-        .rotation_to_body()
+        .rotation_tagged_as::<arika::frame::SimpleEci>()
+        .inverse()
         .transform(&b_eci)
         .into_inner();
     let expected_torque = m_cmd.cross(&b_body);

--- a/orts/tests/oracle_pd_control.rs
+++ b/orts/tests/oracle_pd_control.rs
@@ -238,6 +238,7 @@ fn decoupled_nadir_tracking_bounded_error() {
     // Get initial LVLH target
     let orbit0 = orts::OrbitalState::new(Vector3::new(r, 0.0, 0.0), Vector3::new(0.0, v_circ, 0.0));
     let (q_target_0, omega_target_0) = NadirPointing.target(0.0, &orbit0, None);
+    let q_target_0 = q_target_0.into_inner();
 
     // Start with 5° perturbation from nadir
     let perturb_axis = nalgebra::Unit::new_normalize(Vector3::new(1.0, 1.0, 1.0));
@@ -263,6 +264,7 @@ fn decoupled_nadir_tracking_bounded_error() {
             )
         };
         let (q_target_t, _) = NadirPointing.target(t, &orbit_t, None);
+        let q_target_t = q_target_t.into_inner();
         let q_err = state.orientation() * q_target_t.inverse();
         let error_deg = q_err.angle().to_degrees();
         max_error_deg = max_error_deg.max(error_deg);
@@ -325,7 +327,9 @@ fn tracking_pd_with_inertial_pointing_converges() {
     let kp = 1.0;
     let kd = 2.0;
 
-    let ref_point = InertialPointing { target_q };
+    let ref_point = InertialPointing {
+        target_q: arika::frame::Rotation::from_raw(target_q),
+    };
     let ctrl = TrackingPdController::diagonal(kp, kd, ref_point);
 
     let mu = 398600.4418;

--- a/orts/tests/oracle_reaction_wheel.rs
+++ b/orts/tests/oracle_reaction_wheel.rs
@@ -37,7 +37,7 @@ fn total_angular_momentum(
     // Transform total body-frame angular momentum to inertial frame
     state
         .plant
-        .rotation_to_eci()
+        .rotation_tagged_as::<arika::frame::SimpleEci>()
         .transform(&arika::frame::Vec3::from_raw(l_body_sc + l_body_rw))
         .into_inner()
 }

--- a/orts/tests/plugin_bdot_detumbler.rs
+++ b/orts/tests/plugin_bdot_detumbler.rs
@@ -113,7 +113,8 @@ impl<F: MagneticFieldModel> PluginController for PluginBdotCross<F> {
         let b_body = obs
             .spacecraft
             .attitude
-            .rotation_to_body()
+            .rotation_tagged_as::<arika::frame::SimpleEci>()
+            .inverse()
             .transform(&arika::frame::Vec3::from_raw(b_eci))
             .into_inner();
         // Read the rate-gyro measurement directly from the observation.

--- a/orts/tests/plugin_bdot_finitediff.rs
+++ b/orts/tests/plugin_bdot_finitediff.rs
@@ -97,7 +97,8 @@ impl<F: MagneticFieldModel> PluginController for PluginBdotFiniteDiff<F> {
         let b_body = obs
             .spacecraft
             .attitude
-            .rotation_to_body()
+            .rotation_tagged_as::<arika::frame::SimpleEci>()
+            .inverse()
             .transform(&arika::frame::Vec3::from_raw(b_eci))
             .into_inner();
 

--- a/orts/tests/trybuild.rs
+++ b/orts/tests/trybuild.rs
@@ -1,0 +1,24 @@
+//! Compile-fail tests that pin the frame-typing of attitude values (#332):
+//! a quaternion's components depend on the frame it is expressed against, so a
+//! reading or a pointing target from one inertial frame must not be usable
+//! where another is required.
+//!
+//! Each `.rs` file in `tests/trybuild/` must fail to compile for the documented
+//! reason; the corresponding `.stderr` file captures the expected diagnostic.
+//!
+//! Run with: `cargo test -p orts --test trybuild`.
+//!
+//! Updating stderr files: set `TRYBUILD=overwrite` and rerun the test.
+
+#[test]
+fn a_non_simple_eci_attitude_cannot_be_used_where_simple_eci_is_required() {
+    let t = trybuild::TestCases::new();
+    // The v0 plugin WIT payload is defined as body→simple-ECI, so the named
+    // boundary operation exists only for a `SimpleEci`-tagged reading.
+    t.compile_fail("tests/trybuild/gcrs_attitude_at_wit_v0_boundary.rs");
+    // A whole sensor bundle evaluated in `Gcrs` cannot be handed to a plugin.
+    t.compile_fail("tests/trybuild/gcrs_sensors_into_tick_input.rs");
+    // An `InertialPointing` target expressed in `Gcrs` cannot steer a system
+    // integrated in `SimpleEci`.
+    t.compile_fail("tests/trybuild/gcrs_inertial_pointing_in_simple_eci.rs");
+}

--- a/orts/tests/trybuild.rs
+++ b/orts/tests/trybuild.rs
@@ -21,4 +21,7 @@ fn a_non_simple_eci_attitude_cannot_be_used_where_simple_eci_is_required() {
     // An `InertialPointing` target expressed in `Gcrs` cannot steer a system
     // integrated in `SimpleEci`.
     t.compile_fail("tests/trybuild/gcrs_inertial_pointing_in_simple_eci.rs");
+
+    // A model's state frame and its loads frame are one parameter, not two.
+    t.compile_fail("tests/trybuild/model_attitude_frame_differs_from_loads_frame.rs");
 }

--- a/orts/tests/trybuild/gcrs_attitude_at_wit_v0_boundary.rs
+++ b/orts/tests/trybuild/gcrs_attitude_at_wit_v0_boundary.rs
@@ -1,0 +1,17 @@
+//! The v0 plugin WIT `attitude-body-to-inertial` payload carries four bare
+//! floats whose frame is *defined* by the contract to be simple-ECI. The named
+//! boundary operation therefore exists only on
+//! `AttitudeBodyToInertial<SimpleEci>`: handing a `Gcrs` reading to a guest —
+//! whose components denote a different physical attitude, off by
+//! precession/nutation — must be a compile error, not silent nonsense.
+
+use arika::frame::{Body, Gcrs, Rotation};
+use nalgebra::UnitQuaternion;
+use orts::plugin::tick_input::AttitudeBodyToInertial;
+
+fn main() {
+    let reading =
+        AttitudeBodyToInertial::new(Rotation::<Body, Gcrs>::from_raw(UnitQuaternion::identity()));
+    // This must fail: the v0 WIT payload is simple-ECI only.
+    let _q = reading.to_wit_v0_simple_eci_quat();
+}

--- a/orts/tests/trybuild/gcrs_attitude_at_wit_v0_boundary.stderr
+++ b/orts/tests/trybuild/gcrs_attitude_at_wit_v0_boundary.stderr
@@ -1,0 +1,7 @@
+error[E0599]: no method named `to_wit_v0_simple_eci_quat` found for struct `AttitudeBodyToInertial<arika::frame::Gcrs>` in the current scope
+  --> tests/trybuild/gcrs_attitude_at_wit_v0_boundary.rs:16:22
+   |
+16 |     let _q = reading.to_wit_v0_simple_eci_quat();
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `AttitudeBodyToInertial<arika::frame::Gcrs>`
+   |
+   = note: the method was found for `AttitudeBodyToInertial`

--- a/orts/tests/trybuild/gcrs_inertial_pointing_in_simple_eci.rs
+++ b/orts/tests/trybuild/gcrs_inertial_pointing_in_simple_eci.rs
@@ -1,0 +1,23 @@
+//! An inertial-hold target is a quaternion, and its components mean different
+//! physical attitudes in different inertial frames. `InertialPointing<Gcrs>`
+//! therefore implements `AttitudeReference<Gcrs>` only — asking it for a target
+//! in `SimpleEci` must be rejected at compile time.
+
+use arika::frame::{Body, Gcrs, Rotation, SimpleEci};
+use nalgebra::UnitQuaternion;
+use orts::attitude::control::{AttitudeReference, InertialPointing};
+use orts::orbital::OrbitalState;
+use nalgebra::Vector3;
+
+fn main() {
+    let reference = InertialPointing {
+        target_q: Rotation::<Body, Gcrs>::from_raw(UnitQuaternion::identity()),
+    };
+    let orbit = OrbitalState::<SimpleEci>::new_in_frame(
+        Vector3::new(7000.0, 0.0, 0.0),
+        Vector3::new(0.0, 7.5, 0.0),
+    );
+    // This must fail: `InertialPointing<Gcrs>: AttitudeReference<SimpleEci>`
+    // does not hold.
+    let _ = AttitudeReference::<SimpleEci>::target(&reference, 0.0, &orbit, None);
+}

--- a/orts/tests/trybuild/gcrs_inertial_pointing_in_simple_eci.stderr
+++ b/orts/tests/trybuild/gcrs_inertial_pointing_in_simple_eci.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `InertialPointing<arika::frame::Gcrs>: AttitudeReference` is not satisfied
+  --> tests/trybuild/gcrs_inertial_pointing_in_simple_eci.rs:22:52
+   |
+22 |     let _ = AttitudeReference::<SimpleEci>::target(&reference, 0.0, &orbit, None);
+   |             -------------------------------------- ^^^^^^^^^^ the trait `AttitudeReference` is not implemented for `InertialPointing<arika::frame::Gcrs>`
+   |             |
+   |             required by a bound introduced by this call
+   |
+help: the trait `AttitudeReference<arika::frame::SimpleEci>` is not implemented for `InertialPointing<arika::frame::Gcrs>`
+      but trait `AttitudeReference<arika::frame::Gcrs>` is implemented for it
+  --> src/attitude/control/reference.rs
+   |
+   | impl<F: frame::Eci> AttitudeReference<F> for InertialPointing<F> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: for that trait implementation, expected `arika::frame::Gcrs`, found `arika::frame::SimpleEci`

--- a/orts/tests/trybuild/gcrs_sensors_into_tick_input.rs
+++ b/orts/tests/trybuild/gcrs_sensors_into_tick_input.rs
@@ -1,0 +1,31 @@
+//! `TickInput` is the plugin-facing snapshot, and the v0 plugin contract is
+//! defined in simple-ECI. A sensor bundle evaluated in another inertial frame
+//! carries that frame in its type, so it cannot be substituted here.
+
+use arika::frame::Gcrs;
+use nalgebra::{Vector3, Vector4};
+use orts::attitude::AttitudeState;
+use orts::orbital::OrbitalState;
+use orts::plugin::tick_input::{ActuatorTelemetry, Sensors, TickInput};
+use orts::SpacecraftState;
+
+fn main() {
+    let spacecraft = SpacecraftState {
+        orbit: OrbitalState::new(Vector3::new(7000.0, 0.0, 0.0), Vector3::new(0.0, 7.5, 0.0)),
+        attitude: AttitudeState {
+            quaternion: Vector4::new(1.0, 0.0, 0.0, 0.0),
+            angular_velocity: Vector3::zeros(),
+        },
+        mass: 50.0,
+    };
+    let actuators = ActuatorTelemetry::default();
+    let sensors = Sensors::<Gcrs>::empty();
+    // This must fail: `TickInput::sensors` is `&Sensors<SimpleEci>`.
+    let _input = TickInput {
+        t: 0.0,
+        epoch: None,
+        sensors: &sensors,
+        actuators: &actuators,
+        spacecraft: &spacecraft,
+    };
+}

--- a/orts/tests/trybuild/gcrs_sensors_into_tick_input.stderr
+++ b/orts/tests/trybuild/gcrs_sensors_into_tick_input.stderr
@@ -1,0 +1,8 @@
+error[E0308]: mismatched types
+  --> tests/trybuild/gcrs_sensors_into_tick_input.rs:27:18
+   |
+27 |         sensors: &sensors,
+   |                  ^^^^^^^^ expected `&Sensors`, found `&Sensors<Gcrs>`
+   |
+   = note: expected reference `&Sensors<arika::frame::SimpleEci>`
+              found reference `&Sensors<arika::frame::Gcrs>`

--- a/orts/tests/trybuild/model_attitude_frame_differs_from_loads_frame.rs
+++ b/orts/tests/trybuild/model_attitude_frame_differs_from_loads_frame.rs
@@ -1,0 +1,44 @@
+//! A model reads the attitude out of the state and reports loads in the frame it
+//! is installed for. Those are the same frame, and `HasFrame::Frame` is what says
+//! so: `S::Frame` and the loads frame `F` are one type parameter, so installing
+//! this model for a `Gcrs` state while asking it for `SimpleEci` loads is a
+//! compile error.
+//!
+//! What the bound replaced: the state carried no frame, so the model body named
+//! one by hand (`rotation_tagged_as::<F>()`), which produced loads in `F` for
+//! *any* state. The body typechecked either way and the mismatch was invisible —
+//! a `Gcrs` attitude tagged as simple-ECI, ~484 arcsec of silent error at 2024.
+use arika::frame::{Eci, Gcrs, SimpleEci};
+use nalgebra::Vector3;
+use orts::SpacecraftState;
+use orts::model::{ExternalLoads, HasAttitude, HasFrame, Model};
+
+struct BodyThrust;
+
+impl<F: Eci, S: HasFrame<Frame = F> + HasAttitude> Model<S, F> for BodyThrust {
+    fn name(&self) -> &str {
+        "body_thrust"
+    }
+    fn eval(
+        &self,
+        _t: f64,
+        state: &S,
+        _epoch: Option<&arika::epoch::Epoch>,
+    ) -> ExternalLoads<F> {
+        let a_body = arika::frame::Vec3::from_raw(Vector3::new(0.0, 0.0, 1e-3));
+        ExternalLoads {
+            acceleration_inertial: state.attitude_to_inertial().transform(&a_body),
+            torque_body: arika::frame::Vec3::zeros(),
+            mass_rate: 0.0,
+        }
+    }
+}
+
+/// Install `BodyThrust` for a `Gcrs` state while asking it for `SimpleEci` loads.
+fn install_mismatched<M: Model<SpacecraftState<Gcrs>, SimpleEci>>(_m: M) {}
+
+fn main() {
+    // This must fail: `SpacecraftState<Gcrs>` has `HasFrame::Frame = Gcrs`,
+    // which cannot unify with the `SimpleEci` loads frame.
+    install_mismatched(BodyThrust);
+}

--- a/orts/tests/trybuild/model_attitude_frame_differs_from_loads_frame.stderr
+++ b/orts/tests/trybuild/model_attitude_frame_differs_from_loads_frame.stderr
@@ -1,0 +1,20 @@
+error[E0271]: type mismatch resolving `<SpacecraftState<Gcrs> as HasFrame>::Frame == SimpleEci`
+  --> tests/trybuild/model_attitude_frame_differs_from_loads_frame.rs:43:24
+   |
+43 |     install_mismatched(BodyThrust);
+   |     ------------------ ^^^^^^^^^^ expected `SimpleEci`, found `Gcrs`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required for `BodyThrust` to implement `Model<SpacecraftState<arika::frame::Gcrs>>`
+  --> tests/trybuild/model_attitude_frame_differs_from_loads_frame.rs:18:52
+   |
+18 | impl<F: Eci, S: HasFrame<Frame = F> + HasAttitude> Model<S, F> for BodyThrust {
+   |                          ---------                 ^^^^^^^^^^^     ^^^^^^^^^^
+   |                          |
+   |                          unsatisfied trait bound introduced here
+note: required by a bound in `install_mismatched`
+  --> tests/trybuild/model_attitude_frame_differs_from_loads_frame.rs:38:26
+   |
+38 | fn install_mismatched<M: Model<SpacecraftState<Gcrs>, SimpleEci>>(_m: M) {}
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `install_mismatched`

--- a/orts/tests/wasm_async_backend.rs
+++ b/orts/tests/wasm_async_backend.rs
@@ -51,8 +51,7 @@ fn dummy_spacecraft() -> SpacecraftState {
 }
 
 fn dummy_sensors() -> Sensors {
-    use arika::frame::{Body, Vec3};
-    use nalgebra::Vector4;
+    use arika::frame::{Body, Rotation, Vec3};
     use orts::plugin::tick_input::{
         AngularVelocityBody, AttitudeBodyToInertial, MagneticFieldBody,
     };
@@ -61,8 +60,8 @@ fn dummy_sensors() -> Sensors {
         gyroscopes: vec![AngularVelocityBody::new(Vec3::<Body>::new(
             0.1, 0.05, -0.03,
         ))],
-        star_trackers: vec![AttitudeBodyToInertial::new(Vector4::new(
-            1.0, 0.0, 0.0, 0.0,
+        star_trackers: vec![AttitudeBodyToInertial::new(Rotation::from_raw(
+            nalgebra::UnitQuaternion::identity(),
         ))],
         sun_sensors: vec![],
     }

--- a/orts/wit/v0/orts.wit
+++ b/orts/wit/v0/orts.wit
@@ -55,6 +55,9 @@ interface types {
     }
 
     /// ECI 座標系での位置 \[km\]。
+    ///
+    /// v0 の ECI は simple-ECI (歳差・章動・極運動を無視した近似 ECI)。
+    /// この interface の ECI 表記は全てこのフレームを指す。
     record position-eci-km {
         x: f64, y: f64, z: f64,
     }
@@ -72,6 +75,8 @@ interface types {
 
     /// 剛体姿勢: 姿勢クォータニオン (body→inertial) と
     /// 機体座標系での角速度 \[rad/s\]。
+    ///
+    /// inertial は attitude-body-to-inertial と同じく simple-ECI 固定。
     record attitude-state {
         orientation: quat,
         angular-velocity: vec3,
@@ -120,7 +125,7 @@ interface types {
 
     /// 姿勢クォータニオン body→inertial (Hamilton scalar-first)。
     ///
-    /// inertial は simple-ECI (position-eci-km と同じ近似 ECI)。
+    /// inertial は simple-ECI (position-eci-km と同じ、v0 の ECI)。
     /// クォータニオンの成分は基準フレームに依存するので、v0 はこの
     /// フレームを contract として固定している (host 側は型で強制: 他の inertial
     /// frame の姿勢を guest に渡すのは compile error)。他フレームを扱うなら

--- a/orts/wit/v0/orts.wit
+++ b/orts/wit/v0/orts.wit
@@ -119,6 +119,12 @@ interface types {
     }
 
     /// 姿勢クォータニオン body→inertial (Hamilton scalar-first)。
+    ///
+    /// inertial は simple-ECI (position-eci-km と同じ近似 ECI)。
+    /// クォータニオンの成分は基準フレームに依存するので、v0 はこの
+    /// フレームを contract として固定している (host 側は型で強制: 他の inertial
+    /// frame の姿勢を guest に渡すのは compile error)。他フレームを扱うなら
+    /// payload に frame を明記する新しい WIT version が必要。
     record attitude-body-to-inertial {
         w: f64, x: f64, y: f64, z: f64,
     }

--- a/plugin-sdk/wit/v0/orts.wit
+++ b/plugin-sdk/wit/v0/orts.wit
@@ -55,6 +55,9 @@ interface types {
     }
 
     /// ECI 座標系での位置 \[km\]。
+    ///
+    /// v0 の ECI は simple-ECI (歳差・章動・極運動を無視した近似 ECI)。
+    /// この interface の ECI 表記は全てこのフレームを指す。
     record position-eci-km {
         x: f64, y: f64, z: f64,
     }
@@ -72,6 +75,8 @@ interface types {
 
     /// 剛体姿勢: 姿勢クォータニオン (body→inertial) と
     /// 機体座標系での角速度 \[rad/s\]。
+    ///
+    /// inertial は attitude-body-to-inertial と同じく simple-ECI 固定。
     record attitude-state {
         orientation: quat,
         angular-velocity: vec3,
@@ -120,7 +125,7 @@ interface types {
 
     /// 姿勢クォータニオン body→inertial (Hamilton scalar-first)。
     ///
-    /// inertial は simple-ECI (position-eci-km と同じ近似 ECI)。
+    /// inertial は simple-ECI (position-eci-km と同じ、v0 の ECI)。
     /// クォータニオンの成分は基準フレームに依存するので、v0 はこの
     /// フレームを contract として固定している (host 側は型で強制: 他の inertial
     /// frame の姿勢を guest に渡すのは compile error)。他フレームを扱うなら

--- a/plugin-sdk/wit/v0/orts.wit
+++ b/plugin-sdk/wit/v0/orts.wit
@@ -119,6 +119,12 @@ interface types {
     }
 
     /// 姿勢クォータニオン body→inertial (Hamilton scalar-first)。
+    ///
+    /// inertial は simple-ECI (position-eci-km と同じ近似 ECI)。
+    /// クォータニオンの成分は基準フレームに依存するので、v0 はこの
+    /// フレームを contract として固定している (host 側は型で強制: 他の inertial
+    /// frame の姿勢を guest に渡すのは compile error)。他フレームを扱うなら
+    /// payload に frame を明記する新しい WIT version が必要。
     record attitude-body-to-inertial {
         w: f64, x: f64, y: f64, z: f64,
     }


### PR DESCRIPTION
quaternion の成分は基準フレームに依存する。同じ物理的な姿勢でも `SimpleEci` と `Gcrs` では値が違う（両者は歳差・章動の分だけ向きが異なり、2024 epoch で極が ~0.1°）。ところが姿勢を運ぶ型がフレームを記録していなかったので、取り違えても誰も気づけなかった。#317 でフレームを generic にした結果この穴が露出したので、型で塞ぐ。

closes #332

## 型で塞いだもの

| 対象 | 変更前 | 変更後 |
|---|---|---|
| star tracker の出力 | `AttitudeBodyToInertial(Vector4<f64>)` — フレーム情報なし | `AttitudeBodyToInertial<F = SimpleEci>`（`Rotation<Body, F>` の newtype） |
| センサ束 | `Sensors` — frame-dependent な読みを erase | `Sensors<F = SimpleEci>` |
| 姿勢目標 | `InertialPointing { target_q: UnitQuaternion }`、#317 で `SimpleEci` 限定に縮退 | `InertialPointing<F> { target_q: Rotation<Body, F> }`、generic に復帰 |
| state のフレーム | `HasOrbit::Frame` のみ。姿勢のフレームは呼び出し側が turbofish で名乗る | `HasFrame::Frame` に一本化し、`HasAttitude` / `HasOrbit` はその subtrait |

型パラメータには既定値を置いたので、既存の呼び出しはほぼ無変更でコンパイルできる。

## state のフレームと loads のフレームを1つの型パラメータにした

モデルは state から姿勢を読み、install されたフレームで loads を返す。この2つは同じフレームなのに、それを言う型がなかった。`HasOrbit` は `type Frame` を持つのに `HasAttitude` は持たず、body→inertial 回転は呼び出し側が名乗る形だった。

```rust
state.attitude.rotation_to_inertial::<F>()   // 22 箇所、各サイトが自分で F を名乗る
```

22 箇所すべてスコープ内の `F` を渡しており、すべて正しかった。問題は「正しいこと」が各サイトの責任で、間違えられる署名が実在した点にある。

```rust
impl<S: HasAttitude, F: Eci> StateEffector<S, F>  // S のフレームと F が独立
```

これは `Gcrs` の state に `SimpleEci` の loads を出す組み合わせを型検査で通す。`Gcrs` の姿勢が simple-ECI として tag され、2024 epoch で 484 秒角の誤差が黙って入る。

`HasFrame` がフレームを一度だけ宣言し、bound は `S: HasFrame<Frame = F> + HasAttitude + HasOrbit` になる。state のフレームが loads のフレーム**そのもの**になり、加えて「orbit は `Gcrs`、attitude は `SimpleEci`」という食い違った宣言も書けなくなった（従来は独立した2つの宣言で、突き合わせるものがなかった）。

回転の取得経路も整理した。`rotation_to_eci` / `rotation_to_body` / `rotation_to_inertial<F>` / `rotation_from_inertial<F>` の4つを **`rotation_tagged_as<F>()` 1つ**にまとめ、名前が振る舞い（変換ではなく tag）を言うようにした。既定の経路は trait 側の `attitude_to_inertial()` / `attitude_from_inertial()` で、フレームは state の型から来る。panel drag / panel SRP / gravity-gradient の helper は rotation を受け取る形にしたので、フレームを名乗る余地がなくなった（#191 と同じ事故クラスのモデル群）。

`rotation_tagged_as` は姿勢のみを伝播する経路のために public のまま残る。この経路には orbit がなく他のフレームが存在しないので、`impl HasFrame for AttitudeState` が simple-ECI を一度だけ宣言する。

## arika: ZST という事実を sealed trait に一度書く

frame marker は 9 個すべて unit struct で `#[derive(Debug, Clone, Copy, PartialEq, Eq)]` を持ち、`Frame` は sealed。「frame は Copy な ZST」は事実として真なのに型に書かれておらず、frame-generic な型が 3 通りの回避策で同じことを迂回していた。derive を逐語再現した手書き impl が 9 箇所、`Rotation` の `PhantomData<fn() -> (From, To)>`、そして「全フィールドが Send + Sync だから安全」とコメントで主張する `unsafe impl` が 4 本。

`Frame: Debug + Copy + PartialEq + Eq + Send + Sync + 'static` と supertrait で一度言うと 3 つとも消える。sealed trait への supertrait 追加は実装者も利用者も壊さない。

- `unsafe impl` 4 本（`OrbitalSystem` / `SpacecraftDynamics`）を削除。auto impl が効くのでフィールドから導出され、コメントの主張がコンパイラの検査に置き換わった。arika と orts に `unsafe` は残っていない
- `Rotation` / `OrbitalState` / `SpacecraftState` / `ExternalLoads` / `AttitudeBodyToInertial` / `Sensors` の手書き impl を derive に。いずれも derive の逐語再現だったので振る舞いは同じ
- `Rotation` の phantom は `PhantomData<(From, To)>` に戻り（分散はどちらも共変）、`Debug` は `type_name` を `::` で切る hack をやめて `Frame::NAME` を使う
- `Sensors::empty()` が唯一のコンストラクタになった。`derive(Default)` は `F: Default` を要求し、frame marker に既定は存在しない

## WIT 境界

v0 の姿勢 payload は simple ECI 前提の契約で、CLI は `Gcrs` を一切インスタンス化していない（`cli/src` に `Gcrs` の出現なし）。plugin 側に非 SimpleEci の姿勢を要する需要が現時点で無いため、WIT インターフェースは現状のまま、境界の変換を**名前のある操作**にした。

```rust
impl AttitudeBodyToInertial<SimpleEci> {
    pub fn to_wit_v0_simple_eci_quat(&self) -> (f64, f64, f64, f64)
}
```

`SimpleEci` の impl にしか存在しないので、`Gcrs` の読みを guest に送ろうとするとコンパイルエラーになる。操作名にフレームと成分順序の両方が入っているので、暗黙の規約が残らない。`TickInput::sensors` も `&Sensors<SimpleEci>` 固定にしたので、`Gcrs` のセンサ束は plugin に到達できない。

WIT には v0 の慣性系が simple ECI であることを doc として記録した（`position-eci-km` / `attitude-body-to-inertial` / `attitude-state`）。

## テスト

**振る舞い保存**: refactor 前のコミットで既存の値を固定した — star tracker の ideal / isotropic / anisotropic な読みを成分ごとに、`InertialPointing` に対する tracking-PD トルク、hemisphere 選択の分岐（`q_err.w = -0.988` の fixture で実際に発火させる）、v0 payload の成分順序（既存テストは単位 quaternion を使っていて順序を判別できなかった）、および float 述語を持つ全経路の `NaN` / `±∞`。refactor 後もすべて無変更で通る。

**判別テスト**: フレームを消しても通るテストは何も証明しないので、

- trybuild の compile-fail 4 件 — `Gcrs` の読みは WIT 境界メソッドを持たない / `Gcrs` の `Sensors` は `TickInput` に入らない / `Gcrs` の `InertialPointing` は `SimpleEci` の場所で使えない / **`SpacecraftState<Gcrs>` 用のモデルを `SimpleEci` の loads として install できない**。最後の1件は `type mismatch resolving <SpacecraftState<Gcrs> as HasFrame>::Frame == SimpleEci` の**単一の理由**で落ちる（変更前はこの組み合わせが通っていた）
- 値が実際に異なることの確認 — 同一の body→TEME 姿勢を両フレームへ換算すると **484 秒角**（良好な star tracker の ~30 倍）ずれ、その目標での慣性保持は ~1 N·m に対し **2.27e-3 N·m** 異なるトルクを指令する

比較は期待値の大きさに対する相対許容誤差で、絶対床は置いていない。

## ゲート

`cargo fmt --all` clean、CI と同じ clippy 全 tier が 0（`--locked --workspace` / `-p orts --no-default-features --features plugin-wasm` / `-p arika` の `--no-default-features`・`+alloc`・`+sgp4` / `-p tobari --no-default-features` / `-p utsuroi --no-default-features`）。arika と rrd-wasm の wasm32 ビルド green。テストは `--workspace --exclude orts` 974 passed、`-p orts` 全 suite（`oracle_gcrf` の 30 日伝播を含む）passed。`viewer/src/protocol/generated/` に差分なし。

## 残る範囲

`AttitudeState` は積分状態なので `Vector4<f64>` を保持する（`OdeState::project` が各ステップ後に正規化するため、ステップ間は単位 quaternion ではない）。フレームを型に載せるには 106 箇所の struct literal に `PhantomData` を足すか private 化が必要で、`HasFrame` が state 側でフレームを固定した後はモデル経路から誤タグが到達しない。

`DetumblingController::update` は `&AttitudeState` を受けて tag する。trait メソッドなので変更範囲がこの PR より広く、`Fr` は同じ署名の `OrbitalState<Fr>` から来る。

trybuild の `.stderr` は rustc の版に結合しているので、toolchain 更新時は `TRYBUILD=overwrite` が必要（arika の既存 trybuild と同じ性質）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
