### PR TITLE
chore(deps): move off the yanked chacha20 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,9 +830,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
`chacha20 0.10.1` が crates.io で yank され、`cargo deny check advisories` が `error[yanked]` で落ちる。**現在 open な全 PR の CI が赤になっている**ので、依存更新として単独で出す。

```
error[yanked]: detected yanked crate (try `cargo update -p chacha20`)
   ┌─ Cargo.lock:73:1
73 │ chacha20 0.10.1 registry+https://github.com/rust-lang/crates.io-index
   ├ chacha20 v0.10.1
     └── rand v0.10.2
         ├── orts v0.2.0
```

orts が直接依存する `rand 0.10.2` 経由の transitive 依存。`cargo update -p chacha20` で 0.10.2 に上がる。同一 compatible range 内の patch bump で、lockfile の他の行は動かない。

## 検証

先に失敗を再現した。ローカルの crates.io index が 3 日古く、更新前は bump 前の lockfile でも `advisories ok` になっていたので、index を更新してから確認した。

| lockfile | `cargo deny check advisories` |
|---|---|
| bump 前 | `error[yanked]: detected yanked crate` — CI と同一 |
| bump 後 | `advisories ok` |

`cargo build --workspace --locked` 成功、`cargo deny check bans sources` は `bans ok, sources ok`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
