### PR TITLE
docs(getting-started): fix the CLI invocations to match the subcommand interface

### DIFF
--- a/docs/src/content/docs/en/getting-started.mdx
+++ b/docs/src/content/docs/en/getting-started.mdx
@@ -15,18 +15,27 @@ cargo build --workspace
 
 ## Running the Simulator
 
-Run a simulation and output CSV:
+`orts run` propagates an orbit and records the result. It needs an orbit to
+propagate — `--sat altitude=400` is the shortest way to say so:
 
 ```bash
-cargo run --bin orts
+cargo run --bin orts -- run --sat altitude=400
+```
+
+That writes `output.rrd` and, with no `--duration`, covers one orbital period.
+For CSV on stdout instead:
+
+```bash
+cargo run --bin orts -- run --sat altitude=400 --format csv
 ```
 
 ## Starting the Viewer
 
-Start the WebSocket server with the embedded viewer:
+`orts serve` streams the simulation over WebSocket and serves the embedded
+viewer:
 
 ```bash
-cargo run --bin orts -- --serve
+cargo run --bin orts -- serve --sat altitude=400
 ```
 
 Then open `http://localhost:9001` in your browser.
@@ -35,11 +44,23 @@ Then open `http://localhost:9001` in your browser.
 
 ```bash
 # Higher altitude orbit with larger time step
-cargo run --bin orts -- --serve --altitude 800 --dt 5
+cargo run --bin orts -- serve --sat altitude=800 --dt 5
 
 # Fine time step with decimated output
-cargo run --bin orts -- --serve --dt 1 --output-interval 10
+cargo run --bin orts -- serve --sat altitude=400 --dt 1 --output-interval 10
 ```
+
+`--sat` is a shorthand for simple cases. For generated or multi-satellite
+setups, describe the mission in a config file:
+
+```bash
+cargo run --bin orts -- config example > mission.toml
+cargo run --bin orts -- config validate mission.toml
+cargo run --bin orts -- serve --config mission.toml
+```
+
+`orts --help` lists every subcommand (`run`, `serve`, `replay`, `convert`,
+`config`), and `orts <subcommand> --help` lists its options.
 
 ## Project Structure
 


### PR DESCRIPTION
Getting Started のコマンドはすべて subcommand 化以前のもので、そのままコピーしても動かない状態だった。ページ上の 4 つの実行例が全滅している。

## 動かなかったもの

| ページの記載 | 実際の結果 |
|---|---|
| `cargo run --bin orts`（説明は "output CSV"） | exit 2。subcommand が必須。加えて `run` の既定は RRD |
| `cargo run --bin orts -- --serve` | `error: unexpected argument '--serve' found` |
| `... -- --serve --altitude 800 --dt 5` | `error: unexpected argument '--altitude' found` |
| `... -- --serve --dt 1 --output-interval 10` | 同上（`--dt` / `--output-interval` 自体は健在） |

CLI 自身の `long_about`、`cli/README.md`、`ARCHITECTURE.ja.md` は現行の `orts run` / `orts serve` を示しており、このページだけが取り残されていた。

## 直したもの

- `--serve` → `serve` subcommand、`--altitude 800` → `--sat altitude=800`
- 冒頭の実行例を `run --sat altitude=400` にし、既定の出力が `output.rrd` であることと CSV の出し方を分けて書いた
- config ファイル経路（`config example` → `config validate` → `serve --config`）を追記。`--sat` は CLI のヘルプ自身が simple cases 向けの shorthand と述べ、生成系・多衛星は `--config` を勧めているため
- `orts --help` / `orts <subcommand> --help` の案内を 1 行追加

## 検証

書いた 8 コマンドすべてを実行した。

| コマンド | 結果 |
|---|---|
| `run --sat altitude=400` | exit 0、`output.rrd` 209 KB |
| `run --sat altitude=400 --format csv` | CSV が stdout へ。最終時刻 t=5553.6 s |
| `serve --sat altitude=400` | `Server listening on http://localhost:9001` |
| `serve --sat altitude=800 --dt 5` | 同上 |
| `serve --sat altitude=400 --dt 1 --output-interval 10` | 同上 |
| `config example > mission.toml` | exit 0 |
| `config validate mission.toml` | `OK: mission.toml is a valid orts config` |
| `serve --config mission.toml` | 起動 |

「`--duration` を省くと 1 周期」という記述は CSV の最終時刻 5553.6 s で裏取りした。高度 400 km（a=6778 km）の周期 2π√(a³/μ) = 5553 s と一致する。

`astro check` 0 errors / 12 files、`astro build` 152 pages 成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
