### PR TITLE
build: update chacha20 past the yanked 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,9 +830,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
## 起きたこと

main の CI で `cargo-deny` が落ちている（run 33105365121）。

```
error[yanked]: detected yanked crate (try `cargo update -p chacha20`)
```

`chacha20` 0.10.1 が upstream で yank され、`rand` 0.10.2 経由でこのツリーに入っている。

## 変更

`cargo update -p chacha20` で 0.10.2 に上げた。`Cargo.lock` のみ、1 パッケージ 2 行。

## 検証

`cargo check --locked --workspace` pass。

## 補足

#358 の CI でも同じ失敗が出ているが、あちらはテストのみの変更で無関係。main で先に再現していることを確認した上で、別 PR に切っている。
