### PR TITLE
test(history): check scaling instead of a wall-clock budget

### DIFF
--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -939,16 +939,43 @@ mod tests {
         assert_eq!(ds.len(), 5);
     }
 
-    /// Fastest of `reps` measurements, in microseconds.
+    /// Fastest measurement per size, in microseconds.
     ///
-    /// `measure` does its own setup and returns only the timed part, so growing
-    /// input sizes do not charge their construction to the measurement.
+    /// `measure` does its own setup for the size it is handed and returns only
+    /// the timed part, so growing inputs do not charge their construction to
+    /// the measurement.
     ///
-    /// The minimum, not the mean or the median: scheduling noise on a shared
-    /// runner only ever adds time, so the fastest sample is the closest
+    /// Every repetition covers every size, and the starting point rotates
+    /// between repetitions. That ordering is the point: running all
+    /// repetitions of the smallest input before starting the largest would tie
+    /// time order to input size, so a runner that slows down partway through —
+    /// load arriving, thermal throttling — would look exactly like cost
+    /// climbing with size. Taking the minimum per size cannot undo that, since
+    /// the drift covers the whole window that size was measured in. With
+    /// rotation each size is measured in each position, so drift cannot
+    /// systematically favour one of them.
+    ///
+    /// The minimum rather than the mean or the median: scheduling noise on a
+    /// shared runner only ever adds time, so the fastest sample is the closest
     /// available estimate of the cost itself.
-    fn fastest_us(reps: u32, mut measure: impl FnMut() -> u128) -> u128 {
-        (0..reps).map(|_| measure()).min().expect("reps > 0")
+    fn fastest_per_size(
+        sizes: &[usize],
+        reps: usize,
+        mut measure: impl FnMut(usize) -> u128,
+    ) -> Vec<(usize, u128)> {
+        let mut best: Vec<Option<u128>> = vec![None; sizes.len()];
+        for rep in 0..reps {
+            for offset in 0..sizes.len() {
+                let i = (offset + rep) % sizes.len();
+                let us = measure(sizes[i]);
+                best[i] = Some(best[i].map_or(us, |b: u128| b.min(us)));
+            }
+        }
+        sizes
+            .iter()
+            .copied()
+            .zip(best.into_iter().map(|b| b.expect("reps > 0")))
+            .collect()
     }
 
     /// Assert the cost per unit of input does not climb as the input grows —
@@ -999,20 +1026,21 @@ mod tests {
         // enough that the smallest sample is well clear of timer granularity.
         let sizes = [100_000usize, 200_000, 400_000];
 
-        let samples: Vec<(usize, u128)> = sizes
+        // Built once up front: this operation only reads, so the same input can
+        // be measured repeatedly, and construction stays out of the timings.
+        let inputs: Vec<Vec<HistoryState>> = sizes
             .iter()
-            .map(|&n| {
-                let states: Vec<HistoryState> = (0..n).map(|i| make_state(i as f64)).collect();
-                let us = fastest_us(3, || {
-                    let start = std::time::Instant::now();
-                    let ds = HistoryBuffer::downsample(&states, 1000);
-                    let elapsed = start.elapsed();
-                    assert_eq!(ds.len(), 1000, "downsample must hit its target size");
-                    elapsed.as_micros()
-                });
-                (n, us)
-            })
+            .map(|&n| (0..n).map(|i| make_state(i as f64)).collect())
             .collect();
+
+        let samples = fastest_per_size(&sizes, 3, |n| {
+            let states = &inputs[sizes.iter().position(|&s| s == n).expect("known size")];
+            let start = std::time::Instant::now();
+            let ds = HistoryBuffer::downsample(states, 1000);
+            let elapsed = start.elapsed();
+            assert_eq!(ds.len(), 1000, "downsample must hit its target size");
+            elapsed.as_micros()
+        });
 
         assert_cost_per_unit_flat("downsample", &samples);
     }
@@ -1023,28 +1051,21 @@ mod tests {
         // stay modest because each flush encodes and writes a real .rrd.
         let sizes = [625usize, 1250, 2500];
 
-        let samples: Vec<(usize, u128)> = sizes
-            .iter()
-            .map(|&rows| {
-                let us = fastest_us(2, || {
-                    let dir = temp_data_dir(&format!("flush-scale-{rows}"));
-                    let mut buf =
-                        HistoryBuffer::new(10_000, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
-                    for i in 0..(rows * 2) {
-                        buf.states.push_back(make_state(i as f64));
-                    }
+        let samples = fastest_per_size(&sizes, 2, |rows| {
+            let dir = temp_data_dir(&format!("flush-scale-{rows}"));
+            let mut buf = HistoryBuffer::new(10_000, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+            for i in 0..(rows * 2) {
+                buf.states.push_back(make_state(i as f64));
+            }
 
-                    let start = std::time::Instant::now();
-                    buf.flush();
-                    let elapsed = start.elapsed();
+            let start = std::time::Instant::now();
+            buf.flush();
+            let elapsed = start.elapsed();
 
-                    assert_eq!(buf.segment_count, 1, "one flush must write one segment");
-                    cleanup_dir(&dir);
-                    elapsed.as_micros()
-                });
-                (rows, us)
-            })
-            .collect();
+            assert_eq!(buf.segment_count, 1, "one flush must write one segment");
+            cleanup_dir(&dir);
+            elapsed.as_micros()
+        });
 
         assert_cost_per_unit_flat("flush", &samples);
     }
@@ -1065,28 +1086,21 @@ mod tests {
         // thing varying.
         let sizes = [2_500usize, 5_000, 10_000];
 
-        let samples: Vec<(usize, u128)> = sizes
-            .iter()
-            .map(|&n| {
-                let us = fastest_us(2, || {
-                    let dir = temp_data_dir(&format!("load-scale-{n}"));
-                    let mut buf =
-                        HistoryBuffer::new(n / 10, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
-                    for i in 0..n {
-                        buf.push(make_state(i as f64));
-                    }
+        let samples = fastest_per_size(&sizes, 2, |n| {
+            let dir = temp_data_dir(&format!("load-scale-{n}"));
+            let mut buf = HistoryBuffer::new(n / 10, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+            for i in 0..n {
+                buf.push(make_state(i as f64));
+            }
 
-                    let start = std::time::Instant::now();
-                    let all = buf.load_all();
-                    let elapsed = start.elapsed();
+            let start = std::time::Instant::now();
+            let all = buf.load_all();
+            let elapsed = start.elapsed();
 
-                    assert_eq!(all.len(), n, "load_all must return every pushed state");
-                    cleanup_dir(&dir);
-                    elapsed.as_micros()
-                });
-                (n, us)
-            })
-            .collect();
+            assert_eq!(all.len(), n, "load_all must return every pushed state");
+            cleanup_dir(&dir);
+            elapsed.as_micros()
+        });
 
         assert_cost_per_unit_flat("load_all", &samples);
     }

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -545,7 +545,7 @@ mod tests {
         let pushes = [5_000usize, 10_000, 20_000];
 
         assert_scaling_stable("overview vs segments", 3, || {
-            let samples = fastest_per_size(&pushes, pushes.len(), |n| {
+            let samples = typical_per_size(&pushes, pushes.len(), |n| {
                 let dir = temp_data_dir(&format!("overview-perf-{n}"));
                 let mut buf = HistoryBuffer::new(1_000, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
                 for i in 0..n {
@@ -638,7 +638,7 @@ mod tests {
         // count varies.
         let widths = [5usize, 10, 20];
         assert_scaling_stable("overview vs entities", 3, || {
-            let samples = fastest_per_size(&widths, widths.len(), |w| {
+            let samples = typical_per_size(&widths, widths.len(), |w| {
                 let dir = temp_data_dir(&format!("overview-width-{w}"));
                 let pushes = w * 2_000;
                 // Capacity above the push count so nothing flushes: this check is
@@ -666,7 +666,14 @@ mod tests {
                 cleanup_dir(&dir);
                 elapsed.as_micros()
             });
-            check_cost_per_unit_flat(&samples)
+            // Looser than SCALING_BAR, because this cost legitimately grows a
+            // little with entity count: `overview()` flattens one sorted run per
+            // entity and merges them, so the sort carries a log(entities) factor.
+            // Measured on an idle machine across this 4x range: 173.0 / 181.1 /
+            // 251.8 us per entity, a 1.46x rise. Under 16-way CPU load the same
+            // ratio reached 2.0-2.15x, which is why 2.0 is too tight. Quadratic
+            // work would show 4x or more here and still fail.
+            check_cost_per_unit_flat(&samples, 3.0)
         });
     }
 
@@ -973,43 +980,48 @@ mod tests {
         assert_eq!(ds.len(), 5);
     }
 
-    /// Fastest measurement per size, in microseconds.
+    /// Typical measurement per size, in microseconds.
     ///
     /// `measure` does its own setup for the size it is handed and returns only
     /// the timed part, so growing inputs do not charge their construction to
     /// the measurement.
     ///
-    /// Every repetition covers every size, and the starting point rotates
-    /// between repetitions, so `reps` should equal `sizes.len()` for each size
-    /// to occupy each position exactly once. That ordering is the point: running all
-    /// repetitions of the smallest input before starting the largest would tie
-    /// time order to input size, so a runner that slows down partway through —
-    /// load arriving, thermal throttling — would look exactly like cost
-    /// climbing with size. Taking the minimum per size cannot undo that, since
-    /// the drift covers the whole window that size was measured in. With
-    /// rotation each size is measured in each position, so drift cannot
-    /// systematically favour one of them.
+    /// Two things keep measurement order from masquerading as scale.
     ///
-    /// The minimum rather than the mean or the median: scheduling noise on a
-    /// shared runner only ever adds time, so the fastest sample is the closest
-    /// available estimate of the cost itself.
-    fn fastest_per_size(
+    /// Every repetition covers every size and the starting point rotates, so
+    /// with `reps == sizes.len()` each size occupies each position exactly once
+    /// — size 0 lands in positions 0, 2, 1 over three repetitions, and the
+    /// others likewise. Without that, running every repetition of the smallest
+    /// input before starting the largest would tie time order to input size,
+    /// and a runner that slows down partway through would look exactly like
+    /// cost climbing with size.
+    ///
+    /// The samples are then reduced by their median rather than their minimum.
+    /// The minimum looks attractive — scheduling noise only ever adds time —
+    /// but it undoes the balance the rotation just bought: under a monotonic
+    /// slowdown the fastest sample for every size is its first occurrence, and
+    /// the first repetition runs the sizes in ascending order, so the minima
+    /// come back ordered by size again. The median draws on the whole balanced
+    /// set and still discards a single spike.
+    fn typical_per_size(
         sizes: &[usize],
         reps: usize,
         mut measure: impl FnMut(usize) -> u128,
     ) -> Vec<(usize, u128)> {
-        let mut best: Vec<Option<u128>> = vec![None; sizes.len()];
+        let mut samples: Vec<Vec<u128>> = vec![Vec::with_capacity(reps); sizes.len()];
         for rep in 0..reps {
             for offset in 0..sizes.len() {
                 let i = (offset + rep) % sizes.len();
-                let us = measure(sizes[i]);
-                best[i] = Some(best[i].map_or(us, |b: u128| b.min(us)));
+                samples[i].push(measure(sizes[i]));
             }
         }
         sizes
             .iter()
             .copied()
-            .zip(best.into_iter().map(|b| b.expect("reps > 0")))
+            .zip(samples.into_iter().map(|mut s| {
+                s.sort_unstable();
+                s[s.len() / 2]
+            }))
             .collect()
     }
 
@@ -1034,7 +1046,7 @@ mod tests {
     /// The blind spot is a constant-factor regression — ten times slower per
     /// unit, still linear, still passes. Catching that needs a stable machine
     /// and a history to compare against rather than a single CI run.
-    fn check_cost_per_unit_flat(samples: &[(usize, u128)]) -> Result<(), String> {
+    fn check_cost_per_unit_flat(samples: &[(usize, u128)], bar: f64) -> Result<(), String> {
         let per_unit: Vec<f64> = samples
             .iter()
             .map(|(n, us)| *us as f64 / *n as f64)
@@ -1060,10 +1072,10 @@ mod tests {
         // it; comparing only upward movement passes it and still catches 1, 5, 1.
         let mut best_so_far = f64::INFINITY;
         for (i, &cost) in per_unit.iter().enumerate() {
-            if cost / best_so_far > SCALING_BAR {
+            if cost / best_so_far > bar {
                 return Err(format!(
                     "cost per unit rose {:.2}x at n={} against the cheapest smaller \
-                     input (bar {SCALING_BAR:.1}x). Samples — {}",
+                     input (bar {bar:.1}x). Samples — {}",
                     cost / best_so_far,
                     samples[i].0,
                     detail.join(", ")
@@ -1161,7 +1173,7 @@ mod tests {
         // measured across an 8x range, and an injected full-input scan came out
         // at 5.88x, so 3.0x sits clear of both.
         assert_scaling_stable("downsample", 3, || {
-            let samples = fastest_per_size(&sizes, sizes.len(), |n| {
+            let samples = typical_per_size(&sizes, sizes.len(), |n| {
                 let states = &inputs[sizes.iter().position(|&s| s == n).expect("known size")];
                 let start = std::time::Instant::now();
                 let ds = HistoryBuffer::downsample(states, 1000);
@@ -1180,7 +1192,7 @@ mod tests {
         let sizes = [625usize, 1250, 2500];
 
         assert_scaling_stable("flush", 3, || {
-            let samples = fastest_per_size(&sizes, sizes.len(), |rows| {
+            let samples = typical_per_size(&sizes, sizes.len(), |rows| {
                 let dir = temp_data_dir(&format!("flush-scale-{rows}"));
                 let mut buf = HistoryBuffer::new(10_000, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
                 for i in 0..(rows * 2) {
@@ -1195,7 +1207,7 @@ mod tests {
                 cleanup_dir(&dir);
                 elapsed.as_micros()
             });
-            check_cost_per_unit_flat(&samples)
+            check_cost_per_unit_flat(&samples, SCALING_BAR)
         });
     }
 
@@ -1216,7 +1228,7 @@ mod tests {
         let sizes = [2_500usize, 5_000, 10_000];
 
         assert_scaling_stable("load_all", 3, || {
-            let samples = fastest_per_size(&sizes, sizes.len(), |n| {
+            let samples = typical_per_size(&sizes, sizes.len(), |n| {
                 let dir = temp_data_dir(&format!("load-scale-{n}"));
                 let mut buf = HistoryBuffer::new(n / 10, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
                 for i in 0..n {
@@ -1231,7 +1243,7 @@ mod tests {
                 cleanup_dir(&dir);
                 elapsed.as_micros()
             });
-            check_cost_per_unit_flat(&samples)
+            check_cost_per_unit_flat(&samples, SCALING_BAR)
         });
     }
 

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -1051,8 +1051,15 @@ mod tests {
 
     #[test]
     fn load_all_cost_per_state_stays_flat() {
-        // Buffer cap 2000 with 4x that pushed, so every size reads several
-        // segments back off disk rather than answering from memory.
+        // The capacity scales with the input, which keeps two things fixed that
+        // would otherwise move with it: the number of segments on disk
+        // (~2n/capacity) and the fraction still in memory (~capacity/2n). A
+        // fixed capacity fails this test on unchanged code — at 2500 states
+        // most of the data is still in the cheap in-memory tail, while at
+        // 10_000 most has gone through the far more expensive per-segment rerun
+        // decode, so the cost per state climbs for reasons that have nothing to
+        // do with complexity. Holding the mix still leaves rows-per-segment as
+        // the only thing varying.
         let sizes = [2_500usize, 5_000, 10_000];
 
         let samples: Vec<(usize, u128)> = sizes
@@ -1060,7 +1067,8 @@ mod tests {
             .map(|&n| {
                 let us = fastest_us(2, || {
                     let dir = temp_data_dir(&format!("load-scale-{n}"));
-                    let mut buf = HistoryBuffer::new(2000, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+                    let mut buf =
+                        HistoryBuffer::new(n / 10, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
                     for i in 0..n {
                         buf.push(make_state(i as f64));
                     }

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -672,8 +672,10 @@ mod tests {
             // Measured rather than derived: on an idle machine across this 4x
             // range the cost is 173.0 / 181.1 / 251.8 us per entity, a 1.46x
             // rise, and under 16-way CPU load the same ratio reached 2.0-2.15x.
-            // A 2.0 bar sits inside that. Quadratic work would show 4x or more
-            // and still fail.
+            // SCALING_BAR at 2.0 sits inside that, so this check takes 3.0 —
+            // 2.1x clear of the idle measurement, 1.4x clear of the loaded one,
+            // and still below the 4x or more that quadratic work would show
+            // over this range.
             check_cost_per_unit_flat(&samples, 3.0)
         });
     }
@@ -1026,8 +1028,10 @@ mod tests {
             .collect()
     }
 
-    /// Ratio between the worst and best sample allowed by the two assertions
-    /// below.
+    /// Default ratio the checks below allow between their worst and best
+    /// sample. Callers pass their own where the work has a shape this does not
+    /// fit — `overview()` across entity counts and `downsample` across input
+    /// sizes both take 3.0, each with its measurements recorded at the call.
     ///
     /// Quadratic growth over a 4x size range shows up as ~4x in cost per unit;
     /// n log n over the same range is ~1.3x. 2.0 sits between them.
@@ -1293,10 +1297,11 @@ mod tests {
             .map(|&n| (0..n).map(|i| make_state(i as f64)).collect())
             .collect();
 
-        // Looser than SCALING_BAR: these samples are a few hundred microseconds,
-        // where timer granularity and cache effects weigh more. 1.10x was
-        // measured across an 8x range, and an injected full-input scan came out
-        // at 5.88x, so 3.0x sits clear of both.
+        // Looser than SCALING_BAR at 3.0: these samples are a few hundred
+        // microseconds, where timer granularity and cache effects weigh more.
+        // Measured 1.10x across an 8x range, and an injected full-input scan
+        // came out at 5.88x — so the bar is 2.7x clear of the clean measurement
+        // and 2.0x below the fault it has to catch.
         assert_scaling_stable("downsample", 3, || {
             let samples = typical_per_size(&sizes, sizes.len(), |n| {
                 let states = &inputs[sizes.iter().position(|&s| s == n).expect("known size")];

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -536,51 +536,58 @@ mod tests {
 
     #[test]
     fn overview_cost_is_constant_regardless_of_disk_segments() {
-        // TODO: this and `overview_multi_entity_cost_is_bounded` still assert an
-        // absolute millisecond budget, which on CI runners measures machine
-        // load as much as the code (see the note on
-        // `assert_cost_per_unit_flat`). The claim here — cost independent of
-        // segment count — is naturally a scaling check: measure at 10 and 40
-        // segments and require the cost not to climb.
-        //
-        // Regression gate. With the old `load_all()` based implementation
-        // this test fails because the cost scales with the number of
-        // flushed segments (disk I/O + decode + sort). The incremental
-        // overview buffer must answer from memory in ~O(OVERVIEW_MAX_POINTS_PER_ENTITY)
-        // time regardless of how many segments exist.
-        let dir = temp_data_dir("overview-perf");
-        let mut buf = HistoryBuffer::new(1_000, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
-        for i in 0..20_000 {
-            buf.push(make_state(i as f64));
-        }
-        assert!(
-            buf.segment_count >= 10,
-            "precondition: enough flushes to make load_all expensive"
-        );
+        // Regression gate. With the old `load_all()` based implementation the
+        // cost scaled with the number of flushed segments (disk I/O + decode +
+        // sort). The incremental overview buffer must answer from memory in
+        // ~O(OVERVIEW_MAX_POINTS_PER_ENTITY) time however many segments exist,
+        // so pushing 4x as much must not cost more — which is what makes this a
+        // raw-time check rather than a millisecond budget.
+        let pushes = [5_000usize, 10_000, 20_000];
 
-        let start = std::time::Instant::now();
-        let ov = buf.overview();
-        let elapsed = start.elapsed();
+        assert_scaling_stable("overview vs segments", 3, || {
+            let samples = fastest_per_size(&pushes, pushes.len(), |n| {
+                let dir = temp_data_dir(&format!("overview-perf-{n}"));
+                let mut buf = HistoryBuffer::new(1_000, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+                for i in 0..n {
+                    buf.push(make_state(i as f64));
+                }
+                assert!(
+                    buf.segment_count >= 5,
+                    "precondition: enough flushes to make load_all expensive, got {}",
+                    buf.segment_count
+                );
 
-        assert!(ov.len() <= OVERVIEW_MAX_POINTS_PER_ENTITY);
-        assert!(
-            elapsed.as_millis() < 20,
-            "overview() took {}ms with {} flushed segments; expected < 20ms \
-             (must not touch disk, must not call load_all)",
-            elapsed.as_millis(),
-            buf.segment_count
-        );
-        cleanup_dir(&dir);
+                let start = std::time::Instant::now();
+                let ov = buf.overview();
+                let elapsed = start.elapsed();
+
+                assert!(
+                    ov.len() <= OVERVIEW_MAX_POINTS_PER_ENTITY,
+                    "overview must stay bounded, got {}",
+                    ov.len()
+                );
+                cleanup_dir(&dir);
+                elapsed.as_micros()
+            });
+            // Same bar and reasoning as the downsample check: the samples are
+            // small, so timer granularity and cache effects weigh more than they
+            // do on the millisecond-scale ones.
+            check_raw_time_flat(&samples, 3.0)
+        });
     }
 
     #[test]
     fn overview_multi_entity_cost_is_bounded() {
-        // The per-entity overview design flattens every entity buffer into
-        // a Vec and sorts by `t` on each read. For realistic constellation
-        // sizes (10+ sats) the sort cost must stay comfortably under the
-        // perf gate — this test guards against accidental O(N^2) or
+        // The per-entity overview design flattens every entity buffer into a Vec
+        // and sorts by `t` on each read, so its cost should grow about linearly
+        // with the number of entities. This guards against accidental O(N^2) or
         // disk-touching regressions if `OVERVIEW_MAX_POINTS_PER_ENTITY` is
         // bumped, or if `overview()` grows auxiliary computation.
+        //
+        // Behaviour is checked at every entity count below; the cost check is a
+        // ratio across counts rather than a millisecond ceiling, because a
+        // ceiling here failed once in five runs under deliberate CPU load with
+        // nothing wrong.
         let dir = temp_data_dir("overview-multi-perf");
         // Small capacity keeps `flush()` I/O bounded during setup; the
         // per-entity overview fills up regardless of flush cadence.
@@ -624,16 +631,43 @@ mod tests {
             assert!(s.t >= prev, "overview must be sorted by t");
             prev = s.t;
         }
-        // Perf gate: flatten + sort of ~10k points in a Vec is expected
-        // to run in a few ms. 50ms is a loose CI-safe ceiling that still
-        // catches order-of-magnitude regressions.
-        assert!(
-            elapsed.as_millis() < 50,
-            "multi-entity overview() took {}ms for {} sats, expected < 50ms",
-            elapsed.as_millis(),
-            sats.len()
-        );
         cleanup_dir(&dir);
+
+        // Cost per entity must not climb as entities are added. Measured with
+        // the same push count per satellite at each width, so only the entity
+        // count varies.
+        let widths = [5usize, 10, 20];
+        assert_scaling_stable("overview vs entities", 3, || {
+            let samples = fastest_per_size(&widths, widths.len(), |w| {
+                let dir = temp_data_dir(&format!("overview-width-{w}"));
+                let pushes = w * 2_000;
+                // Capacity above the push count so nothing flushes: this check is
+                // about `overview()` scaling with entities, and writing hundreds
+                // of .rrd segments during setup made it a 60-second test. The
+                // sibling test above covers the disk-touching claim with real
+                // segments.
+                let mut buf =
+                    HistoryBuffer::new(pushes + 1, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+                let names: Vec<String> = (0..w).map(|i| format!("sat-{i}")).collect();
+                for i in 0..pushes {
+                    buf.push(make_state_for(&names[i % w], i as f64));
+                }
+                assert_eq!(buf.segment_count, 0, "setup must not flush");
+
+                let start = std::time::Instant::now();
+                let ov = buf.overview();
+                let elapsed = start.elapsed();
+
+                assert!(
+                    ov.len() <= w * OVERVIEW_MAX_POINTS_PER_ENTITY,
+                    "overview size must be bounded, got {} for {w} entities",
+                    ov.len()
+                );
+                cleanup_dir(&dir);
+                elapsed.as_micros()
+            });
+            check_cost_per_unit_flat(&samples)
+        });
     }
 
     // query_range in-memory fast path
@@ -946,7 +980,8 @@ mod tests {
     /// the measurement.
     ///
     /// Every repetition covers every size, and the starting point rotates
-    /// between repetitions. That ordering is the point: running all
+    /// between repetitions, so `reps` should equal `sizes.len()` for each size
+    /// to occupy each position exactly once. That ordering is the point: running all
     /// repetitions of the smallest input before starting the largest would tie
     /// time order to input size, so a runner that slows down partway through —
     /// load arriving, thermal throttling — would look exactly like cost
@@ -978,6 +1013,13 @@ mod tests {
             .collect()
     }
 
+    /// Ratio between the worst and best sample allowed by the two assertions
+    /// below.
+    ///
+    /// Quadratic growth over a 4x size range shows up as ~4x in cost per unit;
+    /// n log n over the same range is ~1.3x. 2.0 sits between them.
+    const SCALING_BAR: f64 = 2.0;
+
     /// Assert the cost per unit of input does not climb as the input grows —
     /// that is, the work stays about linear.
     ///
@@ -992,39 +1034,120 @@ mod tests {
     /// The blind spot is a constant-factor regression — ten times slower per
     /// unit, still linear, still passes. Catching that needs a stable machine
     /// and a history to compare against rather than a single CI run.
-    fn assert_cost_per_unit_flat(label: &str, samples: &[(usize, u128)]) {
-        // Quadratic growth over a 4x size range shows up as ~4x here; n log n
-        // over the same range is ~1.3x. 2.0 sits between them.
-        const BAR: f64 = 2.0;
-
+    fn check_cost_per_unit_flat(samples: &[(usize, u128)]) -> Result<(), String> {
         let per_unit: Vec<f64> = samples
             .iter()
             .map(|(n, us)| *us as f64 / *n as f64)
             .collect();
-        let first = per_unit[0];
-        let last = per_unit[per_unit.len() - 1];
 
         let detail: Vec<String> = samples
             .iter()
             .zip(&per_unit)
-            .map(|((n, us), c)| format!("n={n}: {us}us ({c:.3}us/unit)"))
+            .map(|((n, us), c)| format!("n={n}: {us}us ({c:.4}us/unit)"))
             .collect();
 
-        assert!(
-            last / first <= BAR,
-            "{label}: cost per unit grew {:.2}x from the smallest to the largest \
-             input (bar {BAR:.1}x), which is the signature of super-linear work. \
-             Samples — {}",
-            last / first,
-            detail.join(", ")
+        // Only a *rise* against an earlier, smaller size is a problem, and each
+        // size is checked so a spike in the middle cannot hide between its
+        // neighbours.
+        //
+        // The direction matters. A per-unit cost that falls as the input grows
+        // is what amortising a fixed cost looks like, and `load_all` does
+        // exactly that: it pays per-segment decode for a segment count this
+        // fixture holds constant, so the smallest input carries the largest
+        // share of it. Measured under deliberate CPU load, that legitimately
+        // produced 215.6 / 139.0 / 71.0 us per state — a 3.04x spread with
+        // nothing wrong. Comparing the extremes regardless of direction failed
+        // it; comparing only upward movement passes it and still catches 1, 5, 1.
+        let mut best_so_far = f64::INFINITY;
+        for (i, &cost) in per_unit.iter().enumerate() {
+            if cost / best_so_far > SCALING_BAR {
+                return Err(format!(
+                    "cost per unit rose {:.2}x at n={} against the cheapest smaller \
+                     input (bar {SCALING_BAR:.1}x). Samples — {}",
+                    cost / best_so_far,
+                    samples[i].0,
+                    detail.join(", ")
+                ));
+            }
+            best_so_far = best_so_far.min(cost);
+        }
+        Ok(())
+    }
+
+    /// Run `attempt` until it reports no violation, failing only if every
+    /// attempt does.
+    ///
+    /// This is what separates the two things a timing gate can see. Work that
+    /// became super-linear trips the bar every time; a runner that stalled for a
+    /// moment trips it once. Rotation and a per-size minimum reduce the second
+    /// without removing it — measured under 16-way saturation, one size came out
+    /// at 340us/unit while its neighbours sat at 140 and 119, which is noise
+    /// wearing the shape of a regression.
+    ///
+    /// Each attempt is reported as it happens, so a genuine regression leaves
+    /// the full trail in the log rather than only its last measurement.
+    fn assert_scaling_stable(
+        label: &str,
+        attempts: u32,
+        mut attempt: impl FnMut() -> Result<(), String>,
+    ) {
+        let mut last = String::new();
+        for i in 1..=attempts {
+            match attempt() {
+                Ok(()) => return,
+                Err(msg) => {
+                    eprintln!("{label}: attempt {i}/{attempts} tripped the bar — {msg}");
+                    last = msg;
+                }
+            }
+        }
+        panic!(
+            "{label}: all {attempts} attempts tripped the bar, so this is the shape of \
+             the work rather than a busy machine. Last — {last}"
         );
     }
 
+    /// Assert the raw time does not grow with the input — for work whose cost is
+    /// set by something other than the input length.
+    ///
+    /// `downsample_states` is the case that needs this: it performs
+    /// `max_points - 2` stride-indexed clones, so a larger input changes the
+    /// index arithmetic and nothing else. Measured at a fixed `max_points` of
+    /// 1000, it takes 164 / 167 / 165 / 180us for 100k / 200k / 400k / 800k
+    /// states — 1.10x across an 8x size range.
+    ///
+    /// Normalising that by input length would make the check vacuous, and worse
+    /// than vacuous: an accidental full-input scan would turn raw time linear,
+    /// which flattens cost-per-state and looks like success. Holding raw time
+    /// flat catches it, since such a regression grows with the size range.
+    fn check_raw_time_flat(samples: &[(usize, u128)], bar: f64) -> Result<(), String> {
+        let times: Vec<f64> = samples.iter().map(|(_, us)| *us as f64).collect();
+        let best = times.iter().copied().fold(f64::INFINITY, f64::min);
+        let worst = times.iter().copied().fold(0.0_f64, f64::max);
+
+        let detail: Vec<String> = samples
+            .iter()
+            .map(|(n, us)| format!("n={n}: {us}us"))
+            .collect();
+
+        if worst / best > bar {
+            return Err(format!(
+                "raw time spread {:.2}x across sizes (bar {bar:.1}x) for work whose \
+                 cost should not depend on input length. Samples — {}",
+                worst / best,
+                detail.join(", ")
+            ));
+        }
+        Ok(())
+    }
+
     #[test]
-    fn downsample_cost_per_state_stays_flat() {
-        // Sizes span 4x so quadratic work is unmistakable, and start high
-        // enough that the smallest sample is well clear of timer granularity.
-        let sizes = [100_000usize, 200_000, 400_000];
+    fn downsample_cost_stays_independent_of_input_size() {
+        // Sizes span 8x. A 4x range leaves too little margin: an injected
+        // full-input scan measured 3.06x against a 3.0x bar, because the
+        // constant part of the work dilutes the ratio. Over 8x the same fault
+        // lands far clear of the bar while the clean measurement stays at 1.10x.
+        let sizes = [100_000usize, 200_000, 400_000, 800_000];
 
         // Built once up front: this operation only reads, so the same input can
         // be measured repeatedly, and construction stays out of the timings.
@@ -1033,16 +1156,21 @@ mod tests {
             .map(|&n| (0..n).map(|i| make_state(i as f64)).collect())
             .collect();
 
-        let samples = fastest_per_size(&sizes, 3, |n| {
-            let states = &inputs[sizes.iter().position(|&s| s == n).expect("known size")];
-            let start = std::time::Instant::now();
-            let ds = HistoryBuffer::downsample(states, 1000);
-            let elapsed = start.elapsed();
-            assert_eq!(ds.len(), 1000, "downsample must hit its target size");
-            elapsed.as_micros()
+        // Looser than SCALING_BAR: these samples are a few hundred microseconds,
+        // where timer granularity and cache effects weigh more. 1.10x was
+        // measured across an 8x range, and an injected full-input scan came out
+        // at 5.88x, so 3.0x sits clear of both.
+        assert_scaling_stable("downsample", 3, || {
+            let samples = fastest_per_size(&sizes, sizes.len(), |n| {
+                let states = &inputs[sizes.iter().position(|&s| s == n).expect("known size")];
+                let start = std::time::Instant::now();
+                let ds = HistoryBuffer::downsample(states, 1000);
+                let elapsed = start.elapsed();
+                assert_eq!(ds.len(), 1000, "downsample must hit its target size");
+                elapsed.as_micros()
+            });
+            check_raw_time_flat(&samples, 3.0)
         });
-
-        assert_cost_per_unit_flat("downsample", &samples);
     }
 
     #[test]
@@ -1051,23 +1179,24 @@ mod tests {
         // stay modest because each flush encodes and writes a real .rrd.
         let sizes = [625usize, 1250, 2500];
 
-        let samples = fastest_per_size(&sizes, 2, |rows| {
-            let dir = temp_data_dir(&format!("flush-scale-{rows}"));
-            let mut buf = HistoryBuffer::new(10_000, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
-            for i in 0..(rows * 2) {
-                buf.states.push_back(make_state(i as f64));
-            }
+        assert_scaling_stable("flush", 3, || {
+            let samples = fastest_per_size(&sizes, sizes.len(), |rows| {
+                let dir = temp_data_dir(&format!("flush-scale-{rows}"));
+                let mut buf = HistoryBuffer::new(10_000, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+                for i in 0..(rows * 2) {
+                    buf.states.push_back(make_state(i as f64));
+                }
 
-            let start = std::time::Instant::now();
-            buf.flush();
-            let elapsed = start.elapsed();
+                let start = std::time::Instant::now();
+                buf.flush();
+                let elapsed = start.elapsed();
 
-            assert_eq!(buf.segment_count, 1, "one flush must write one segment");
-            cleanup_dir(&dir);
-            elapsed.as_micros()
+                assert_eq!(buf.segment_count, 1, "one flush must write one segment");
+                cleanup_dir(&dir);
+                elapsed.as_micros()
+            });
+            check_cost_per_unit_flat(&samples)
         });
-
-        assert_cost_per_unit_flat("flush", &samples);
     }
 
     #[test]
@@ -1086,23 +1215,24 @@ mod tests {
         // thing varying.
         let sizes = [2_500usize, 5_000, 10_000];
 
-        let samples = fastest_per_size(&sizes, 2, |n| {
-            let dir = temp_data_dir(&format!("load-scale-{n}"));
-            let mut buf = HistoryBuffer::new(n / 10, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
-            for i in 0..n {
-                buf.push(make_state(i as f64));
-            }
+        assert_scaling_stable("load_all", 3, || {
+            let samples = fastest_per_size(&sizes, sizes.len(), |n| {
+                let dir = temp_data_dir(&format!("load-scale-{n}"));
+                let mut buf = HistoryBuffer::new(n / 10, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+                for i in 0..n {
+                    buf.push(make_state(i as f64));
+                }
 
-            let start = std::time::Instant::now();
-            let all = buf.load_all();
-            let elapsed = start.elapsed();
+                let start = std::time::Instant::now();
+                let all = buf.load_all();
+                let elapsed = start.elapsed();
 
-            assert_eq!(all.len(), n, "load_all must return every pushed state");
-            cleanup_dir(&dir);
-            elapsed.as_micros()
+                assert_eq!(all.len(), n, "load_all must return every pushed state");
+                cleanup_dir(&dir);
+                elapsed.as_micros()
+            });
+            check_cost_per_unit_flat(&samples)
         });
-
-        assert_cost_per_unit_flat("load_all", &samples);
     }
 
     #[test]

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -1056,12 +1056,13 @@ mod tests {
         // size ends with 18 segments on disk and exactly `capacity` states in
         // memory, i.e. 10% of the input.
         //
-        // A fixed capacity fails this test on unchanged code. At capacity 2000
-        // the in-memory share runs 60% / 20% / 10% across these three sizes, so
-        // the work migrates from the cheap in-memory tail to the far more
-        // expensive per-segment rerun decode and the cost per state climbs for
-        // reasons that have nothing to do with complexity. Holding the mix
-        // still leaves rows-per-segment as the only thing varying.
+        // A fixed capacity fails this test on unchanged code. Measured at
+        // capacity 2000, the in-memory share runs 60% / 40% / 20% across these
+        // three sizes (1 / 3 / 8 segments), so the work migrates from the cheap
+        // in-memory tail to the far more expensive per-segment rerun decode and
+        // the cost per state climbs for reasons that have nothing to do with
+        // complexity. Holding the mix still leaves rows-per-segment as the only
+        // thing varying.
         let sizes = [2_500usize, 5_000, 10_000];
 
         let samples: Vec<(usize, u128)> = sizes

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -605,9 +605,7 @@ mod tests {
             buf.push(make_state_for(sat, i as f64));
         }
 
-        let start = std::time::Instant::now();
         let ov = buf.overview();
-        let elapsed = start.elapsed();
 
         // Size bound: at most num_entities × cap points.
         assert!(
@@ -667,12 +665,15 @@ mod tests {
                 elapsed.as_micros()
             });
             // Looser than SCALING_BAR, because this cost legitimately grows a
-            // little with entity count: `overview()` flattens one sorted run per
-            // entity and merges them, so the sort carries a log(entities) factor.
-            // Measured on an idle machine across this 4x range: 173.0 / 181.1 /
-            // 251.8 us per entity, a 1.46x rise. Under 16-way CPU load the same
-            // ratio reached 2.0-2.15x, which is why 2.0 is too tight. Quadratic
-            // work would show 4x or more here and still fail.
+            // little with entity count. `overview()` concatenates every entity's
+            // buffer into one Vec and sorts that whole vector by `t`, so adding
+            // entities adds both length and interleaving.
+            //
+            // Measured rather than derived: on an idle machine across this 4x
+            // range the cost is 173.0 / 181.1 / 251.8 us per entity, a 1.46x
+            // rise, and under 16-way CPU load the same ratio reached 2.0-2.15x.
+            // A 2.0 bar sits inside that. Quadratic work would show 4x or more
+            // and still fail.
             check_cost_per_unit_flat(&samples, 3.0)
         });
     }
@@ -1151,6 +1152,130 @@ mod tests {
             ));
         }
         Ok(())
+    }
+
+    // The gates above are only as good as these two functions, and the timing
+    // tests exercise whichever branch the machine happens to produce. These feed
+    // them fixed samples so a regression in the logic itself cannot pass
+    // unnoticed.
+
+    #[test]
+    fn cost_per_unit_check_rejects_a_rise_at_any_size() {
+        // Flat cost per unit: 1us per unit at every size.
+        assert!(
+            check_cost_per_unit_flat(&[(100, 100), (200, 200), (400, 400)], 2.0).is_ok(),
+            "a flat series must pass"
+        );
+
+        // A spike in the middle. This is the case an endpoint comparison misses,
+        // since the first and last samples are identical.
+        let err = check_cost_per_unit_flat(&[(100, 100), (200, 1000), (400, 400)], 2.0)
+            .expect_err("a 5x spike in the middle must fail");
+        assert!(
+            err.contains("n=200"),
+            "the message must name the size: {err}"
+        );
+
+        // A rise only at the largest size.
+        assert!(
+            check_cost_per_unit_flat(&[(100, 100), (200, 200), (400, 1600)], 2.0).is_err(),
+            "a 4x rise at the largest size must fail"
+        );
+
+        // Falling cost per unit is what amortising a fixed cost looks like, and
+        // must pass however far it falls.
+        assert!(
+            check_cost_per_unit_flat(&[(100, 1000), (200, 800), (400, 400)], 2.0).is_ok(),
+            "a decreasing series must pass"
+        );
+
+        // Right at the bar, and just past it.
+        assert!(
+            check_cost_per_unit_flat(&[(100, 100), (200, 400)], 2.0).is_ok(),
+            "exactly 2.0x must pass at a 2.0 bar"
+        );
+        assert!(
+            check_cost_per_unit_flat(&[(100, 100), (200, 420)], 2.0).is_err(),
+            "2.1x must fail at a 2.0 bar"
+        );
+    }
+
+    #[test]
+    fn raw_time_check_rejects_growth_in_either_direction() {
+        // Constant work: the input grows 8x and the time does not.
+        assert!(
+            check_raw_time_flat(&[(100, 500), (200, 510), (800, 520)], 3.0).is_ok(),
+            "flat raw time must pass"
+        );
+
+        // The O(n) regression this guards against.
+        let err = check_raw_time_flat(&[(100, 500), (200, 1000), (800, 4000)], 3.0)
+            .expect_err("8x growth must fail");
+        assert!(
+            err.contains("n=800"),
+            "the message must carry the samples: {err}"
+        );
+
+        // Unlike the per-unit check, this one is a spread: a dip is as
+        // interesting as a rise, since either means the cost tracks the input.
+        assert!(
+            check_raw_time_flat(&[(100, 4000), (200, 1000), (800, 500)], 3.0).is_err(),
+            "an 8x fall must fail too"
+        );
+    }
+
+    #[test]
+    fn scaling_retry_needs_every_attempt_to_trip() {
+        // Trips once, then passes: the machine was busy, not the code.
+        let mut calls = 0;
+        assert_scaling_stable("transient", 3, || {
+            calls += 1;
+            if calls == 1 {
+                Err("first attempt".to_string())
+            } else {
+                Ok(())
+            }
+        });
+        assert_eq!(calls, 2, "must stop as soon as an attempt passes");
+
+        // Passes first time: no repetition at all.
+        let mut calls = 0;
+        assert_scaling_stable("clean", 3, || {
+            calls += 1;
+            Ok(())
+        });
+        assert_eq!(calls, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "all 3 attempts tripped the bar")]
+    fn scaling_retry_fails_when_every_attempt_trips() {
+        assert_scaling_stable("persistent", 3, || Err("every time".to_string()));
+    }
+
+    #[test]
+    fn typical_per_size_rotates_and_takes_the_median() {
+        // Record the order the sizes are measured in, and hand back a value that
+        // identifies which call it was, so the median is checkable.
+        let mut order = Vec::new();
+        let mut nth = 0u128;
+        let samples = typical_per_size(&[10usize, 20, 30], 3, |n| {
+            order.push(n);
+            nth += 1;
+            // size 20's three calls return 5, 1, 3 -> median 3
+            match n {
+                20 => [5u128, 1, 3][(order.iter().filter(|&&s| s == 20).count()) - 1],
+                _ => nth,
+            }
+        });
+
+        assert_eq!(
+            order,
+            vec![10, 20, 30, 20, 30, 10, 30, 10, 20],
+            "each size must occupy each position exactly once"
+        );
+        let mid = samples.iter().find(|(n, _)| *n == 20).expect("size 20");
+        assert_eq!(mid.1, 3, "the median of 5, 1, 3 is 3");
     }
 
     #[test]

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -1091,10 +1091,10 @@ mod tests {
     ///
     /// This is what separates the two things a timing gate can see. Work that
     /// became super-linear trips the bar every time; a runner that stalled for a
-    /// moment trips it once. Rotation and a per-size minimum reduce the second
-    /// without removing it — measured under 16-way saturation, one size came out
-    /// at 340us/unit while its neighbours sat at 140 and 119, which is noise
-    /// wearing the shape of a regression.
+    /// moment trips it once. Rotating the order and taking a median per size
+    /// reduce the second without removing it — measured under 16-way saturation,
+    /// one size came out at 340us/unit while its neighbours sat at 140 and 119,
+    /// which is noise wearing the shape of a regression.
     ///
     /// Each attempt is reported as it happens, so a genuine regression leaves
     /// the full trail in the log rather than only its last measurement.

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -1052,14 +1052,16 @@ mod tests {
     #[test]
     fn load_all_cost_per_state_stays_flat() {
         // The capacity scales with the input, which keeps two things fixed that
-        // would otherwise move with it: the number of segments on disk
-        // (~2n/capacity) and the fraction still in memory (~capacity/2n). A
-        // fixed capacity fails this test on unchanged code — at 2500 states
-        // most of the data is still in the cheap in-memory tail, while at
-        // 10_000 most has gone through the far more expensive per-segment rerun
-        // decode, so the cost per state climbs for reasons that have nothing to
-        // do with complexity. Holding the mix still leaves rows-per-segment as
-        // the only thing varying.
+        // would otherwise move with it. Measured against this fixture: every
+        // size ends with 18 segments on disk and exactly `capacity` states in
+        // memory, i.e. 10% of the input.
+        //
+        // A fixed capacity fails this test on unchanged code. At capacity 2000
+        // the in-memory share runs 60% / 20% / 10% across these three sizes, so
+        // the work migrates from the cheap in-memory tail to the far more
+        // expensive per-segment rerun decode and the cost per state climbs for
+        // reasons that have nothing to do with complexity. Holding the mix
+        // still leaves rows-per-segment as the only thing varying.
         let sizes = [2_500usize, 5_000, 10_000];
 
         let samples: Vec<(usize, u128)> = sizes

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -536,6 +536,13 @@ mod tests {
 
     #[test]
     fn overview_cost_is_constant_regardless_of_disk_segments() {
+        // TODO: this and `overview_multi_entity_cost_is_bounded` still assert an
+        // absolute millisecond budget, which on CI runners measures machine
+        // load as much as the code (see the note on
+        // `assert_cost_per_unit_flat`). The claim here — cost independent of
+        // segment count — is naturally a scaling check: measure at 10 and 40
+        // segments and require the cost not to climb.
+        //
         // Regression gate. With the old `load_all()` based implementation
         // this test fails because the cost scales with the number of
         // flushed segments (disk I/O + decode + sort). The incremental
@@ -932,65 +939,145 @@ mod tests {
         assert_eq!(ds.len(), 5);
     }
 
-    #[test]
-    fn downsample_performance() {
-        let states: Vec<HistoryState> = (0..100_000).map(|i| make_state(i as f64)).collect();
-        let start = std::time::Instant::now();
-        let ds = HistoryBuffer::downsample(&states, 1000);
-        let elapsed = start.elapsed();
+    /// Fastest of `reps` measurements, in microseconds.
+    ///
+    /// `measure` does its own setup and returns only the timed part, so growing
+    /// input sizes do not charge their construction to the measurement.
+    ///
+    /// The minimum, not the mean or the median: scheduling noise on a shared
+    /// runner only ever adds time, so the fastest sample is the closest
+    /// available estimate of the cost itself.
+    fn fastest_us(reps: u32, mut measure: impl FnMut() -> u128) -> u128 {
+        (0..reps).map(|_| measure()).min().expect("reps > 0")
+    }
 
-        assert_eq!(ds.len(), 1000);
+    /// Assert the cost per unit of input does not climb as the input grows —
+    /// that is, the work stays about linear.
+    ///
+    /// This says nothing about absolute speed, deliberately. The same flush
+    /// measured 364-400ms on a Linux runner, 642-717ms on a Windows one, and
+    /// 705-1610ms once the rest of the test suite was running alongside it;
+    /// Windows also moved 2x between runs of the same image. A millisecond
+    /// budget across that spread reports how busy the machine was. A ratio
+    /// between sizes measured back to back on one machine does not: both halves
+    /// absorb the same noise.
+    ///
+    /// The blind spot is a constant-factor regression — ten times slower per
+    /// unit, still linear, still passes. Catching that needs a stable machine
+    /// and a history to compare against rather than a single CI run.
+    fn assert_cost_per_unit_flat(label: &str, samples: &[(usize, u128)]) {
+        // Quadratic growth over a 4x size range shows up as ~4x here; n log n
+        // over the same range is ~1.3x. 2.0 sits between them.
+        const BAR: f64 = 2.0;
+
+        let per_unit: Vec<f64> = samples
+            .iter()
+            .map(|(n, us)| *us as f64 / *n as f64)
+            .collect();
+        let first = per_unit[0];
+        let last = per_unit[per_unit.len() - 1];
+
+        let detail: Vec<String> = samples
+            .iter()
+            .zip(&per_unit)
+            .map(|((n, us), c)| format!("n={n}: {us}us ({c:.3}us/unit)"))
+            .collect();
+
         assert!(
-            elapsed.as_millis() < 10,
-            "downsample took {}ms, expected <10ms",
-            elapsed.as_millis()
+            last / first <= BAR,
+            "{label}: cost per unit grew {:.2}x from the smallest to the largest \
+             input (bar {BAR:.1}x), which is the signature of super-linear work. \
+             Samples — {}",
+            last / first,
+            detail.join(", ")
         );
     }
 
     #[test]
-    fn flush_performance() {
-        let dir = temp_data_dir("flush-perf");
-        let mut buf = HistoryBuffer::new(10_000, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+    fn downsample_cost_per_state_stays_flat() {
+        // Sizes span 4x so quadratic work is unmistakable, and start high
+        // enough that the smallest sample is well clear of timer granularity.
+        let sizes = [100_000usize, 200_000, 400_000];
 
-        for i in 0..5000 {
-            buf.states.push_back(make_state(i as f64));
-        }
+        let samples: Vec<(usize, u128)> = sizes
+            .iter()
+            .map(|&n| {
+                let states: Vec<HistoryState> = (0..n).map(|i| make_state(i as f64)).collect();
+                let us = fastest_us(3, || {
+                    let start = std::time::Instant::now();
+                    let ds = HistoryBuffer::downsample(&states, 1000);
+                    let elapsed = start.elapsed();
+                    assert_eq!(ds.len(), 1000, "downsample must hit its target size");
+                    elapsed.as_micros()
+                });
+                (n, us)
+            })
+            .collect();
 
-        let start = std::time::Instant::now();
-        buf.flush();
-        let elapsed = start.elapsed();
-
-        assert!(
-            elapsed.as_millis() < 2000,
-            "flush took {}ms, expected <2000ms",
-            elapsed.as_millis()
-        );
-        assert_eq!(buf.segment_count, 1);
-
-        cleanup_dir(&dir);
+        assert_cost_per_unit_flat("downsample", &samples);
     }
 
     #[test]
-    fn load_all_performance() {
-        let dir = temp_data_dir("load-perf");
-        let mut buf = HistoryBuffer::new(2000, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+    fn flush_cost_per_row_stays_flat() {
+        // `flush` drains half the buffer, so twice the target is pushed. Sizes
+        // stay modest because each flush encodes and writes a real .rrd.
+        let sizes = [625usize, 1250, 2500];
 
-        for i in 0..10_000 {
-            buf.push(make_state(i as f64));
-        }
+        let samples: Vec<(usize, u128)> = sizes
+            .iter()
+            .map(|&rows| {
+                let us = fastest_us(2, || {
+                    let dir = temp_data_dir(&format!("flush-scale-{rows}"));
+                    let mut buf =
+                        HistoryBuffer::new(10_000, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+                    for i in 0..(rows * 2) {
+                        buf.states.push_back(make_state(i as f64));
+                    }
 
-        let start = std::time::Instant::now();
-        let all = buf.load_all();
-        let elapsed = start.elapsed();
+                    let start = std::time::Instant::now();
+                    buf.flush();
+                    let elapsed = start.elapsed();
 
-        assert_eq!(all.len(), 10_000);
-        assert!(
-            elapsed.as_millis() < 2000,
-            "load_all took {}ms, expected <2000ms",
-            elapsed.as_millis()
-        );
+                    assert_eq!(buf.segment_count, 1, "one flush must write one segment");
+                    cleanup_dir(&dir);
+                    elapsed.as_micros()
+                });
+                (rows, us)
+            })
+            .collect();
 
-        cleanup_dir(&dir);
+        assert_cost_per_unit_flat("flush", &samples);
+    }
+
+    #[test]
+    fn load_all_cost_per_state_stays_flat() {
+        // Buffer cap 2000 with 4x that pushed, so every size reads several
+        // segments back off disk rather than answering from memory.
+        let sizes = [2_500usize, 5_000, 10_000];
+
+        let samples: Vec<(usize, u128)> = sizes
+            .iter()
+            .map(|&n| {
+                let us = fastest_us(2, || {
+                    let dir = temp_data_dir(&format!("load-scale-{n}"));
+                    let mut buf = HistoryBuffer::new(2000, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
+                    for i in 0..n {
+                        buf.push(make_state(i as f64));
+                    }
+
+                    let start = std::time::Instant::now();
+                    let all = buf.load_all();
+                    let elapsed = start.elapsed();
+
+                    assert_eq!(all.len(), n, "load_all must return every pushed state");
+                    cleanup_dir(&dir);
+                    elapsed.as_micros()
+                });
+                (n, us)
+            })
+            .collect();
+
+        assert_cost_per_unit_flat("load_all", &samples);
     }
 
     #[test]


### PR DESCRIPTION
## 問題

性能テストが時間の絶対値を assert していて、windows-latest で落ちた。

```
flush took 2149ms, expected <2000ms
```

flush のコードは変更していない。同じ flush の実測値は条件次第で 378ms から 1610ms まで動く（プラットフォーム差、他のテストとの並列実行、run ごとの runner の当たり外れ）。この幅に 2000ms の線を引いても、コードが遅くなったかは判定できない。

同じ形の閾値が 5 テストにあった。

## 変更

**時間の絶対値ではなく、入力サイズを変えたときのコストの伸びを見る**形にした。マシンが遅ければ全サイズが同じだけ遅くなるので、比は変わらない。

**`flush_performance` → `flush_cost_per_row_stays_flat`**

625 / 1250 / 2500 行を flush して、1 行あたりの時間を比べる。flush は行数に比例した仕事をするので、1 行あたりは一定のはず。大きいサイズで 2 倍を超えて上がったら落ちる（行あたりの処理が増えたか、O(n²) が入った）。

**`load_all_performance` → `load_all_cost_per_state_stays_flat`**

2500 / 5000 / 10000 件を読み戻して、1 件あたりの時間を比べる。判定は flush と同じ。

**`downsample_performance` → `downsample_cost_stays_independent_of_input_size`**

100k / 200k / 400k / 800k 件で downsample して、**実行時間そのもの**を比べる。この関数は入力が何件でも `max_points`（1000）件しかコピーしないので、時間は入力サイズに依存しないはず。最大と最小が 3 倍を超えて開いたら落ちる（入力全体を走査する処理が入った）。

**`overview_cost_is_constant_regardless_of_disk_segments`**（改名なし）

5000 / 10000 / 20000 件 push した状態で `overview()` を呼び、実行時間そのものを比べる。`overview()` はメモリ上の固定サイズのバッファだけを見るので、push 量とディスク上の segment 数が増えても時間は変わらないはず。開いたら落ちる（ディスクを読み始めたか、`load_all()` を呼ぶようになった）。

**`overview_multi_entity_cost_is_bounded`**（改名なし）

衛星 5 / 10 / 20 機で `overview()` を呼び、1 機あたりの時間を比べる。3 倍を超えて上がったら落ちる。閾値が他より緩いのは、この関数が全機のバッファを 1 つの Vec に連結してソートするため、機数が増えると 1 機あたりも多少増えるのが正常だから（実測 1.46 倍）。

振る舞いの assert は維持し、各サイズで実行するので回数は増えた。実行時間は 5 テスト合計 12 秒。

## 検証

- **二次的な処理を注入 → 落ちる**（`0.547 → 1.072 → 2.144 us/unit`、3.92 倍）
- **O(n) の全走査を注入 → 落ちる**（5.88 倍）
- **要素あたり 200 倍だが線形の処理 → 通る**。定数倍の回帰は捕らえられない。これは設計上の限界で、ヘルパの rustdoc に明記した
- **16 コア全負荷で 5 回 → すべて pass**
- 判定ロジック自体の決定的テストを 5 件追加（固定サンプルなので時間測定に依存しない）
- 231 テスト pass、clippy 通過

## レビューで見てほしい箇所

`load_all` のテストは容量を n に比例させている。固定すると未変更のコードで落ちる。

`push` は満杯時にバッファの半分を flush するので、容量固定だとデータの居場所が n で変わる（実装に対して実測）。

| n | 容量 2000 のメモリ比率 | 容量 n/10 |
|---|---|---|
| 2500 | 60.0% | 10.0% |
| 5000 | 40.0% | 10.0% |
| 10000 | 20.0% | 10.0% |

安価なメモリ経路から高価な rerun decode 経路へ重心が移り、それだけで per-unit コストが 2.47 倍になる。初版がこれで CI に落ちた。

<details>
<summary>ノイズ対策と閾値の根拠</summary>

3 つ組み合わせている。

**測定順序の回転** — サイズごとに全反復を終えてから次に進むと実行順序とサイズが交絡する。各反復で全サイズを測り開始位置を回転させ、各サイズが各位置を 1 回ずつ通る（3 サイズなら 10,20,30 / 20,30,10 / 30,10,20）。

**median 集約** — min は使わない。単調に遅くなる状況では各サイズの最小値がその最初の出現から来て、最初の反復は昇順なので、最小値が再びサイズ順に並ぶ。

**3 回の再現要求** — 違反が 3 試行すべてで出たときのみ失敗させる。複雑度の回帰は毎回再現し、負荷スパイクは 1 回しか出ない。

閾値。

| テスト | 閾値 | 根拠 |
|---|---|---|
| flush, load_all | 2.0 | 4 倍のサイズ幅で二次なら約 4 倍、n log n なら約 1.3 倍 |
| downsample | 3.0 | 清浄時 1.10 倍、注入した O(n) が 5.88 倍 |
| overview（エンティティ） | 3.0 | 清浄時 1.46 倍、負荷下 2.0-2.15 倍 |

`overview()` は全エンティティのバッファを 1 つの Vec に連結してソートするので、エンティティを増やすと長さと交錯の両方が増える。この上昇は正常なので 2.0 では落ちる。

`load_all` の実際の複雑度は最終ソートによる O(n log n)。4 倍幅で約 1.18 倍なので閾値内。

</details>

<details>
<summary>Windows で顕著に出た理由（調査記録、テスト変更の判断には影響しない）</summary>

同じ flush の実測値。

| | テスト単独 | 全 suite 並列 |
|---|---|---|
| macOS | 378-432ms | 705ms |
| Linux | 364-400ms | 820ms |
| Windows | 642-717ms | 約1610ms |

Windows は同一 image の run 間でも 343-358ms と 642-717ms の両方を記録した。

3 つが積み上がる。

- 並列時の目減りが最大。固定の計算を 1 プロセスで走らせた時間と全コア同時の wall clock の比が、Windows 2.11-2.23 倍 / Linux 1.72 倍 / macOS 1.18 倍
- run 間のばらつきが約 2 倍
- 単独実行値そのものが Linux の約 1.8 倍

調べて外れたもの。

- **Defender** — runner 上で `RealTimeProtectionEnabled : False`
- **disk I/O** — 666KB + fsync が Linux 0.68-1.20ms / macOS 0.55-1.22ms / Windows 7.48-24.26ms。Windows は 10 倍以上遅いが、flush が書くのは 1 ファイルで、最悪 24ms は並列時 1610ms の 1.5%
- **rerun / arrow の既知問題** — 両者の issue・discussion・リリースノートに、encode / save 経路の Windows 固有の報告は見つからなかった
- **スペック差** — Linux も Windows も 4 vCPU / 16 GB。最も貧弱な macOS（3 core / 7 GB）の flush が最速

未解明はCPU 速度差で補正した後の残差の帰属。flush の内訳は Linux で enqueue 165ms (73%) / drain 55ms (24%) / drop 4ms (2%) で、呼び出しスレッドの `rec.log()` ループが支配的。プラットフォーム別の内訳測定は未完。

CPU 速度の切り分けに使った probe は CPython のループで、CPython は int 演算ごとにヒープ確保するため、測れているのはインタプリタとアロケータのスループット。同一マシン内の比なら Python の版差は打ち消されるが、プラットフォーム間の絶対値比較には使えない。

</details>


