### PR TITLE
fix(arika)!: keep the equatorial periapsis direction, rotate the Meeus ephemerides to J2000, and make EOP lookups honest

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -34,6 +34,11 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   SimpleEci>` で `ExternalLoads<F>` を返す (`Model<S, F>` と同様)。effector は
   host の慣性 frame で荷重を生成するようになった。既定の `F` により既存の
   `StateEffector<S>` 実装はそのままコンパイル可能。([#148](https://github.com/sksat/orts/pull/148))
+- `arika` の暦フレーム修正に伴い、太陽・月に依存する結果 (SRP、第三体重力、日陰幾何、
+  sun sensor、Harris-Priester の密度 bulge) が動く。暦が mean equinox of date ではなく
+  J2000 の方向を返すようになったためで、2024 年で 0.335°。Orekit との一致はその分改善し、
+  GEO 3 日の third-body oracle は 218 m → 0.33 m、短い Harris-Priester oracle 3 件は
+  20-40% 改善する。([#359](https://github.com/sksat/orts/pull/359))
 
 #### Fixed
 - `SpacecraftDynamics` の不正な frame 再タグを除去。`ExternalLoads<SimpleEci>`
@@ -175,11 +180,59 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - `earth::topocentric` — 地上局の look angle: `TopocentricSite<F: Ecef>`
   (WGS-84 `Geodetic` から構築し局所 ENU 基底を事前計算) と `LookAngles`
   (方位 / 仰角 / slant range)。`look_angles(target)` で算出。([#112](https://github.com/sksat/orts/pull/112))
+- `frame::MeanEquinoxOfDate` marker — 日付の平均赤道・平均春分点 (MOD)、`Eci`
+  category。古典的な解析級数が基準にし、GMST が測られる equinox。
+  `earth::mean_equinox` が `Gcrs` との間の IAU 1976 precession を持つ
+  (`Rotation<MeanEquinoxOfDate, Gcrs>::iau1976_precession` と逆向き)。局所時角
+  `GMST + λ − α` を組む利用者が、赤経を GMST と同じ equinox のフレームに置ける。
+  ([#359](https://github.com/sksat/orts/pull/359))
+- `EopTable::clamped()` / `EopTable::into_clamped()` → `ClampedEop`。範囲外の
+  照会に最近端点の値を返す EOP provider。dUT1 は連続量 `UT1 − TAI` 経由で保持する
+  ので、テーブル終端より後のうるう秒は UT1 に段差を作らず dUT1 を 1 s 動かす。
+  ([#359](https://github.com/sksat/orts/pull/359))
 
 #### Changed
 - `Epoch::from_iso8601` が ordinal / day-of-year 形式
   (`YYYY-DDDTHH:MM:SS`、CCSDS OMM で使用) も受理し、末尾の `Z` が任意になった。
   厳密な緩和で、従来受理した入力は引き続きパース可能。([#87](https://github.com/sksat/orts/pull/87))
+- **BREAKING**: `EopTable` は EOP capability trait
+  (`Ut1Offset` / `PolarMotion` / `NutationCorrections` / `LengthOfDay`) を実装しない。
+  これらの trait は infallible で、有限の MJD 区間しか覆わないテーブルは範囲外で
+  正しい infallible な答を持たない (従来は `.expect()` で、通常の範囲外 epoch が
+  `Epoch::to_ut1` や IAU 2006 full chain の内側からプロセスを abort させていた)。
+  `table.clamped()` (借用) / `table.into_clamped()` (所有) で範囲外 policy を
+  名指しするか、`*_checked` accessor で `EopLookupError::OutOfRange` を受ける。
+  ([#359](https://github.com/sksat/orts/pull/359))
+- `KeplerianElements::from_state_vector` の退化幾何の規約を型の doc に明記した
+  (円軌道 / 赤道軌道 / 円赤道軌道で `raan` / `argument_of_periapsis` /
+  `true_anomaly` が何を保持するかの表)。面内角は軌道法線まわりに測る `atan2`
+  ベースのヘルパ 1 本で計算し、従来の `acos` + 象限判定が ν = 0 / i = 0 付近で
+  落としていた mantissa の半分を回復した。非退化な軌道の値は変わらない。([#359](https://github.com/sksat/orts/pull/359))
+
+#### Fixed
+- `KeplerianElements::from_state_vector` が離心率のある赤道軌道の近地点方向を
+  失っていた。RAAN と argument of periapsis の両方を 0 にしつつ真近点角を離心率
+  ベクトルから測っていたため、赤道面内の近地点経度がどの要素にも保存されなかった。
+  a = 10,000 km, e = 0.2, i = 0, ϖ = π/2 が 90° 回転して戻り、往復の位置誤差が
+  11,313.7 km。赤道軌道では true longitude of periapsis ϖ = Ω + ω を保存する
+  (逆行では符号反転。`to_state_vector` の i = π と整合)。([#359](https://github.com/sksat/orts/pull/359))
+- Meeus の太陽・月暦が mean equinox of date のベクトルを `Vec3<Gcrs>` として
+  返していた。平均黄経の係数が tropical rate で、黄道 → 赤道の回転も of-date の
+  平均黄道傾斜角を使うため、J2000 からの累積歳差がそのまま乗っていた: 2024 年で
+  0.335°、~1.4°/century で増加し、月ベクトルで約 2,250 km の横方向誤差 — 級数
+  自身の ~1′ 精度より 1 桁大きい。IAU 1976 precession で J2000 に戻す (nutation
+  ≤ 17″ と J2000→GCRS frame bias ~20 mas は入れない)。太陽・月に依存する結果
+  (SRP、第三体重力、日陰、sun sensor) はこの角度ぶん動く。従来「Meeus model の
+  精度 0.35°」と記録されていた量は、この回転ぶんだった。([#359](https://github.com/sksat/orts/pull/359))
+- `sun::sun_direction_from_body` の惑星分岐が、Standish の惑星要素 (J2000 mean
+  ecliptic 基準) を **of-date の** 黄道傾斜角で赤道座標に回していた (2024 年で
+  11″、2075 年で 35″ の frame error)。固定の J2000 傾斜角を使う。([#359](https://github.com/sksat/orts/pull/359))
+- `EopTable::dut1_checked` がうるう秒を跨いで dUT1 を直接補間し、1 s の跳びの
+  半分を前日に塗り広げていた。2017-01-01 を挟む IERS の 2 行 (−0.5928 s /
+  +0.4068 s) で中点が ≈ −0.593 s ではなく −0.093 s になり、UT1 で 0.5 s
+  (ERA で 3.7e-5 rad、赤道で約 230 m) の誤差。連続量
+  `UT1 − TAI = dUT1 − (TAI − UTC)` を補間し、照会時点の `TAI − UTC` を足し戻す。
+  ([#359](https://github.com/sksat/orts/pull/359))
 
 ### `utsuroi` (Rust, crates.io)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ section is subdivided by package.
   SimpleEci>` returning `ExternalLoads<F>`, like `Model<S, F>` — so effectors
   produce loads already in the host inertial frame. The defaulted `F` keeps
   existing `StateEffector<S>` impls compiling unchanged. ([#148](https://github.com/sksat/orts/pull/148))
+- Sun- and Moon-dependent results move with `arika`'s ephemeris frame fix (SRP,
+  third-body, eclipse geometry, sun sensors, and the Harris-Priester density
+  bulge): the ephemerides return J2000 directions now instead of
+  mean-equinox-of-date ones, a 0.335° change in 2024. Agreement with Orekit
+  improves accordingly — the GEO 3-day third-body oracle goes from 218 m to
+  0.33 m, and the three shorter Harris-Priester oracles by 20-40%. ([#359](https://github.com/sksat/orts/pull/359))
 
 #### Fixed
 - Removed an unsound frame re-tag in `SpacecraftDynamics`: effector loads tagged
@@ -189,11 +195,66 @@ section is subdivided by package.
 - `earth::topocentric` — ground-site look angles: `TopocentricSite<F: Ecef>`
   (from a WGS-84 `Geodetic`, precomputing the local ENU basis) and `LookAngles`
   (azimuth / elevation / slant range), via `look_angles(target)`. ([#112](https://github.com/sksat/orts/pull/112))
+- `frame::MeanEquinoxOfDate` marker — the mean equator and equinox of date (MOD),
+  in the `Eci` category: the frame the classical analytic series are referred to
+  and the equinox GMST is measured from. `earth::mean_equinox` carries the IAU
+  1976 precession between it and `Gcrs`
+  (`Rotation<MeanEquinoxOfDate, Gcrs>::iau1976_precession` and the reverse), so a
+  consumer building a local hour angle `GMST + λ − α` can put its right ascension
+  in the frame GMST belongs to. ([#359](https://github.com/sksat/orts/pull/359))
+- `EopTable::clamped()` / `EopTable::into_clamped()` → `ClampedEop`, an EOP
+  provider that answers out-of-range queries with its nearest endpoint. dUT1 is
+  held through the continuous `UT1 − TAI`, so a leap second past the end of the
+  table moves dUT1 by a second instead of stepping UT1. ([#359](https://github.com/sksat/orts/pull/359))
 
 #### Changed
 - `Epoch::from_iso8601` also accepts the ordinal / day-of-year form
   (`YYYY-DDDTHH:MM:SS`, used by CCSDS OMM), and the trailing `Z` is now optional.
   A strict relaxation — previously-accepted inputs still parse. ([#87](https://github.com/sksat/orts/pull/87))
+- **BREAKING**: `EopTable` no longer implements the EOP capability traits
+  (`Ut1Offset`, `PolarMotion`, `NutationCorrections`, `LengthOfDay`). Those traits
+  are infallible, and a table covering a finite MJD span has no correct infallible
+  answer outside it — it used to `.expect()`, turning an ordinary out-of-range
+  epoch into a process abort from inside `Epoch::to_ut1` and the IAU 2006 full
+  chain. Pass `table.clamped()` (borrowing) or `table.into_clamped()` (owning) to
+  name the out-of-range policy, or use the `*_checked` accessors to get
+  `EopLookupError::OutOfRange`. ([#359](https://github.com/sksat/orts/pull/359))
+- `KeplerianElements::from_state_vector` now states its degenerate-geometry
+  conventions on the type (a table of what `raan` /
+  `argument_of_periapsis` / `true_anomaly` hold for circular, equatorial and
+  circular-equatorial orbits), and computes every in-plane angle with one
+  `atan2`-based helper measured about the orbit normal — recovering the half
+  mantissa the previous `acos` + quadrant tests lost near ν = 0 and i = 0.
+  Non-degenerate orbits are unchanged. ([#359](https://github.com/sksat/orts/pull/359))
+
+#### Fixed
+- `KeplerianElements::from_state_vector` lost the periapsis direction of an
+  eccentric equatorial orbit: it zeroed both the RAAN and the argument of
+  periapsis while still measuring the true anomaly from the eccentricity vector,
+  so the in-plane periapsis longitude was stored nowhere. a = 10,000 km, e = 0.2,
+  i = 0, ϖ = π/2 came back rotated 90°, an 11,313.7 km round-trip position error.
+  The equatorial branch now stores the true longitude of periapsis ϖ = Ω + ω
+  (negated for retrograde, matching `to_state_vector` at i = π). ([#359](https://github.com/sksat/orts/pull/359))
+- The Meeus Sun and Moon ephemerides returned mean-equinox-of-date vectors typed
+  `Vec3<Gcrs>`. Their mean longitudes advance at the tropical rate and their
+  ecliptic → equatorial rotation uses the mean obliquity of date, so the result
+  carried the whole precession accumulated since J2000: 0.335° in 2024, growing
+  ~1.4°/century — ~2,250 km transverse on the Moon vector, an order of magnitude
+  above the series' own ~1′ accuracy. They now rotate back to J2000 with the IAU
+  1976 precession (nutation, ≤ 17″, and the J2000→GCRS frame bias, ~20 mas, stay
+  out). This moves Sun/Moon-dependent results — SRP, third-body, eclipse, sun
+  sensors — by that angle. The 0.35° figure previously documented as Meeus model
+  accuracy was this rotation, not model error. ([#359](https://github.com/sksat/orts/pull/359))
+- `sun::sun_direction_from_body`'s planet branch rotated the Standish
+  heliocentric elements — referred to the J2000 mean ecliptic — into equatorial
+  coordinates with the obliquity *of date*, leaving 11″ of frame error in 2024 and
+  35″ by 2075. It now uses the fixed J2000 obliquity. ([#359](https://github.com/sksat/orts/pull/359))
+- `EopTable::dut1_checked` interpolated dUT1 straight through a leap second,
+  smearing half of the 1 s step over the preceding day: the IERS rows bracketing
+  2017-01-01 (−0.5928 s / +0.4068 s) gave −0.093 s at the midpoint instead of
+  ≈ −0.593 s, a 0.5 s UT1 error — 3.7e-5 rad of ERA, ~230 m at the equator. It now
+  interpolates the continuous `UT1 − TAI = dUT1 − (TAI − UTC)` and adds the query
+  instant's own `TAI − UTC` back. ([#359](https://github.com/sksat/orts/pull/359))
 
 ### `utsuroi` (Rust, crates.io)
 

--- a/arika/DESIGN.md
+++ b/arika/DESIGN.md
@@ -41,6 +41,9 @@ category trait は structural operation (magnitude / dot / cross / 非依存 mat
 - `Cirs` (Celestial Intermediate Reference System) — IAU 2006 CIO chain 中間
 - `Tirs` (Terrestrial Intermediate Reference System) — polar motion 未適用の Earth-fixed
 - `Itrs` (International Terrestrial Reference System) — polar motion 適用済み、Geodetic 変換はこの frame に紐づく
+- `MeanEquinoxOfDate` — 日付の平均赤道・平均春分点 (MOD)。古典的な解析級数 (Meeus の太陽・月) が
+  表現されている frame であり、GMST が基準にする equinox でもある。`Gcrs` との差は累積歳差
+  (2024 年で 0.335°)。`earth::mean_equinox` が IAU 1976 precession で両方向を繋ぐ
 
 `Rotation<SimpleEci, Gcrs>` / `Rotation<SimpleEcef, Itrs>` のような「簡易 path から高精度 path への
 upgrade 変換」は提供しない。silent な degradation 経路を作らないため。

--- a/arika/DESIGN.md
+++ b/arika/DESIGN.md
@@ -178,7 +178,17 @@ ECI 位置ベクトルから WGS-84 測地高度を直接計算するユーテ�
 ### 天体暦の精度レベル
 
 Meeus "Astronomical Algorithms" に基づく低精度解析解を採用。
-太陽位置で ~0.35°（vs DE405）、月位置で ~1% 距離誤差がある。
+方向で ~1 arcmin（太陽）/ ~10 arcsec（月の黄経）、月距離で ~1% の誤差がある。
+
+Meeus の級数は **mean equinox of date** で表現されている（平均黄経の係数が
+tropical rate、黄道傾斜角も of-date）ため、`Vec3<Gcrs>` として返す前に IAU 1976
+precession で J2000 に戻す（`arika::earth::fk5`）。この回転を省くと J2000 からの
+累積 precession ぶん（2024 年で 0.335°、100 年で ~1.4°）方向がずれ、月ベクトルで
+~2,250 km、太陽ベクトルで ~875,000 km に相当する。nutation（≤ 17″）と
+J2000→GCRS frame bias（~20 mas）は級数自身の精度より十分小さいので無視する。
+
+`arika::planets` の Standish 惑星要素は J2000 mean ecliptic 基準（平均黄経の係数が
+sidereal rate）なので precession 回転は不要。
 
 高精度暦（JPL DE430 等）への拡張は将来の選択肢。現状の軌道力学シミュレーションでは十分な精度。
 

--- a/arika/src/earth/eop/mod.rs
+++ b/arika/src/earth/eop/mod.rs
@@ -24,12 +24,26 @@
 //! のは provider-free な API (例: `Epoch<Utc>::to_ut1_naive`、`Epoch<Tai>::to_tt`) のみ
 //! で、EOP trait bound を要求する全ての API では compile error を誘発する。
 //!
+//! # 有限区間の provider と out-of-range policy
+//!
+//! 上記 4 trait は infallible (`-> f64`) である。これは高精度 API を trait bound で
+//! gate するための設計だが、その代償として **有限区間しか持たないデータ源は
+//! これらの trait を直接実装できない** ことになる。[`EopTable`] は finals2000A の
+//! 覆う MJD 区間しか答えを持たないので、trait を実装せず、fallible な
+//! `*_checked` accessor と、policy を明示した adapter
+//! ([`EopTable::clamped`]) だけを提供する。範囲外 epoch は
+//! `EopLookupError::OutOfRange` として型に現れ、runtime panic にはならない。
+//!
 //! # Leap second は別体系
 //!
 //! Leap second table は arika 内の compiled-in データ
 //! ([`crate::epoch`] の `LEAP_SECONDS`) であり、EOP provider 経由では取得しない。
 //! 更新 cadence (leap second = 6 ヶ月ごとの IERS Bulletin C、EOP = ほぼ毎日の
 //! IERS Bulletin A/B) も意味論も異なるため、完全に別扱い。
+//!
+//! ただし dUT1 の **補間** は leap second table を必要とする: dUT1 は leap second を
+//! 跨ぐと 1 s 跳ぶ不連続量で、連続量は `UT1 − TAI = dUT1 − (TAI − UTC)` の方である。
+//! [`EopTable::dut1_checked`] はこの連続量を補間する。
 
 // EOP parameter traits
 
@@ -199,7 +213,7 @@ pub use error::{EopLookupError, EopParseError};
 #[cfg(feature = "alloc")]
 pub use finals2000a::Finals2000A;
 #[cfg(feature = "alloc")]
-pub use table::EopTable;
+pub use table::{ClampedEop, EopTable};
 
 #[cfg(test)]
 mod tests {

--- a/arika/src/earth/eop/table.rs
+++ b/arika/src/earth/eop/table.rs
@@ -111,7 +111,12 @@ impl EopTable {
         let first = self.entries.first().unwrap();
         let last = self.entries.last().unwrap();
 
-        if utc_mjd < first.mjd || utc_mjd > last.mjd {
+        // Written as a negated in-range test so that a NaN query is an error
+        // too: `NaN < start` and `NaN > end` are both false, so the direct form
+        // would let NaN through and interpolate it into an `Ok(NaN)` — a
+        // lookup that reports success while carrying a value that poisons every
+        // rotation it reaches.
+        if !(utc_mjd >= first.mjd && utc_mjd <= last.mjd) {
             return Err(EopLookupError::OutOfRange {
                 mjd: utc_mjd,
                 start: first.mjd,
@@ -172,8 +177,8 @@ impl<T: core::borrow::Borrow<EopTable>> ClampedEop<T> {
     ///
     /// Written out rather than using `f64::clamp`, which asserts `min <= max`
     /// (an unsorted table would turn a lookup into a panic) and to leave NaN
-    /// alone: NaN cannot be clamped into range, so the checked lookup below
-    /// reports it as out of range and the adapter yields NaN instead of a
+    /// alone: NaN has no nearest endpoint, so it stays NaN, the checked lookup
+    /// rejects it as out of range, and the adapter yields NaN rather than a
     /// plausible-looking number.
     fn clamp_mjd(&self, utc_mjd: f64) -> f64 {
         let (start, end) = self.table().mjd_range();

--- a/arika/src/earth/eop/table.rs
+++ b/arika/src/earth/eop/table.rs
@@ -4,13 +4,20 @@ use alloc::vec::Vec;
 
 use super::entry::EopEntry;
 use super::error::EopLookupError;
+use crate::epoch::tai_minus_utc_at_mjd;
 
 /// Interpolated EOP lookup table.
 ///
-/// Stores sorted EOP entries and provides interpolated parameter
-/// lookups at arbitrary MJD values. Implements all four EOP
-/// capability traits (`Ut1Offset`, `PolarMotion`, `NutationCorrections`,
-/// `LengthOfDay`).
+/// Stores sorted EOP entries and provides interpolated parameter lookups at
+/// arbitrary MJD values through the fallible `*_checked` accessors, which report
+/// [`EopLookupError::OutOfRange`] outside the covered MJD span.
+///
+/// The table does **not** implement the EOP capability traits (`Ut1Offset`,
+/// `PolarMotion`, `NutationCorrections`, `LengthOfDay`) itself: those are
+/// infallible, and a table covering a finite span has no correct infallible
+/// answer for an epoch it does not cover. Call [`EopTable::clamped`] (or
+/// [`EopTable::into_clamped`]) to get a provider with a stated out-of-range
+/// policy — see [`ClampedEop`].
 pub struct EopTable {
     entries: Vec<EopEntry>,
 }
@@ -51,8 +58,23 @@ impl EopTable {
     }
 
     /// Checked UT1-UTC lookup with linear interpolation.
+    ///
+    /// # Leap seconds
+    ///
+    /// dUT1 is *not* the quantity interpolated here. It jumps by a full second
+    /// across a leap second (finals2000A rows are daily, so the pair bracketing
+    /// 2017-01-01 reads −0.5928 s and +0.4068 s), and interpolating it directly
+    /// smears half of that step over the preceding day — a ~0.5 s UT1 error,
+    /// i.e. 3.7e-5 rad of ERA and ~230 m of equatorial ITRS displacement.
+    ///
+    /// `UT1 − TAI = dUT1 − (TAI − UTC)` is continuous by construction, so that
+    /// is what gets interpolated, using arika's compiled-in leap-second table
+    /// ([`crate::epoch`]) for each bracketing row; the query instant's own
+    /// `TAI − UTC` is then added back. Inside a single leap-second regime this
+    /// is algebraically identical to interpolating dUT1.
     pub fn dut1_checked(&self, utc_mjd: f64) -> Result<f64, EopLookupError> {
-        self.interpolate(utc_mjd, |e| e.dut1)
+        let ut1_minus_tai = self.interpolate(utc_mjd, |e| e.dut1 - tai_minus_utc_at_mjd(e.mjd))?;
+        Ok(ut1_minus_tai + tai_minus_utc_at_mjd(utc_mjd))
     }
 
     /// Checked x-pole lookup.
@@ -116,37 +138,107 @@ impl EopTable {
     }
 }
 
-// EOP trait implementations
+// Out-of-range policy adapters
 
 use super::{LengthOfDay, NutationCorrections, PolarMotion, Ut1Offset};
 
-impl Ut1Offset for EopTable {
-    fn dut1(&self, utc_mjd: f64) -> f64 {
-        self.dut1_checked(utc_mjd)
-            .expect("EOP UT1-UTC lookup failed")
+/// An [`EopTable`] that answers out-of-range queries with its nearest endpoint.
+///
+/// The EOP capability traits ([`Ut1Offset`] and friends) are infallible by
+/// design, so they gate the high-precision APIs at compile time
+/// ([`Epoch::<Utc>::to_ut1`](crate::epoch::Epoch::to_ut1),
+/// [`Rotation::<Gcrs, Itrs>::iau2006_full_from_utc`](crate::frame::Rotation)).
+/// An `EopTable` covers a finite MJD span and therefore cannot honour an
+/// infallible contract; it deliberately does *not* implement those traits, so a
+/// caller has to name an out-of-range policy first. This adapter is the
+/// "hold the endpoint value" policy, obtained from
+/// [`EopTable::clamped`] / [`EopTable::into_clamped`].
+///
+/// Clamping means dUT1, polar motion and dX/dY are held constant beyond the
+/// table — acceptable for a short overshoot past the end of a prediction file,
+/// increasingly wrong the further out the query goes. Use the `*_checked`
+/// accessors when an out-of-range query must be an error instead.
+pub struct ClampedEop<T>(T);
+
+impl<T: core::borrow::Borrow<EopTable>> ClampedEop<T> {
+    /// The wrapped table.
+    pub fn table(&self) -> &EopTable {
+        self.0.borrow()
+    }
+
+    /// Clamp `utc_mjd` into the table's covered range.
+    ///
+    /// Written out rather than using `f64::clamp`, which asserts `min <= max`
+    /// (an unsorted table would turn a lookup into a panic) and to leave NaN
+    /// alone: NaN cannot be clamped into range, so the checked lookup below
+    /// reports it as out of range and the adapter yields NaN instead of a
+    /// plausible-looking number.
+    fn clamp_mjd(&self, utc_mjd: f64) -> f64 {
+        let (start, end) = self.table().mjd_range();
+        if utc_mjd < start {
+            start
+        } else if utc_mjd > end {
+            end
+        } else {
+            utc_mjd
+        }
     }
 }
 
-impl PolarMotion for EopTable {
+impl EopTable {
+    /// Borrow this table as an endpoint-clamping EOP provider.
+    ///
+    /// See [`ClampedEop`] for what the policy means.
+    pub fn clamped(&self) -> ClampedEop<&EopTable> {
+        ClampedEop(self)
+    }
+
+    /// Consume this table into an owned endpoint-clamping EOP provider.
+    ///
+    /// See [`ClampedEop`] for what the policy means.
+    pub fn into_clamped(self) -> ClampedEop<EopTable> {
+        ClampedEop(self)
+    }
+}
+
+impl<T: core::borrow::Borrow<EopTable>> Ut1Offset for ClampedEop<T> {
+    fn dut1(&self, utc_mjd: f64) -> f64 {
+        self.table()
+            .dut1_checked(self.clamp_mjd(utc_mjd))
+            .unwrap_or(f64::NAN)
+    }
+}
+
+impl<T: core::borrow::Borrow<EopTable>> PolarMotion for ClampedEop<T> {
     fn x_pole(&self, utc_mjd: f64) -> f64 {
-        self.xp_checked(utc_mjd).expect("EOP x-pole lookup failed")
+        self.table()
+            .xp_checked(self.clamp_mjd(utc_mjd))
+            .unwrap_or(f64::NAN)
     }
     fn y_pole(&self, utc_mjd: f64) -> f64 {
-        self.yp_checked(utc_mjd).expect("EOP y-pole lookup failed")
+        self.table()
+            .yp_checked(self.clamp_mjd(utc_mjd))
+            .unwrap_or(f64::NAN)
     }
 }
 
-impl NutationCorrections for EopTable {
+impl<T: core::borrow::Borrow<EopTable>> NutationCorrections for ClampedEop<T> {
     fn dx(&self, utc_mjd: f64) -> f64 {
-        self.dx_checked(utc_mjd).expect("EOP dX lookup failed")
+        self.table()
+            .dx_checked(self.clamp_mjd(utc_mjd))
+            .unwrap_or(f64::NAN)
     }
     fn dy(&self, utc_mjd: f64) -> f64 {
-        self.dy_checked(utc_mjd).expect("EOP dY lookup failed")
+        self.table()
+            .dy_checked(self.clamp_mjd(utc_mjd))
+            .unwrap_or(f64::NAN)
     }
 }
 
-impl LengthOfDay for EopTable {
+impl<T: core::borrow::Borrow<EopTable>> LengthOfDay for ClampedEop<T> {
     fn lod(&self, utc_mjd: f64) -> f64 {
-        self.lod_checked(utc_mjd).expect("EOP LOD lookup failed")
+        self.table()
+            .lod_checked(self.clamp_mjd(utc_mjd))
+            .unwrap_or(f64::NAN)
     }
 }

--- a/arika/src/earth/eop/table.rs
+++ b/arika/src/earth/eop/table.rs
@@ -154,8 +154,10 @@ use super::{LengthOfDay, NutationCorrections, PolarMotion, Ut1Offset};
 /// "hold the endpoint value" policy, obtained from
 /// [`EopTable::clamped`] / [`EopTable::into_clamped`].
 ///
-/// Clamping means dUT1, polar motion and dX/dY are held constant beyond the
-/// table — acceptable for a short overshoot past the end of a prediction file,
+/// Clamping means polar motion, dX/dY and LOD are held constant beyond the
+/// table, and `UT1 - TAI` — the continuous part of dUT1 — is held constant while
+/// dUT1 itself still follows the leap seconds (see the `Ut1Offset` impl below).
+/// Acceptable for a short overshoot past the end of a prediction file,
 /// increasingly wrong the further out the query goes. Use the `*_checked`
 /// accessors when an out-of-range query must be an error instead.
 pub struct ClampedEop<T>(T);
@@ -202,10 +204,22 @@ impl EopTable {
 }
 
 impl<T: core::borrow::Borrow<EopTable>> Ut1Offset for ClampedEop<T> {
+    /// dUT1 held at the nearest endpoint — through `UT1 - TAI`, not through
+    /// dUT1 itself.
+    ///
+    /// dUT1 steps by a second at every leap second, so holding *it* constant
+    /// would put that step into UT1 instead, in the one region where nothing
+    /// corrects it. Holding the continuous `UT1 - TAI` and adding the query
+    /// instant's own `TAI - UTC` keeps UT1 continuous and reproduces the real
+    /// post-leap dUT1 to within its drift: a table ending 2016-12-30 at
+    /// dUT1 = -0.5928 s answers +0.4072 s for 2017-01-02, where IERS has
+    /// +0.4068 s.
     fn dut1(&self, utc_mjd: f64) -> f64 {
-        self.table()
-            .dut1_checked(self.clamp_mjd(utc_mjd))
-            .unwrap_or(f64::NAN)
+        let edge = self.clamp_mjd(utc_mjd);
+        match self.table().dut1_checked(edge) {
+            Ok(dut1_edge) => dut1_edge - tai_minus_utc_at_mjd(edge) + tai_minus_utc_at_mjd(utc_mjd),
+            Err(_) => f64::NAN,
+        }
     }
 }
 

--- a/arika/src/earth/fk5/mod.rs
+++ b/arika/src/earth/fk5/mod.rs
@@ -141,6 +141,17 @@ pub(crate) fn precession_matrix(t: f64) -> Matrix3<f64> {
     rot_z(-z) * rot_y(theta) * rot_z(-zeta)
 }
 
+/// Mean equator/equinox of date → J2000 rotation matrix `r_J2000 = Pᵀ · r_MOD`,
+/// the inverse of [`precession_matrix`].
+///
+/// Analytic ephemerides whose angles are referred to the mean equinox of date —
+/// Meeus' Sun and Moon series, whose mean longitudes advance at the *tropical*
+/// rate — need this to land in J2000/GCRS. Nutation is not undone (≤ 17″,
+/// an order of magnitude below those series' own accuracy).
+pub(crate) fn mean_of_date_to_j2000_matrix(t: f64) -> Matrix3<f64> {
+    precession_matrix(t).transpose()
+}
+
 /// IAU 1980 nutation matrix `r_TOD = N · r_MOD` (ERFA `numat`):
 /// `R1(−ε̄−Δε) · R3(−Δψ) · R1(ε̄)`.
 pub(crate) fn nutation_matrix(t: f64) -> Matrix3<f64> {

--- a/arika/src/earth/mean_equinox.rs
+++ b/arika/src/earth/mean_equinox.rs
@@ -1,0 +1,97 @@
+//! [`MeanEquinoxOfDate`] ↔ [`Gcrs`] rotations (IAU 1976 precession).
+//!
+//! The classical analytic ephemerides (Meeus' Sun and Moon series) and GMST are
+//! referred to the mean equator and equinox of date, while the force models and
+//! the integration frames work in J2000/GCRS. These factories are the single
+//! step between the two, so a consumer that needs one frame cannot silently
+//! read a value expressed in the other.
+//!
+//! Only precession is undone: nutation (≤ 17″) and the J2000→GCRS frame bias
+//! (~20 mas) stay in, both far below the ~1′ accuracy of the series this serves.
+
+use nalgebra::{Matrix3, Rotation3, UnitQuaternion};
+
+use crate::earth::fk5;
+use crate::epoch::{Epoch, Tt};
+use crate::frame::{Gcrs, MeanEquinoxOfDate, Rotation};
+
+fn matrix3_to_unit_quaternion(m: Matrix3<f64>) -> UnitQuaternion<f64> {
+    // `m` is a product of elemental rotations (a proper orthonormal rotation
+    // matrix), so `from_matrix_unchecked` is sound here.
+    UnitQuaternion::from_rotation_matrix(&Rotation3::from_matrix_unchecked(m))
+}
+
+impl Rotation<MeanEquinoxOfDate, Gcrs> {
+    /// Mean equinox of date → GCRS at TT epoch `tt`, undoing the IAU 1976
+    /// precession accumulated since J2000.
+    pub fn iau1976_precession(tt: &Epoch<Tt>) -> Self {
+        Self::from_raw(matrix3_to_unit_quaternion(
+            fk5::mean_of_date_to_j2000_matrix(tt.centuries_since_j2000()),
+        ))
+    }
+}
+
+impl Rotation<Gcrs, MeanEquinoxOfDate> {
+    /// GCRS → mean equinox of date at TT epoch `tt`, applying the IAU 1976
+    /// precession accumulated since J2000.
+    pub fn iau1976_precession(tt: &Epoch<Tt>) -> Self {
+        Self::from_raw(matrix3_to_unit_quaternion(fk5::precession_matrix(
+            tt.centuries_since_j2000(),
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frame::Vec3;
+
+    #[test]
+    fn the_two_directions_are_inverses() {
+        let tt = Epoch::from_gregorian(2035, 8, 9, 3, 0, 0.0).to_tt();
+        let fwd = Rotation::<Gcrs, MeanEquinoxOfDate>::iau1976_precession(&tt);
+        let back = Rotation::<MeanEquinoxOfDate, Gcrs>::iau1976_precession(&tt);
+        for v in [
+            Vec3::<Gcrs>::new(1.0, 0.0, 0.0),
+            Vec3::<Gcrs>::new(0.0, 1.0, 0.0),
+            Vec3::<Gcrs>::new(0.3, -0.7, 0.65),
+        ] {
+            let round = back.transform(&fwd.transform(&v));
+            assert!(
+                (round.into_inner() - v.into_inner()).magnitude() < 1e-14,
+                "round trip drifted: {:?} -> {:?}",
+                v.into_inner(),
+                round.into_inner()
+            );
+        }
+    }
+
+    #[test]
+    fn the_rotation_angle_is_the_accumulated_precession() {
+        // IAU general precession in longitude [arcsec/Julian century], quoted
+        // independently of arika's IAU 1976 coefficient (5029.0966″/century).
+        const GENERAL_PRECESSION_ARCSEC_PER_CENTURY: f64 = 5028.796195;
+
+        for y in [1970, 2024, 2075] {
+            let tt = Epoch::from_gregorian(y, 1, 1, 0, 0, 0.0).to_tt();
+            let t = tt.centuries_since_j2000();
+            // The vernal equinox direction sits on the ecliptic, so the whole
+            // precession in longitude shows up as an angle there.
+            let x = Vec3::<MeanEquinoxOfDate>::new(1.0, 0.0, 0.0);
+            let rotated = Rotation::<MeanEquinoxOfDate, Gcrs>::iau1976_precession(&tt)
+                .transform(&x)
+                .into_inner();
+            let sep_arcsec = rotated
+                .dot(&nalgebra::Vector3::new(1.0, 0.0, 0.0))
+                .clamp(-1.0, 1.0)
+                .acos()
+                .to_degrees()
+                * 3600.0;
+            let expected = (GENERAL_PRECESSION_ARCSEC_PER_CENTURY * t).abs();
+            assert!(
+                (sep_arcsec - expected).abs() < 5.0,
+                "{y}: rotation is {sep_arcsec:.1}″, expected ~{expected:.1}″"
+            );
+        }
+    }
+}

--- a/arika/src/earth/mod.rs
+++ b/arika/src/earth/mod.rs
@@ -27,6 +27,7 @@ pub mod eop;
 pub mod fk5;
 pub mod geodetic;
 pub mod iau2006;
+pub mod mean_equinox;
 pub mod rotation;
 pub mod teme;
 pub mod topocentric;

--- a/arika/src/epoch/leap.rs
+++ b/arika/src/epoch/leap.rs
@@ -61,7 +61,7 @@ pub(super) const LEAP_SECONDS: &[(f64, f64)] = &[
 /// arika redesign. Callers requiring bit-accurate pre-1972 ephemerides
 /// should use [`Epoch::<Tdb>::from_jd_tdb`](super::Epoch::from_jd_tdb) directly
 /// with an externally computed TDB Julian Date.
-pub(super) fn tai_minus_utc_at_mjd(utc_mjd: f64) -> f64 {
+pub(crate) fn tai_minus_utc_at_mjd(utc_mjd: f64) -> f64 {
     let mut offset = 10.0;
     for &(mjd_start, val) in LEAP_SECONDS {
         if utc_mjd >= mjd_start {

--- a/arika/src/epoch/mod.rs
+++ b/arika/src/epoch/mod.rs
@@ -56,6 +56,11 @@ pub use jd2::{JdRepr, TwoPartJd};
 pub use precision::{Coarse, Precise, Precision};
 pub use scale::{Gps, Tai, Tdb, TimeScale, Tt, Utc};
 
+// Consumed by the EOP table's dUT1 interpolation (`alloc`-gated) and by
+// `convert.rs` via the private `leap` module path.
+#[cfg(feature = "alloc")]
+pub(crate) use leap::tai_minus_utc_at_mjd;
+
 use convert::TaiLens;
 use convert::era_formula;
 use datetime::to_datetime_from_jd;

--- a/arika/src/frame.rs
+++ b/arika/src/frame.rs
@@ -292,10 +292,18 @@ impl Eci for Teme {}
 /// This is the frame the classical analytic series are actually referred to:
 /// their mean longitudes advance at the *tropical* rate and their
 /// ecliptic → equatorial rotation uses the mean obliquity of date. It is also
-/// the equinox that GMST is measured from ([`crate::earth::fk5::gmst1982`],
-/// reached via [`Epoch::<Utc>::gmst`](crate::epoch::Epoch::gmst)), so a local
-/// hour angle built as `GMST + λ − α` is only self-consistent when `α` is a
-/// right ascension *in this frame*.
+/// the equinox GMST is measured from ([`crate::earth::fk5::gmst1982`]), so a
+/// local hour angle built as `GMST + λ − α` needs `α` to be a right ascension
+/// *in this frame*.
+///
+/// The CIO-based counterpart is `ERA + λ − α`, which
+/// [`Epoch::<Utc>::gmst`](crate::epoch::Epoch::gmst) (a legacy name for the
+/// Earth rotation angle) feeds; there `α` belongs in [`Cirs`]. A [`Gcrs`] right
+/// ascension is not the exact partner either, but it is far closer than one in
+/// this frame: the dominant precession-in-right-ascension term (m ≈ 4612″ per
+/// century) is common to `GMST − ERA` and to `α_MOD − α_GCRS` and cancels,
+/// leaving the declination-dependent `n·sin α·tan δ` part (≤ 0.06° in 2024)
+/// instead of the whole 0.31°.
 ///
 /// Differs from [`Gcrs`] by the accumulated precession — 0.335° in 2024, growing
 /// ~1.4°/century — and from the true equator of date by nutation (≤ 17″).

--- a/arika/src/frame.rs
+++ b/arika/src/frame.rs
@@ -16,7 +16,7 @@
 //! - [`SimpleEcef`] — [`SimpleEci`] からの ERA-only Z 回転先。近似的 Earth-fixed
 //! - [`Gcrs`] — Geocentric Celestial Reference System。IAU 2006 CIO chain の
 //!   celestial side。Meeus ephemeris の返り型でもあり、その値は低精度 analytic
-//!   model 由来なので strict な GCRS とは限らない
+//!   model 由来なので strict な GCRS とは限らない (nutation / frame bias 未適用)
 //! - [`Cirs`] — Celestial Intermediate Reference System (CIO chain の中間)
 //! - [`Tirs`] — Terrestrial Intermediate Reference System (polar motion 未適用)
 //! - [`Itrs`] — International Terrestrial Reference System (polar motion 適用済み)。
@@ -191,7 +191,10 @@ impl Ecef for SimpleEcef {}
 /// Geocentric Celestial Reference System. IAU 2006 CIO chain の celestial side。
 ///
 /// Meeus ephemeris (低精度 analytic model) の返り型としても使うため、その値は
-/// 厳密な GCRS とは限らない。GCRS → ITRS の高精度変換は
+/// 厳密な GCRS とは限らない。Meeus 側は of-date の級数を IAU 1976 precession で
+/// J2000 に戻してから返すので precession は入っているが、nutation (≤ 17″)、
+/// J2000→GCRS frame bias (~20 mas)、および model 自身の精度 (~1′) ぶんの残差がある。
+/// GCRS → ITRS の高精度変換は
 /// [`Rotation::<Gcrs, Itrs>::iau2006_full`] を参照。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Gcrs;

--- a/arika/src/frame.rs
+++ b/arika/src/frame.rs
@@ -23,6 +23,9 @@
 //!   geodetic 変換はこの frame に紐づく
 //! - [`Teme`] — True Equator, Mean Equinox。SGP4 / TLE / OMM の平均要素フレーム
 //!   (↔ Gcrs/SimpleEci 回転は IAU-76/FK5 換算で実装済み: [`crate::earth::teme`])
+//! - [`MeanEquinoxOfDate`] — 日付の平均赤道・平均春分点 (MOD)。古典的な解析級数と
+//!   GMST が基準にする equinox。↔ Gcrs 回転は
+//!   [`crate::earth::mean_equinox`]
 //! - [`Rsw`] — Radial / Along-track / Cross-track 軌道ローカル系。
 //!   軸順は標準 RSW 規約 [R̂, Ŝ, Ŵ] (R̂=normalize(r), Ŵ=normalize(r×v), Ŝ=Ŵ×R̂)
 //! - [`Body`] — 宇宙機機体座標系
@@ -30,7 +33,7 @@
 //! # Category trait
 //!
 //! - [`Eci`] — structural category for earth-centered inertial frames.
-//!   実装者: `SimpleEci`, `Gcrs`, `Cirs`, `Teme`
+//!   実装者: `SimpleEci`, `Gcrs`, `Cirs`, `Teme`, `MeanEquinoxOfDate`
 //! - [`Ecef`] — structural category for earth-fixed frames.
 //!   実装者: `SimpleEcef`, `Tirs`, `Itrs`
 //! - [`LocalOrbital`] — structural category for local orbital frames.
@@ -88,6 +91,7 @@ pub enum FrameDescriptor {
     Tirs,
     Itrs,
     Teme,
+    MeanEquinoxOfDate,
     Rsw,
     Body,
 }
@@ -102,6 +106,7 @@ impl FrameDescriptor {
             FrameDescriptor::Tirs => "Tirs",
             FrameDescriptor::Itrs => "Itrs",
             FrameDescriptor::Teme => "Teme",
+            FrameDescriptor::MeanEquinoxOfDate => "MeanEquinoxOfDate",
             FrameDescriptor::Rsw => "Rsw",
             FrameDescriptor::Body => "Body",
         }
@@ -112,7 +117,8 @@ impl FrameDescriptor {
             FrameDescriptor::SimpleEci
             | FrameDescriptor::Gcrs
             | FrameDescriptor::Cirs
-            | FrameDescriptor::Teme => FrameCategory::Eci,
+            | FrameDescriptor::Teme
+            | FrameDescriptor::MeanEquinoxOfDate => FrameCategory::Eci,
             FrameDescriptor::SimpleEcef | FrameDescriptor::Tirs | FrameDescriptor::Itrs => {
                 FrameCategory::Ecef
             }
@@ -279,6 +285,30 @@ impl Frame for Teme {
     const DESCRIPTOR: FrameDescriptor = FrameDescriptor::Teme;
 }
 impl Eci for Teme {}
+
+/// Mean equator and equinox of date (MOD) — the equinox-based quasi-inertial
+/// frame that drifts with precession. Belongs to the [`Eci`] category.
+///
+/// This is the frame the classical analytic series are actually referred to:
+/// their mean longitudes advance at the *tropical* rate and their
+/// ecliptic → equatorial rotation uses the mean obliquity of date. It is also
+/// the equinox that GMST is measured from ([`crate::earth::fk5::gmst1982`],
+/// reached via [`Epoch::<Utc>::gmst`](crate::epoch::Epoch::gmst)), so a local
+/// hour angle built as `GMST + λ − α` is only self-consistent when `α` is a
+/// right ascension *in this frame*.
+///
+/// Differs from [`Gcrs`] by the accumulated precession — 0.335° in 2024, growing
+/// ~1.4°/century — and from the true equator of date by nutation (≤ 17″).
+/// [`crate::earth::mean_equinox`] carries the IAU 1976 rotations to and from
+/// [`Gcrs`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MeanEquinoxOfDate;
+impl sealed::Sealed for MeanEquinoxOfDate {}
+impl Frame for MeanEquinoxOfDate {
+    const NAME: &'static str = "MeanEquinoxOfDate";
+    const DESCRIPTOR: FrameDescriptor = FrameDescriptor::MeanEquinoxOfDate;
+}
+impl Eci for MeanEquinoxOfDate {}
 
 /// Local orbital frame: Radial / Along-track / Cross-track.
 ///

--- a/arika/src/kepler.rs
+++ b/arika/src/kepler.rs
@@ -77,7 +77,34 @@ pub fn true_to_mean_anomaly(true_anomaly: f64, eccentricity: f64) -> f64 {
     eccentric_to_mean_anomaly(e_anom, eccentricity)
 }
 
+/// Normalize an angle to `[0, 2π)`.
+fn normalize_angle(x: f64) -> f64 {
+    let w = x % (2.0 * PI);
+    if w < 0.0 { w + 2.0 * PI } else { w }
+}
+
 /// Classical Keplerian orbital elements.
+///
+/// # Degenerate geometries
+///
+/// Two of the six angles are undefined when the orbit is circular and/or
+/// equatorial. [`KeplerianElements::from_state_vector`] resolves this with the
+/// classical singular conventions (Vallado, *Fundamentals of Astrodynamics and
+/// Applications*, §2.4), which fold the undefined angle into the next
+/// well-defined one so that the state is still fully recoverable by
+/// [`KeplerianElements::to_state_vector`]:
+///
+/// | geometry | `raan` | `argument_of_periapsis` | `true_anomaly` |
+/// |---|---|---|---|
+/// | general | Ω | ω | ν |
+/// | circular inclined (`e ≈ 0`) | Ω | 0 | argument of latitude `u = ω + ν` |
+/// | eccentric equatorial (`i ≈ 0` or `π`) | 0 | true longitude of periapsis `ϖ = Ω + ω` | ν |
+/// | circular equatorial | 0 | 0 | true longitude `λ = Ω + ω + ν` |
+///
+/// For the *retrograde* equatorial cases (`i ≈ π`) the stored angle is the
+/// negated in-plane longitude, because `to_state_vector` maps `i = π, Ω = 0`
+/// onto a clockwise sweep of the x-y plane. That keeps the round trip exact for
+/// both `i ≈ 0` and `i ≈ π`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct KeplerianElements {
     /// Semi-major axis [km]
@@ -96,6 +123,9 @@ pub struct KeplerianElements {
 
 impl KeplerianElements {
     /// Convert a Cartesian state vector (position, velocity) to Keplerian elements.
+    ///
+    /// Degenerate geometries (circular and/or equatorial) follow the singular
+    /// conventions documented on [`KeplerianElements`].
     ///
     /// # Arguments
     /// * `pos` - Position vector [km]
@@ -122,54 +152,53 @@ impl KeplerianElements {
         let energy = v * v / 2.0 - mu / r;
         let a = -mu / (2.0 * energy);
 
-        // Inclination: cos(i) = h_z / |h|
-        let i = (h[2] / h_mag).acos();
+        // Inclination: tan(i) = |k x h| / h_z. `atan2` rather than
+        // `acos(h_z/|h|)`, which loses half the mantissa near i = 0 and i = π.
+        let i = f64::atan2(n_mag, h[2]);
+
+        // An equatorial orbit has no node line, so Ω is undefined and the
+        // in-plane angles are referred to the x-axis instead of the node.
+        let equatorial = n_mag <= 1e-15;
+        let reference = if equatorial {
+            Vector3::new(1.0, 0.0, 0.0)
+        } else {
+            n
+        };
+
+        // Signed angle from `from` to `to` in the orbit plane, measured about
+        // the orbit normal and normalized to [0, 2π). Measuring about the
+        // normal is what makes the retrograde-equatorial case come out
+        // clockwise in the x-y plane, matching `to_state_vector` at i = π.
+        let h_hat = h / h_mag;
+        let plane_angle = |from: &Vector3<f64>, to: &Vector3<f64>| {
+            normalize_angle(f64::atan2(from.cross(to).dot(&h_hat), from.dot(to)))
+        };
 
         // Right ascension of ascending node
-        let raan = if n_mag > 1e-15 {
-            let omega = (n[0] / n_mag).acos();
-            if n[1] >= 0.0 { omega } else { 2.0 * PI - omega }
-        } else {
+        let raan = if equatorial {
             0.0
+        } else {
+            normalize_angle(f64::atan2(n[1], n[0]))
         };
 
-        // Argument of periapsis
-        let omega = if n_mag > 1e-15 && e > 1e-15 {
-            let cos_omega = n.dot(&e_vec) / (n_mag * e);
-            let w = cos_omega.clamp(-1.0, 1.0).acos();
-            if e_vec[2] >= 0.0 { w } else { 2.0 * PI - w }
-        } else {
+        // Argument of periapsis. Circular: undefined, folded into the true
+        // anomaly. Equatorial: this is the true longitude of periapsis
+        // ϖ = Ω + ω, since raan is 0 — the true anomaly is measured from the
+        // eccentricity vector, so storing 0 here would lose the periapsis
+        // direction entirely and rotate the orbit by ϖ on the way back.
+        let omega = if e <= 1e-15 {
             0.0
+        } else {
+            plane_angle(&reference, &e_vec)
         };
 
-        // True anomaly
+        // True anomaly, from periapsis when it is defined and from the
+        // reference direction (argument of latitude / true longitude) when the
+        // orbit is circular.
         let nu = if e > 1e-15 {
-            let cos_nu = e_vec.dot(pos) / (e * r);
-            let nu_val = cos_nu.clamp(-1.0, 1.0).acos();
-            if pos.dot(vel) >= 0.0 {
-                nu_val
-            } else {
-                2.0 * PI - nu_val
-            }
+            plane_angle(&e_vec, pos)
         } else {
-            // Circular orbit: measure from ascending node or x-axis
-            if n_mag > 1e-15 {
-                let cos_nu = n.dot(pos) / (n_mag * r);
-                let nu_val = cos_nu.clamp(-1.0, 1.0).acos();
-                if pos[2] >= 0.0 {
-                    nu_val
-                } else {
-                    2.0 * PI - nu_val
-                }
-            } else {
-                // Circular equatorial: measure from x-axis
-                let nu_val = (pos[0] / r).clamp(-1.0, 1.0).acos();
-                if pos[1] >= 0.0 {
-                    nu_val
-                } else {
-                    2.0 * PI - nu_val
-                }
-            }
+            plane_angle(&reference, pos)
         };
 
         KeplerianElements {
@@ -320,6 +349,133 @@ mod tests {
         let vel_err = (vel - vel2).magnitude();
         assert!(pos_err < 1e-6, "position roundtrip error: {pos_err} km");
         assert!(vel_err < 1e-9, "velocity roundtrip error: {vel_err} km/s");
+    }
+
+    /// Build an exactly planar state: `z = v_z = 0`, so `k × h` vanishes bit-exactly
+    /// and `from_state_vector` is forced down the equatorial singular branch.
+    ///
+    /// `periapsis_lon` is the azimuth of the periapsis direction in the x-y plane
+    /// and `sense` is +1 for prograde (counterclockwise) or -1 for retrograde.
+    fn planar_state(
+        a: f64,
+        e: f64,
+        periapsis_lon: f64,
+        nu: f64,
+        sense: f64,
+        mu: f64,
+    ) -> (Vector3<f64>, Vector3<f64>) {
+        let p = a * (1.0 - e * e);
+        let r = p / (1.0 + e * nu.cos());
+        let theta = periapsis_lon + sense * nu;
+        let (st, ct) = (theta.sin(), theta.cos());
+        let r_hat = Vector3::new(ct, st, 0.0);
+        let t_hat = Vector3::new(-st, ct, 0.0);
+        let vf = (mu / p).sqrt();
+        let v_radial = vf * e * nu.sin();
+        let v_transverse = vf * (1.0 + e * nu.cos());
+        (r * r_hat, v_radial * r_hat + sense * v_transverse * t_hat)
+    }
+
+    #[test]
+    fn eccentric_equatorial_keeps_the_periapsis_longitude() {
+        // Regression: the equatorial branch used to zero BOTH raan and the
+        // argument of periapsis while still measuring the true anomaly from the
+        // eccentricity vector, so the periapsis longitude was stored nowhere.
+        // a=10000 km, e=0.2, ϖ=π/2, ν=0 came back rotated by 90°, an 8000·√2 =
+        // 11313.7 km round-trip error.
+        for &sense in &[1.0_f64, -1.0] {
+            for &periapsis_lon in &[0.0, 0.5, PI / 2.0, 2.0, 4.0, 6.0] {
+                for &e in &[0.01, 0.1, 0.2, 0.4] {
+                    for &nu in &[0.0, 1.0, 3.0, 5.0] {
+                        let (pos, vel) =
+                            planar_state(10000.0, e, periapsis_lon, nu, sense, MU_EARTH);
+                        let el = KeplerianElements::from_state_vector(&pos, &vel, MU_EARTH);
+
+                        // The singular branch really is the one under test.
+                        assert_eq!(
+                            el.raan, 0.0,
+                            "equatorial orbits carry raan = 0 by convention"
+                        );
+                        let expected_i = if sense > 0.0 { 0.0 } else { PI };
+                        assert!(
+                            (el.inclination - expected_i).abs() < 1e-12,
+                            "i: expected {expected_i}, got {}",
+                            el.inclination
+                        );
+                        // The stored angle is the (sense-signed) true longitude
+                        // of periapsis, so the direction survives.
+                        let expected_argp = normalize_angle(sense * periapsis_lon);
+                        let d_argp =
+                            normalize_angle(el.argument_of_periapsis - expected_argp + PI) - PI;
+                        assert!(
+                            d_argp.abs() < 1e-9,
+                            "ϖ: expected {expected_argp}, got {} (sense={sense}, e={e}, ν={nu})",
+                            el.argument_of_periapsis
+                        );
+
+                        let (pos2, vel2) = el.to_state_vector(MU_EARTH);
+                        let pos_err = (pos - pos2).magnitude();
+                        let vel_err = (vel - vel2).magnitude();
+                        assert!(
+                            pos_err < 1e-6,
+                            "position roundtrip {pos_err} km (sense={sense}, ϖ={periapsis_lon}, e={e}, ν={nu})"
+                        );
+                        assert!(
+                            vel_err < 1e-9,
+                            "velocity roundtrip {vel_err} km/s (sense={sense}, ϖ={periapsis_lon}, e={e}, ν={nu})"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn circular_equatorial_true_longitude_follows_the_sense_of_motion() {
+        // The circular equatorial branch measured the true longitude as the raw
+        // x-axis azimuth, which runs backwards for retrograde motion.
+        for &sense in &[1.0_f64, -1.0] {
+            for &nu in &[0.0, 1.0, 3.0, 5.0] {
+                let (pos, vel) = planar_state(10000.0, 0.0, 0.0, nu, sense, MU_EARTH);
+                let el = KeplerianElements::from_state_vector(&pos, &vel, MU_EARTH);
+                assert!(el.eccentricity < 1e-15);
+                let d = normalize_angle(el.true_anomaly - nu + PI) - PI;
+                assert!(
+                    d.abs() < 1e-9,
+                    "λ: expected {nu}, got {} (sense={sense})",
+                    el.true_anomaly
+                );
+                let (pos2, vel2) = el.to_state_vector(MU_EARTH);
+                assert!((pos - pos2).magnitude() < 1e-6, "sense={sense}, ν={nu}");
+                assert!((vel - vel2).magnitude() < 1e-9, "sense={sense}, ν={nu}");
+            }
+        }
+    }
+
+    #[test]
+    fn equatorial_singularity_is_continuous_in_the_periapsis_longitude() {
+        // Ω and ω are individually undefined at i = 0, but Ω + ω (the true
+        // longitude of periapsis) is not — so the value recovered just off the
+        // singularity must match the value recovered exactly on it.
+        let periapsis_lon = 2.0;
+        let nu = 1.0;
+        let (pos0, vel0) = planar_state(10000.0, 0.2, periapsis_lon, nu, 1.0, MU_EARTH);
+        let el0 = KeplerianElements::from_state_vector(&pos0, &vel0, MU_EARTH);
+
+        // Same orbit tilted by 1e-9 rad about the periapsis direction, which
+        // leaves the periapsis longitude unchanged.
+        let tilt = 1e-9_f64;
+        let axis = Vector3::new(periapsis_lon.cos(), periapsis_lon.sin(), 0.0);
+        let rot = nalgebra::Rotation3::from_axis_angle(&nalgebra::Unit::new_normalize(axis), tilt);
+        let el1 = KeplerianElements::from_state_vector(&(rot * pos0), &(rot * vel0), MU_EARTH);
+
+        let lon0 = normalize_angle(el0.raan + el0.argument_of_periapsis);
+        let lon1 = normalize_angle(el1.raan + el1.argument_of_periapsis);
+        let d = normalize_angle(lon0 - lon1 + PI) - PI;
+        assert!(
+            d.abs() < 1e-6,
+            "Ω+ω discontinuous across i=0: {lon0} (i=0) vs {lon1} (i={tilt})"
+        );
     }
 
     #[test]

--- a/arika/src/lib.rs
+++ b/arika/src/lib.rs
@@ -44,8 +44,10 @@ pub type SimpleEcef = frame::Vec3<frame::SimpleEcef>;
 /// Geocentric Celestial Reference System frame vector.
 ///
 /// Type alias for `frame::Vec3<frame::Gcrs>`. Current usage: return type of
-/// the Meeus analytic ephemerides (Sun / Moon / planets). In a later phase
-/// the IAU 2006 precession/nutation chain will make this a strict GCRS.
+/// the Meeus analytic ephemerides (Sun / Moon / planets), which rotate their
+/// of-date series back to J2000 with the IAU 1976 precession but leave nutation
+/// and the J2000→GCRS frame bias out. In a later phase the IAU 2006
+/// precession/nutation chain will make this a strict GCRS.
 pub type Gcrs = frame::Vec3<frame::Gcrs>;
 
 /// Local orbital frame vector (Radial / Along-track / Cross-track).

--- a/arika/src/moon/ephemeris.rs
+++ b/arika/src/moon/ephemeris.rs
@@ -39,8 +39,10 @@ use crate::frame::{self, Vec3};
 /// see [`MeeusMoonEphemeris`].)
 pub fn moon_position_eci(epoch: &Epoch<Tdb>) -> Vec3<frame::Gcrs> {
     let of_date = moon_position_mean_of_date(epoch);
-    let p = crate::earth::fk5::mean_of_date_to_j2000_matrix(epoch.centuries_since_j2000());
-    Vec3::from_raw(p * of_date)
+    crate::frame::Rotation::<frame::MeanEquinoxOfDate, frame::Gcrs>::iau1976_precession(
+        &epoch.to_tt(),
+    )
+    .transform(&of_date)
 }
 
 /// Moon position [km] referred to the mean equator and equinox of date — the
@@ -48,7 +50,7 @@ pub fn moon_position_eci(epoch: &Epoch<Tdb>) -> Vec3<frame::Gcrs> {
 ///
 /// Kept separate from [`moon_position_eci`] so the precession rotation to J2000
 /// is a single visible step, and so tests can measure the size of that step.
-pub(crate) fn moon_position_mean_of_date(epoch: &Epoch<Tdb>) -> nalgebra::Vector3<f64> {
+pub(crate) fn moon_position_mean_of_date(epoch: &Epoch<Tdb>) -> Vec3<frame::MeanEquinoxOfDate> {
     let t = epoch.centuries_since_j2000();
     let t2 = t * t;
     let t3 = t2 * t;
@@ -266,7 +268,7 @@ pub(crate) fn moon_position_mean_of_date(epoch: &Epoch<Tdb>) -> nalgebra::Vector
     let y = distance_km * (cos_eps * cos_beta * sin_lam - sin_eps * sin_beta);
     let z = distance_km * (sin_eps * cos_beta * sin_lam + cos_eps * sin_beta);
 
-    nalgebra::Vector3::new(x, y, z)
+    Vec3::new(x, y, z)
 }
 
 /// Moon ephemeris source abstraction.
@@ -467,7 +469,7 @@ mod tests {
             let epoch = Epoch::from_gregorian(y, m, d, 6, 0, 0.0).to_tdb();
             let t = epoch.centuries_since_j2000();
 
-            let of_date = moon_position_mean_of_date(&epoch);
+            let of_date = moon_position_mean_of_date(&epoch).into_inner();
             let j2000 = moon_position_eci(&epoch).into_inner();
 
             // Distance is frame-independent.

--- a/arika/src/moon/ephemeris.rs
+++ b/arika/src/moon/ephemeris.rs
@@ -18,6 +18,18 @@ use crate::frame::{self, Vec3};
 ///
 /// Accuracy: ~10" in ecliptic longitude, ~1% in distance (~4,000 km).
 ///
+/// # Frame
+///
+/// The Meeus series is referred to the **mean equinox and equator of date** (its
+/// mean longitude `L' = 218.3164477 + 481267.88123421·T` advances at the
+/// tropical rate, and the ecliptic → equatorial rotation uses the mean obliquity
+/// of date), so the result is rotated back to J2000 with the IAU 1976 precession
+/// ([`crate::earth::fk5`]) before being typed `Vec3<Gcrs>`. Skipping that
+/// rotation would be a secular 0.335° direction error in 2024 — ~2,250 km
+/// transverse on the Moon vector, well above the model's own ~10″ longitude
+/// accuracy. Nutation (≤ 17″) and the J2000→GCRS frame bias (~20 mas) are
+/// neglected.
+///
 /// # Time scale
 ///
 /// Meeus ephemerides take a dynamical time argument (TDB), so this signature
@@ -26,6 +38,17 @@ use crate::frame::{self, Vec3};
 /// UTC-indexed Horizons table, deliberately keeps a `&Epoch<Utc>` interface;
 /// see [`MeeusMoonEphemeris`].)
 pub fn moon_position_eci(epoch: &Epoch<Tdb>) -> Vec3<frame::Gcrs> {
+    let of_date = moon_position_mean_of_date(epoch);
+    let p = crate::earth::fk5::mean_of_date_to_j2000_matrix(epoch.centuries_since_j2000());
+    Vec3::from_raw(p * of_date)
+}
+
+/// Moon position [km] referred to the mean equator and equinox of date — the
+/// frame the Meeus series is actually expressed in.
+///
+/// Kept separate from [`moon_position_eci`] so the precession rotation to J2000
+/// is a single visible step, and so tests can measure the size of that step.
+pub(crate) fn moon_position_mean_of_date(epoch: &Epoch<Tdb>) -> nalgebra::Vector3<f64> {
     let t = epoch.centuries_since_j2000();
     let t2 = t * t;
     let t3 = t2 * t;
@@ -243,7 +266,7 @@ pub fn moon_position_eci(epoch: &Epoch<Tdb>) -> Vec3<frame::Gcrs> {
     let y = distance_km * (cos_eps * cos_beta * sin_lam - sin_eps * sin_beta);
     let z = distance_km * (sin_eps * cos_beta * sin_lam + cos_eps * sin_beta);
 
-    Vec3::new(x, y, z)
+    nalgebra::Vector3::new(x, y, z)
 }
 
 /// Moon ephemeris source abstraction.
@@ -425,6 +448,57 @@ impl MoonEphemeris for HorizonsMoonEphemeris {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// IAU general precession in longitude [arcsec per Julian century].
+    /// Independent of arika's own precession code (which uses the IAU 1976
+    /// 5029.0966″/century; the two differ by ~0.3″/century).
+    const GENERAL_PRECESSION_ARCSEC_PER_CENTURY: f64 = 5028.796195;
+
+    #[test]
+    fn moon_of_date_to_j2000_step_is_the_accumulated_precession() {
+        // The series is of-date; the returned vector must be J2000. Precession
+        // is a rotation about the ecliptic pole, so it moves a body at ecliptic
+        // latitude β by ψ·cos β — and the Moon's β stays within ±5.3°. The
+        // expected magnitude comes from the IAU general-precession rate, not
+        // from arika's own precession code, so this pins both that the rotation
+        // happens at all (it used to be omitted entirely: 0.335° = ~2,250 km
+        // transverse in 2024) and that it is the right size.
+        for (y, m, d) in [(2024, 1, 15), (2024, 7, 1), (2050, 3, 20), (1980, 11, 5)] {
+            let epoch = Epoch::from_gregorian(y, m, d, 6, 0, 0.0).to_tdb();
+            let t = epoch.centuries_since_j2000();
+
+            let of_date = moon_position_mean_of_date(&epoch);
+            let j2000 = moon_position_eci(&epoch).into_inner();
+
+            // Distance is frame-independent.
+            assert!(
+                (of_date.norm() - j2000.norm()).abs() < 1e-6,
+                "the rotation must not change |r|"
+            );
+
+            // Ecliptic latitude of the of-date vector, using the of-date
+            // obliquity the series itself used.
+            let epsilon = (23.439291 - 0.0130042 * t).to_radians();
+            let (ce, se) = (epsilon.cos(), epsilon.sin());
+            let z_ecl = -se * of_date.y + ce * of_date.z;
+            let beta = (z_ecl / of_date.norm()).asin();
+            assert!(
+                beta.abs() < 6.0_f64.to_radians(),
+                "the Moon's ecliptic latitude should be within ±5.3°, got {}°",
+                beta.to_degrees()
+            );
+
+            let sep = (of_date.normalize().dot(&j2000.normalize()))
+                .clamp(-1.0, 1.0)
+                .acos()
+                .to_degrees();
+            let expected = (GENERAL_PRECESSION_ARCSEC_PER_CENTURY * t / 3600.0).abs() * beta.cos();
+            assert!(
+                (sep - expected).abs() < 0.002,
+                "{y}-{m:02}-{d:02}: of-date → J2000 step {sep:.4}°, expected {expected:.4}°"
+            );
+        }
+    }
 
     #[test]
     fn moon_distance_range() {

--- a/arika/src/sun/ephemeris.rs
+++ b/arika/src/sun/ephemeris.rs
@@ -34,9 +34,8 @@ use nalgebra::Vector3;
 #[allow(unused_imports)]
 use crate::math::F64Ext;
 
-use crate::earth::fk5;
 use crate::epoch::{Epoch, Tdb};
-use crate::frame::{self, Vec3};
+use crate::frame::{self, Rotation, Vec3};
 use crate::planets;
 use crate::sun::AU_KM;
 
@@ -90,19 +89,23 @@ fn j2000_obliquity() -> f64 {
     planets::obliquity(&Epoch::<Tdb>::from_jd_tdb(crate::epoch::J2000_JD))
 }
 
-/// Sun direction (unit vector) referred to the mean equator and equinox of
-/// date — the frame the Meeus series is actually expressed in.
+/// Sun direction (unit vector) referred to the mean equator and equinox of date
+/// — the frame the Meeus series is actually expressed in.
 ///
 /// Kept separate from [`sun_direction_eci`] so the precession rotation to J2000
 /// is a single visible step, and so tests can measure the size of that step.
-pub(crate) fn sun_direction_mean_of_date(epoch: &Epoch<Tdb>) -> Vector3<f64> {
+/// A caller that needs this frame — a right ascension that has to share GMST's
+/// equinox, as in a local hour angle `GMST + λ − α` — rotates the public
+/// J2000 direction with
+/// [`Rotation::<Gcrs, MeanEquinoxOfDate>::iau1976_precession`](crate::earth::mean_equinox).
+pub(crate) fn sun_direction_mean_of_date(epoch: &Epoch<Tdb>) -> Vec3<frame::MeanEquinoxOfDate> {
     let el = solar_elements(epoch);
 
     let x = el.lambda_rad.cos();
     let y = el.epsilon_rad.cos() * el.lambda_rad.sin();
     let z = el.epsilon_rad.sin() * el.lambda_rad.sin();
 
-    Vector3::new(x, y, z).normalize()
+    Vec3::from_raw(Vector3::new(x, y, z).normalize())
 }
 
 /// Approximate sun direction (unit vector) in ECI (J2000) frame.
@@ -115,9 +118,8 @@ pub(crate) fn sun_direction_mean_of_date(epoch: &Epoch<Tdb>) -> Vector3<f64> {
 ///
 /// Reference: Meeus, "Astronomical Algorithms", Chapter 25.
 pub fn sun_direction_eci(epoch: &Epoch<Tdb>) -> Vec3<frame::Gcrs> {
-    let of_date = sun_direction_mean_of_date(epoch);
-    let p = fk5::mean_of_date_to_j2000_matrix(epoch.centuries_since_j2000());
-    Vec3::from_raw(p * of_date)
+    Rotation::<frame::MeanEquinoxOfDate, frame::Gcrs>::iau1976_precession(&epoch.to_tt())
+        .transform(&sun_direction_mean_of_date(epoch))
 }
 
 /// Equation of Time [hours].
@@ -322,7 +324,7 @@ mod tests {
         for y in [2024, 2050, 1975] {
             let epoch = Epoch::from_gregorian(y, 7, 1, 0, 0, 0.0).to_tdb();
             let t = epoch.centuries_since_j2000();
-            let of_date = sun_direction_mean_of_date(&epoch);
+            let of_date = sun_direction_mean_of_date(&epoch).into_inner();
             let j2000 = sun_direction_eci(&epoch).into_inner();
             let sep = of_date.dot(&j2000).clamp(-1.0, 1.0).acos().to_degrees();
             // The Sun sits on the ecliptic (β ≈ 0), so the separation is the

--- a/arika/src/sun/ephemeris.rs
+++ b/arika/src/sun/ephemeris.rs
@@ -80,6 +80,16 @@ fn solar_elements(epoch: &Epoch<Tdb>) -> SolarElements {
     }
 }
 
+/// Mean obliquity of the ecliptic at J2000 [rad].
+///
+/// The fixed obliquity that rotates a J2000 *ecliptic* vector — such as the
+/// Standish planetary elements' output — into J2000 equatorial coordinates.
+/// Evaluating [`planets::obliquity`] at J2000 keeps the polynomial's leading
+/// coefficient as the single source of truth.
+fn j2000_obliquity() -> f64 {
+    planets::obliquity(&Epoch::<Tdb>::from_jd_tdb(crate::epoch::J2000_JD))
+}
+
 /// Sun direction (unit vector) referred to the mean equator and equinox of
 /// date — the frame the Meeus series is actually expressed in.
 ///
@@ -194,16 +204,17 @@ pub fn sun_direction_from_body(body: &str, epoch: &Epoch<Tdb>) -> Vec3<frame::Gc
         "earth" | "moon" => sun_direction_eci(epoch),
         _ => {
             if let Some(body_pos_ecl) = planets::heliocentric_position_ecliptic(body, epoch) {
-                // The Standish/Meeus planetary elements are referred to the
-                // J2000 mean ecliptic (their mean longitudes advance at the
+                // The Standish planetary elements are referred to the J2000 mean
+                // ecliptic and equinox (their mean longitudes advance at the
                 // sidereal rate), so this branch needs no precession rotation —
-                // unlike the geocentric Meeus Sun above. The remaining
-                // inconsistency is the obliquity of date used for the ecliptic →
-                // equatorial rotation (11″ in 2024, well inside the ~1′ model
-                // accuracy).
+                // unlike the geocentric Meeus Sun above — and the ecliptic →
+                // equatorial rotation takes the *J2000* obliquity, not the
+                // obliquity of date (which would leave 11″ of frame error in
+                // 2024, 35″ in 2075).
                 let sun_dir_ecl = -body_pos_ecl;
-                let epsilon = planets::obliquity(epoch);
-                Vec3::from_raw(planets::ecliptic_to_equatorial(&sun_dir_ecl, epsilon).normalize())
+                Vec3::from_raw(
+                    planets::ecliptic_to_equatorial(&sun_dir_ecl, j2000_obliquity()).normalize(),
+                )
             } else {
                 // Unknown body: fallback to +X (vernal equinox direction)
                 Vec3::new(1.0, 0.0, 0.0)
@@ -234,25 +245,36 @@ mod tests {
         // (0.335° in 2024, 0.70° in 2050); they now agree to well within the
         // ~1 arcminute accuracy both models claim.
         for (y, m, d) in [
+            (1950, 6, 1),
             (2000, 1, 1),
             (2024, 3, 20),
             (2024, 9, 22),
             (2050, 1, 1),
             (2075, 7, 4),
+            (2100, 1, 1),
         ] {
             let epoch = Epoch::from_gregorian(y, m, d, 12, 0, 0.0).to_tdb();
             let sun = sun_direction_eci(&epoch).into_inner();
             let earth = planets::heliocentric_position_ecliptic("earth", &epoch)
                 .expect("earth is a known body");
+            // The J2000 obliquity, matching the frame the Standish elements
+            // are referred to — an obliquity of date here would tilt the
+            // expectation by the same amount the implementation used to.
             let geocentric_sun =
-                planets::ecliptic_to_equatorial(&(-earth), planets::obliquity(&epoch)).normalize();
+                planets::ecliptic_to_equatorial(&(-earth), j2000_obliquity()).normalize();
             let sep = sun
                 .dot(&geocentric_sun)
                 .clamp(-1.0, 1.0)
                 .acos()
                 .to_degrees();
+            // The residual is flat at 4.5-8.0" across 1950-2100 (the two
+            // models' own accuracy). The bound is set just above that so it
+            // also catches a frame error that grows with |T| — either the
+            // missing precession (0.335° in 2024, 1.4° by 2100) or an
+            // obliquity-of-date rotation applied to the J2000 planetary
+            // elements (11″ in 2024, 35″ by 2075).
             assert!(
-                sep < 0.05,
+                sep < 0.005,
                 "{y}-{m:02}-{d:02}: Meeus Sun and the planetary model disagree by {sep:.4}° \
                  (precession left unremoved would give ~{:.2}°)",
                 GENERAL_PRECESSION_ARCSEC_PER_CENTURY * epoch.centuries_since_j2000() / 3600.0

--- a/arika/src/sun/ephemeris.rs
+++ b/arika/src/sun/ephemeris.rs
@@ -283,6 +283,35 @@ mod tests {
     }
 
     #[test]
+    fn planet_branch_rotates_the_ecliptic_with_the_j2000_obliquity() {
+        // `sun_direction_from_body`'s planet branch takes the Standish
+        // heliocentric elements — J2000 mean ecliptic and equinox — into
+        // equatorial coordinates. Rotating that result back about the x-axis by
+        // the J2000 obliquity must land exactly on -r_body in the ecliptic
+        // frame. It does not if the forward rotation used the obliquity of
+        // date: the mismatch is 11 arcsec in 2024 and 35 arcsec by 2075, which
+        // no other test on this branch (unit norm, variation over six months)
+        // can see.
+        for (body, y) in [("mars", 2024), ("mars", 2075), ("jupiter", 2100)] {
+            let epoch = Epoch::from_gregorian(y, 5, 10, 0, 0, 0.0).to_tdb();
+            let dir_eq = sun_direction_from_body(body, &epoch).into_inner();
+            // The inverse rotation is the same x-rotation with the sign flipped.
+            let dir_ecl = planets::ecliptic_to_equatorial(&dir_eq, -j2000_obliquity());
+
+            let expected = (-planets::heliocentric_position_ecliptic(body, &epoch)
+                .expect("known body"))
+            .normalize();
+            let sep_arcsec = dir_ecl.dot(&expected).clamp(-1.0, 1.0).acos().to_degrees() * 3600.0;
+            let of_date_error_arcsec = (0.0130042 * epoch.centuries_since_j2000()).abs() * 3600.0;
+            assert!(
+                sep_arcsec < 1e-3,
+                "{body} {y}: ecliptic round trip off by {sep_arcsec:.3} arcsec \
+                 (an obliquity of date would give ~{of_date_error_arcsec:.1})"
+            );
+        }
+    }
+
+    #[test]
     fn sun_of_date_to_j2000_step_is_the_accumulated_precession() {
         // The rotation applied on the way out must be precession-sized, not
         // zero (the old behaviour) and not something else. The expected value

--- a/arika/src/sun/ephemeris.rs
+++ b/arika/src/sun/ephemeris.rs
@@ -2,10 +2,25 @@
 //!
 //! Low-precision (~1 arcminute) analytic model from Meeus "Astronomical
 //! Algorithms" Chapter 25 / Chapter 28. Returns positions in [`crate::frame::Gcrs`]
-//! (the analytical "geocentric inertial") rather than [`crate::frame::SimpleEci`] —
-//! Meeus ephemerides apply no precession/nutation/frame-bias, so numerically
-//! the two frames agree, but the returned type documents that this is not a
-//! propagator state vector.
+//! (the analytical "geocentric inertial") rather than [`crate::frame::SimpleEci`],
+//! documenting that this is not a propagator state vector.
+//!
+//! # Frame
+//!
+//! The series itself is referred to the **mean equinox and equator of date**:
+//! the mean longitude `L₀ = 280.46646 + 36000.76983·T` advances at the tropical
+//! rate (360.0076983°/Julian year) and the obliquity used to rotate ecliptic →
+//! equatorial is the mean obliquity of date. The returned vectors are therefore
+//! rotated back to J2000 with the IAU 1976 precession
+//! ([`crate::earth::fk5`]) before being typed `Vec3<Gcrs>`; nutation and the
+//! J2000→GCRS frame bias are neglected (≤ 17″ and ~20 mas respectively, both
+//! far below the model's own ~1′ accuracy).
+//!
+//! Skipping that rotation is a secular direction error equal to the accumulated
+//! precession — 0.335° in 2024, growing ~1.4°/century — and it does not cancel
+//! against a propagator state, so it is not a frame-labelling technicality.
+//! [`equation_of_time`] deliberately stays in of-date coordinates: it is a
+//! difference of two of-date longitudes.
 //!
 //! # Time scale
 //!
@@ -19,6 +34,7 @@ use nalgebra::Vector3;
 #[allow(unused_imports)]
 use crate::math::F64Ext;
 
+use crate::earth::fk5;
 use crate::epoch::{Epoch, Tdb};
 use crate::frame::{self, Vec3};
 use crate::planets;
@@ -64,21 +80,34 @@ fn solar_elements(epoch: &Epoch<Tdb>) -> SolarElements {
     }
 }
 
+/// Sun direction (unit vector) referred to the mean equator and equinox of
+/// date — the frame the Meeus series is actually expressed in.
+///
+/// Kept separate from [`sun_direction_eci`] so the precession rotation to J2000
+/// is a single visible step, and so tests can measure the size of that step.
+pub(crate) fn sun_direction_mean_of_date(epoch: &Epoch<Tdb>) -> Vector3<f64> {
+    let el = solar_elements(epoch);
+
+    let x = el.lambda_rad.cos();
+    let y = el.epsilon_rad.cos() * el.lambda_rad.sin();
+    let z = el.epsilon_rad.sin() * el.lambda_rad.sin();
+
+    Vector3::new(x, y, z).normalize()
+}
+
 /// Approximate sun direction (unit vector) in ECI (J2000) frame.
 ///
 /// Uses a low-precision analytical model based on mean orbital elements.
 /// Accuracy is ~1 arcminute, sufficient for visualization purposes.
 ///
+/// The Meeus series is referred to the mean equinox of date, so the result is
+/// rotated back to J2000 by the IAU 1976 precession (see the module docs).
+///
 /// Reference: Meeus, "Astronomical Algorithms", Chapter 25.
 pub fn sun_direction_eci(epoch: &Epoch<Tdb>) -> Vec3<frame::Gcrs> {
-    let el = solar_elements(epoch);
-
-    // Sun direction in ECI (equatorial coordinates)
-    let x = el.lambda_rad.cos();
-    let y = el.epsilon_rad.cos() * el.lambda_rad.sin();
-    let z = el.epsilon_rad.sin() * el.lambda_rad.sin();
-
-    Vec3::from_raw(Vector3::new(x, y, z).normalize())
+    let of_date = sun_direction_mean_of_date(epoch);
+    let p = fk5::mean_of_date_to_j2000_matrix(epoch.centuries_since_j2000());
+    Vec3::from_raw(p * of_date)
 }
 
 /// Equation of Time [hours].
@@ -165,7 +194,13 @@ pub fn sun_direction_from_body(body: &str, epoch: &Epoch<Tdb>) -> Vec3<frame::Gc
         "earth" | "moon" => sun_direction_eci(epoch),
         _ => {
             if let Some(body_pos_ecl) = planets::heliocentric_position_ecliptic(body, epoch) {
-                // Sun is at origin in heliocentric frame, so direction to sun = -body_pos
+                // The Standish/Meeus planetary elements are referred to the
+                // J2000 mean ecliptic (their mean longitudes advance at the
+                // sidereal rate), so this branch needs no precession rotation —
+                // unlike the geocentric Meeus Sun above. The remaining
+                // inconsistency is the obliquity of date used for the ecliptic →
+                // equatorial rotation (11″ in 2024, well inside the ~1′ model
+                // accuracy).
                 let sun_dir_ecl = -body_pos_ecl;
                 let epsilon = planets::obliquity(epoch);
                 Vec3::from_raw(planets::ecliptic_to_equatorial(&sun_dir_ecl, epsilon).normalize())
@@ -180,6 +215,74 @@ pub fn sun_direction_from_body(body: &str, epoch: &Epoch<Tdb>) -> Vec3<frame::Gc
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// IAU general precession in longitude [arcsec per Julian century].
+    /// Independent of arika's own precession code (which uses the IAU 1976
+    /// 5029.0966″/century; the two differ by ~0.3″/century).
+    const GENERAL_PRECESSION_ARCSEC_PER_CENTURY: f64 = 5028.796195;
+
+    // Frame tests: the Meeus series is of-date, the returned vector is J2000
+
+    #[test]
+    fn sun_direction_agrees_with_the_planetary_model_in_j2000() {
+        // Cross-model consistency, no external ephemeris required. The
+        // Standish/Meeus planetary elements (`planets`) are referred to the
+        // J2000 mean ecliptic — their mean longitudes advance at the sidereal
+        // rate — so -r_earth is an independent J2000 geocentric Sun direction.
+        // The Meeus geocentric series is of-date, so before the precession
+        // rotation the two disagreed by the whole accumulated precession
+        // (0.335° in 2024, 0.70° in 2050); they now agree to well within the
+        // ~1 arcminute accuracy both models claim.
+        for (y, m, d) in [
+            (2000, 1, 1),
+            (2024, 3, 20),
+            (2024, 9, 22),
+            (2050, 1, 1),
+            (2075, 7, 4),
+        ] {
+            let epoch = Epoch::from_gregorian(y, m, d, 12, 0, 0.0).to_tdb();
+            let sun = sun_direction_eci(&epoch).into_inner();
+            let earth = planets::heliocentric_position_ecliptic("earth", &epoch)
+                .expect("earth is a known body");
+            let geocentric_sun =
+                planets::ecliptic_to_equatorial(&(-earth), planets::obliquity(&epoch)).normalize();
+            let sep = sun
+                .dot(&geocentric_sun)
+                .clamp(-1.0, 1.0)
+                .acos()
+                .to_degrees();
+            assert!(
+                sep < 0.05,
+                "{y}-{m:02}-{d:02}: Meeus Sun and the planetary model disagree by {sep:.4}° \
+                 (precession left unremoved would give ~{:.2}°)",
+                GENERAL_PRECESSION_ARCSEC_PER_CENTURY * epoch.centuries_since_j2000() / 3600.0
+            );
+        }
+    }
+
+    #[test]
+    fn sun_of_date_to_j2000_step_is_the_accumulated_precession() {
+        // The rotation applied on the way out must be precession-sized, not
+        // zero (the old behaviour) and not something else. The expected value
+        // comes from the IAU general-precession rate, not from arika's own
+        // precession code.
+        // 2024 → 0.335°, 2050 → 0.698°, 1975 → 0.349° (before J2000, the same
+        // rotation the other way).
+        for y in [2024, 2050, 1975] {
+            let epoch = Epoch::from_gregorian(y, 7, 1, 0, 0, 0.0).to_tdb();
+            let t = epoch.centuries_since_j2000();
+            let of_date = sun_direction_mean_of_date(&epoch);
+            let j2000 = sun_direction_eci(&epoch).into_inner();
+            let sep = of_date.dot(&j2000).clamp(-1.0, 1.0).acos().to_degrees();
+            // The Sun sits on the ecliptic (β ≈ 0), so the separation is the
+            // full precession in longitude.
+            let expected = (GENERAL_PRECESSION_ARCSEC_PER_CENTURY * t / 3600.0).abs();
+            assert!(
+                (sep - expected).abs() < 0.002,
+                "{y}: of-date → J2000 step {sep:.4}°, expected {expected:.4}°"
+            );
+        }
+    }
 
     // Equation of Time tests
 

--- a/arika/tests/eclipse_astronomical_events.rs
+++ b/arika/tests/eclipse_astronomical_events.rs
@@ -10,6 +10,11 @@
 //!
 //! Timing tolerances are generous (minutes) due to Meeus ephemeris
 //! precision (~1 arcminute).
+//!
+//! These tests compare the Sun and Moon vectors *against each other*, so a
+//! rotation common to both cancels exactly: they cannot detect a frame error in
+//! the ephemerides. The frame of each vector is pinned by the unit tests in
+//! `arika::sun::ephemeris` / `arika::moon::ephemeris` instead.
 
 use arika::eclipse::{self, SUN_RADIUS_KM, ShadowModel};
 use arika::epoch::Epoch;

--- a/arika/tests/eop_finals2000a.rs
+++ b/arika/tests/eop_finals2000a.rs
@@ -163,8 +163,16 @@ fn table_dut1_interpolated_midpoint() {
 /// A positive leap second is inserted as dUT1 approaches −0.9 s and lifts it by
 /// a full second, so the daily rows differ by ~1.0 s.
 fn leap_crossing_table() -> EopTable {
-    use arika::earth::eop::EopEntry;
-    let entry = |mjd: f64, dut1: f64| EopEntry {
+    EopTable::new(vec![
+        entry_dut1(57753.0, -0.5928),
+        entry_dut1(57754.0, 0.4068),
+    ])
+    .unwrap()
+}
+
+/// A row carrying only dUT1; the other parameters are not under test here.
+fn entry_dut1(mjd: f64, dut1: f64) -> arika::earth::eop::EopEntry {
+    arika::earth::eop::EopEntry {
         mjd,
         xp: 0.0,
         yp: 0.0,
@@ -172,8 +180,7 @@ fn leap_crossing_table() -> EopTable {
         lod: None,
         dx: None,
         dy: None,
-    };
-    EopTable::new(vec![entry(57753.0, -0.5928), entry(57754.0, 0.4068)]).unwrap()
+    }
 }
 
 #[test]
@@ -192,6 +199,51 @@ fn table_dut1_interpolates_ut1_minus_tai_across_a_leap_second() {
     // Endpoints are still reproduced exactly.
     assert!((table.dut1_checked(57753.0).unwrap() - (-0.5928)).abs() < 1e-12);
     assert!((table.dut1_checked(57754.0).unwrap() - 0.4068).abs() < 1e-12);
+}
+
+#[test]
+fn clamped_dut1_extrapolates_ut1_minus_tai_past_a_leap_second() {
+    // The clamp holds the *continuous* quantity. A table that stops on
+    // 2016-12-30 (dUT1 = -0.5928 s, TAI-UTC = 36 s) answers a 2017-01-02 query
+    // (TAI-UTC = 37 s) with -0.5928 - 36 + 37 = +0.4072 s, which is the real
+    // post-leap dUT1 to within its daily drift (IERS: +0.4068 s). Holding dUT1
+    // itself constant would answer -0.5928 s and put a second-sized step into
+    // UT1 exactly where nothing corrects it.
+    let table = EopTable::new(vec![
+        entry_dut1(57751.0, -0.5905),
+        entry_dut1(57752.0, -0.5928),
+    ])
+    .unwrap();
+    let clamped = table.clamped();
+
+    let after_leap = Ut1Offset::dut1(&clamped, 57755.0);
+    assert!(
+        (after_leap - 0.4072).abs() < 1e-9,
+        "clamped dUT1 after the leap second should be +0.4072 s, got {after_leap}"
+    );
+
+    // Inside the table the adapter still agrees with the checked lookup.
+    let inside = Ut1Offset::dut1(&clamped, 57751.5);
+    assert!((inside - table.dut1_checked(57751.5).unwrap()).abs() < 1e-15);
+
+    // UT1 - TAI has no step across the clamp boundary or the leap second.
+    let ut1_tai = |mjd: f64| {
+        let tai_utc = if mjd >= 57754.0 { 37.0 } else { 36.0 };
+        Ut1Offset::dut1(&clamped, mjd) - tai_utc
+    };
+    let mut prev = ut1_tai(57751.0);
+    let mut k = 1;
+    while k <= 500 {
+        let mjd = 57751.0 + 0.01 * k as f64;
+        let v = ut1_tai(mjd);
+        assert!(
+            (v - prev).abs() < 1e-3,
+            "UT1-TAI jumped by {} s at MJD {mjd}",
+            (v - prev).abs()
+        );
+        prev = v;
+        k += 1;
+    }
 }
 
 #[test]

--- a/arika/tests/eop_finals2000a.rs
+++ b/arika/tests/eop_finals2000a.rs
@@ -128,7 +128,6 @@ fn table_dut1_at_exact_entry() {
 #[test]
 fn table_dut1_interpolated_midpoint() {
     let table = EopTable::from_finals2000a(SAMPLE).unwrap();
-    // Midpoint between MJD 60389 and 60390 should be average of the two
     let entries = Finals2000A::parse(SAMPLE).unwrap();
     let e0 = entries
         .iter()
@@ -138,13 +137,95 @@ fn table_dut1_interpolated_midpoint() {
         .iter()
         .find(|e| (e.mjd - 60390.0).abs() < 0.01)
         .unwrap();
-    let expected = (e0.dut1 + e1.dut1) / 2.0;
+
+    // The interpolated quantity is `UT1 - TAI = dUT1 - (TAI - UTC)`, which is
+    // continuous; dUT1 itself is not. The expectation used to be the average of
+    // the two rows' dUT1 — the implementation's own formula, which is why it
+    // could not detect that the formula was wrong. It happens to agree here
+    // because this fixture (2024-03) sits entirely inside one leap-second
+    // regime, where TAI - UTC is the constant 37 s and cancels; the
+    // leap-crossing case is pinned by `table_dut1_interpolates_ut1_minus_tai_*`.
+    const TAI_MINUS_UTC_2024: f64 = 37.0;
+    let ut1_tai_0 = e0.dut1 - TAI_MINUS_UTC_2024;
+    let ut1_tai_1 = e1.dut1 - TAI_MINUS_UTC_2024;
+    let expected = (ut1_tai_0 + ut1_tai_1) / 2.0 + TAI_MINUS_UTC_2024;
 
     let dut1 = table.dut1_checked(60389.5).unwrap();
     assert!(
         (dut1 - expected).abs() < 1e-10,
         "interpolated dut1 should be ~{expected}, got {dut1}"
     );
+}
+
+// Leap-second handling in the dUT1 interpolation
+
+/// The two IERS rows bracketing the 2017-01-01 leap second (TAI-UTC 36 → 37 s).
+/// A positive leap second is inserted as dUT1 approaches −0.9 s and lifts it by
+/// a full second, so the daily rows differ by ~1.0 s.
+fn leap_crossing_table() -> EopTable {
+    use arika::earth::eop::EopEntry;
+    let entry = |mjd: f64, dut1: f64| EopEntry {
+        mjd,
+        xp: 0.0,
+        yp: 0.0,
+        dut1,
+        lod: None,
+        dx: None,
+        dy: None,
+    };
+    EopTable::new(vec![entry(57753.0, -0.5928), entry(57754.0, 0.4068)]).unwrap()
+}
+
+#[test]
+fn table_dut1_interpolates_ut1_minus_tai_across_a_leap_second() {
+    let table = leap_crossing_table();
+    // Halfway through 2016-12-31 the leap second has not happened yet, so UT1 -
+    // UTC is still near −0.593 s. Interpolating dUT1 directly would smear half
+    // the 1 s step backwards and return ≈ −0.093 s: a 0.5 s UT1 error, i.e.
+    // 3.65e-5 rad of ERA and ~233 m of equatorial ITRS displacement.
+    let dut1 = table.dut1_checked(57753.5).unwrap();
+    assert!(
+        (dut1 - (-0.5928)).abs() < 0.01,
+        "dUT1 at MJD 57753.5 should stay near -0.593 s, got {dut1}"
+    );
+
+    // Endpoints are still reproduced exactly.
+    assert!((table.dut1_checked(57753.0).unwrap() - (-0.5928)).abs() < 1e-12);
+    assert!((table.dut1_checked(57754.0).unwrap() - 0.4068).abs() < 1e-12);
+}
+
+#[test]
+fn table_dut1_interpolates_ut1_minus_tai_continuously() {
+    // Data-free invariant: `UT1 - TAI` is continuous, so sampling it finely
+    // across the leap second must show no step larger than the day-to-day
+    // drift. This holds for any table, without hand-picked expected values.
+    let table = leap_crossing_table();
+    const TAI_MINUS_UTC: [(f64, f64); 2] = [(57753.0, 36.0), (57754.0, 37.0)];
+    let tai_utc = |mjd: f64| {
+        if mjd >= TAI_MINUS_UTC[1].0 {
+            TAI_MINUS_UTC[1].1
+        } else {
+            TAI_MINUS_UTC[0].1
+        }
+    };
+
+    let step = 0.01;
+    let mut prev: Option<f64> = None;
+    let mut k = 0;
+    while k <= 100 {
+        let mjd = 57753.0 + step * k as f64;
+        let ut1_tai = table.dut1_checked(mjd).unwrap() - tai_utc(mjd);
+        if let Some(p) = prev {
+            let jump = (ut1_tai - p).abs();
+            assert!(
+                jump < 1e-3,
+                "UT1-TAI jumped by {jump} s between MJD {} and {mjd}",
+                mjd - step
+            );
+        }
+        prev = Some(ut1_tai);
+        k += 1;
+    }
 }
 
 #[test]
@@ -165,18 +246,22 @@ fn table_out_of_range_returns_error() {
 
 // EOP trait implementation tests
 
+// The capability traits are implemented by the `clamped()` adapter, not by
+// `EopTable` itself: a finite-range table has no correct infallible answer
+// outside its span, so the out-of-range policy has to be named at the call site.
+
 #[test]
 fn trait_ut1_offset() {
     let table = EopTable::from_finals2000a(SAMPLE).unwrap();
-    let dut1 = Ut1Offset::dut1(&table, 60389.0);
+    let dut1 = Ut1Offset::dut1(&table.clamped(), 60389.0);
     assert!((dut1 - (-0.0091683)).abs() < 1e-6);
 }
 
 #[test]
 fn trait_polar_motion() {
     let table = EopTable::from_finals2000a(SAMPLE).unwrap();
-    let xp = PolarMotion::x_pole(&table, 60389.0);
-    let yp = PolarMotion::y_pole(&table, 60389.0);
+    let xp = PolarMotion::x_pole(&table.clamped(), 60389.0);
+    let yp = PolarMotion::y_pole(&table.clamped(), 60389.0);
     assert!((xp - (-0.013421)).abs() < 1e-6);
     assert!((yp - 0.313052).abs() < 1e-6);
 }
@@ -184,19 +269,68 @@ fn trait_polar_motion() {
 #[test]
 fn trait_nutation_corrections() {
     let table = EopTable::from_finals2000a(SAMPLE).unwrap();
-    let dx = NutationCorrections::dx(&table, 60389.0);
+    let dx = NutationCorrections::dx(&table.clamped(), 60389.0);
     assert!((dx - 0.378).abs() < 0.01);
 }
 
 #[test]
 fn trait_length_of_day() {
     let table = EopTable::from_finals2000a(SAMPLE).unwrap();
-    let lod = LengthOfDay::lod(&table, 60389.0);
+    let lod = LengthOfDay::lod(&table.clamped(), 60389.0);
     // LOD in seconds
     assert!(
         (lod - 0.1693e-3).abs() < 1e-7,
         "LOD should be ~0.1693 ms, got {lod}"
     );
+}
+
+#[test]
+fn out_of_range_epoch_reaches_the_caller_as_an_error_not_a_panic() {
+    // The trait methods used to be implemented directly on `EopTable` with
+    // `.expect(...)`, so an ordinary out-of-range epoch — a forward propagation
+    // running past the end of a finals2000A prediction file — aborted the
+    // process from inside `Epoch::to_ut1` / the IAU 2006 full chain.
+    let table = EopTable::from_finals2000a(SAMPLE).unwrap();
+    let (start, end) = table.mjd_range();
+
+    for mjd in [start - 1.0, end + 1.0, start - 1000.0] {
+        match table.dut1_checked(mjd) {
+            Err(arika::earth::eop::EopLookupError::OutOfRange { .. }) => {}
+            other => panic!("expected OutOfRange at MJD {mjd}, got {other:?}"),
+        }
+    }
+
+    // The clamping adapter is the explicit "hold the endpoint" policy, and it
+    // must not panic either.
+    let clamped = table.clamped();
+    assert_eq!(
+        Ut1Offset::dut1(&clamped, start - 1.0),
+        table.dut1_checked(start).unwrap()
+    );
+    assert_eq!(
+        Ut1Offset::dut1(&clamped, end + 1.0),
+        table.dut1_checked(end).unwrap()
+    );
+    assert!(PolarMotion::x_pole(&clamped, end + 500.0).is_finite());
+    assert!(LengthOfDay::lod(&clamped, start - 500.0).is_finite());
+}
+
+#[test]
+fn to_ut1_and_the_full_chain_accept_an_out_of_range_epoch_via_the_policy() {
+    use arika::epoch::{Epoch, Utc};
+    use arika::frame::{self, Rotation, Vec3};
+
+    // 2024-03-20 is inside the fixture; 2030-01-01 is far past its end.
+    let table = EopTable::from_finals2000a(SAMPLE).unwrap();
+    let clamped = table.clamped();
+    let far = Epoch::<Utc>::from_gregorian(2030, 1, 1, 0, 0, 0.0);
+
+    let ut1 = far.to_ut1(&clamped);
+    assert!(ut1.jd().is_finite(), "UT1 conversion must not abort");
+
+    let rot = Rotation::<frame::Gcrs, frame::Itrs>::iau2006_full_from_utc(&far, &clamped);
+    let v = rot.transform(&Vec3::<frame::Gcrs>::new(1.0, 0.0, 0.0));
+    assert!((v.magnitude() - 1.0).abs() < 1e-14);
 }
 
 // Integration: EopTable works with Rotation chain
@@ -211,7 +345,7 @@ fn eop_table_works_with_iau2006_full() {
 
     // This should compile and not panic — real EOP data flowing through
     // the full IAU 2006 CIO chain.
-    let rot = Rotation::<frame::Gcrs, frame::Itrs>::iau2006_full_from_utc(&utc, &table);
+    let rot = Rotation::<frame::Gcrs, frame::Itrs>::iau2006_full_from_utc(&utc, &table.clamped());
     let v = Vec3::<frame::Gcrs>::new(1.0, 0.0, 0.0);
     let v_itrs = rot.transform(&v);
 

--- a/arika/tests/eop_finals2000a.rs
+++ b/arika/tests/eop_finals2000a.rs
@@ -369,6 +369,39 @@ fn out_of_range_epoch_reaches_the_caller_as_an_error_not_a_panic() {
 }
 
 #[test]
+fn a_nan_mjd_is_an_error_not_a_successful_nan() {
+    // A NaN MJD compares false against both ends of the range, so a range check
+    // written as `mjd < start || mjd > end` lets it through and interpolates it
+    // into `Ok(NaN)`: a lookup that reports success while handing back a value
+    // that poisons every rotation it reaches.
+    let table = EopTable::from_finals2000a(SAMPLE).unwrap();
+
+    for lookup in [
+        EopTable::dut1_checked,
+        EopTable::xp_checked,
+        EopTable::yp_checked,
+        EopTable::dx_checked,
+        EopTable::dy_checked,
+        EopTable::lod_checked,
+    ] {
+        match lookup(&table, f64::NAN) {
+            Err(arika::earth::eop::EopLookupError::OutOfRange { mjd, .. }) => assert!(mjd.is_nan()),
+            other => panic!("expected OutOfRange for a NaN MJD, got {other:?}"),
+        }
+    }
+    assert!(table.dut1_checked(f64::INFINITY).is_err());
+    assert!(table.dut1_checked(f64::NEG_INFINITY).is_err());
+
+    // The clamping adapter has no endpoint to hold for NaN, so it yields NaN —
+    // never an endpoint value that would look like a real answer.
+    let clamped = table.clamped();
+    assert!(Ut1Offset::dut1(&clamped, f64::NAN).is_nan());
+    assert!(PolarMotion::x_pole(&clamped, f64::NAN).is_nan());
+    assert!(NutationCorrections::dx(&clamped, f64::NAN).is_nan());
+    assert!(LengthOfDay::lod(&clamped, f64::NAN).is_nan());
+}
+
+#[test]
 fn to_ut1_and_the_full_chain_accept_an_out_of_range_epoch_via_the_policy() {
     use arika::epoch::{Epoch, Utc};
     use arika::frame::{self, Rotation, Vec3};

--- a/arika/tests/eop_finals2000a.rs
+++ b/arika/tests/eop_finals2000a.rs
@@ -203,15 +203,16 @@ fn table_dut1_interpolates_ut1_minus_tai_across_a_leap_second() {
 
 #[test]
 fn clamped_dut1_extrapolates_ut1_minus_tai_past_a_leap_second() {
-    // The clamp holds the *continuous* quantity. A table that stops on
-    // 2016-12-30 (dUT1 = -0.5928 s, TAI-UTC = 36 s) answers a 2017-01-02 query
-    // (TAI-UTC = 37 s) with -0.5928 - 36 + 37 = +0.4072 s, which is the real
-    // post-leap dUT1 to within its daily drift (IERS: +0.4068 s). Holding dUT1
-    // itself constant would answer -0.5928 s and put a second-sized step into
-    // UT1 exactly where nothing corrects it.
+    // The clamp holds the *continuous* quantity. A table whose last row is
+    // 2016-12-31 (MJD 57753, dUT1 = -0.5928 s, TAI-UTC = 36 s) answers a
+    // 2017-01-02 query (TAI-UTC = 37 s) with -0.5928 - 36 + 37 = +0.4072 s. The
+    // IERS row one day earlier, just after the leap second, reads +0.4068 s, so
+    // the extrapolation lands within the daily drift. Holding dUT1 itself
+    // constant would answer -0.5928 s and put a second-sized step into UT1
+    // exactly where nothing corrects it.
     let table = EopTable::new(vec![
-        entry_dut1(57751.0, -0.5905),
-        entry_dut1(57752.0, -0.5928),
+        entry_dut1(57752.0, -0.5905),
+        entry_dut1(57753.0, -0.5928),
     ])
     .unwrap();
     let clamped = table.clamped();
@@ -223,18 +224,18 @@ fn clamped_dut1_extrapolates_ut1_minus_tai_past_a_leap_second() {
     );
 
     // Inside the table the adapter still agrees with the checked lookup.
-    let inside = Ut1Offset::dut1(&clamped, 57751.5);
-    assert!((inside - table.dut1_checked(57751.5).unwrap()).abs() < 1e-15);
+    let inside = Ut1Offset::dut1(&clamped, 57752.5);
+    assert!((inside - table.dut1_checked(57752.5).unwrap()).abs() < 1e-15);
 
     // UT1 - TAI has no step across the clamp boundary or the leap second.
     let ut1_tai = |mjd: f64| {
         let tai_utc = if mjd >= 57754.0 { 37.0 } else { 36.0 };
         Ut1Offset::dut1(&clamped, mjd) - tai_utc
     };
-    let mut prev = ut1_tai(57751.0);
+    let mut prev = ut1_tai(57752.0);
     let mut k = 1;
-    while k <= 500 {
-        let mjd = 57751.0 + 0.01 * k as f64;
+    while k <= 400 {
+        let mjd = 57752.0 + 0.01 * k as f64;
         let v = ut1_tai(mjd);
         assert!(
             (v - prev).abs() < 1e-3,

--- a/arika/tests/eop_finals2000a.rs
+++ b/arika/tests/eop_finals2000a.rs
@@ -142,8 +142,8 @@ fn table_dut1_interpolated_midpoint() {
     // continuous; dUT1 itself is not. The expectation used to be the average of
     // the two rows' dUT1 — the implementation's own formula, which is why it
     // could not detect that the formula was wrong. It happens to agree here
-    // because this fixture (2024-03) sits entirely inside one leap-second
-    // regime, where TAI - UTC is the constant 37 s and cancels; the
+    // because this fixture (2024-03-01..04-30) sits entirely inside one
+    // leap-second regime, where TAI - UTC is the constant 37 s and cancels; the
     // leap-crossing case is pinned by `table_dut1_interpolates_ut1_minus_tai_*`.
     const TAI_MINUS_UTC_2024: f64 = 37.0;
     let ut1_tai_0 = e0.dut1 - TAI_MINUS_UTC_2024;

--- a/arika/tests/trybuild/null_eop_in_iau2006.stderr
+++ b/arika/tests/trybuild/null_eop_in_iau2006.stderr
@@ -14,8 +14,8 @@ help: the following other types implement trait `NutationCorrections`
    |
   ::: src/earth/eop/table.rs
    |
-   | impl NutationCorrections for EopTable {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `EopTable`
+   | impl<T: core::borrow::Borrow<EopTable>> NutationCorrections for ClampedEop<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ClampedEop<T>`
 note: required by a bound in `cio_chain::<impl Rotation<arika::frame::Gcrs, arika::frame::Cirs>>::iau2006`
   --> src/earth/iau2006/cio_chain.rs
    |

--- a/arika/tests/trybuild/null_eop_in_iau2006_full_from_utc.stderr
+++ b/arika/tests/trybuild/null_eop_in_iau2006_full_from_utc.stderr
@@ -14,8 +14,8 @@ help: the following other types implement trait `Ut1Offset`
    |
   ::: src/earth/eop/table.rs
    |
-   | impl Ut1Offset for EopTable {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `EopTable`
+   | impl<T: core::borrow::Borrow<EopTable>> Ut1Offset for ClampedEop<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ClampedEop<T>`
 note: required by a bound in `cio_chain::<impl Rotation<arika::frame::Gcrs, arika::frame::Itrs>>::iau2006_full_from_utc`
   --> src/earth/iau2006/cio_chain.rs
    |
@@ -41,8 +41,8 @@ help: the following other types implement trait `NutationCorrections`
    |
   ::: src/earth/eop/table.rs
    |
-   | impl NutationCorrections for EopTable {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `EopTable`
+   | impl<T: core::borrow::Borrow<EopTable>> NutationCorrections for ClampedEop<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ClampedEop<T>`
 note: required by a bound in `cio_chain::<impl Rotation<arika::frame::Gcrs, arika::frame::Itrs>>::iau2006_full_from_utc`
   --> src/earth/iau2006/cio_chain.rs
    |
@@ -68,8 +68,8 @@ help: the following other types implement trait `PolarMotion`
    |
   ::: src/earth/eop/table.rs
    |
-   | impl PolarMotion for EopTable {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `EopTable`
+   | impl<T: core::borrow::Borrow<EopTable>> PolarMotion for ClampedEop<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ClampedEop<T>`
 note: required by a bound in `cio_chain::<impl Rotation<arika::frame::Gcrs, arika::frame::Itrs>>::iau2006_full_from_utc`
   --> src/earth/iau2006/cio_chain.rs
    |

--- a/arika/tests/trybuild/null_eop_in_polar_motion.stderr
+++ b/arika/tests/trybuild/null_eop_in_polar_motion.stderr
@@ -14,8 +14,8 @@ help: the following other types implement trait `PolarMotion`
    |
   ::: src/earth/eop/table.rs
    |
-   | impl PolarMotion for EopTable {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `EopTable`
+   | impl<T: core::borrow::Borrow<EopTable>> PolarMotion for ClampedEop<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ClampedEop<T>`
 note: required by a bound in `cio_chain::<impl Rotation<arika::frame::Tirs, arika::frame::Itrs>>::polar_motion`
   --> src/earth/iau2006/cio_chain.rs
    |

--- a/arika/tests/trybuild/null_eop_in_to_ut1.stderr
+++ b/arika/tests/trybuild/null_eop_in_to_ut1.stderr
@@ -14,8 +14,8 @@ help: the following other types implement trait `Ut1Offset`
    |
   ::: src/earth/eop/table.rs
    |
-   | impl Ut1Offset for EopTable {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `EopTable`
+   | impl<T: core::borrow::Borrow<EopTable>> Ut1Offset for ClampedEop<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ClampedEop<T>`
 note: required by a bound in `epoch::convert::<impl arika::epoch::Epoch<Utc, P>>::to_ut1`
   --> src/epoch/convert.rs
    |

--- a/orts/src/sensor/sun_sensor.rs
+++ b/orts/src/sensor/sun_sensor.rs
@@ -240,9 +240,16 @@ mod tests {
         }
     }
 
-    /// Characterization: pinned pre-refactor `SimpleEci` body-frame Sun
-    /// direction, so rotating the (GCRS) Sun ephemeris into a generic frame `F`
-    /// — identity for `SimpleEci` — cannot change it.
+    /// Characterization: pinned `SimpleEci` body-frame Sun direction, so
+    /// rotating the (GCRS) Sun ephemeris into a generic frame `F` — identity for
+    /// `SimpleEci` — cannot change it.
+    ///
+    /// Re-baselined when `arika::sun` started rotating the Meeus series from the
+    /// mean equinox of date back to J2000: the direction moved by 0.3383°, which
+    /// is the J2000→2024 accumulated precession the ephemeris used to leave in.
+    /// The frame generalization this test guards is unaffected — `SimpleEci` is
+    /// still the identity bridge — so the snapshot value is the only thing that
+    /// moved.
     #[test]
     fn simple_eci_direction_snapshot() {
         let mut sensor = SunSensor::for_earth();
@@ -256,7 +263,11 @@ mod tests {
             panic!("expected Fine output");
         };
         let got = direction.expect("sunlit").into_inner().into_inner();
-        let expected = Vector3::new(0.7903661281325338, -0.551312799346672, -0.2671620870882);
+        let expected = Vector3::new(
+            0.7868574856732309,
+            -0.5560253910118033,
+            -0.26775186608158713,
+        );
         assert!(
             (got - expected).magnitude() <= 1e-12 * expected.magnitude().max(1.0),
             "SimpleEci sun direction changed: {got:?}"

--- a/orts/tests/oracle_gcrf.rs
+++ b/orts/tests/oracle_gcrf.rs
@@ -228,8 +228,10 @@ fn load_eop_table() -> arika::earth::eop::EopTable {
 }
 
 fn build_gcrs_system_real_eop(scenario: &Scenario) -> OrbitalSystem<frame::Gcrs> {
-    // `into_clamped` names the out-of-range policy: the fixture covers only
-    // 2024-03-01..16, and the scenarios propagate past its end.
+    // The EOP capability traits are infallible, so a finite-range table only
+    // implements them through an adapter that names its out-of-range policy.
+    // The fixture spans MJD 60370..60430 (2024-03-01..04-30) and the longest
+    // scenario here is 30 days from 2024-03-01, so the clamp never engages.
     build_gcrs_system_with_eop(
         scenario,
         GcrsEopStorage::new(load_eop_table().into_clamped()),

--- a/orts/tests/oracle_gcrf.rs
+++ b/orts/tests/oracle_gcrf.rs
@@ -228,7 +228,12 @@ fn load_eop_table() -> arika::earth::eop::EopTable {
 }
 
 fn build_gcrs_system_real_eop(scenario: &Scenario) -> OrbitalSystem<frame::Gcrs> {
-    build_gcrs_system_with_eop(scenario, GcrsEopStorage::new(load_eop_table()))
+    // `into_clamped` names the out-of-range policy: the fixture covers only
+    // 2024-03-01..16, and the scenarios propagate past its end.
+    build_gcrs_system_with_eop(
+        scenario,
+        GcrsEopStorage::new(load_eop_table().into_clamped()),
+    )
 }
 
 /// Propagate the Gcrs path and return the final position [km].

--- a/orts/tests/oracle_orekit.rs
+++ b/orts/tests/oracle_orekit.rs
@@ -6,7 +6,7 @@
 //! **Tier structure**:
 //! - Tier 1: Gravity-only (J2, J2+J3+J4) — should agree to cm-level
 //! - Tier 2: Gravity + third-body (Sun, Moon) — ephemeris difference dominates
-//! - Tier 3: Gravity + SRP — Sun direction error ~0.35°
+//! - Tier 3: Gravity + SRP — Sun direction error ~1' (Meeus model accuracy)
 //! - Tier 4: Gravity + HP drag — geodetic altitude differences
 //! - Tier 5: Full force model (HP) — all differences combined
 //! - Tier 6: Gravity + NRLMSISE-00 drag — LST approximation dominates
@@ -15,8 +15,11 @@
 //!
 //! Known difference sources:
 //! - **J2 coefficient**: Orekit EGM96 C̄₂₀ → J2 differs by ~3e-9 (negligible)
-//! - **Sun position**: Meeus analytical vs DE405 (~0.35°)
-//! - **Moon position**: Simplified analytical vs DE405 (~10')
+//! - **Sun position**: Meeus analytical vs DE405 (~1'). This used to read
+//!   ~0.35°, which was the accumulated J2000→of-date precession the Meeus
+//!   series was returning unrotated, mis-attributed to model accuracy; the
+//!   ephemeris now rotates to J2000 and only the model error remains
+//! - **Moon position**: Meeus Ch.47 analytical vs DE405 (~10' / ~1% distance)
 //! - **LST**: Orekit precise solar time vs our UT+lon/15 (~±16 min → 1-5% density)
 
 use arika::earth::{J2 as J2_EARTH, J3 as J3_EARTH, J4 as J4_EARTH, MU as MU_EARTH, R as R_EARTH};
@@ -420,7 +423,7 @@ fn orekit_j2_equatorial_5orbits() {
 }
 
 // Tier 2: Gravity + Third-body
-// Sun: Meeus vs DE405 (~0.35°), Moon: full Meeus Ch.47 vs DE405 (~1% distance).
+// Sun: Meeus vs DE405 (~1'), Moon: full Meeus Ch.47 vs DE405 (~1% distance).
 // These tolerances include BOTH integration error AND ephemeris difference.
 // The ephemeris difference dominates for long-duration/high-altitude scenarios.
 //
@@ -447,7 +450,7 @@ fn orekit_j2_sun_moon_geo_3days() {
 }
 
 // Tier 3: Gravity + SRP
-// Sun direction error ~0.35° affects SRP vector; shadow timing may differ slightly.
+// Sun direction error ~1' affects SRP vector; shadow timing may differ slightly.
 // Expected: ~1-2 m over 10 SSO orbits.
 
 #[test]
@@ -457,7 +460,7 @@ fn orekit_j2_srp_sso_10orbits() {
 
 // Tier 4: Gravity + HP Drag
 // With geodetic altitude (WGS-84), remaining differences are:
-// - J2 constant (~3e-9), Meeus Sun direction for HP bulge (~0.35°)
+// - J2 constant (~3e-9), Meeus Sun direction for HP bulge (~1')
 // - Minor geodetic algorithm differences (Bowring vs Orekit's WGS-84)
 
 #[test]

--- a/orts/tests/oracle_orekit.rs
+++ b/orts/tests/oracle_orekit.rs
@@ -464,12 +464,12 @@ fn orekit_j2_srp_sso_10orbits() {
 // With geodetic altitude (WGS-84), remaining differences are:
 // - J2 constant (~3e-9)
 // - Sun direction for the HP bulge (~1' of Meeus model error). The bulge's local
-//   hour angle is `ERA + λ − α_sun`, so it needs the solar right ascension in the
-//   frame the Earth rotation angle refers to — which is what `arika::sun` returns
-//   now that it rotates the of-date Meeus series to J2000. Before that it was
-//   0.34° (2024) of bulge phase, and these four scenarios measured 2.7 / 3.6 /
-//   13.4 / 191 m; see the 30-day case below for why the longest one moved the
-//   other way
+//   hour angle is `ERA + λ − α_sun`, so α_sun has to be CIO-based. The J2000
+//   direction `arika::sun` returns now that it rotates the of-date Meeus series
+//   back is close to that — the dominant precession-in-right-ascension term
+//   cancels against `GMST − ERA` — while the of-date direction it used to return
+//   sat 0.31° away in bulge phase. These four scenarios measured 2.7 / 3.6 /
+//   13.4 / 191 m then; see the 30-day case below
 // - Minor geodetic algorithm differences (Bowring vs Orekit's WGS-84)
 
 #[test]
@@ -492,14 +492,15 @@ fn orekit_j2_hp_iss_7days() {
 
 #[test]
 fn orekit_j2_hp_iss_30days() {
-    // Re-locked from 230 m when the HP bulge's hour angle became
-    // frame-consistent (see the tier notes above). The three shorter HP
-    // scenarios improved by 20-40% (2.7 → 1.7 m, 3.6 → 2.2 m, 13.4 → 10.7 m);
-    // this one grew from 191 m to 336 m, because at 30 days the residual is an
-    // along-track drift fed by the *remaining* differences against Orekit's HP
-    // (density-table interpolation, lag-angle convention, geodetic altitude),
-    // and the 0.34° phase error had been partially cancelling it. 336 m is 5e-5
-    // of the orbit radius after 30 days of ISS drag.
+    // Re-locked from 230 m when the HP bulge's hour angle became frame-consistent
+    // (see the tier notes above). The three shorter HP scenarios improved by
+    // 20-40% (2.7 → 1.7 m, 3.6 → 2.2 m, 13.4 → 10.7 m); this one grew from 191 m
+    // to 336 m. Over 30 days the residual is a secular along-track drift, so it
+    // integrates the remaining differences against Orekit's HP rather than
+    // tracking the bulge phase directly, and the observed net cancellation the
+    // old phase error provided is gone. Which of those remaining differences
+    // dominates is not resolved by these four measurements. 336 m is 5e-5 of the
+    // orbit radius after 30 days of ISS drag.
     run_scenario("j2_hp_iss_30days", 0.400); // 400 m (measured: 336 m, baseline lock)
 }
 

--- a/orts/tests/oracle_orekit.rs
+++ b/orts/tests/oracle_orekit.rs
@@ -432,21 +432,23 @@ fn orekit_j2_equatorial_5orbits() {
 // (Tier 2a), then testing ephemeris accuracy independently (Tier 2c).
 // See: https://github.com/... (tracking issue)
 //
-// Expected: sub-meter (LEO) to ~250 m (GEO, 3 days).
+// Expected: sub-meter, GEO 3 days included.
 
 #[test]
 fn orekit_j2_sun_moon_sso_10orbits() {
-    run_scenario("j2_sun_moon_sso_10orbits", 0.002); // 2 m (measured: 0.4 m)
+    run_scenario("j2_sun_moon_sso_10orbits", 0.002); // 2 m (measured: 0.55 m)
 }
 
 #[test]
 fn orekit_j2_sun_moon_geo_3days() {
-    // Tolerance widened from 150m to 250m after upgrading Moon ephemeris from
-    // simplified 5-term to full 60-term Meeus (arika::moon). The new model is
-    // more accurate (~1% distance vs ~5%), but the error pattern vs Orekit's
-    // DE405 changed, increasing the trajectory divergence at this epoch.
-    // This does NOT indicate a regression — the integration is correct.
-    run_scenario("j2_sun_moon_geo_3days", 0.250); // 250 m (measured: 218 m)
+    // This scenario is the sharpest in-tree measurement of the Sun/Moon
+    // ephemeris frame: at GEO over 3 days the third-body acceleration dominates
+    // and a direction error shows up directly. It measured 218 m while
+    // `arika::sun` / `arika::moon` returned mean-equinox-of-date vectors typed
+    // GCRS; rotating them back to J2000 with the IAU 1976 precession brought it
+    // to 0.33 m against Orekit's DE405. The tolerance is set just above that, so
+    // dropping the rotation again fails here by 600x rather than passing.
+    run_scenario("j2_sun_moon_geo_3days", 0.001); // 1 m (measured: 0.33 m)
 }
 
 // Tier 3: Gravity + SRP
@@ -460,17 +462,24 @@ fn orekit_j2_srp_sso_10orbits() {
 
 // Tier 4: Gravity + HP Drag
 // With geodetic altitude (WGS-84), remaining differences are:
-// - J2 constant (~3e-9), Meeus Sun direction for HP bulge (~1')
+// - J2 constant (~3e-9)
+// - Sun direction for the HP bulge (~1' of Meeus model error). The bulge's local
+//   hour angle is `ERA + λ − α_sun`, so it needs the solar right ascension in the
+//   frame the Earth rotation angle refers to — which is what `arika::sun` returns
+//   now that it rotates the of-date Meeus series to J2000. Before that it was
+//   0.34° (2024) of bulge phase, and these four scenarios measured 2.7 / 3.6 /
+//   13.4 / 191 m; see the 30-day case below for why the longest one moved the
+//   other way
 // - Minor geodetic algorithm differences (Bowring vs Orekit's WGS-84)
 
 #[test]
 fn orekit_j2_hp_iss_equatorial_5orbits() {
-    run_scenario("j2_hp_iss_equatorial_5orbits", 0.004); // 4 m (measured: 2.7 m, baseline lock)
+    run_scenario("j2_hp_iss_equatorial_5orbits", 0.004); // 4 m (measured: 1.7 m, baseline lock)
 }
 
 #[test]
 fn orekit_j2_hp_iss_10orbits() {
-    run_scenario("j2_hp_iss_10orbits", 0.005); // 5 m (measured: 3.6 m, baseline lock)
+    run_scenario("j2_hp_iss_10orbits", 0.005); // 5 m (measured: 2.2 m, baseline lock)
 }
 
 // Long-duration HP drag: validates error growth over ISS decay timescales.
@@ -478,12 +487,20 @@ fn orekit_j2_hp_iss_10orbits() {
 
 #[test]
 fn orekit_j2_hp_iss_7days() {
-    run_scenario("j2_hp_iss_7days", 0.017); // 17 m (measured: 13.4 m, baseline lock)
+    run_scenario("j2_hp_iss_7days", 0.017); // 17 m (measured: 10.7 m, baseline lock)
 }
 
 #[test]
 fn orekit_j2_hp_iss_30days() {
-    run_scenario("j2_hp_iss_30days", 0.230); // 230 m (measured: 191 m, baseline lock)
+    // Re-locked from 230 m when the HP bulge's hour angle became
+    // frame-consistent (see the tier notes above). The three shorter HP
+    // scenarios improved by 20-40% (2.7 → 1.7 m, 3.6 → 2.2 m, 13.4 → 10.7 m);
+    // this one grew from 191 m to 336 m, because at 30 days the residual is an
+    // along-track drift fed by the *remaining* differences against Orekit's HP
+    // (density-table interpolation, lag-angle convention, geodetic altitude),
+    // and the 0.34° phase error had been partially cancelling it. 336 m is 5e-5
+    // of the orbit radius after 30 days of ISS drag.
+    run_scenario("j2_hp_iss_30days", 0.400); // 400 m (measured: 336 m, baseline lock)
 }
 
 // Tier 5: Full force model
@@ -491,7 +508,7 @@ fn orekit_j2_hp_iss_30days() {
 
 #[test]
 fn orekit_full_iss_10orbits() {
-    run_scenario("full_iss_10orbits", 0.006); // 6 m (measured: 4.5 m, baseline lock)
+    run_scenario("full_iss_10orbits", 0.006); // 6 m (measured: 2.1 m, baseline lock)
 }
 
 #[test]
@@ -542,7 +559,7 @@ fn orekit_j2_msise_iss_moderate_30days() {
 
 #[test]
 fn orekit_full_msise_iss_moderate_10orbits() {
-    run_scenario("full_msise_iss_moderate_10orbits", 0.016); // 16 m (measured: 12.8 m, baseline lock)
+    run_scenario("full_msise_iss_moderate_10orbits", 0.016); // 16 m (measured: 11.9 m, baseline lock)
 }
 
 #[test]
@@ -569,5 +586,5 @@ fn orekit_j2_msise_cssi_iss_7days() {
 
 #[test]
 fn orekit_full_msise_cssi_iss_10orbits() {
-    run_scenario("full_msise_cssi_iss_10orbits", 0.016); // 16 m (measured: 13.2 m, baseline lock)
+    run_scenario("full_msise_cssi_iss_10orbits", 0.016); // 16 m (measured: 12.3 m, baseline lock)
 }

--- a/tobari/src/harris_priester.rs
+++ b/tobari/src/harris_priester.rs
@@ -507,6 +507,98 @@ mod tests {
         }
     }
 
+    /// The bulge apex must land on apparent solar noon, cross-checked against the
+    /// equation of time rather than against the same solar direction the model
+    /// reads.
+    ///
+    /// At the equator `cos ψ = cos δ · cos h`, so with no lag the density
+    /// maximum over longitude sits exactly at hour angle `h = 0` — the subsolar
+    /// meridian. Reached independently, that meridian is where apparent solar
+    /// time is 12 h: `λ = 15° · (12 h − UT − EoT)`. The two paths share no code:
+    /// one goes through the Earth rotation angle and the solar right ascension,
+    /// the other through UT and the equation of time.
+    ///
+    /// This is what pins the *frame* of the solar right ascension. `Epoch::gmst`
+    /// is the Earth rotation angle (CIO-based, not the equinox of date), so
+    /// `ra_sat = gmst + λ` pairs with a J2000/GCRS solar right ascension. Feeding
+    /// it a mean-equinox-of-date direction instead — which is what the Meeus
+    /// series produces before it is rotated to J2000 — shifts the apex by the
+    /// accumulated precession, 0.34° in 2024 and 0.70° in 2050.
+    ///
+    /// The dates sit within a day of an equinox on purpose. Precession moves a
+    /// body's right ascension by `m + n·sin α·tan δ`, so away from `δ = 0` the
+    /// equinox-based and CIO-based hour angles differ by a declination-dependent
+    /// term (up to 0.06° in 2024, 0.12° by 2050) that neither this test nor the
+    /// model is about. At `δ ≈ 0` that term vanishes and the residual is a flat
+    /// 0.0064° from 1980 to 2075 — the models' own accuracy — so the bound below
+    /// stays an order of magnitude under the error it has to catch.
+    #[test]
+    fn bulge_apex_sits_at_apparent_solar_noon() {
+        let hp = HarrisPriester::new().with_lag_angle(0.0);
+
+        for (y, m, d, hh) in [
+            (1980, 3, 20, 6),
+            (2024, 3, 20, 12),
+            (2024, 9, 22, 3),
+            (2050, 3, 20, 18),
+            (2075, 9, 22, 21),
+        ] {
+            let epoch = Epoch::from_gregorian(y, m, d, hh, 0, 0.0);
+
+            // Longitude of the density maximum at the equator: a coarse scan
+            // followed by refinement passes around the winner.
+            let density_at = |lon_deg: f64| {
+                hp.density(&make_input(
+                    Geodetic {
+                        latitude: 0.0,
+                        longitude: lon_deg.to_radians(),
+                        altitude: 400.0,
+                    },
+                    &epoch,
+                ))
+            };
+            let mut best = -180.0;
+            let mut best_rho = f64::NEG_INFINITY;
+            let mut step = 0.5;
+            let mut lo = -180.0;
+            let mut hi = 180.0;
+            for _ in 0..4 {
+                let n = ((hi - lo) / step).round() as i32;
+                for k in 0..=n {
+                    let lon = lo + step * k as f64;
+                    let rho = density_at(lon);
+                    if rho > best_rho {
+                        best_rho = rho;
+                        best = lon;
+                    }
+                }
+                lo = best - step;
+                hi = best + step;
+                step /= 20.0;
+            }
+
+            // Apparent solar noon from UT and the equation of time.
+            let eot_hours = arika::sun::equation_of_time(&epoch.to_tdb());
+            let noon_lon_deg = {
+                let raw = 15.0 * (12.0 - hh as f64 - eot_hours);
+                (raw + 180.0).rem_euclid(360.0) - 180.0
+            };
+            let diff = {
+                let raw = best - noon_lon_deg;
+                (raw + 180.0).rem_euclid(360.0) - 180.0
+            };
+            // The two paths agree to ~0.01°: the residual is the ~1' Meeus
+            // accuracy plus the equation-of-origins/frame-bias terms neither
+            // path models. The bound sits an order of magnitude below the
+            // precession-sized error it has to catch.
+            assert!(
+                diff.abs() < 0.03,
+                "{y}-{m:02}-{d:02} {hh}h: bulge apex at longitude {best:.3}deg, \
+                 apparent solar noon at {noon_lon_deg:.3}deg (off by {diff:.3}deg)"
+            );
+        }
+    }
+
     #[test]
     fn density_at_table_boundary_apex() {
         // At the bulge apex (same direction as sun+lag), should get rho_max

--- a/tobari/src/harris_priester.rs
+++ b/tobari/src/harris_priester.rs
@@ -513,25 +513,25 @@ mod tests {
     ///
     /// At the equator `cos ψ = cos δ · cos h`, so with no lag the density
     /// maximum over longitude sits exactly at hour angle `h = 0` — the subsolar
-    /// meridian. Reached independently, that meridian is where apparent solar
-    /// time is 12 h: `λ = 15° · (12 h − UT − EoT)`. The two paths share no code:
-    /// one goes through the Earth rotation angle and the solar right ascension,
-    /// the other through UT and the equation of time.
+    /// meridian. Reached the other way, that meridian is where apparent solar
+    /// time is 12 h: `λ = 15° · (12 h − UT − EoT)`. Both routes read the same
+    /// solar series, but only this one keeps out of the frame question — it never
+    /// forms a right ascension, so it cannot inherit the error under test.
     ///
-    /// This is what pins the *frame* of the solar right ascension. `Epoch::gmst`
-    /// is the Earth rotation angle (CIO-based, not the equinox of date), so
-    /// `ra_sat = gmst + λ` pairs with a J2000/GCRS solar right ascension. Feeding
-    /// it a mean-equinox-of-date direction instead — which is what the Meeus
-    /// series produces before it is rotated to J2000 — shifts the apex by the
-    /// accumulated precession, 0.34° in 2024 and 0.70° in 2050.
+    /// What that pins is the *frame* of the solar right ascension the model
+    /// reads. `Epoch::gmst` is the Earth rotation angle (a legacy name), so
+    /// `ra_sat = gmst + λ` is CIO-based, and feeding it the mean-equinox-of-date
+    /// direction the Meeus series produces before it is rotated to J2000 misses
+    /// by the precession in right ascension: 0.25-0.31° over 1980-2075. The
+    /// J2000/GCRS direction is not the exact partner (that would be a CIRS right
+    /// ascension), but the dominant precession term cancels between `GMST − ERA`
+    /// and `α_MOD − α_GCRS`, leaving only the declination-dependent part.
     ///
-    /// The dates sit within a day of an equinox on purpose. Precession moves a
-    /// body's right ascension by `m + n·sin α·tan δ`, so away from `δ = 0` the
-    /// equinox-based and CIO-based hour angles differ by a declination-dependent
-    /// term (up to 0.06° in 2024, 0.12° by 2050) that neither this test nor the
-    /// model is about. At `δ ≈ 0` that term vanishes and the residual is a flat
-    /// 0.0064° from 1980 to 2075 — the models' own accuracy — so the bound below
-    /// stays an order of magnitude under the error it has to catch.
+    /// That is why the dates sit within a day of an equinox: the leftover term is
+    /// `n·sin α·tan δ` (up to 0.06° in 2024, 0.12° by 2050) and vanishes at
+    /// `δ ≈ 0`, where the two routes agree to a flat 0.0064° from 1980 to 2075.
+    /// The bound below therefore stays an order of magnitude under the error it
+    /// has to catch.
     #[test]
     fn bulge_apex_sits_at_apparent_solar_noon() {
         let hp = HarrisPriester::new().with_lag_angle(0.0);


### PR DESCRIPTION
arika の座標系・暦・EOP に、独立に検証した 4 件の欠陥があった。いずれも値が「間違ったフレーム」または「間違った補間空間」で扱われていたことに起因する。

## 背景

**1. 離心率のある赤道軌道で近地点方向が失われる** (`arika::kepler`)

`KeplerianElements::from_state_vector` は赤道軌道 (`|k×h| ≈ 0`) で RAAN と argument of periapsis の両方を無条件に 0 にしていた。一方で真近点角は離心率ベクトルから測るため、赤道面内の近地点経度がどの要素にも保存されない。`a = 10,000 km, e = 0.2, i = 0, Ω = 0, ω = π/2, ν = 0` を往復させると軌道が 90° 回転し、位置が 11,313.7 km ずれる。

**2. Meeus の太陽・月暦が「日付の平均赤道座標」を GCRS として返す** (`arika::sun` / `arika::moon`)

Meeus の級数は mean equinox of date 基準である（平均黄経の係数が tropical rate、黄道 → 赤道の回転も of-date の平均黄道傾斜角）。それを歳差の逆変換なしに `Vec3<Gcrs>` として返していたため、J2000 からの累積歳差ぶんの secular な方向誤差が乗っていた。2024 年で 0.335°、~1.4°/century で増加し、月ベクトルで約 2,250 km の横方向誤差に相当する。級数自身の精度（太陽方向 ~1′、月黄経 ~10″）より 1 桁以上大きい。

この誤差は「Meeus model の精度 ~0.35°」として `arika/DESIGN.md` と Orekit oracle test のコメントに記録され、GEO 3 日の third-body シナリオでは 250 m の tolerance として許容されていた。実際にはモデル精度ではなく歳差ぶんで、除いた後の同シナリオの Orekit (DE405) との差は 0.33 m である。

同じ経路で、`sun_direction_from_body` の惑星分岐が Standish の惑星要素（J2000 mean ecliptic 基準）を **of-date の** 黄道傾斜角で赤道座標に回していた。2024 年で 11″、2075 年で 35″ の frame error。

**3. うるう秒を挟む区間で dUT1 を線形補間している** (`arika::earth::eop`)

dUT1 = UT1 − UTC はうるう秒で 1 s 跳ぶ不連続量である。finals2000A の日次 2 行（2017-01-01 を挟む −0.5928 s / +0.4068 s）を直接補間すると、跳びの半分が前日に塗り広げられ、MJD 57753.5 で −0.093 s（正しくは ≈ −0.593 s）を返す。UT1 で 0.5 s、ERA で 3.65e-5 rad、赤道の ITRS 位置で約 233 m。

**4. EOP 範囲外で公開 API が panic する** (`arika::earth::eop`)

`EopTable` が infallible な capability trait 4 つ（`Ut1Offset` ほか）を checked lookup の `.expect()` で実装していたため、予報ファイルの終端を越える前進伝播のような通常の入力が `Epoch::to_ut1` や IAU 2006 full chain の内側からプロセスを abort させていた。

## 変更内容

**近地点方向** — Vallado の古典的な特異点規約を採用し、型の doc に表で明記した。equatorial では `argument_of_periapsis` に true longitude of periapsis `ϖ = Ω + ω` を、circular では `true_anomaly` に argument of latitude / true longitude を入れる。逆行赤道 (i ≈ π) は `to_state_vector` が `i = π, Ω = 0` を x-y 平面の時計回り掃引に写すので、符号を反転した面内経度を保存する。

面内角は「軌道法線まわりに測る `atan2` ベースの plane_angle」1 本に統一した。逆行の符号が幾何から自動的に出るうえ、従来の `acos` + 象限判定が ν ≈ 0 / i ≈ 0 付近で落としていた mantissa の半分も戻る。inclination も `acos(h_z/|h|)` から `atan2(|k×h|, h_z)` にした。

**暦のフレーム** — 級数の結果を IAU 1976 precession で J2000 に戻してから返す。nutation (≤ 17″) と J2000→GCRS frame bias (~20 mas) は級数自身の精度より十分小さいので入れず、その旨を doc に書いた。惑星分岐は固定の J2000 黄道傾斜角で回す。

再発防止として `frame::MeanEquinoxOfDate` marker（`Eci` category）と `arika::earth::mean_equinox` の `Rotation<MeanEquinoxOfDate, Gcrs>` / 逆向き factory を追加し、暦の中間値を `Vec3<MeanEquinoxOfDate>` として型に出した。`arika/DESIGN.md` と oracle test のコメントの「~0.35° はモデル精度」という記述も実態に合わせた。

**dUT1** — 連続量 `UT1 − TAI = dUT1 − (TAI − UTC)` を補間し、照会時点の `TAI − UTC` を足し戻す。単一のうるう秒 regime 内では従来の式と代数的に一致する。範囲外の clamp policy も同じく `UT1 − TAI` を保持するので、テーブル終端より後のうるう秒は UT1 に段差を作らず dUT1 を 1 s 動かす（2016-12-30 で終わるテーブルは 2017-01-02 に +0.4072 s と答える。IERS の実測は +0.4068 s）。

**EOP 範囲外** — 有限区間のテーブルは infallible contract を守れないので、`EopTable` は capability trait を実装しない。`EopTable::clamped()` / `into_clamped()` が返す `ClampedEop` adapter（端点保持 policy）が実装する。範囲外 epoch は `*_checked` では `EopLookupError::OutOfRange` として型に現れる。

### 挙動の変化

- 太陽・月の方向が 2024 年で 0.335° 動く。SRP、第三体重力、日陰判定、sun sensor が影響を受ける。GEO 3 日の third-body シナリオでは Orekit (DE405) との差が **218 m → 0.33 m** に縮む。
- Harris-Priester の diurnal bulge も改善する。bulge の局所時角は `ERA + λ − α_sun` で、`Epoch::gmst` は名前に反して Earth Rotation Angle を返す（doc に明記された legacy method）ため、α_sun は CIO 基準であるべきものだ。J2000/GCRS の赤経は厳密な相手（CIRS の赤経）ではないが、歳差の赤経変化の主要項 m ≈ 4612″/century が `GMST − ERA` と `α_MOD − α_GCRS` の間で相殺するので、残るのは declination 依存の `n·sin α·tan δ`（2024 年で最大 0.06°）だけになる。of-date の赤経は 0.31° ずれていた。equation of time から求めた apparent solar noon の経度と比べると、bulge apex のずれは **0.25–0.31° から 0.0064°** になる。
- **BREAKING**: `EopTable` を EOP provider として直接渡していたコードは `.clamped()` / `.into_clamped()` を挟む必要がある。リポジトリ内の利用箇所は `orts/tests/oracle_gcrf.rs` のみで、fixture は MJD 60370..60430 を覆い最長シナリオ 30 日は範囲内なので clamp は発動しない。
- 赤道軌道・円軌道の要素は `argument_of_periapsis` / `true_anomaly` の意味が特異点規約に従う（`KeplerianElements` の doc に表で記載）。非退化な軌道の値は変わらない。

### Orekit oracle の tolerance

- `j2_sun_moon_geo_3days`: 250 m → **1 m**（実測 0.33 m）。従来許していた残差が歳差ぶんだったので締める。歳差の回転を外すと 224.5 m で落ちる。
- HP tier の実測値: `5orbits` 2.7 → 1.7 m、`10orbits` 3.6 → 2.2 m、`7days` 13.4 → 10.7 m（いずれも tolerance 据え置き）。`30days` は 191 m → **336 m** に増えたので tolerance を 230 m → 400 m にする。30 日では残差が secular な along-track drift になり、bulge の位相を直接追うのではなく Orekit の HP との残りの差を積分する。旧位相誤差が与えていた net cancellation が消えた、というのがこの 4 点の測定から言えることで、残りの差のどれが支配的かは分解できていない。336 m は 30 日後の軌道半径の 5e-5。
- `full_iss_10orbits` 4.5 → 2.1 m、`full_msise_iss_moderate_10orbits` 12.8 → 11.9 m、`full_msise_cssi_iss_10orbits` 13.2 → 12.3 m、`j2_sun_moon_sso_10orbits` 0.4 → 0.55 m（コメントの実測値のみ更新）。
- `orts` の `simple_eci_direction_snapshot` は 0.3383° ぶん re-baseline。

## テスト

外部データに依存しない検証を優先した。修正を戻すと落ちることを実測で確認している。

- `eccentric_equatorial_keeps_the_periapsis_longitude` — `z = v_z = 0` の厳密に平面な状態で特異点分岐を強制し、prograde / retrograde × 近地点経度 6 通り × e 4 通り × ν 4 通りの往復を 1e-6 km / 1e-9 km/s で検証。修正前は `ϖ: expected 0.5, got 0` で落ちる。
- `circular_equatorial_true_longitude_follows_the_sense_of_motion`、`equatorial_singularity_is_continuous_in_the_periapsis_longitude`（i = 0 と i = 1e-9 rad で `Ω + ω` が一致すること）。
- 歳差の大きさは arika 自身の precession コードから独立に、IAU general precession 5028.796195″/century で期待値を作る（太陽・月それぞれ）。太陽は in-repo の独立モデル（Standish 惑星要素の `−r_earth`）との突き合わせも追加し、残差が 1950–2100 で 4.5–8.0″ に平坦であることを 0.005° の bound で固定した。修正前は 1950-06-01 で 0.6914° ずれて落ちる。
- `bulge_apex_sits_at_apparent_solar_noon` (tobari) — HP の密度最大となる経度を走査で求め、UT と equation of time から求めた apparent solar noon の経度と比べる。両者は同じ solar series を読むが、後者は赤経を作らないので検証対象のフレーム誤差を受け取らない。日付は δ ≈ 0（分点）に置き、`n·sin α·tan δ` の declination 依存項を落としてある。1980–2075 で残差は 0.0064° に平坦、bound は 0.03°。修正前は 0.247° で落ちる。
- 惑星分岐は返り値を J2000 傾斜角で黄道に戻すと `−r_body` に一致することを 1e-3 arcsec で検証（of-date 傾斜角だと 4.4″ で落ちる）。
- dUT1 はうるう秒を挟む 2 行のテーブルで、(a) MJD 57753.5 が −0.593 s 付近に留まること、(b) `UT1 − TAI` を 0.01 日刻みでサンプリングして 1e-3 s を超える跳びがないこと（期待値を手で置かないデータ非依存の不変量）、(c) clamp が終端の `UT1 − TAI` を保ち、うるう秒を越えた照会で +0.4072 s を返すことを検証。
- 範囲外 epoch が `Epoch::to_ut1` と IAU 2006 full chain を panic させずに通ることを検証。

既存の `table_dut1_interpolated_midpoint` は期待値を実装と同じ式 `(e0.dut1 + e1.dut1)/2` から作っていたため、うるう秒バグを仕様として固定していた。`UT1 − TAI` 補間の期待値に直し、元の期待値がなぜ誤りだったか（この fixture が単一のうるう秒 regime 内で両者が一致すること含む）をコメントに残した。

`cargo test --workspace`、`cargo clippy --workspace -- -D warnings`、arika の 3 feature tier（no_std / no_std + alloc / no_std + sgp4）の clippy、`cargo build -p arika --target wasm32-unknown-unknown` を確認済み。
