### PR TITLE
fix(ci): make the Pages deploy recoverable by re-running it

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,10 @@ name: Deploy Site
 on:
   push:
     branches: [main]
+  # A deployment that stalls on GitHub's side fails the run for reasons the
+  # commit had nothing to do with. This is the way back to a published site
+  # without an empty commit.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -96,11 +100,29 @@ jobs:
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
+      # The artifact name carries the attempt number because `deploy-pages`
+      # lists the artifacts of the whole run, not of the current attempt, and
+      # picks by name. With the default `github-pages`, a re-run uploads a second
+      # artifact under the name the first attempt already used, and the deploy
+      # step stops at "Multiple artifacts named github-pages were unexpectedly
+      # found for this workflow run. Artifact count is 2." A run that failed for
+      # a reason outside this repository therefore could not be recovered by
+      # re-running it — which is how it failed: the deployment sat in
+      # `updating_pages` until this action's own 10-minute cap (not raisable, v5
+      # clamps `timeout` to 600000 ms) cancelled it.
+      #
+      # Splitting build and deploy into separate jobs would need this expression
+      # reconsidered: under "Re-run failed jobs" the build would stay on the
+      # earlier attempt while the deploy moved to the next one, and the deploy
+      # would look for a name nothing uploaded.
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
+          name: github-pages-${{ github.run_attempt }}
           path: docs/dist
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        with:
+          artifact_name: github-pages-${{ github.run_attempt }}


### PR DESCRIPTION
main の `Deploy Site` が失敗し、**リトライしても復旧できない**状態だった（run 33098223341、sha 0d0726cb）。同じ sha の `CI` は success なのでコード起因ではない。

- **attempt 1** — deployment が `updating_pages` のまま進まず、action 自身の 10 分 cap で cancel された。この cap は上げられない（v5 が `timeout` を 600000 ms に clamp する）
- **attempt 2** — `Error: Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.`

`deploy-pages` は **run 全体**の artifact を列挙して名前で選ぶ。両ステップが既定名 `github-pages` を使っていたので、リトライすると attempt 1 が既に使った名前で 2 個目が上がり、deploy が 2 個見つけて止まる。つまりこの workflow は一度失敗すると再実行では戻れなかった。

REST API で run 33098223341 に `github-pages` が 2 件（attempt 1 と attempt 2 の時刻）残っていることを確認済み。

## 変更内容

artifact 名を attempt ごとに変え、`deploy-pages` の `artifact_name` も合わせる。

```yaml
- uses: actions/upload-pages-artifact@...
  with:
    name: github-pages-${{ github.run_attempt }}
- uses: actions/deploy-pages@...
  with:
    artifact_name: github-pages-${{ github.run_attempt }}
```

`workflow_dispatch` も追加した。再実行では戻れない状態になったときに、空コミットなしで復旧できるように。

## job 分割を採らなかった理由

公式の starter workflow は build job と deploy job を分ける形だが、**それではこの失敗は直らない**。`Re-run failed jobs`（deploy だけ再実行）なら artifact が再アップロードされないので効くが、`Re-run all jobs` では build も走って同名 artifact が再び 2 個になる。

分割自体には別の利点がある（deploy job だけに `environment` と最小権限を置ける、deployment が止まっても再ビルドを払わずに済む）ので、独立した変更として検討する価値はある。ただし分割するなら attempt 番号の式を見直す必要があり、その理由を workflow のコメントに残した — `Re-run failed jobs` では build が前の attempt に留まる一方で deploy が次の attempt に進むので、deploy が誰も上げていない名前を探すことになる。

## 検証

- `actionlint .github/workflows/deploy.yml` 通過
- `github.run_attempt` が `workflow_dispatch` でも定義される（event 固有でなく全 run が持つ。初回は `"1"`）ことを GitHub の context reference で確認
- `retention-days` は既定 1 日なので、attempt ごとに artifact が増えても残らない
- リポジトリ内に既定名 `github-pages` を別途参照する箇所は無い

## マージ後

main に入っても、既に失敗した run 33098223341 は直らない（その run の artifact は既に 2 個ある）。マージ自体が新しい push になるので、そこで publish される。
