### PR TITLE
fix: join scalar columns on the recording time index in both .rrd decoders

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -54,7 +54,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   なった。独自の名前の timeline で index された recording も、その timeline で結合する。
   `sim_time` と `step` は orts が書く名前で、それ以外を timeline なしとして扱うと列の
   位置で結合していた。その名前は recording 全体で 1 つ。軸が 2 つあれば別の次元なので、
-  `frame` の 1 と `iteration` の 1 は同じ瞬間ではない。この PR が直すブラウザ側の
+  `frame` の 1 は `iteration` の 1 でも `step` の 1 でもない。この PR が直すブラウザ側の
   decoder と同じ欠陥で、3 つは独立に
   decode するため 3 つとも抱えていた。([#366](https://github.com/sksat/orts/pull/366))
 - `AttitudeState::q_dot` が、和を計算した後でなく積を作る前に角速度を半分にする
@@ -526,8 +526,8 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   列がこの結合に入るのは、外部で書かれた `.rrd` と、attitude が state ごとに optional な
   `orts serve` の history segment。独自の名前の timeline で index された recording も、
   列の位置に落ちるのでなくその timeline で結合する (`sim_time` と `step` 以外はすべて
-  列の位置になっていた)。その名前は recording 全体で 1 つなので、raw な値が一致する
-  2 つの軸が同じ行に載ることはない。([#366](https://github.com/sksat/orts/pull/366))
+  列の位置になっていた)。その名前は recording 全体で 1 つで、`step` とも区別する。
+  2 つの軸で値が一致しても同じ行には載らない。([#366](https://github.com/sksat/orts/pull/366))
 
 ### Docs
 

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -515,8 +515,10 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   成分は後の値が前の行にずれ込んでいた。`y` が t=10 にだけ logging されている場合、
   t=0 の行にその値が載り、t=10 の行は `y = 0.0` になる。行を出すのは position 3 成分
   (recording が velocity 列を持つ場合は velocity 3 成分も) がその時刻に揃ったときで、
-  揃わない行はゼロ埋めせず落とす。`orts` が書く recording は影響を受けない (writer が
-  全列を毎 step logging するため)。([#366](https://github.com/sksat/orts/pull/366))
+  揃わない行はゼロ埋めせず落とす。`orts run --format rrd` は 1 回の run のすべての
+  step で同じ component を logging するので、その出力のデコード結果は以前と同じ。疎な
+  列がこの結合に入るのは、外部で書かれた `.rrd` と、attitude が state ごとに optional な
+  `orts serve` の history segment。([#366](https://github.com/sksat/orts/pull/366))
 
 ### Docs
 

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -46,11 +46,13 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   `load_rrd_data` は `orts replay` と `orts serve` の history 読み戻し、
   `load_as_recording` は `orts convert` が通る。後者では疎な列が 2 つの時刻の値の
   混合として CSV に出ていた (`Position3D` が `[100.0, 201.0, 0.0]` になり、ある時刻の
-  `x` と別の時刻の `y` が組になっていた)。こちらはどれかの field が記録した時刻すべてが
-  行になる。`EntityStore` は entity の全列で 1 つの timeline を共有するため。ある時刻に
-  無い field はゼロを読み、別の時刻の値を借りることはない。この PR が直すブラウザ側の
-  decoder と同じ欠陥で、3 つは独立に decode するため 3 つとも抱えていた。
-  ([#366](https://github.com/sksat/orts/pull/366))
+  `x` と別の時刻の `y` が組になっていた)。`EntityStore` は entity の全列で 1 つの
+  timeline を共有するので、行の key も entity で 1 つに決め、position と velocity に
+  合わせる。どちらかが揃わない時刻は行にしない。一部の時刻にしか記録されていない
+  component はゼロ埋めせず落とす。ゼロは下流で実測値と区別できないため。timeline を
+  持たない static field と、独自の時刻を持つ子 entity は、上位 entity の行を増やさなく
+  なった。この PR が直すブラウザ側の decoder と同じ欠陥で、3 つは独立に decode するため
+  3 つとも抱えていた。([#366](https://github.com/sksat/orts/pull/366))
 - `AttitudeState::q_dot` が、和を計算した後でなく積を作る前に角速度を半分にする
   ようになった。結果が有限な入力で overflow しなくなる: `q = [0, 1/√2, 1/√2, 0]`、
   `ω = [1.4e308, 1.4e308, 0]` の `q̇.w` は約 -9.9e307 だが、途中の和が -1.98e308 に

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -53,8 +53,10 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   持たない static field と、独自の時刻を持つ子 entity は、上位 entity の行を増やさなく
   なった。独自の名前の timeline で index された recording も、その timeline で結合する。
   `sim_time` と `step` は orts が書く名前で、それ以外を timeline なしとして扱うと列の
-  位置で結合していた。その名前は recording 全体で 1 つ。軸が 2 つあれば別の次元なので、
-  `frame` の 1 は `iteration` の 1 でも `step` の 1 でもない。この PR が直すブラウザ側の
+  位置で結合していた。その名前は recording 全体で 1 つで、`sim_time` と `step` の代わりでなく
+  それらと並んで行を識別する。軸が 2 つあれば別の次元なので、`frame` の 1 は
+  `iteration` の 1 でも `step` の 1 でもなく、同じ `sim_time` で `frame` が違う 2 行は
+  別の瞬間。この PR が直すブラウザ側の
   decoder と同じ欠陥で、3 つは独立に
   decode するため 3 つとも抱えていた。([#366](https://github.com/sksat/orts/pull/366))
 - `AttitudeState::q_dot` が、和を計算した後でなく積を作る前に角速度を半分にする
@@ -528,8 +530,9 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   row `i` を entity の timeline の row `i` に書くため、遅れて始まる attitude はファイルの
   時点で既に誤った時刻にある。こちらは writer の修正が先に必要。独自の名前の timeline で index された recording も、
   列の位置に落ちるのでなくその timeline で結合する (`sim_time` と `step` 以外はすべて
-  列の位置になっていた)。その名前は recording 全体で 1 つで、`step` とも区別する。
-  2 つの軸で値が一致しても同じ行には載らない。([#366](https://github.com/sksat/orts/pull/366))
+  列の位置になっていた)。その名前は recording 全体で 1 つで、`sim_time` と `step` と
+  並んで行を識別する。ある index が一致していても別の index の値が違えば同じ行には
+  載らない。([#366](https://github.com/sksat/orts/pull/366))
 
 ### Docs
 

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -41,11 +41,15 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   20-40% 改善する。([#359](https://github.com/sksat/orts/pull/359))
 
 #### Fixed
-- `load_rrd_data` が scalar 列を recording 自身の時刻 index で結合するようになった。
+- .rrd の loader 2 つが、scalar 列を recording 自身の時刻 index で結合するようになった。
   一部の時刻にしか現れない component が、後の値を前の行にずらすことがなくなる。
-  `orts convert`・`orts replay`・`orts serve` の history 読み戻しがこの経路を通る。
-  この PR が直すブラウザ側の decoder と同じ欠陥・同じ修正で、両者は独立に decode する
-  ため双方が抱えていた。([#366](https://github.com/sksat/orts/pull/366))
+  `load_rrd_data` は `orts replay` と `orts serve` の history 読み戻し、
+  `load_as_recording` は `orts convert` が通る。後者では疎な列が 2 つの時刻の値の
+  混合として CSV に出ていた (`Position3D` が `[100.0, 201.0, 0.0]` になり、ある時刻の
+  `x` と別の時刻の `y` が組になっていた)。component は全 field が揃うか揃わないかの
+  どちらかなので、揃わない行はゼロを入れた軸として報告せず落とす。この PR が直す
+  ブラウザ側の decoder と同じ欠陥で、3 つは独立に decode するため 3 つとも抱えていた。
+  ([#366](https://github.com/sksat/orts/pull/366))
 - `AttitudeState::q_dot` が、和を計算した後でなく積を作る前に角速度を半分にする
   ようになった。結果が有限な入力で overflow しなくなる: `q = [0, 1/√2, 1/√2, 0]`、
   `ω = [1.4e308, 1.4e308, 0]` の `q̇.w` は約 -9.9e307 だが、途中の和が -1.98e308 に

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -53,7 +53,9 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   持たない static field と、独自の時刻を持つ子 entity は、上位 entity の行を増やさなく
   なった。独自の名前の timeline で index された recording も、その timeline で結合する。
   `sim_time` と `step` は orts が書く名前で、それ以外を timeline なしとして扱うと列の
-  位置で結合していた。この PR が直すブラウザ側の decoder と同じ欠陥で、3 つは独立に
+  位置で結合していた。その名前は recording 全体で 1 つ。軸が 2 つあれば別の次元なので、
+  `frame` の 1 と `iteration` の 1 は同じ瞬間ではない。この PR が直すブラウザ側の
+  decoder と同じ欠陥で、3 つは独立に
   decode するため 3 つとも抱えていた。([#366](https://github.com/sksat/orts/pull/366))
 - `AttitudeState::q_dot` が、和を計算した後でなく積を作る前に角速度を半分にする
   ようになった。結果が有限な入力で overflow しなくなる: `q = [0, 1/√2, 1/√2, 0]`、
@@ -524,7 +526,8 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   列がこの結合に入るのは、外部で書かれた `.rrd` と、attitude が state ごとに optional な
   `orts serve` の history segment。独自の名前の timeline で index された recording も、
   列の位置に落ちるのでなくその timeline で結合する (`sim_time` と `step` 以外はすべて
-  列の位置になっていた)。([#366](https://github.com/sksat/orts/pull/366))
+  列の位置になっていた)。その名前は recording 全体で 1 つなので、raw な値が一致する
+  2 つの軸が同じ行に載ることはない。([#366](https://github.com/sksat/orts/pull/366))
 
 ### Docs
 

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -41,6 +41,11 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   20-40% 改善する。([#359](https://github.com/sksat/orts/pull/359))
 
 #### Fixed
+- `load_rrd_data` が scalar 列を recording 自身の時刻 index で結合するようになった。
+  一部の時刻にしか現れない component が、後の値を前の行にずらすことがなくなる。
+  `orts convert`・`orts replay`・`orts serve` の history 読み戻しがこの経路を通る。
+  この PR が直すブラウザ側の decoder と同じ欠陥・同じ修正で、両者は独立に decode する
+  ため双方が抱えていた。([#366](https://github.com/sksat/orts/pull/366))
 - `AttitudeState::q_dot` が、和を計算した後でなく積を作る前に角速度を半分にする
   ようになった。結果が有限な入力で overflow しなくなる: `q = [0, 1/√2, 1/√2, 0]`、
   `ω = [1.4e308, 1.4e308, 0]` の `q̇.w` は約 -9.9e307 だが、途中の和が -1.98e308 に

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -496,6 +496,18 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   origin に対して絶対化する。DuckDB が worker を `blob:` URL から生成するため、
   root-relative パスでは解決できないことへの対処。([#171](https://github.com/sksat/orts/pull/171))
 
+### `rrd-wasm` (Rust, crates.io)
+
+#### Fixed
+- scalar 列を、列内の値の位置ではなく recording 自身の時刻 index で結合するように
+  なった。scalar の各成分は独立した entity path (`<base>/x`, `<base>/y`, …) に載り、
+  両者が一致するのは全列が全 step で値を持つ間だけで、一部の step にしか出てこない
+  成分は後の値が前の行にずれ込んでいた。`y` が t=10 にだけ logging されている場合、
+  t=0 の行にその値が載り、t=10 の行は `y = 0.0` になる。行を出すのは position 3 成分
+  (recording が velocity 列を持つ場合は velocity 3 成分も) がその時刻に揃ったときで、
+  揃わない行はゼロ埋めせず落とす。`orts` が書く recording は影響を受けない (writer が
+  全列を毎 step logging するため)。([#366](https://github.com/sksat/orts/pull/366))
+
 ### Docs
 
 #### Added

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -46,9 +46,10 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   `load_rrd_data` は `orts replay` と `orts serve` の history 読み戻し、
   `load_as_recording` は `orts convert` が通る。後者では疎な列が 2 つの時刻の値の
   混合として CSV に出ていた (`Position3D` が `[100.0, 201.0, 0.0]` になり、ある時刻の
-  `x` と別の時刻の `y` が組になっていた)。component は全 field が揃うか揃わないかの
-  どちらかなので、揃わない行はゼロを入れた軸として報告せず落とす。この PR が直す
-  ブラウザ側の decoder と同じ欠陥で、3 つは独立に decode するため 3 つとも抱えていた。
+  `x` と別の時刻の `y` が組になっていた)。こちらはどれかの field が記録した時刻すべてが
+  行になる。`EntityStore` は entity の全列で 1 つの timeline を共有するため。ある時刻に
+  無い field はゼロを読み、別の時刻の値を借りることはない。この PR が直すブラウザ側の
+  decoder と同じ欠陥で、3 つは独立に decode するため 3 つとも抱えていた。
   ([#366](https://github.com/sksat/orts/pull/366))
 - `AttitudeState::q_dot` が、和を計算した後でなく積を作る前に角速度を半分にする
   ようになった。結果が有限な入力で overflow しなくなる: `q = [0, 1/√2, 1/√2, 0]`、

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -523,8 +523,10 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   (recording が velocity 列を持つ場合は velocity 3 成分も) がその時刻に揃ったときで、
   揃わない行はゼロ埋めせず落とす。`orts run --format rrd` は 1 回の run のすべての
   step で同じ component を logging するので、その出力のデコード結果は以前と同じ。疎な
-  列がこの結合に入るのは、外部で書かれた `.rrd` と、attitude が state ごとに optional な
-  `orts serve` の history segment。独自の名前の timeline で index された recording も、
+  列がこの結合に入るのは、外部で書かれた `.rrd`。`orts serve` の history segment は
+  attitude が state ごとに optional なので疎になりうるが、`save_as_rrd` が component の
+  row `i` を entity の timeline の row `i` に書くため、遅れて始まる attitude はファイルの
+  時点で既に誤った時刻にある。こちらは writer の修正が先に必要。独自の名前の timeline で index された recording も、
   列の位置に落ちるのでなくその timeline で結合する (`sim_time` と `step` 以外はすべて
   列の位置になっていた)。その名前は recording 全体で 1 つで、`step` とも区別する。
   2 つの軸で値が一致しても同じ行には載らない。([#366](https://github.com/sksat/orts/pull/366))

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -51,8 +51,10 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   合わせる。どちらかが揃わない時刻は行にしない。一部の時刻にしか記録されていない
   component はゼロ埋めせず落とす。ゼロは下流で実測値と区別できないため。timeline を
   持たない static field と、独自の時刻を持つ子 entity は、上位 entity の行を増やさなく
-  なった。この PR が直すブラウザ側の decoder と同じ欠陥で、3 つは独立に decode するため
-  3 つとも抱えていた。([#366](https://github.com/sksat/orts/pull/366))
+  なった。独自の名前の timeline で index された recording も、その timeline で結合する。
+  `sim_time` と `step` は orts が書く名前で、それ以外を timeline なしとして扱うと列の
+  位置で結合していた。この PR が直すブラウザ側の decoder と同じ欠陥で、3 つは独立に
+  decode するため 3 つとも抱えていた。([#366](https://github.com/sksat/orts/pull/366))
 - `AttitudeState::q_dot` が、和を計算した後でなく積を作る前に角速度を半分にする
   ようになった。結果が有限な入力で overflow しなくなる: `q = [0, 1/√2, 1/√2, 0]`、
   `ω = [1.4e308, 1.4e308, 0]` の `q̇.w` は約 -9.9e307 だが、途中の和が -1.98e308 に
@@ -520,7 +522,9 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   揃わない行はゼロ埋めせず落とす。`orts run --format rrd` は 1 回の run のすべての
   step で同じ component を logging するので、その出力のデコード結果は以前と同じ。疎な
   列がこの結合に入るのは、外部で書かれた `.rrd` と、attitude が state ごとに optional な
-  `orts serve` の history segment。([#366](https://github.com/sksat/orts/pull/366))
+  `orts serve` の history segment。独自の名前の timeline で index された recording も、
+  列の位置に落ちるのでなくその timeline で結合する (`sim_time` と `step` 以外はすべて
+  列の位置になっていた)。([#366](https://github.com/sksat/orts/pull/366))
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,8 +60,10 @@ section is subdivided by package.
   entity above them. A recording indexed by a timeline of its own naming joins on
   that timeline as well: `sim_time` and `step` are the names `orts` writes, and
   treating any other as no timeline at all fell back to column position. One
-  such name serves the whole recording, since two axes are separate dimensions
-  and a `frame` of 1 is neither an `iteration` of 1 nor a `step` of 1. Same
+  such name serves the whole recording, and it identifies a row alongside
+  `sim_time` and `step` rather than instead of them: two axes are separate
+  dimensions, so a `frame` of 1 is neither an `iteration` of 1 nor a `step` of
+  1, and two rows of one `sim_time` at different `frame`s are two moments. Same
   defect as the browser-side decoder in this PR: the three decode independently,
   and all three carried it. ([#366](https://github.com/sksat/orts/pull/366))
 - `AttitudeState::q_dot` halves the angular velocity before forming the
@@ -590,8 +592,9 @@ section is subdivided by package.
   needs the writer fixed first. A recording indexed by
   a timeline of its own naming joins on that timeline too, rather than falling
   back to column position as it did for every name but `sim_time` and `step`; one
-  such name serves the whole recording, and it is kept apart from `step`, so
-  values that coincide on two axes do not share a row.
+  such name serves the whole recording, and it identifies a row alongside
+  `sim_time` and `step`, so values that coincide on one index but sit at
+  different values of another do not share a row.
   ([#366](https://github.com/sksat/orts/pull/366))
 
 ### Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -573,8 +573,11 @@ section is subdivided by package.
   carried that value and the t=10 row read `y = 0.0`. A row is emitted only when
   the whole position triple — and the velocity triple, where the recording has
   one — is present at that time; an incomplete row is dropped rather than padded
-  with zeros. Recordings `orts` writes are unaffected: its writer logs every
-  column at every step. ([#366](https://github.com/sksat/orts/pull/366))
+  with zeros. `orts run --format rrd` logs the same components at every step of a
+  run, so its output decodes to the same values as before; a sparse column
+  reaches this join from `.rrd` files written elsewhere and from `orts serve`
+  history segments, whose attitude is optional per state.
+  ([#366](https://github.com/sksat/orts/pull/366))
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -583,8 +583,11 @@ section is subdivided by package.
   one — is present at that time; an incomplete row is dropped rather than padded
   with zeros. `orts run --format rrd` logs the same components at every step of a
   run, so its output decodes to the same values as before; a sparse column
-  reaches this join from `.rrd` files written elsewhere and from `orts serve`
-  history segments, whose attitude is optional per state. A recording indexed by
+  reaches this join from `.rrd` files written elsewhere. `orts serve` history
+  segments can hold one, their attitude being optional per state, but
+  `save_as_rrd` writes a component's row `i` at the entity's timeline row `i`,
+  so a late-starting attitude is already at the wrong time in the file: that
+  needs the writer fixed first. A recording indexed by
   a timeline of its own naming joins on that timeline too, rather than falling
   back to column position as it did for every name but `sim_time` and `step`; one
   such name serves the whole recording, and it is kept apart from `step`, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,9 @@ section is subdivided by package.
   and a child entity, which has times of its own, no longer add rows to the
   entity above them. A recording indexed by a timeline of its own naming joins on
   that timeline as well: `sim_time` and `step` are the names `orts` writes, and
-  treating any other as no timeline at all fell back to column position. Same
+  treating any other as no timeline at all fell back to column position. One
+  such name serves the whole recording, since two axes are separate dimensions
+  and a `frame` of 1 is not an `iteration` of 1. Same
   defect as the browser-side decoder in this PR: the three decode independently,
   and all three carried it. ([#366](https://github.com/sksat/orts/pull/366))
 - `AttitudeState::q_dot` halves the angular velocity before forming the
@@ -584,8 +586,9 @@ section is subdivided by package.
   reaches this join from `.rrd` files written elsewhere and from `orts serve`
   history segments, whose attitude is optional per state. A recording indexed by
   a timeline of its own naming joins on that timeline too, rather than falling
-  back to column position as it did for every name but `sim_time` and `step`.
-  ([#366](https://github.com/sksat/orts/pull/366))
+  back to column position as it did for every name but `sim_time` and `step`; one
+  such name serves the whole recording, so two axes whose raw values coincide do
+  not share a row. ([#366](https://github.com/sksat/orts/pull/366))
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,11 +50,12 @@ section is subdivided by package.
   earlier rows. `load_rrd_data` serves `orts replay` and `orts serve`'s history
   read-back; `load_as_recording` serves `orts convert`, where a sparse column
   used to reach the CSV as a mix of two times (`Position3D` came back as
-  `[100.0, 201.0, 0.0]`, pairing one time's `x` with another's `y`). A component
-  is all of its fields or none of them, so an incomplete row is dropped rather
-  than reported with a zeroed axis. Same defect as the browser-side decoder in
-  this PR: the three decode independently, and all three carried it.
-  ([#366](https://github.com/sksat/orts/pull/366))
+  `[100.0, 201.0, 0.0]`, pairing one time's `x` with another's `y`). Every
+  moment any field records is a row there, because `EntityStore` keeps one
+  timeline for all of an entity's columns; a field absent at a moment reads as
+  zero rather than borrowing another moment's value. Same defect as the
+  browser-side decoder in this PR: the three decode independently, and all three
+  carried it. ([#366](https://github.com/sksat/orts/pull/366))
 - `AttitudeState::q_dot` halves the angular velocity before forming the
   products rather than the sum afterwards, so it no longer overflows where its
   result is finite: `q = [0, 1/√2, 1/√2, 0]` with `ω = [1.4e308, 1.4e308, 0]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ section is subdivided by package.
   0.33 m, and the three shorter Harris-Priester oracles by 20-40%. ([#359](https://github.com/sksat/orts/pull/359))
 
 #### Fixed
+- `load_rrd_data` joins scalar columns on the recording's time index, so a
+  component present at only some of the times no longer shifts its values onto
+  earlier rows — reached through `orts convert`, `orts replay` and `orts serve`'s
+  history read-back. Same defect and same fix as the browser-side decoder in
+  this PR; the two decode independently, so both carried it.
+  ([#366](https://github.com/sksat/orts/pull/366))
 - `AttitudeState::q_dot` halves the angular velocity before forming the
   products rather than the sum afterwards, so it no longer overflows where its
   result is finite: `q = [0, 1/√2, 1/√2, 0]` with `ω = [1.4e308, 1.4e308, 0]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ section is subdivided by package.
   that timeline as well: `sim_time` and `step` are the names `orts` writes, and
   treating any other as no timeline at all fell back to column position. One
   such name serves the whole recording, since two axes are separate dimensions
-  and a `frame` of 1 is not an `iteration` of 1. Same
+  and a `frame` of 1 is neither an `iteration` of 1 nor a `step` of 1. Same
   defect as the browser-side decoder in this PR: the three decode independently,
   and all three carried it. ([#366](https://github.com/sksat/orts/pull/366))
 - `AttitudeState::q_dot` halves the angular velocity before forming the
@@ -587,8 +587,9 @@ section is subdivided by package.
   history segments, whose attitude is optional per state. A recording indexed by
   a timeline of its own naming joins on that timeline too, rather than falling
   back to column position as it did for every name but `sim_time` and `step`; one
-  such name serves the whole recording, so two axes whose raw values coincide do
-  not share a row. ([#366](https://github.com/sksat/orts/pull/366))
+  such name serves the whole recording, and it is kept apart from `step`, so
+  values that coincide on two axes do not share a row.
+  ([#366](https://github.com/sksat/orts/pull/366))
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,12 +50,16 @@ section is subdivided by package.
   earlier rows. `load_rrd_data` serves `orts replay` and `orts serve`'s history
   read-back; `load_as_recording` serves `orts convert`, where a sparse column
   used to reach the CSV as a mix of two times (`Position3D` came back as
-  `[100.0, 201.0, 0.0]`, pairing one time's `x` with another's `y`). Every
-  moment any field records is a row there, because `EntityStore` keeps one
-  timeline for all of an entity's columns; a field absent at a moment reads as
-  zero rather than borrowing another moment's value. Same defect as the
-  browser-side decoder in this PR: the three decode independently, and all three
-  carried it. ([#366](https://github.com/sksat/orts/pull/366))
+  `[100.0, 201.0, 0.0]`, pairing one time's `x` with another's `y`). One row-key
+  set now serves all of an entity's columns, since `EntityStore` keeps one
+  timeline for them, and it follows position and velocity: a moment where either
+  is incomplete is no row at all, and a component recorded at only some of the
+  times is left out rather than zero-filled, a zero being indistinguishable
+  downstream from a measured coordinate. A static field, which has no timeline,
+  and a child entity, which has times of its own, no longer add rows to the
+  entity above them. Same defect as the browser-side decoder in this PR: the
+  three decode independently, and all three carried it.
+  ([#366](https://github.com/sksat/orts/pull/366))
 - `AttitudeState::q_dot` halves the angular velocity before forming the
   products rather than the sum afterwards, so it no longer overflows where its
   result is finite: `q = [0, 1/√2, 1/√2, 0]` with `ω = [1.4e308, 1.4e308, 0]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,11 @@ section is subdivided by package.
   times is left out rather than zero-filled, a zero being indistinguishable
   downstream from a measured coordinate. A static field, which has no timeline,
   and a child entity, which has times of its own, no longer add rows to the
-  entity above them. Same defect as the browser-side decoder in this PR: the
-  three decode independently, and all three carried it.
-  ([#366](https://github.com/sksat/orts/pull/366))
+  entity above them. A recording indexed by a timeline of its own naming joins on
+  that timeline as well: `sim_time` and `step` are the names `orts` writes, and
+  treating any other as no timeline at all fell back to column position. Same
+  defect as the browser-side decoder in this PR: the three decode independently,
+  and all three carried it. ([#366](https://github.com/sksat/orts/pull/366))
 - `AttitudeState::q_dot` halves the angular velocity before forming the
   products rather than the sum afterwards, so it no longer overflows where its
   result is finite: `q = [0, 1/√2, 1/√2, 0]` with `ω = [1.4e308, 1.4e308, 0]`
@@ -580,7 +582,9 @@ section is subdivided by package.
   with zeros. `orts run --format rrd` logs the same components at every step of a
   run, so its output decodes to the same values as before; a sparse column
   reaches this join from `.rrd` files written elsewhere and from `orts serve`
-  history segments, whose attitude is optional per state.
+  history segments, whose attitude is optional per state. A recording indexed by
+  a timeline of its own naming joins on that timeline too, rather than falling
+  back to column position as it did for every name but `sim_time` and `step`.
   ([#366](https://github.com/sksat/orts/pull/366))
 
 ### Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -551,6 +551,20 @@ section is subdivided by package.
   worker origin inside `initDuckDB`, because DuckDB instantiates its worker from a
   `blob:` URL against which a root-relative path cannot resolve. ([#171](https://github.com/sksat/orts/pull/171))
 
+### `rrd-wasm` (Rust, crates.io)
+
+#### Fixed
+- Scalar columns are joined on the recording's own time index rather than on a
+  value's position within its column. Every scalar field lives on its own entity
+  path (`<base>/x`, `<base>/y`, …), and the two agree only while every column
+  carries a value at every step: a component logged at only some of them shifted
+  its later values onto earlier rows. With `y` logged at t=10 alone, the t=0 row
+  carried that value and the t=10 row read `y = 0.0`. A row is emitted only when
+  the whole position triple — and the velocity triple, where the recording has
+  one — is present at that time; an incomplete row is dropped rather than padded
+  with zeros. Recordings `orts` writes are unaffected: its writer logs every
+  column at every step. ([#366](https://github.com/sksat/orts/pull/366))
+
 ### Docs
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,11 +45,15 @@ section is subdivided by package.
   0.33 m, and the three shorter Harris-Priester oracles by 20-40%. ([#359](https://github.com/sksat/orts/pull/359))
 
 #### Fixed
-- `load_rrd_data` joins scalar columns on the recording's time index, so a
+- Both .rrd loaders join scalar columns on the recording's time index, so a
   component present at only some of the times no longer shifts its values onto
-  earlier rows — reached through `orts convert`, `orts replay` and `orts serve`'s
-  history read-back. Same defect and same fix as the browser-side decoder in
-  this PR; the two decode independently, so both carried it.
+  earlier rows. `load_rrd_data` serves `orts replay` and `orts serve`'s history
+  read-back; `load_as_recording` serves `orts convert`, where a sparse column
+  used to reach the CSV as a mix of two times (`Position3D` came back as
+  `[100.0, 201.0, 0.0]`, pairing one time's `x` with another's `y`). A component
+  is all of its fields or none of them, so an incomplete row is dropped rather
+  than reported with a zeroed axis. Same defect as the browser-side decoder in
+  this PR: the three decode independently, and all three carried it.
   ([#366](https://github.com/sksat/orts/pull/366))
 - `AttitudeState::q_dot` halves the angular velocity before forming the
   products rather than the sum afterwards, so it no longer overflows where its

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,9 +820,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,9 +820,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -4029,9 +4029,11 @@ dependencies = [
  "re_chunk",
  "re_log_encoding",
  "re_log_types",
+ "re_sdk",
  "re_sdk_types",
  "serde",
  "serde-wasm-bindgen",
+ "tempfile",
  "wasm-bindgen",
 ]
 

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -754,43 +754,107 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
             .get(&schema_key)
             .and_then(|json| serde_json::from_str(json).ok());
 
-        // Collect all field names under this base path.
+        // Fields of this entity. A `<base>/child/x` key belongs to the child
+        // entity, which gets a store of its own, so it is not a field here:
+        // counting it would put the child's times among this entity's rows.
         // Scalar keys may have a leading slash; normalize for comparison.
         let field_names: Vec<String> = scalars
             .keys()
             .filter_map(|k| {
                 let normalized = k.strip_prefix('/').unwrap_or(k);
-                normalized
-                    .strip_prefix(base)?
-                    .strip_prefix('/')
-                    .map(String::from)
+                let field = normalized.strip_prefix(base)?.strip_prefix('/')?;
+                (!field.contains('/')).then(|| field.to_string())
             })
             .collect();
+        let field_set: BTreeSet<&str> = field_names.iter().map(|s| s.as_str()).collect();
+
+        // The components this entity records over time, and its static ones
+        // apart from them: a static value carries no timeline, so it is not a
+        // row of the entity.
+        let mut temporal: Vec<(String, Vec<String>)> = Vec::new();
+        let mut statics: Vec<(String, Vec<String>)> = Vec::new();
+        match &schema {
+            Some(schema) => {
+                for entry in schema {
+                    let Some(name) = entry["name"].as_str() else {
+                        continue;
+                    };
+                    let fields: Vec<String> = entry["fields"]
+                        .as_array()
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(String::from))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    if fields.is_empty() {
+                        continue;
+                    }
+                    if entry
+                        .get("static")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false)
+                    {
+                        statics.push((name.to_string(), fields));
+                    } else {
+                        temporal.push((name.to_string(), fields));
+                    }
+                }
+            }
+            // Legacy .rrd files carry no schema: recognize a component by its
+            // field names.
+            None => {
+                for &(name, fields) in KNOWN_COMPONENTS {
+                    if fields.iter().all(|f| field_set.contains(f)) {
+                        temporal.push((
+                            name.to_string(),
+                            fields.iter().map(|f| (*f).to_string()).collect(),
+                        ));
+                    }
+                }
+            }
+        }
 
         // One row-key set for the whole entity. `EntityStore` keeps a single
-        // timeline shared by every component column, so a component that
-        // compacted onto its own surviving times would leave the columns
-        // disagreeing on what row 0 means — a position from one time beside a
-        // velocity from another.
+        // timeline shared by every component column, so a component compacted
+        // onto its own surviving times would leave the columns disagreeing on
+        // what row 0 means: a position from one time beside a velocity from
+        // another.
         //
-        // The keys come from the union of every field's own keys, so a moment
-        // any field records is a row. A component absent at that moment gets
-        // zeros in that row, which is what `ComponentColumn` can express.
-        //
-        // A moment whose fields disagree on how many values they recorded is
-        // left out entirely, as in the other two decoders: the repeat numbers
-        // are per field, so with two samples at one time of which the first
-        // omits `y`, repeat 0 would pair the first sample's `x` with the
-        // second's `y` — the cross-sample mix this join exists to remove.
-        let row_keys: Vec<RowKey> = {
-            let present: Vec<&Column> = field_names
+        // `ComponentColumn` has no way to say "no value at this row", so a row
+        // exists only where the state components are whole. Anchoring on
+        // position and velocity keeps the trajectory intact when an optional
+        // component such as attitude was recorded at only some of the times.
+        // That component is then left out rather than filled with zeros, which
+        // downstream would read as a measured value: `orts convert` writes them
+        // to CSV and computes orbital elements from them.
+        let anchors: Vec<&(String, Vec<String>)> = {
+            let state: Vec<&(String, Vec<String>)> = temporal
                 .iter()
+                .filter(|(name, _)| name.ends_with("Position3D") || name.ends_with("Velocity3D"))
+                .collect();
+            if state.is_empty() {
+                temporal.iter().collect()
+            } else {
+                state
+            }
+        };
+
+        let row_keys: Vec<RowKey> = {
+            let anchor_columns: Vec<&Column> = anchors
+                .iter()
+                .flat_map(|(_, fields)| fields)
                 .filter_map(|field| get_scalar_data(&scalars, base, field))
                 .collect();
 
+            // A moment whose fields disagree on how many values they recorded
+            // is left out entirely, as in the other two decoders: the repeat
+            // numbers are per field, so with two samples at one time of which
+            // the first omits `y`, repeat 0 would pair the first sample's `x`
+            // with the second's `y`, the cross-sample mix this join removes.
             let mut ambiguous: BTreeSet<TimeKey> = BTreeSet::new();
             let mut checked: BTreeSet<TimeKey> = BTreeSet::new();
-            for col in &present {
+            for col in &anchor_columns {
                 for &key in col.keys() {
                     let RowKey::Timed { time_ns, step, .. } = key else {
                         continue;
@@ -801,7 +865,7 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
                     if !checked.insert(time) {
                         continue;
                     }
-                    let counts: Vec<usize> = present
+                    let counts: Vec<usize> = anchor_columns
                         .iter()
                         .map(|c| repeats_at(c, time))
                         .filter(|&n| n != 0)
@@ -812,150 +876,95 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
                 }
             }
 
-            let mut keys: BTreeSet<RowKey> = BTreeSet::new();
-            for col in &present {
-                for &key in col.keys() {
-                    if let RowKey::Timed { time_ns, step, .. } = key
-                        && ambiguous.contains(&(time_ns, step))
-                    {
-                        continue;
-                    }
-                    keys.insert(key);
-                }
-            }
-            keys.into_iter().collect()
+            let mut keys: Vec<RowKey> = match anchor_columns.split_first() {
+                Some((first, rest)) => first
+                    .keys()
+                    .copied()
+                    .filter(|key| rest.iter().all(|col| col.contains_key(key)))
+                    .collect(),
+                None => Vec::new(),
+            };
+            keys.retain(|key| match key {
+                RowKey::Timed { time_ns, step, .. } => !ambiguous.contains(&(*time_ns, *step)),
+                RowKey::Index(_) => true,
+            });
+            keys
         };
         let entity_times: Vec<TimeIndex> = row_keys
             .iter()
             .map(|k| TimeIndex::Seconds(k.t_secs()))
             .collect();
 
-        if let Some(schema) = schema {
-            // Schema-based reconstruction: group fields into components
-            for entry in &schema {
-                let comp_name_str = entry["name"].as_str().unwrap_or("");
-                let is_static = entry
-                    .get("static")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false);
-                let fields: Vec<String> = entry["fields"]
-                    .as_array()
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(String::from))
-                            .collect()
-                    })
-                    .unwrap_or_default();
-
-                if is_static {
-                    // Reconstruct static data
-                    let mut static_scalars = Vec::new();
-                    for field in &fields {
-                        if let Some(data) = get_scalar_data(&scalars, base, field)
-                            && let Some((_, val)) = data.iter().next()
-                        {
-                            static_scalars.push(*val);
-                        } else if let Some(&val) = meta_scalars.get(&format!("{base}/{field}")) {
-                            static_scalars.push(val);
-                        }
-                    }
-                    if !static_scalars.is_empty() {
-                        let comp_name: Cow<'static, str> = Cow::Owned(comp_name_str.to_string());
-                        let store = rec.entity_mut(&entity);
-                        store.static_data.insert(comp_name.clone(), static_scalars);
-                        rec.register_component_fields(
-                            comp_name,
-                            fields.iter().map(|s| s.as_str()).collect(),
-                        );
-                    }
-                } else {
-                    // Reconstruct temporal ComponentColumn
-                    let n_fields = fields.len();
-                    if n_fields == 0 {
-                        continue;
-                    }
-
-                    // Rows come from the entity's shared key set, not from a
-                    // field's position in its own column: a field present at
-                    // only some of the times would otherwise put its values on
-                    // earlier rows. Same join as `load_rrd_data`.
-                    let mut column = ComponentColumn::new(n_fields);
-                    for &key in &row_keys {
-                        let mut row = Vec::with_capacity(n_fields);
-                        for field in &fields {
-                            row.push(
-                                get_scalar_data(&scalars, base, field)
-                                    .and_then(|col| col.get(&key).copied())
-                                    .unwrap_or(0.0),
-                            );
-                        }
-                        column.push(&row);
-                    }
-
-                    let store = rec.entity_mut(&entity);
-                    store
-                        .timelines
-                        .entry(TimelineName::SimTime)
-                        .or_insert_with(|| entity_times.clone());
-                    store.num_rows = row_keys.len();
-
-                    let comp_name: Cow<'static, str> = Cow::Owned(comp_name_str.to_string());
-                    store.columns.insert(comp_name.clone(), column);
-                    rec.register_component_fields(
-                        comp_name,
-                        fields.iter().map(|s| s.as_str()).collect(),
-                    );
+        for (name, fields) in &statics {
+            let mut static_scalars = Vec::new();
+            for field in fields {
+                if let Some(data) = get_scalar_data(&scalars, base, field)
+                    && let Some((_, val)) = data.iter().next()
+                {
+                    static_scalars.push(*val);
+                } else if let Some(&val) = meta_scalars.get(&format!("{base}/{field}")) {
+                    static_scalars.push(val);
                 }
             }
-        } else {
-            // Fallback: no schema metadata (legacy rrd files).
-            // Group fields by known Component field_names.
-            // Build reverse lookup from field_names
-            let known: &[(&str, &[&str])] = &[
-                ("orts.Position3D", &["x", "y", "z"]),
-                ("orts.Velocity3D", &["vx", "vy", "vz"]),
-                ("orts.Quaternion4D", &["qw", "qx", "qy", "qz"]),
-                ("orts.AngularVelocity3D", &["wx", "wy", "wz"]),
-                ("orts.MtqCommand3D", &["mtq_mx", "mtq_my", "mtq_mz"]),
-                ("orts.RwTorqueCommand3D", &["rw_tx", "rw_ty", "rw_tz"]),
-                ("orts.RwMomentum3D", &["rw_hx", "rw_hy", "rw_hz"]),
-            ];
-
-            let field_set: BTreeSet<&str> = field_names.iter().map(|s| s.as_str()).collect();
-
-            for &(comp_name_str, comp_fields) in known {
-                if comp_fields.iter().all(|f| field_set.contains(f)) {
-                    let n_fields = comp_fields.len();
-                    let mut column = ComponentColumn::new(n_fields);
-                    for &key in &row_keys {
-                        let mut row = Vec::with_capacity(n_fields);
-                        for field in comp_fields {
-                            row.push(
-                                get_scalar_data(&scalars, base, field)
-                                    .and_then(|col| col.get(&key).copied())
-                                    .unwrap_or(0.0),
-                            );
-                        }
-                        column.push(&row);
-                    }
-
-                    let store = rec.entity_mut(&entity);
-                    store
-                        .timelines
-                        .entry(TimelineName::SimTime)
-                        .or_insert_with(|| entity_times.clone());
-                    store.num_rows = row_keys.len().max(store.num_rows);
-
-                    let comp_name: Cow<'static, str> = Cow::Owned(comp_name_str.to_string());
-                    store.columns.insert(comp_name.clone(), column);
-                    rec.register_component_fields(comp_name, comp_fields.to_vec());
-                }
+            if !static_scalars.is_empty() {
+                let comp_name: Cow<'static, str> = Cow::Owned(name.clone());
+                let store = rec.entity_mut(&entity);
+                store.static_data.insert(comp_name.clone(), static_scalars);
+                rec.register_component_fields(
+                    comp_name,
+                    fields.iter().map(|s| s.as_str()).collect(),
+                );
             }
+        }
+
+        for (name, fields) in &temporal {
+            let mut column = ComponentColumn::new(fields.len());
+            let mut whole = true;
+            for &key in &row_keys {
+                let mut row = Vec::with_capacity(fields.len());
+                for field in fields {
+                    match get_scalar_data(&scalars, base, field).and_then(|col| col.get(&key)) {
+                        Some(&v) => row.push(v),
+                        None => {
+                            whole = false;
+                            break;
+                        }
+                    }
+                }
+                if !whole {
+                    break;
+                }
+                column.push(&row);
+            }
+            if !whole {
+                continue;
+            }
+
+            let comp_name: Cow<'static, str> = Cow::Owned(name.clone());
+            let store = rec.entity_mut(&entity);
+            store
+                .timelines
+                .entry(TimelineName::SimTime)
+                .or_insert_with(|| entity_times.clone());
+            store.num_rows = row_keys.len();
+            store.columns.insert(comp_name.clone(), column);
+            rec.register_component_fields(comp_name, fields.iter().map(|s| s.as_str()).collect());
         }
     }
 
     Ok(rec)
 }
+
+/// Components a legacy .rrd, one without schema metadata, is recognized by.
+const KNOWN_COMPONENTS: &[(&str, &[&str])] = &[
+    ("orts.Position3D", &["x", "y", "z"]),
+    ("orts.Velocity3D", &["vx", "vy", "vz"]),
+    ("orts.Quaternion4D", &["qw", "qx", "qy", "qz"]),
+    ("orts.AngularVelocity3D", &["wx", "wy", "wz"]),
+    ("orts.MtqCommand3D", &["mtq_mx", "mtq_my", "mtq_mz"]),
+    ("orts.RwTorqueCommand3D", &["rw_tx", "rw_ty", "rw_tz"]),
+    ("orts.RwMomentum3D", &["rw_hx", "rw_hy", "rw_hz"]),
+];
 
 /// Look up scalar data, trying both with and without leading slash.
 fn get_scalar_data<'a>(
@@ -1634,12 +1643,6 @@ mod tests {
     /// present at only some of the times put its values on earlier rows:
     /// `Position3D` came back as `[100.0, 201.0, 0.0]`, pairing the t=0 `x` with
     /// the t=10 `y`.
-    ///
-    /// Every moment any field records is a row, because `EntityStore` keeps one
-    /// timeline for all of an entity's columns: dropping a row from one
-    /// component would leave the columns disagreeing on what row 0 means. A
-    /// field absent at a moment reads as zero there, which is what
-    /// `ComponentColumn` can express.
     #[test]
     fn load_as_recording_joins_a_sparse_column_by_time() {
         let dir = std::env::temp_dir().join(format!(
@@ -1685,23 +1688,18 @@ mod tests {
             .map(|(_, col)| col)
             .expect("a position column");
 
-        assert_eq!(store.num_rows, 2, "both t=0 and t=10 are recorded moments");
+        // `ComponentColumn` cannot say "no value here", so t=0 — whose position
+        // lacks `y` — is no row at all rather than a row with a zeroed axis.
+        assert_eq!(store.num_rows, 1, "only t=10 has a whole position");
         assert_eq!(
             store.timelines.get(&TimelineName::SimTime),
-            Some(&vec![TimeIndex::Seconds(0.0), TimeIndex::Seconds(10.0)]),
-            "the timeline must cover the same moments as the columns"
+            Some(&vec![TimeIndex::Seconds(10.0)])
         );
-        // Each row is one moment's values. Before the fix, row 0 read
-        // `[100.0, 201.0, 0.0]`: the t=0 `x` beside the t=10 `y`.
+        let row = column.get_row(0).expect("the one row");
         assert_eq!(
-            column.get_row(0).expect("row 0"),
-            &[100.0, 0.0, 0.0],
-            "t=0 recorded no y, so it reads zero rather than t=10's value"
-        );
-        assert_eq!(
-            column.get_row(1).expect("row 1"),
+            row,
             &[110.0, 201.0, 0.0],
-            "t=10 recorded all three"
+            "the row must be one time's values, not a mix"
         );
     }
 
@@ -1774,13 +1772,7 @@ mod tests {
             .get(&TimelineName::SimTime)
             .expect("a sim_time timeline");
         assert_eq!(times.len(), store.num_rows, "timeline and rows must agree");
-        assert_eq!(
-            times,
-            &vec![TimeIndex::Seconds(0.0), TimeIndex::Seconds(10.0)]
-        );
-
-        // Row 1 is t=10 in every column: position and velocity from the same
-        // moment, which is what the shared timeline promises.
+        assert_eq!(times, &vec![TimeIndex::Seconds(10.0)]);
         for (name, col) in &store.columns {
             assert_eq!(
                 col.num_rows(),
@@ -1790,6 +1782,9 @@ mod tests {
                 store.num_rows
             );
         }
+
+        // The one row is t=10 in both columns, which is what a shared timeline
+        // promises.
         let position = store
             .columns
             .iter()
@@ -1802,8 +1797,8 @@ mod tests {
             .find(|(name, _)| name.contains("Velocity3D"))
             .map(|(_, c)| c)
             .expect("a velocity column");
-        assert_eq!(position.get_row(1).expect("row 1"), &[110.0, 201.0, 0.0]);
-        assert_eq!(velocity.get_row(1).expect("row 1"), &[4.0, 5.0, 6.0]);
+        assert_eq!(position.get_row(0).expect("row 0"), &[110.0, 201.0, 0.0]);
+        assert_eq!(velocity.get_row(0).expect("row 0"), &[4.0, 5.0, 6.0]);
     }
 
     /// A moment whose fields disagree on repeat count yields no row.
@@ -1854,5 +1849,135 @@ mod tests {
         for (name, col) in &store.columns {
             assert_eq!(col.num_rows(), 0, "{name} must be empty too");
         }
+    }
+
+    /// Only this entity's own timed fields decide its rows.
+    ///
+    /// The row keys were the union over every scalar key under the entity's
+    /// path, which reaches further than the entity: a static field has no
+    /// timeline and a child entity has times of its own. Measured with a static
+    /// `mass`, a position at t=10 and t=20, and a child at t=11 and t=12: five
+    /// rows came back where two are recorded, three of them a position of
+    /// `[0.0, 0.0, 0.0]` that was never logged.
+    #[test]
+    fn a_static_field_and_a_child_entity_add_no_rows() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_scope_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("scope.rrd");
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-scope-test")
+                .save(&path)
+                .expect("recording stream");
+            rec.log_static(
+                "/world/sat/scoped/mass",
+                &re_sdk_types::archetypes::Scalars::new([12.5f64]),
+            )
+            .expect("log static");
+            for (t, x) in [(10.0f64, 100.0f64), (20.0, 110.0)] {
+                rec.set_duration_secs("sim_time", t);
+                for (field, value) in [("x", x), ("y", 1.0), ("z", 2.0)] {
+                    rec.log(
+                        format!("/world/sat/scoped/{field}"),
+                        &re_sdk_types::archetypes::Scalars::new([value]),
+                    )
+                    .expect("log");
+                }
+            }
+            // A child entity, logged at times the parent never records.
+            for t in [11.0f64, 12.0] {
+                rec.set_duration_secs("sim_time", t);
+                rec.log(
+                    "/world/sat/scoped/child/x",
+                    &re_sdk_types::archetypes::Scalars::new([7.0f64]),
+                )
+                .expect("log child");
+            }
+            rec.flush_blocking().expect("flush");
+        }
+
+        let loaded = load_as_recording(path.to_str().unwrap()).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        let entity = EntityPath::parse("/world/sat/scoped");
+        let store = loaded.entity(&entity).expect("the parent entity");
+        assert_eq!(
+            store.timelines.get(&TimelineName::SimTime),
+            Some(&vec![TimeIndex::Seconds(10.0), TimeIndex::Seconds(20.0)]),
+            "only the parent's own times are rows"
+        );
+        assert_eq!(store.num_rows, 2);
+        let position = store
+            .columns
+            .iter()
+            .find(|(name, _)| name.contains("Position3D"))
+            .map(|(_, c)| c)
+            .expect("a position column");
+        assert_eq!(position.get_row(0).expect("row 0"), &[100.0, 1.0, 2.0]);
+        assert_eq!(position.get_row(1).expect("row 1"), &[110.0, 1.0, 2.0]);
+    }
+
+    /// A component recorded at only some of the times is left out.
+    ///
+    /// Filling its absent rows with zeros would put an attitude that was never
+    /// logged into the CSV `orts convert` writes, where a zero quaternion is
+    /// indistinguishable from a measured one. Dropping those rows instead would
+    /// cost the trajectory, so the rows follow position and velocity and the
+    /// optional component is the part that goes.
+    #[test]
+    fn a_partially_recorded_optional_component_is_left_out() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_opt_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("optional.rrd");
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-optional-test")
+                .save(&path)
+                .expect("recording stream");
+            for (t, with_attitude) in [(0.0f64, false), (10.0, true)] {
+                rec.set_duration_secs("sim_time", t);
+                for (field, value) in [("x", t), ("y", 1.0), ("z", 2.0)] {
+                    rec.log(
+                        format!("/world/sat/opt/{field}"),
+                        &re_sdk_types::archetypes::Scalars::new([value]),
+                    )
+                    .expect("log");
+                }
+                if with_attitude {
+                    for (field, value) in [("qw", 1.0f64), ("qx", 0.0), ("qy", 0.0), ("qz", 0.0)] {
+                        rec.log(
+                            format!("/world/sat/opt/{field}"),
+                            &re_sdk_types::archetypes::Scalars::new([value]),
+                        )
+                        .expect("log");
+                    }
+                }
+            }
+            rec.flush_blocking().expect("flush");
+        }
+
+        let loaded = load_as_recording(path.to_str().unwrap()).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        let entity = EntityPath::parse("/world/sat/opt");
+        let store = loaded.entity(&entity).expect("entity");
+        assert_eq!(store.num_rows, 2, "both positions are kept");
+        assert!(
+            store.columns.keys().any(|name| name.contains("Position3D")),
+            "the trajectory survives"
+        );
+        assert!(
+            !store
+                .columns
+                .keys()
+                .any(|name| name.contains("Quaternion4D")),
+            "an attitude present at only one of the two times is not reported"
+        );
     }
 }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -280,6 +280,12 @@ impl RowKey {
 /// `log_time` and `log_tick`, which rerun adds to every log call, say when a
 /// value was logged rather than when it happened: two fields of one state carry
 /// different ones and could never pair.
+///
+/// The axis is settled by the first chunk of the file to carry one, so a
+/// recording whose earlier chunks have none keys those without it and they no
+/// longer join with the later ones. Deciding it up front would mean decoding
+/// the file twice; the rows are lost rather than mixed, which is the failure
+/// this decode prefers.
 fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<ChunkKeys> {
     let timeline = |wanted: &str| {
         chunk
@@ -324,16 +330,12 @@ fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<Chun
         (Some(chosen), Some((name, col))) if name.as_str() == chosen.as_str() => {
             keys(Some(col.times_raw().to_vec()))
         }
-        // An axis that is not the recording's. A chunk that also carries
-        // `sim_time` or `step` still has a place among the rows; one that does
-        // not has nothing to place it by.
-        (Some(_), Some(_)) => {
-            if sim_time.is_some() || step.is_some() {
-                keys(None)
-            } else {
-                None
-            }
-        }
+        // An axis that is not the recording's. Keying on `sim_time` and `step`
+        // alone would drop it, and the row would then join fields that sit at
+        // no value of it at all: `x` at `sim_time = 0` beside a `y` at
+        // `sim_time = 0, iteration = 7`. The key holds one axis, so a chunk on
+        // another is left out rather than projected onto fewer dimensions.
+        (Some(_), Some(_)) => None,
         // No axis of its own: the two names above place the row, or its
         // column-local position does, which never joins with a timed key.
         (_, None) => keys(None),
@@ -917,15 +919,17 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
             }
         }
 
-        // A component the file has no column for cannot be reconstructed
+        // A component the file has no values for cannot be reconstructed
         // whatever the rows are, so it gets no say in what they are. Its
         // remaining fields would otherwise narrow them: `x` and `z` recorded at
         // one time, with `y` absent from the file, cost a whole velocity its
-        // rows at every other time.
+        // rows at every other time. An empty `Scalars` batch leaves a column
+        // behind with no values in it, which carries the field no further than
+        // having no column at all.
         temporal.retain(|(_, fields)| {
-            fields
-                .iter()
-                .all(|field| get_scalar_data(&scalars, base, field).is_some())
+            fields.iter().all(|field| {
+                get_scalar_data(&scalars, base, field).is_some_and(|col| !col.is_empty())
+            })
         });
 
         // One row-key set for the whole entity. `EntityStore` keeps a single
@@ -2528,5 +2532,128 @@ mod tests {
             &[110.0, 201.0, 201.0],
             "every axis of the row must be frame 2's"
         );
+    }
+
+    /// No row is assembled across two axes of the recording's own naming.
+    ///
+    /// Keying a chunk on `sim_time` and `step` alone drops the axis it does
+    /// carry, and the row can then join fields that sit at no value of it: `x`
+    /// and `z` at `sim_time = 0` beside a `y` at `sim_time = 0, iteration = 7`.
+    /// Which of two axes a file settles on depends on the order its chunks
+    /// arrive, so this holds the outcome rather than reproducing one ordering:
+    /// either way the position is never whole.
+    #[test]
+    fn no_row_is_assembled_across_two_named_axes() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_other_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("other.rrd");
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-other-axis-test")
+                .save(&path)
+                .expect("recording stream");
+            // The recording's axis, settled here: `frame`.
+            rec.set_duration_secs("sim_time", 0.0);
+            rec.set_time_sequence("frame", 1i64);
+            rec.log(
+                "/world/sat/other/x",
+                &re_sdk_types::archetypes::Scalars::new([100.0f64]),
+            )
+            .expect("log x");
+            rec.disable_timeline("frame");
+            rec.log(
+                "/world/sat/other/z",
+                &re_sdk_types::archetypes::Scalars::new([300.0f64]),
+            )
+            .expect("log z");
+            // `y` sits on an axis of its own.
+            rec.set_time_sequence("iteration", 7i64);
+            rec.log(
+                "/world/sat/other/y",
+                &re_sdk_types::archetypes::Scalars::new([999.0f64]),
+            )
+            .expect("log y");
+            rec.flush_blocking().expect("flush");
+        }
+
+        let loaded = load_as_recording(path.to_str().unwrap()).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        let entity = EntityPath::parse("/world/sat/other");
+        let rows = loaded.entity(&entity).map_or(0, |store| store.num_rows);
+        assert_eq!(
+            rows, 0,
+            "the `iteration` chunk cannot be placed among the rest"
+        );
+    }
+
+    /// A field whose column holds no values carries it no further than none.
+    ///
+    /// An empty `Scalars` batch leaves a column behind with nothing in it. That
+    /// column counted as the file carrying the field, so an empty `y` made
+    /// position a state anchor with no moments at all, and the velocity rows
+    /// that are there went with it.
+    #[test]
+    fn a_field_with_an_empty_column_does_not_narrow_another() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_empty_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("empty.rrd");
+        let schema = r#"[
+            {"name":"orts.Position3D","fields":["x","y","z"]},
+            {"name":"orts.Velocity3D","fields":["vx","vy","vz"]}
+        ]"#;
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-empty-column-test")
+                .save(&path)
+                .expect("recording stream");
+            rec.log_static(
+                "/meta/schema/world/sat/emptied",
+                &re_sdk_types::archetypes::TextDocument::new(schema),
+            )
+            .expect("log schema");
+            for (t, x, vx) in [(0.0f64, 100.0f64, 1.0f64), (10.0, 110.0, 4.0)] {
+                rec.set_duration_secs("sim_time", t);
+                for (field, value) in [("x", x), ("z", 0.0), ("vx", vx), ("vy", 2.0), ("vz", 3.0)] {
+                    rec.log(
+                        format!("/world/sat/emptied/{field}"),
+                        &re_sdk_types::archetypes::Scalars::new([value]),
+                    )
+                    .expect("log");
+                }
+                // `y` is logged as an empty batch: a column, no values.
+                rec.log(
+                    "/world/sat/emptied/y",
+                    &re_sdk_types::archetypes::Scalars::new(Vec::<f64>::new()),
+                )
+                .expect("log empty y");
+            }
+            rec.flush_blocking().expect("flush");
+        }
+
+        let loaded = load_as_recording(path.to_str().unwrap()).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        let entity = EntityPath::parse("/world/sat/emptied");
+        let store = loaded.entity(&entity).expect("entity");
+        assert!(
+            !store.columns.keys().any(|name| name.contains("Position3D")),
+            "a position whose `y` holds no value is not reported"
+        );
+        assert_eq!(store.num_rows, 2, "the velocity keeps both of its times");
+        let velocity = store
+            .columns
+            .iter()
+            .find(|(name, _)| name.contains("Velocity3D"))
+            .map(|(_, c)| c)
+            .expect("a velocity column");
+        assert_eq!(velocity.get_row(0).expect("row 0"), &[1.0, 2.0, 3.0]);
+        assert_eq!(velocity.get_row(1).expect("row 1"), &[4.0, 2.0, 3.0]);
     }
 }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::record::component::Component;
 use crate::record::components::Position3D;
@@ -207,7 +207,6 @@ pub struct RrdData {
     pub metadata: SimMetadata,
 }
 
-/// Load orbital data and metadata from an .rrd file.
 /// Where one scalar value sits on the recording's timelines.
 ///
 /// Ordered by time first, so a recording whose chunks carry no `sim_time` still
@@ -303,17 +302,19 @@ impl ChunkKeys {
     }
 }
 
-// Columns are joined on the recording's time index, so a component logged at
-// only some of the time steps never shifts the remaining components onto the
-// wrong row. A row is emitted only when the whole position triple — and, when
-// the recording has velocity columns, the whole velocity triple — is present at
-// that exact time; incomplete rows are dropped rather than padded with zeros.
-//
-// That guarantee needs a time index to join on, which every recording orts
-// writes carries (`sim_time`, `step`, or both). A chunk with neither timeline
-// has no join key available, so its values are keyed by position within their
-// own column — the arrangement this join replaced, and one a sparse column
-// still shifts. Such a recording does not come from orts.
+/// Load orbital data and metadata from an .rrd file.
+///
+/// Columns are joined on the recording's time index, so a component logged at
+/// only some of the time steps never shifts the remaining components onto the
+/// wrong row. A row is emitted only when the whole position triple — and, when
+/// the recording has velocity columns, the whole velocity triple — is present at
+/// that exact time; incomplete rows are dropped rather than padded with zeros.
+///
+/// That guarantee needs a time index to join on, which every recording orts
+/// writes carries (`sim_time`, `step`, or both). A chunk with neither timeline
+/// has no join key available, so its values are keyed by position within their
+/// own column — the arrangement this join replaced, and one a sparse column
+/// still shifts. Such a recording does not come from orts.
 pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> {
     use re_chunk::Chunk;
     use re_log_encoding::DecoderApp;
@@ -508,21 +509,38 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
         .flatten()
         .collect();
 
+        // Counted once per moment, not once per repeat: a `Scalars` batch puts
+        // k values at one timestamp, and re-counting for each of them would
+        // make reconstruction quadratic in k.
+        let mut ambiguous: BTreeSet<TimeKey> = BTreeSet::new();
+        let mut checked: BTreeSet<TimeKey> = BTreeSet::new();
         for &key in x_col.keys() {
-            if let RowKey::Timed { time_ns, step, .. } = key {
-                let time = (time_ns, step);
-                // Only a moment that actually repeats can be ambiguous: with one
-                // value per column the ordinal is 0 everywhere, and a column
-                // absent at that moment is simply absent from the row.
-                let x_count = repeats_at(x_col, time);
-                if x_count > 1
-                    && present
-                        .iter()
-                        .map(|c| repeats_at(c, time))
-                        .any(|n| n != 0 && n != x_count)
-                {
-                    continue;
-                }
+            let RowKey::Timed { time_ns, step, .. } = key else {
+                continue;
+            };
+            let time = (time_ns, step);
+            if !checked.insert(time) {
+                continue;
+            }
+            // Only a moment that actually repeats can be ambiguous: with one
+            // value per column the ordinal is 0 everywhere, and a column absent
+            // at that moment is simply absent from the row.
+            let x_count = repeats_at(x_col, time);
+            if x_count > 1
+                && present
+                    .iter()
+                    .map(|c| repeats_at(c, time))
+                    .any(|n| n != 0 && n != x_count)
+            {
+                ambiguous.insert(time);
+            }
+        }
+
+        for &key in x_col.keys() {
+            if let RowKey::Timed { time_ns, step, .. } = key
+                && ambiguous.contains(&(time_ns, step))
+            {
+                continue;
             }
 
             let triple = |cols: (Option<&Column>, Option<&Column>, Option<&Column>)| {
@@ -594,7 +612,8 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
 
     // Collect all data from the rrd file
     // scalars: "entity_path/field_name" -> Vec<(time_ns, f64)>
-    let mut scalars: BTreeMap<String, Vec<(i64, f64)>> = BTreeMap::new();
+    let mut scalars: BTreeMap<String, Column> = BTreeMap::new();
+    let mut repeat_counters: RepeatCounters = BTreeMap::new();
     let mut meta_scalars: BTreeMap<String, f64> = BTreeMap::new();
     let mut meta_texts: BTreeMap<String, String> = BTreeMap::new();
 
@@ -638,29 +657,58 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
             continue;
         }
 
-        let sim_time_col = chunk
-            .timelines()
-            .iter()
-            .find(|(name, _)| name.as_str() == "sim_time");
-        let times: Vec<i64> = if let Some((_, col)) = sim_time_col {
-            col.times_raw().to_vec()
-        } else {
-            vec![0; n]
+        let timeline = |wanted: &str| {
+            chunk
+                .timelines()
+                .iter()
+                .find(|(name, _)| name.as_str() == wanted)
+                .map(|(_, col)| col.times_raw().to_vec())
+        };
+        let keys = ChunkKeys {
+            sim_time: timeline("sim_time"),
+            step: timeline("step"),
         };
 
         for comp_id in chunk.components_identifiers() {
             let comp_name = comp_id.as_str();
             if comp_name.contains("Scalar") || comp_name.contains("scalars") {
-                for (row_idx, &t) in times.iter().enumerate() {
+                let column = scalars.entry(entity_path.clone()).or_default();
+                for row_idx in 0..n {
                     let batch =
                         chunk.component_batch::<re_sdk_types::components::Scalar>(comp_id, row_idx);
-                    if let Some(Ok(scalar_vec)) = batch {
-                        for s in scalar_vec {
-                            scalars
-                                .entry(entity_path.clone())
-                                .or_default()
-                                .push((t, s.0.0));
-                        }
+                    let Some(Ok(scalar_vec)) = batch else {
+                        continue;
+                    };
+                    let timed = match keys.row(row_idx) {
+                        RowIndex::Timed { time_ns, step } => Some((time_ns, step)),
+                        RowIndex::Untimed => None,
+                        RowIndex::Missing => continue,
+                    };
+                    let counter = timed.map(|time| {
+                        repeat_counters
+                            .entry(entity_path.clone())
+                            .or_default()
+                            .entry(time)
+                            .or_insert(0)
+                    });
+                    let mut next_repeat = counter.as_ref().map_or(0, |c| **c);
+                    for value in scalar_vec.iter() {
+                        let key = match timed {
+                            Some((time_ns, step)) => {
+                                let key = RowKey::Timed {
+                                    time_ns,
+                                    step,
+                                    repeat: next_repeat,
+                                };
+                                next_repeat += 1;
+                                key
+                            }
+                            None => RowKey::Index(column.len()),
+                        };
+                        column.insert(key, value.0.0);
+                    }
+                    if let Some(counter) = counter {
+                        *counter = next_repeat;
                     }
                 }
             }
@@ -739,7 +787,7 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
                     let mut static_scalars = Vec::new();
                     for field in &fields {
                         if let Some(data) = get_scalar_data(&scalars, base, field)
-                            && let Some((_, val)) = data.first()
+                            && let Some((_, val)) = data.iter().next()
                         {
                             static_scalars.push(*val);
                         } else if let Some(&val) = meta_scalars.get(&format!("{base}/{field}")) {
@@ -762,37 +810,47 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
                         continue;
                     }
 
-                    // Get data for first field to determine row count and times
+                    // Rows come from the recording's time index, not from a
+                    // field's position in its own column: a field present at
+                    // only some of the times would otherwise put its values on
+                    // earlier rows. Same join as `load_rrd_data`.
                     let Some(first_data) = get_scalar_data(&scalars, base, &fields[0]) else {
                         continue;
                     };
 
-                    let n_rows = first_data.len();
                     let mut column = ComponentColumn::new(n_fields);
+                    let mut times: Vec<TimeIndex> = Vec::new();
 
-                    for i in 0..n_rows {
+                    for &key in first_data.keys() {
                         let mut row = Vec::with_capacity(n_fields);
+                        let mut whole = true;
                         for field in &fields {
-                            let val = get_scalar_data(&scalars, base, field)
-                                .and_then(|data| data.get(i))
-                                .map(|(_, v)| *v)
-                                .unwrap_or(0.0);
-                            row.push(val);
+                            match get_scalar_data(&scalars, base, field)
+                                .and_then(|col| col.get(&key).copied())
+                            {
+                                Some(v) => row.push(v),
+                                // A component is all of its fields or none of
+                                // them: a partial row would report a position
+                                // with a zeroed axis.
+                                None => {
+                                    whole = false;
+                                    break;
+                                }
+                            }
+                        }
+                        if !whole {
+                            continue;
                         }
                         column.push(&row);
+                        times.push(TimeIndex::Seconds(key.t_secs()));
                     }
 
-                    // Set timelines from first field's timestamps
+                    let n_rows = times.len();
                     let store = rec.entity_mut(&entity);
                     store
                         .timelines
                         .entry(TimelineName::SimTime)
-                        .or_insert_with(|| {
-                            first_data
-                                .iter()
-                                .map(|(t_ns, _)| TimeIndex::Seconds(*t_ns as f64 / 1e9))
-                                .collect()
-                        });
+                        .or_insert(times);
                     store.num_rows = n_rows;
 
                     let comp_name: Cow<'static, str> = Cow::Owned(comp_name_str.to_string());
@@ -824,32 +882,37 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
                     let Some(first_data) = get_scalar_data(&scalars, base, comp_fields[0]) else {
                         continue;
                     };
-                    let n_rows = first_data.len();
                     let n_fields = comp_fields.len();
                     let mut column = ComponentColumn::new(n_fields);
+                    let mut times: Vec<TimeIndex> = Vec::new();
 
-                    for i in 0..n_rows {
+                    for &key in first_data.keys() {
                         let mut row = Vec::with_capacity(n_fields);
+                        let mut whole = true;
                         for field in comp_fields {
-                            let val = get_scalar_data(&scalars, base, field)
-                                .and_then(|data| data.get(i))
-                                .map(|(_, v)| *v)
-                                .unwrap_or(0.0);
-                            row.push(val);
+                            match get_scalar_data(&scalars, base, field)
+                                .and_then(|col| col.get(&key).copied())
+                            {
+                                Some(v) => row.push(v),
+                                None => {
+                                    whole = false;
+                                    break;
+                                }
+                            }
+                        }
+                        if !whole {
+                            continue;
                         }
                         column.push(&row);
+                        times.push(TimeIndex::Seconds(key.t_secs()));
                     }
+                    let n_rows = times.len();
 
                     let store = rec.entity_mut(&entity);
                     store
                         .timelines
                         .entry(TimelineName::SimTime)
-                        .or_insert_with(|| {
-                            first_data
-                                .iter()
-                                .map(|(t_ns, _)| TimeIndex::Seconds(*t_ns as f64 / 1e9))
-                                .collect()
-                        });
+                        .or_insert(times);
                     store.num_rows = n_rows.max(store.num_rows);
 
                     let comp_name: Cow<'static, str> = Cow::Owned(comp_name_str.to_string());
@@ -865,10 +928,10 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
 
 /// Look up scalar data, trying both with and without leading slash.
 fn get_scalar_data<'a>(
-    scalars: &'a BTreeMap<String, Vec<(i64, f64)>>,
+    scalars: &'a BTreeMap<String, Column>,
     base: &str,
     field: &str,
-) -> Option<&'a Vec<(i64, f64)>> {
+) -> Option<&'a Column> {
     scalars
         .get(&format!("{base}/{field}"))
         .or_else(|| scalars.get(&format!("/{base}/{field}")))
@@ -1531,5 +1594,69 @@ mod tests {
         assert_eq!(rows.len(), 1, "{rows:?}");
         assert_eq!(rows[0].x, 100.0);
         assert!(rows[0].quaternion.is_none());
+    }
+
+    /// `load_as_recording` joins on the time index too.
+    ///
+    /// A third copy of the same index join lived here, reached by
+    /// `orts convert`. It read each field at its own position, so a field
+    /// present at only some of the times put its values on earlier rows:
+    /// `Position3D` came back as `[100.0, 201.0, 0.0]`, pairing the t=0 `x` with
+    /// the t=10 `y`.
+    ///
+    /// A component is all of its fields or none of them, so the t=0 row is
+    /// dropped rather than reported with a zeroed axis.
+    #[test]
+    fn load_as_recording_joins_a_sparse_column_by_time() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_lar_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("sparse.rrd");
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-lar-test")
+                .save(&path)
+                .expect("recording stream");
+            for (t, fields) in [
+                (0.0f64, vec![("x", 100.0f64), ("z", 0.0)]),
+                (10.0, vec![("x", 110.0), ("y", 201.0), ("z", 0.0)]),
+            ] {
+                rec.set_duration_secs("sim_time", t);
+                for (field, value) in fields {
+                    rec.log(
+                        format!("/world/sat/loader/{field}"),
+                        &re_sdk_types::archetypes::Scalars::new([value]),
+                    )
+                    .expect("log");
+                }
+            }
+            rec.flush_blocking().expect("flush");
+        }
+
+        let loaded = load_as_recording(path.to_str().unwrap()).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        let entity = loaded
+            .entity_paths()
+            .next()
+            .cloned()
+            .expect("one entity was written");
+        let store = loaded.entity(&entity).expect("entity");
+        let column = store
+            .columns
+            .iter()
+            .find(|(name, _)| name.contains("Position3D"))
+            .map(|(_, col)| col)
+            .expect("a position column");
+
+        assert_eq!(store.num_rows, 1, "only t=10 has a whole position");
+        let row = column.get_row(0).expect("the one row");
+        assert_eq!(
+            row,
+            &[110.0, 201.0, 0.0],
+            "the row must be one time's values, not a mix"
+        );
     }
 }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -908,6 +908,17 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
             }
         }
 
+        // A component the file has no column for cannot be reconstructed
+        // whatever the rows are, so it gets no say in what they are. Its
+        // remaining fields would otherwise narrow them: `x` and `z` recorded at
+        // one time, with `y` absent from the file, cost a whole velocity its
+        // rows at every other time.
+        temporal.retain(|(_, fields)| {
+            fields
+                .iter()
+                .all(|field| get_scalar_data(&scalars, base, field).is_some())
+        });
+
         // One row-key set for the whole entity. `EntityStore` keeps a single
         // timeline shared by every component column, so a component compacted
         // onto its own surviving times would leave the columns disagreeing on
@@ -934,6 +945,8 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
         };
 
         let row_keys: Vec<RowKey> = {
+            // Every field of a surviving group has a column, so nothing is
+            // dropped here.
             let columns_of = |groups: &[&(String, Vec<String>)]| -> Vec<&Column> {
                 groups
                     .iter()
@@ -2364,5 +2377,85 @@ mod tests {
             rows, 0,
             "neither the step nor the frame carries a whole position"
         );
+    }
+
+    /// A component the file cannot carry does not narrow another's rows.
+    ///
+    /// Rows follow the state components, and a component missing one of its
+    /// fields was still among them: its remaining fields narrowed the rows to
+    /// the times they happen to hold. Measured with `y` absent from the file,
+    /// `x` and `z` at t=0, and a whole velocity at t=0 and t=10: one row came
+    /// back, the t=10 velocity dropped for a position that is never reported
+    /// either way.
+    #[test]
+    fn a_component_the_file_cannot_carry_does_not_narrow_another() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_narrow_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("narrow.rrd");
+        let schema = r#"[
+            {"name":"orts.Position3D","fields":["x","y","z"]},
+            {"name":"orts.Velocity3D","fields":["vx","vy","vz"]}
+        ]"#;
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-narrow-test")
+                .save(&path)
+                .expect("recording stream");
+            rec.log_static(
+                "/meta/schema/world/sat/narrowed",
+                &re_sdk_types::archetypes::TextDocument::new(schema),
+            )
+            .expect("log schema");
+            // `y` is never logged, and `x` and `z` appear at t=0 alone.
+            rec.set_duration_secs("sim_time", 0.0);
+            for (field, value) in [
+                ("x", 100.0f64),
+                ("z", 300.0),
+                ("vx", 1.0),
+                ("vy", 2.0),
+                ("vz", 3.0),
+            ] {
+                rec.log(
+                    format!("/world/sat/narrowed/{field}"),
+                    &re_sdk_types::archetypes::Scalars::new([value]),
+                )
+                .expect("log");
+            }
+            rec.set_duration_secs("sim_time", 10.0);
+            for (field, value) in [("vx", 4.0f64), ("vy", 5.0), ("vz", 6.0)] {
+                rec.log(
+                    format!("/world/sat/narrowed/{field}"),
+                    &re_sdk_types::archetypes::Scalars::new([value]),
+                )
+                .expect("log");
+            }
+            rec.flush_blocking().expect("flush");
+        }
+
+        let loaded = load_as_recording(path.to_str().unwrap()).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        let entity = EntityPath::parse("/world/sat/narrowed");
+        let store = loaded.entity(&entity).expect("entity");
+        assert!(
+            !store.columns.keys().any(|name| name.contains("Position3D")),
+            "a position without a `y` column is not reported"
+        );
+        assert_eq!(store.num_rows, 2, "the velocity keeps both of its times");
+        assert_eq!(
+            store.timelines.get(&TimelineName::SimTime),
+            Some(&vec![TimeIndex::Seconds(0.0), TimeIndex::Seconds(10.0)])
+        );
+        let velocity = store
+            .columns
+            .iter()
+            .find(|(name, _)| name.contains("Velocity3D"))
+            .map(|(_, c)| c)
+            .expect("a velocity column");
+        assert_eq!(velocity.get_row(0).expect("row 0"), &[1.0, 2.0, 3.0]);
+        assert_eq!(velocity.get_row(1).expect("row 1"), &[4.0, 5.0, 6.0]);
     }
 }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -522,16 +522,18 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
             if !checked.insert(time) {
                 continue;
             }
-            // Only a moment that actually repeats can be ambiguous: with one
-            // value per column the ordinal is 0 everywhere, and a column absent
-            // at that moment is simply absent from the row.
-            let x_count = repeats_at(x_col, time);
-            if x_count > 1
-                && present
-                    .iter()
-                    .map(|c| repeats_at(c, time))
-                    .any(|n| n != 0 && n != x_count)
-            {
+            // Every column that has values at this moment must have the same
+            // number of them. A count of zero is a column absent there, which
+            // is simply absent from the row; any other disagreement means the
+            // ordinal points at different samples in different columns. Checked
+            // whichever column repeats — `x` holding one value while `y` holds
+            // two is just as unpairable as the other way round.
+            let counts: Vec<usize> = present
+                .iter()
+                .map(|c| repeats_at(c, time))
+                .filter(|&n| n != 0)
+                .collect();
+            if counts.iter().any(|&n| n != counts[0]) {
                 ambiguous.insert(time);
             }
         }
@@ -765,6 +767,29 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
             })
             .collect();
 
+        // One row-key set for the whole entity. `EntityStore` keeps a single
+        // timeline shared by every component column, so a component that
+        // compacted onto its own surviving times would leave the columns
+        // disagreeing on what row 0 means — a position from one time beside a
+        // velocity from another.
+        //
+        // The keys come from the union of every field's own keys, so a moment
+        // any field records is a row. A component absent at that moment gets
+        // zeros in that row, which is what `ComponentColumn` can express.
+        let row_keys: Vec<RowKey> = {
+            let mut keys: BTreeSet<RowKey> = BTreeSet::new();
+            for field in &field_names {
+                if let Some(col) = get_scalar_data(&scalars, base, field) {
+                    keys.extend(col.keys().copied());
+                }
+            }
+            keys.into_iter().collect()
+        };
+        let entity_times: Vec<TimeIndex> = row_keys
+            .iter()
+            .map(|k| TimeIndex::Seconds(k.t_secs()))
+            .collect();
+
         if let Some(schema) = schema {
             // Schema-based reconstruction: group fields into components
             for entry in &schema {
@@ -810,48 +835,29 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
                         continue;
                     }
 
-                    // Rows come from the recording's time index, not from a
+                    // Rows come from the entity's shared key set, not from a
                     // field's position in its own column: a field present at
                     // only some of the times would otherwise put its values on
                     // earlier rows. Same join as `load_rrd_data`.
-                    let Some(first_data) = get_scalar_data(&scalars, base, &fields[0]) else {
-                        continue;
-                    };
-
                     let mut column = ComponentColumn::new(n_fields);
-                    let mut times: Vec<TimeIndex> = Vec::new();
-
-                    for &key in first_data.keys() {
+                    for &key in &row_keys {
                         let mut row = Vec::with_capacity(n_fields);
-                        let mut whole = true;
                         for field in &fields {
-                            match get_scalar_data(&scalars, base, field)
-                                .and_then(|col| col.get(&key).copied())
-                            {
-                                Some(v) => row.push(v),
-                                // A component is all of its fields or none of
-                                // them: a partial row would report a position
-                                // with a zeroed axis.
-                                None => {
-                                    whole = false;
-                                    break;
-                                }
-                            }
-                        }
-                        if !whole {
-                            continue;
+                            row.push(
+                                get_scalar_data(&scalars, base, field)
+                                    .and_then(|col| col.get(&key).copied())
+                                    .unwrap_or(0.0),
+                            );
                         }
                         column.push(&row);
-                        times.push(TimeIndex::Seconds(key.t_secs()));
                     }
 
-                    let n_rows = times.len();
                     let store = rec.entity_mut(&entity);
                     store
                         .timelines
                         .entry(TimelineName::SimTime)
-                        .or_insert(times);
-                    store.num_rows = n_rows;
+                        .or_insert_with(|| entity_times.clone());
+                    store.num_rows = row_keys.len();
 
                     let comp_name: Cow<'static, str> = Cow::Owned(comp_name_str.to_string());
                     store.columns.insert(comp_name.clone(), column);
@@ -879,41 +885,26 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
 
             for &(comp_name_str, comp_fields) in known {
                 if comp_fields.iter().all(|f| field_set.contains(f)) {
-                    let Some(first_data) = get_scalar_data(&scalars, base, comp_fields[0]) else {
-                        continue;
-                    };
                     let n_fields = comp_fields.len();
                     let mut column = ComponentColumn::new(n_fields);
-                    let mut times: Vec<TimeIndex> = Vec::new();
-
-                    for &key in first_data.keys() {
+                    for &key in &row_keys {
                         let mut row = Vec::with_capacity(n_fields);
-                        let mut whole = true;
                         for field in comp_fields {
-                            match get_scalar_data(&scalars, base, field)
-                                .and_then(|col| col.get(&key).copied())
-                            {
-                                Some(v) => row.push(v),
-                                None => {
-                                    whole = false;
-                                    break;
-                                }
-                            }
-                        }
-                        if !whole {
-                            continue;
+                            row.push(
+                                get_scalar_data(&scalars, base, field)
+                                    .and_then(|col| col.get(&key).copied())
+                                    .unwrap_or(0.0),
+                            );
                         }
                         column.push(&row);
-                        times.push(TimeIndex::Seconds(key.t_secs()));
                     }
-                    let n_rows = times.len();
 
                     let store = rec.entity_mut(&entity);
                     store
                         .timelines
                         .entry(TimelineName::SimTime)
-                        .or_insert(times);
-                    store.num_rows = n_rows.max(store.num_rows);
+                        .or_insert_with(|| entity_times.clone());
+                    store.num_rows = row_keys.len().max(store.num_rows);
 
                     let comp_name: Cow<'static, str> = Cow::Owned(comp_name_str.to_string());
                     store.columns.insert(comp_name.clone(), column);
@@ -1604,8 +1595,11 @@ mod tests {
     /// `Position3D` came back as `[100.0, 201.0, 0.0]`, pairing the t=0 `x` with
     /// the t=10 `y`.
     ///
-    /// A component is all of its fields or none of them, so the t=0 row is
-    /// dropped rather than reported with a zeroed axis.
+    /// Every moment any field records is a row, because `EntityStore` keeps one
+    /// timeline for all of an entity's columns: dropping a row from one
+    /// component would leave the columns disagreeing on what row 0 means. A
+    /// field absent at a moment reads as zero there, which is what
+    /// `ComponentColumn` can express.
     #[test]
     fn load_as_recording_joins_a_sparse_column_by_time() {
         let dir = std::env::temp_dir().join(format!(
@@ -1651,12 +1645,124 @@ mod tests {
             .map(|(_, col)| col)
             .expect("a position column");
 
-        assert_eq!(store.num_rows, 1, "only t=10 has a whole position");
-        let row = column.get_row(0).expect("the one row");
+        assert_eq!(store.num_rows, 2, "both t=0 and t=10 are recorded moments");
         assert_eq!(
-            row,
-            &[110.0, 201.0, 0.0],
-            "the row must be one time's values, not a mix"
+            store.timelines.get(&TimelineName::SimTime),
+            Some(&vec![TimeIndex::Seconds(0.0), TimeIndex::Seconds(10.0)]),
+            "the timeline must cover the same moments as the columns"
         );
+        // Each row is one moment's values. Before the fix, row 0 read
+        // `[100.0, 201.0, 0.0]`: the t=0 `x` beside the t=10 `y`.
+        assert_eq!(
+            column.get_row(0).expect("row 0"),
+            &[100.0, 0.0, 0.0],
+            "t=0 recorded no y, so it reads zero rather than t=10's value"
+        );
+        assert_eq!(
+            column.get_row(1).expect("row 1"),
+            &[110.0, 201.0, 0.0],
+            "t=10 recorded all three"
+        );
+    }
+
+    /// Every component column lines up with the entity's one timeline.
+    ///
+    /// `EntityStore` keeps a single timeline shared by all of an entity's
+    /// columns, so a component that compacted onto its own surviving times left
+    /// the columns disagreeing on what a row means. Measured with position
+    /// whole only at t=10 and velocity at both: the timeline came back as
+    /// `[10.0]` while `num_rows` was 2, and row 0 held the t=10 position beside
+    /// the t=0 velocity.
+    #[test]
+    fn every_component_column_matches_the_entity_timeline() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_tl_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("mixed.rrd");
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-timeline-test")
+                .save(&path)
+                .expect("recording stream");
+            for (t, fields) in [
+                // t=0: velocity whole, position missing y.
+                (
+                    0.0f64,
+                    vec![
+                        ("x", 100.0f64),
+                        ("z", 0.0),
+                        ("vx", 1.0),
+                        ("vy", 2.0),
+                        ("vz", 3.0),
+                    ],
+                ),
+                // t=10: both whole.
+                (
+                    10.0,
+                    vec![
+                        ("x", 110.0),
+                        ("y", 201.0),
+                        ("z", 0.0),
+                        ("vx", 4.0),
+                        ("vy", 5.0),
+                        ("vz", 6.0),
+                    ],
+                ),
+            ] {
+                rec.set_duration_secs("sim_time", t);
+                for (field, value) in fields {
+                    rec.log(
+                        format!("/world/sat/loader/{field}"),
+                        &re_sdk_types::archetypes::Scalars::new([value]),
+                    )
+                    .expect("log");
+                }
+            }
+            rec.flush_blocking().expect("flush");
+        }
+
+        let loaded = load_as_recording(path.to_str().unwrap()).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        let entity = loaded.entity_paths().next().cloned().expect("one entity");
+        let store = loaded.entity(&entity).expect("entity");
+
+        let times = store
+            .timelines
+            .get(&TimelineName::SimTime)
+            .expect("a sim_time timeline");
+        assert_eq!(times.len(), store.num_rows, "timeline and rows must agree");
+        assert_eq!(
+            times,
+            &vec![TimeIndex::Seconds(0.0), TimeIndex::Seconds(10.0)]
+        );
+
+        // Row 1 is t=10 in every column: position and velocity from the same
+        // moment, which is what the shared timeline promises.
+        for (name, col) in &store.columns {
+            assert_eq!(
+                col.num_rows(),
+                store.num_rows,
+                "{name} has {} rows, entity has {}",
+                col.num_rows(),
+                store.num_rows
+            );
+        }
+        let position = store
+            .columns
+            .iter()
+            .find(|(name, _)| name.contains("Position3D"))
+            .map(|(_, c)| c)
+            .expect("a position column");
+        let velocity = store
+            .columns
+            .iter()
+            .find(|(name, _)| name.contains("Velocity3D"))
+            .map(|(_, c)| c)
+            .expect("a velocity column");
+        assert_eq!(position.get_row(1).expect("row 1"), &[110.0, 201.0, 0.0]);
+        assert_eq!(velocity.get_row(1).expect("row 1"), &[4.0, 5.0, 6.0]);
     }
 }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -339,8 +339,6 @@ fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<Chun
 /// One decoded scalar field: its value at each time index of the recording.
 type Column = BTreeMap<RowKey, f64>;
 
-/// The non-repeat part of a [`RowKey::Timed`]: one moment on the recording's
-/// timelines.
 /// One moment of a recording: a [`RowKey`] with its repeat number cleared, so
 /// that every value logged at that moment ranges within it.
 type Moment = RowKey;

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -482,25 +482,45 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
         let has_velocity = vel_cols.0.is_some() || vel_cols.1.is_some() || vel_cols.2.is_some();
 
         // Repeat ordinals are assigned per column, so they only identify a row
-        // while every required column has the same number of values at that
+        // while every column present has the same number of values at that
         // moment. Where the counts disagree, which value pairs with which is
         // unknowable from the file: the moment is skipped rather than joined on
         // an ordinal that means different things in different columns.
-        let required: Vec<&Column> = [Some(x_col), pos_cols.1, pos_cols.2]
-            .into_iter()
-            .chain(if has_velocity {
-                [vel_cols.0, vel_cols.1, vel_cols.2]
-            } else {
-                [None, None, None]
-            })
-            .flatten()
-            .collect();
+        //
+        // The optional columns count too. Attitude logged for only the second of
+        // two states at one moment would otherwise attach to the first.
+        let present: Vec<&Column> = [
+            Some(x_col),
+            pos_cols.1,
+            pos_cols.2,
+            vel_cols.0,
+            vel_cols.1,
+            vel_cols.2,
+            quat_cols.0,
+            quat_cols.1,
+            quat_cols.2,
+            quat_cols.3,
+            omega_cols.0,
+            omega_cols.1,
+            omega_cols.2,
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
 
         for &key in x_col.keys() {
             if let RowKey::Timed { time_ns, step, .. } = key {
                 let time = (time_ns, step);
-                let counts: Vec<usize> = required.iter().map(|c| repeats_at(c, time)).collect();
-                if counts.iter().any(|&n| n != counts[0]) {
+                // Only a moment that actually repeats can be ambiguous: with one
+                // value per column the ordinal is 0 everywhere, and a column
+                // absent at that moment is simply absent from the row.
+                let x_count = repeats_at(x_col, time);
+                if x_count > 1
+                    && present
+                        .iter()
+                        .map(|c| repeats_at(c, time))
+                        .any(|n| n != 0 && n != x_count)
+                {
                     continue;
                 }
             }
@@ -1469,5 +1489,47 @@ mod tests {
         }
         assert_eq!(rows[0].x, 100.0);
         assert_eq!(rows[1].x, 110.0);
+    }
+
+    /// The optional columns count toward the repeat check too.
+    ///
+    /// Two complete states at one moment with attitude on the second only: the
+    /// quaternion holds repeat 0, so joining on the ordinal attached it to the
+    /// first state and left the second without one.
+    #[test]
+    fn an_optional_column_disagreeing_on_repeats_yields_no_row() {
+        let rows = load_written(|rec| {
+            rec.set_duration_secs("sim_time", 0.0);
+            log_fields(rec, &[("x", 100.0), ("y", 0.0), ("z", 0.0)]);
+            log_fields(
+                rec,
+                &[
+                    ("x", 110.0),
+                    ("y", 0.0),
+                    ("z", 0.0),
+                    ("qw", 1.0),
+                    ("qx", 0.5),
+                    ("qy", 0.0),
+                    ("qz", 0.0),
+                ],
+            );
+        });
+        assert!(
+            rows.is_empty(),
+            "the quaternion cannot be assigned to either state; got {rows:?}"
+        );
+    }
+
+    /// A moment with one value per column is never ambiguous, whichever
+    /// optional columns are absent.
+    #[test]
+    fn a_single_sample_with_absent_optional_columns_still_yields_a_row() {
+        let rows = load_written(|rec| {
+            rec.set_duration_secs("sim_time", 0.0);
+            log_fields(rec, &[("x", 100.0), ("y", 200.0), ("z", 300.0)]);
+        });
+        assert_eq!(rows.len(), 1, "{rows:?}");
+        assert_eq!(rows[0].x, 100.0);
+        assert!(rows[0].quaternion.is_none());
     }
 }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -208,6 +208,91 @@ pub struct RrdData {
 }
 
 /// Load orbital data and metadata from an .rrd file.
+/// Where one scalar value sits on the recording's timelines.
+///
+/// Ordered by time first, so a recording whose chunks carry no `sim_time` still
+/// yields rows in `step` order.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum RowKey {
+    /// A recording time index: `sim_time` \[ns\] and the `step` sequence
+    /// number, each present only when the recording has that timeline.
+    Timed {
+        time_ns: Option<i64>,
+        step: Option<i64>,
+        repeat: u32,
+    },
+    /// Neither timeline is present: fall back to the column-local index. Rows
+    /// keyed this way carry no time information and all report `t = 0`.
+    Index(usize),
+}
+
+impl RowKey {
+    /// Simulation time of this row \[s\], or 0 when the recording carries none.
+    fn t_secs(self) -> f64 {
+        match self {
+            RowKey::Timed {
+                time_ns: Some(ns), ..
+            } => ns as f64 / 1e9,
+            RowKey::Timed { time_ns: None, .. } | RowKey::Index(_) => 0.0,
+        }
+    }
+}
+
+/// One decoded scalar field: its value at each time index of the recording.
+type Column = BTreeMap<RowKey, f64>;
+
+/// How many values `column` already holds at one time index. `key` builds the
+/// key for the n-th repeat at that time, so the count is the next free slot.
+fn repeats(column: &Column, key: impl Fn(u32) -> RowKey) -> u32 {
+    column.range(key(0)..=key(u32::MAX)).count() as u32
+}
+
+/// Time index of every row in one chunk, per timeline the chunk carries.
+struct ChunkKeys {
+    sim_time: Option<Vec<i64>>,
+    step: Option<Vec<i64>>,
+}
+
+/// Where one chunk row sits on the recording's timelines.
+#[derive(Clone, Copy)]
+enum RowIndex {
+    /// The chunk's timelines place the row at this time index.
+    Timed {
+        time_ns: Option<i64>,
+        step: Option<i64>,
+    },
+    /// The chunk carries no timeline; keys come from the column-local position.
+    Untimed,
+    /// A timeline the chunk does carry has no value for this row — skip it.
+    Missing,
+}
+
+impl ChunkKeys {
+    fn row(&self, row_idx: usize) -> RowIndex {
+        // A timeline the chunk carries must have a value for this row.
+        let index = |times: &Option<Vec<i64>>| match times {
+            Some(times) => times.get(row_idx).copied().map(Some).ok_or(()),
+            None => Ok(None),
+        };
+        match (index(&self.sim_time), index(&self.step)) {
+            (Ok(None), Ok(None)) => RowIndex::Untimed,
+            (Ok(time_ns), Ok(step)) => RowIndex::Timed { time_ns, step },
+            _ => RowIndex::Missing,
+        }
+    }
+}
+
+// Columns are joined on the recording's time index, so a component logged at
+// only some of the time steps never shifts the remaining components onto the
+// wrong row. A row is emitted only when the whole position triple — and, when
+// the recording has velocity columns, the whole velocity triple — is present at
+// that exact time; incomplete rows are dropped rather than padded with zeros.
+//
+// That guarantee needs a time index to join on, which every recording orts
+// writes carries (`sim_time`, `step`, or both). A chunk with neither timeline
+// has no join key available, so its values are keyed by position within their
+// own column — the arrangement this join replaced, and one a sparse column
+// still shifts. Such a recording does not come from orts.
 pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> {
     use re_chunk::Chunk;
     use re_log_encoding::DecoderApp;
@@ -216,8 +301,8 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
     let file = std::fs::File::open(path)?;
     let reader = std::io::BufReader::new(file);
 
-    // Collect f64 scalars: entity_path -> Vec<(time_ns, f64)>
-    let mut scalars: BTreeMap<String, Vec<(i64, f64)>> = BTreeMap::new();
+    // Collect f64 scalars: entity_path -> (time index -> value)
+    let mut scalars: BTreeMap<String, Column> = BTreeMap::new();
     // Collect metadata scalars: entity_path -> f64 (static/timeless)
     let mut meta_scalars: BTreeMap<String, f64> = BTreeMap::new();
     // Collect text metadata
@@ -266,29 +351,57 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
             continue;
         }
 
-        let sim_time_col = chunk
-            .timelines()
-            .iter()
-            .find(|(name, _)| name.as_str() == "sim_time");
-        let times: Vec<i64> = if let Some((_, col)) = sim_time_col {
-            col.times_raw().to_vec()
-        } else {
-            vec![0; n]
+        let timeline = |wanted: &str| {
+            chunk
+                .timelines()
+                .iter()
+                .find(|(name, _)| name.as_str() == wanted)
+                .map(|(_, col)| col.times_raw().to_vec())
+        };
+        let keys = ChunkKeys {
+            sim_time: timeline("sim_time"),
+            step: timeline("step"),
         };
 
         for comp_id in chunk.components_identifiers() {
             let comp_name = comp_id.as_str();
             if comp_name.contains("Scalar") || comp_name.contains("scalars") {
-                for (row_idx, &t) in times.iter().enumerate() {
+                let column = scalars.entry(entity_path.clone()).or_default();
+                for row_idx in 0..n {
                     let batch =
                         chunk.component_batch::<re_sdk_types::components::Scalar>(comp_id, row_idx);
-                    if let Some(Ok(scalar_vec)) = batch {
-                        for s in scalar_vec {
-                            scalars
-                                .entry(entity_path.clone())
-                                .or_default()
-                                .push((t, s.0.0));
-                        }
+                    let Some(Ok(scalar_vec)) = batch else {
+                        continue;
+                    };
+                    let timed = match keys.row(row_idx) {
+                        RowIndex::Timed { time_ns, step } => Some((time_ns, step)),
+                        RowIndex::Untimed => None,
+                        RowIndex::Missing => continue,
+                    };
+                    // A batch usually holds one value per row, but `Scalars`
+                    // takes a slice: several values at one time index become
+                    // consecutive repeats rather than being dropped.
+                    let mut next_repeat = timed.map_or(0, |(time_ns, step)| {
+                        repeats(column, |repeat| RowKey::Timed {
+                            time_ns,
+                            step,
+                            repeat,
+                        })
+                    });
+                    for value in scalar_vec.iter() {
+                        let key = match timed {
+                            Some((time_ns, step)) => {
+                                let key = RowKey::Timed {
+                                    time_ns,
+                                    step,
+                                    repeat: next_repeat,
+                                };
+                                next_repeat += 1;
+                                key
+                            }
+                            None => RowKey::Index(column.len()),
+                        };
+                        column.insert(key, value.0.0);
                     }
                 }
             }
@@ -323,50 +436,55 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
 
     let mut rows: Vec<RrdRow> = Vec::new();
     for base in &base_paths {
-        let x_data = scalars.get(&format!("{base}/x"));
-        let y_data = scalars.get(&format!("{base}/y"));
-        let z_data = scalars.get(&format!("{base}/z"));
-        let vx_data = scalars.get(&format!("{base}/vx"));
-        let vy_data = scalars.get(&format!("{base}/vy"));
-        let vz_data = scalars.get(&format!("{base}/vz"));
+        let column = |field: &str| scalars.get(&format!("{base}/{field}"));
+        // Value of one field at one time index, or `None` when the recording
+        // has no such column or no value there.
+        let at = |col: Option<&Column>, key: RowKey| col?.get(&key).copied();
 
-        // Use x as the reference for row count and time
-        let Some(x_data) = x_data else { continue };
+        // A row is a position, so the whole triple has to be there.
+        let Some(x_col) = column("x") else { continue };
+        let pos_cols = (Some(x_col), column("y"), column("z"));
+        let vel_cols = (column("vx"), column("vy"), column("vz"));
+        let quat_cols = (column("qw"), column("qx"), column("qy"), column("qz"));
+        let omega_cols = (column("wx"), column("wy"), column("wz"));
 
-        // Attitude components (optional)
-        let qw_data = scalars.get(&format!("{base}/qw"));
-        let qx_data = scalars.get(&format!("{base}/qx"));
-        let qy_data = scalars.get(&format!("{base}/qy"));
-        let qz_data = scalars.get(&format!("{base}/qz"));
-        let wx_data = scalars.get(&format!("{base}/wx"));
-        let wy_data = scalars.get(&format!("{base}/wy"));
-        let wz_data = scalars.get(&format!("{base}/wz"));
+        // A recording with no velocity column at all is position-only; one that
+        // has velocity columns must supply all three at a time for the row to
+        // be a state vector.
+        let has_velocity = vel_cols.0.is_some() || vel_cols.1.is_some() || vel_cols.2.is_some();
 
-        for (i, (t_ns, x)) in x_data.iter().enumerate() {
-            let t_sec = *t_ns as f64 / 1e9;
+        for &key in x_col.keys() {
+            let triple = |cols: (Option<&Column>, Option<&Column>, Option<&Column>)| {
+                Some([at(cols.0, key)?, at(cols.1, key)?, at(cols.2, key)?])
+            };
 
-            let quaternion = qw_data.and_then(|qw| {
-                let qw = qw.get(i)?.1;
-                let qx = qx_data?.get(i)?.1;
-                let qy = qy_data?.get(i)?.1;
-                let qz = qz_data?.get(i)?.1;
-                Some([qw, qx, qy, qz])
-            });
-            let angular_velocity = wx_data.and_then(|wx| {
-                let wx = wx.get(i)?.1;
-                let wy = wy_data?.get(i)?.1;
-                let wz = wz_data?.get(i)?.1;
-                Some([wx, wy, wz])
-            });
+            let Some([x, y, z]) = triple(pos_cols) else {
+                continue;
+            };
+            let velocity = triple(vel_cols);
+            if has_velocity && velocity.is_none() {
+                continue;
+            }
+            let [vx, vy, vz] = velocity.unwrap_or([0.0; 3]);
+
+            let quaternion = (|| {
+                Some([
+                    at(quat_cols.0, key)?,
+                    at(quat_cols.1, key)?,
+                    at(quat_cols.2, key)?,
+                    at(quat_cols.3, key)?,
+                ])
+            })();
+            let angular_velocity = triple(omega_cols);
 
             rows.push(RrdRow {
-                t: t_sec,
-                x: *x,
-                y: y_data.and_then(|v| v.get(i)).map(|v| v.1).unwrap_or(0.0),
-                z: z_data.and_then(|v| v.get(i)).map(|v| v.1).unwrap_or(0.0),
-                vx: vx_data.and_then(|v| v.get(i)).map(|v| v.1).unwrap_or(0.0),
-                vy: vy_data.and_then(|v| v.get(i)).map(|v| v.1).unwrap_or(0.0),
-                vz: vz_data.and_then(|v| v.get(i)).map(|v| v.1).unwrap_or(0.0),
+                t: key.t_secs(),
+                x,
+                y,
+                z,
+                vx,
+                vy,
+                vz,
                 entity_path: Some(base.clone()),
                 quaternion,
                 angular_velocity,
@@ -694,7 +812,9 @@ fn to_rerun_path(path: &EntityPath) -> String {
 mod tests {
     use super::*;
     use crate::record::archetypes::OrbitalState;
-    use crate::record::components::{BodyRadius, GravitationalParameter};
+    use crate::record::components::{
+        BodyRadius, GravitationalParameter, Position3D, Quaternion4D, Velocity3D,
+    };
     use crate::record::timeline::TimePoint;
     use nalgebra::Vector3;
 
@@ -1094,5 +1214,170 @@ mod tests {
         assert!(metadata.len() > 0);
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    /// Write an .rrd with `write`, then load it back.
+    ///
+    /// Writes through `re_sdk` directly rather than through [`save_as_rrd`],
+    /// because that is the only way to put a sparse column in the file:
+    /// `ComponentColumn` carries no timeline row, so `save_as_rrd` writes a
+    /// component that is present at only some steps at the wrong times. What
+    /// is under test here is the loader, so the file it reads has to be right.
+    ///
+    /// The recording lives in a directory of its own, removed when the call
+    /// returns, so tests running in parallel cannot meet on one path.
+    fn load_written(write: impl FnOnce(&re_sdk::RecordingStream)) -> Vec<RrdRow> {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_rrd_load_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("test.rrd");
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-loader-test")
+                .save(&path)
+                .expect("recording stream");
+            write(&rec);
+            rec.flush_blocking().expect("flush");
+        }
+        let rows = load_from_rrd(path.to_str().unwrap()).expect("failed to load .rrd");
+        std::fs::remove_dir_all(&dir).ok();
+        rows
+    }
+
+    /// Log one scalar per named field at the stream's current time.
+    fn log_fields(rec: &re_sdk::RecordingStream, fields: &[(&str, f64)]) {
+        for (field, value) in fields {
+            rec.log(
+                format!("/world/sat/loader/{field}"),
+                &re_sdk_types::archetypes::Scalars::new([*value]),
+            )
+            .expect("log scalar");
+        }
+    }
+
+    /// A column present at only some of the times does not shift its values
+    /// onto earlier rows.
+    ///
+    /// The loader read every column at the position `x` happened to be at, so a
+    /// `y` present only at t=10 landed on the t=0 row and t=10 read `y = 0.0`.
+    /// Reached through `orts convert` and `orts replay` on a recording written
+    /// elsewhere, and through any column this repository later logs
+    /// conditionally.
+    #[test]
+    fn a_sparse_column_stays_on_its_own_time() {
+        let rows = load_written(|rec| {
+            for (t, fields) in [
+                (0.0f64, vec![("x", 100.0f64), ("z", 0.0)]),
+                (10.0, vec![("x", 110.0), ("y", 201.0), ("z", 0.0)]),
+            ] {
+                rec.set_duration_secs("sim_time", t);
+                log_fields(rec, &fields);
+            }
+        });
+
+        // The t=0 row has no `y`, so it is not a position and is dropped. The
+        // t=10 row is the one that carries 201.0.
+        assert_eq!(rows.len(), 1, "expected only the complete row: {rows:?}");
+        assert!((rows[0].t - 10.0).abs() < 1e-9, "t = {}", rows[0].t);
+        assert!((rows[0].y - 201.0).abs() < 1e-9, "y = {}", rows[0].y);
+    }
+
+    /// Distinct values per time arrive on their own rows.
+    ///
+    /// The round-trip test above writes the same state five times, so an
+    /// index-based join passes it. Every value here differs, so a shifted
+    /// column shows up as a wrong number.
+    #[test]
+    fn every_time_keeps_its_own_values() {
+        let rows = load_written(|rec| {
+            for i in 0..4u64 {
+                let t = i as f64 * 10.0;
+                rec.set_duration_secs("sim_time", t);
+                log_fields(
+                    rec,
+                    &[
+                        ("x", 1000.0 + t),
+                        ("y", 2000.0 + t),
+                        ("z", 3000.0 + t),
+                        ("vx", 1.0 + t / 100.0),
+                        ("vy", 2.0 + t / 100.0),
+                        ("vz", 3.0 + t / 100.0),
+                    ],
+                );
+            }
+        });
+
+        assert_eq!(rows.len(), 4, "expected 4 rows, got {}", rows.len());
+        for (i, row) in rows.iter().enumerate() {
+            let t = i as f64 * 10.0;
+            assert!((row.t - t).abs() < 1e-9, "row {i} at t={}", row.t);
+            assert!((row.x - (1000.0 + t)).abs() < 1e-9, "x at t={t}: {}", row.x);
+            assert!((row.y - (2000.0 + t)).abs() < 1e-9, "y at t={t}: {}", row.y);
+            assert!((row.z - (3000.0 + t)).abs() < 1e-9, "z at t={t}: {}", row.z);
+            assert!(
+                (row.vx - (1.0 + t / 100.0)).abs() < 1e-9,
+                "vx at t={t}: {}",
+                row.vx
+            );
+            assert!(
+                (row.vy - (2.0 + t / 100.0)).abs() < 1e-9,
+                "vy at t={t}: {}",
+                row.vy
+            );
+            assert!(
+                (row.vz - (3.0 + t / 100.0)).abs() < 1e-9,
+                "vz at t={t}: {}",
+                row.vz
+            );
+        }
+    }
+
+    /// Attitude present from the second time on does not attach to the first
+    /// row.
+    #[test]
+    fn attitude_logged_late_does_not_attach_to_the_first_row() {
+        let rows = load_written(|rec| {
+            for i in 0..3u64 {
+                let t = i as f64 * 10.0;
+                rec.set_duration_secs("sim_time", t);
+                let mut fields = vec![
+                    ("x", 7000.0 + t),
+                    ("y", 0.0),
+                    ("z", 0.0),
+                    ("vx", 0.0),
+                    ("vy", 7.5),
+                    ("vz", 0.0),
+                ];
+                if i > 0 {
+                    // A quaternion distinguishable per time.
+                    fields.extend([
+                        ("qw", 1.0),
+                        ("qx", 0.1 * i as f64),
+                        ("qy", 0.0),
+                        ("qz", 0.0),
+                    ]);
+                }
+                log_fields(rec, &fields);
+            }
+        });
+
+        let first = rows
+            .iter()
+            .find(|r| r.t < 5.0)
+            .expect("the t=0 row is a complete state vector");
+        assert!(
+            first.quaternion.is_none(),
+            "a later quaternion landed on the t=0 row: {:?}",
+            first.quaternion
+        );
+
+        let second = rows
+            .iter()
+            .find(|r| (r.t - 10.0).abs() < 1e-9)
+            .expect("the t=10 row is present");
+        let q = second.quaternion.expect("t=10 logged a quaternion");
+        assert!((q[1] - 0.1).abs() < 1e-9, "t=10 quaternion: {q:?}");
     }
 }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -241,10 +241,31 @@ impl RowKey {
 /// One decoded scalar field: its value at each time index of the recording.
 type Column = BTreeMap<RowKey, f64>;
 
-/// How many values `column` already holds at one time index. `key` builds the
-/// key for the n-th repeat at that time, so the count is the next free slot.
-fn repeats(column: &Column, key: impl Fn(u32) -> RowKey) -> u32 {
-    column.range(key(0)..=key(u32::MAX)).count() as u32
+/// The non-repeat part of a [`RowKey::Timed`]: one moment on the recording's
+/// timelines.
+type TimeKey = (Option<i64>, Option<i64>);
+
+/// Next repeat ordinal to assign, per column and moment.
+///
+/// A counter rather than a scan of the column: counting the existing repeats on
+/// every value made decoding quadratic in the length of a recording, even one
+/// with no repeats at all.
+type RepeatCounters = BTreeMap<String, BTreeMap<TimeKey, u32>>;
+
+/// How many values `column` holds at `time`, over every repeat.
+fn repeats_at(column: &Column, time: TimeKey) -> usize {
+    let (time_ns, step) = time;
+    let lo = RowKey::Timed {
+        time_ns,
+        step,
+        repeat: 0,
+    };
+    let hi = RowKey::Timed {
+        time_ns,
+        step,
+        repeat: u32::MAX,
+    };
+    column.range(lo..=hi).count()
 }
 
 /// Time index of every row in one chunk, per timeline the chunk carries.
@@ -303,6 +324,7 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
 
     // Collect f64 scalars: entity_path -> (time index -> value)
     let mut scalars: BTreeMap<String, Column> = BTreeMap::new();
+    let mut repeat_counters: RepeatCounters = BTreeMap::new();
     // Collect metadata scalars: entity_path -> f64 (static/timeless)
     let mut meta_scalars: BTreeMap<String, f64> = BTreeMap::new();
     // Collect text metadata
@@ -380,14 +402,17 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
                     };
                     // A batch usually holds one value per row, but `Scalars`
                     // takes a slice: several values at one time index become
-                    // consecutive repeats rather than being dropped.
-                    let mut next_repeat = timed.map_or(0, |(time_ns, step)| {
-                        repeats(column, |repeat| RowKey::Timed {
-                            time_ns,
-                            step,
-                            repeat,
-                        })
+                    // consecutive repeats rather than being dropped. The
+                    // ordinal comes from a counter, so a long recording does
+                    // not pay a scan of the column per value.
+                    let counter = timed.map(|time| {
+                        repeat_counters
+                            .entry(entity_path.clone())
+                            .or_default()
+                            .entry(time)
+                            .or_insert(0)
                     });
+                    let mut next_repeat = counter.as_ref().map_or(0, |c| **c);
                     for value in scalar_vec.iter() {
                         let key = match timed {
                             Some((time_ns, step)) => {
@@ -402,6 +427,9 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
                             None => RowKey::Index(column.len()),
                         };
                         column.insert(key, value.0.0);
+                    }
+                    if let Some(counter) = counter {
+                        *counter = next_repeat;
                     }
                 }
             }
@@ -453,7 +481,30 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
         // be a state vector.
         let has_velocity = vel_cols.0.is_some() || vel_cols.1.is_some() || vel_cols.2.is_some();
 
+        // Repeat ordinals are assigned per column, so they only identify a row
+        // while every required column has the same number of values at that
+        // moment. Where the counts disagree, which value pairs with which is
+        // unknowable from the file: the moment is skipped rather than joined on
+        // an ordinal that means different things in different columns.
+        let required: Vec<&Column> = [Some(x_col), pos_cols.1, pos_cols.2]
+            .into_iter()
+            .chain(if has_velocity {
+                [vel_cols.0, vel_cols.1, vel_cols.2]
+            } else {
+                [None, None, None]
+            })
+            .flatten()
+            .collect();
+
         for &key in x_col.keys() {
+            if let RowKey::Timed { time_ns, step, .. } = key {
+                let time = (time_ns, step);
+                let counts: Vec<usize> = required.iter().map(|c| repeats_at(c, time)).collect();
+                if counts.iter().any(|&n| n != counts[0]) {
+                    continue;
+                }
+            }
+
             let triple = |cols: (Option<&Column>, Option<&Column>, Option<&Column>)| {
                 Some([at(cols.0, key)?, at(cols.1, key)?, at(cols.2, key)?])
             };
@@ -1379,5 +1430,44 @@ mod tests {
             .expect("the t=10 row is present");
         let q = second.quaternion.expect("t=10 logged a quaternion");
         assert!((q[1] - 0.1).abs() < 1e-9, "t=10 quaternion: {q:?}");
+    }
+
+    /// A moment whose columns hold different numbers of values yields no row.
+    ///
+    /// Repeat ordinals are assigned per column, so they identify a row only
+    /// while every required column has the same count at that moment. With two
+    /// samples at t=0 where the first omits `y`, joining on the ordinal paired
+    /// the first `x` with the second sample's `y` — the same shift this join set
+    /// out to remove, one level in.
+    #[test]
+    fn a_time_whose_columns_disagree_on_repeats_yields_no_row() {
+        let rows = load_written(|rec| {
+            rec.set_duration_secs("sim_time", 0.0);
+            log_fields(rec, &[("x", 100.0), ("z", 0.0)]);
+            log_fields(rec, &[("x", 110.0), ("y", 201.0), ("z", 0.0)]);
+        });
+        assert!(
+            rows.is_empty(),
+            "ordinals cannot pair these values; expected no rows, got {rows:?}"
+        );
+    }
+
+    /// A recording with no timeline at all still decodes, keyed by position.
+    ///
+    /// Nothing `orts` writes lands here — every recording it produces carries
+    /// `sim_time`, `step` or both — but a file read through `orts convert` can,
+    /// and the fallback has to stay reachable.
+    #[test]
+    fn a_recording_with_no_timeline_falls_back_to_column_order() {
+        let rows = load_written(|rec| {
+            log_fields(rec, &[("x", 100.0), ("y", 200.0), ("z", 300.0)]);
+            log_fields(rec, &[("x", 110.0), ("y", 210.0), ("z", 310.0)]);
+        });
+        assert_eq!(rows.len(), 2, "{rows:?}");
+        for row in &rows {
+            assert_eq!(row.t, 0.0, "an untimed row reports t = 0");
+        }
+        assert_eq!(rows[0].x, 100.0);
+        assert_eq!(rows[1].x, 110.0);
     }
 }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -381,10 +381,30 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
                 .find(|(name, _)| name.as_str() == wanted)
                 .map(|(_, col)| col.times_raw().to_vec())
         };
-        let keys = ChunkKeys {
-            sim_time: timeline("sim_time"),
-            step: timeline("step"),
-        };
+        let sim_time = timeline("sim_time");
+        let step = timeline("step").or_else(|| {
+            // A recording written by another tool names its own timeline, and
+            // that timeline is what says which values belong together; joining
+            // such a file on column position is the mix this decode exists to
+            // avoid. `log_time` and `log_tick`, which rerun adds to every log
+            // call, say when a value was logged rather than when it happened,
+            // so two fields of one state carry different ones and cannot pair.
+            if sim_time.is_some() {
+                return None;
+            }
+            let mut named: Vec<_> = chunk
+                .timelines()
+                .iter()
+                .filter(|(name, _)| {
+                    !matches!(name.as_str(), "sim_time" | "step" | "log_time" | "log_tick")
+                })
+                .collect();
+            // The timelines arrive as a set, so choose by name to stay
+            // reproducible from run to run.
+            named.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+            named.first().map(|(_, col)| col.times_raw().to_vec())
+        });
+        let keys = ChunkKeys { sim_time, step };
 
         for comp_id in chunk.components_identifiers() {
             let comp_name = comp_id.as_str();
@@ -666,10 +686,30 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
                 .find(|(name, _)| name.as_str() == wanted)
                 .map(|(_, col)| col.times_raw().to_vec())
         };
-        let keys = ChunkKeys {
-            sim_time: timeline("sim_time"),
-            step: timeline("step"),
-        };
+        let sim_time = timeline("sim_time");
+        let step = timeline("step").or_else(|| {
+            // A recording written by another tool names its own timeline, and
+            // that timeline is what says which values belong together; joining
+            // such a file on column position is the mix this decode exists to
+            // avoid. `log_time` and `log_tick`, which rerun adds to every log
+            // call, say when a value was logged rather than when it happened,
+            // so two fields of one state carry different ones and cannot pair.
+            if sim_time.is_some() {
+                return None;
+            }
+            let mut named: Vec<_> = chunk
+                .timelines()
+                .iter()
+                .filter(|(name, _)| {
+                    !matches!(name.as_str(), "sim_time" | "step" | "log_time" | "log_tick")
+                })
+                .collect();
+            // The timelines arrive as a set, so choose by name to stay
+            // reproducible from run to run.
+            named.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+            named.first().map(|(_, col)| col.times_raw().to_vec())
+        });
+        let keys = ChunkKeys { sim_time, step };
 
         for comp_id in chunk.components_identifiers() {
             let comp_name = comp_id.as_str();
@@ -890,6 +930,13 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
             });
             keys
         };
+        // TODO: the keys also carry the step a row sits on, and only `SimTime`
+        // is filled from them, so a recording indexed by `step` alone comes back
+        // with every row at 0 s and its step timeline gone. Writing the steps
+        // under `TimelineName::Step` needs the name the recording used, which
+        // `RowKey` does not keep, and `Recording`'s CSV path reads `SimTime`
+        // only. Left as it stands on main until the step round-trip is settled
+        // with the writer.
         let entity_times: Vec<TimeIndex> = row_keys
             .iter()
             .map(|k| TimeIndex::Seconds(k.t_secs()))
@@ -1978,6 +2025,60 @@ mod tests {
                 .keys()
                 .any(|name| name.contains("Quaternion4D")),
             "an attitude present at only one of the two times is not reported"
+        );
+    }
+
+    /// A recording indexed by a timeline of its own naming still joins on time.
+    ///
+    /// `sim_time` and `step` are the names `orts` writes; another tool names its
+    /// own, and treating that as no timeline at all fell back to column
+    /// position. Measured with `y` recorded at frame 2 alone: `Position3D` came
+    /// back as `[100.0, 201.0, 0.0]`, the frame-1 `x` beside the frame-2 `y`.
+    #[test]
+    fn a_recording_on_its_own_named_timeline_joins_on_it() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_ctl_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("named.rrd");
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-named-timeline-test")
+                .save(&path)
+                .expect("recording stream");
+            for (frame, fields) in [
+                (1i64, vec![("x", 100.0f64), ("z", 0.0)]),
+                (2, vec![("x", 110.0), ("y", 201.0), ("z", 0.0)]),
+            ] {
+                rec.set_time_sequence("frame", frame);
+                for (field, value) in fields {
+                    rec.log(
+                        format!("/world/sat/named/{field}"),
+                        &re_sdk_types::archetypes::Scalars::new([value]),
+                    )
+                    .expect("log");
+                }
+            }
+            rec.flush_blocking().expect("flush");
+        }
+
+        let loaded = load_as_recording(path.to_str().unwrap()).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        let entity = EntityPath::parse("/world/sat/named");
+        let store = loaded.entity(&entity).expect("entity");
+        let position = store
+            .columns
+            .iter()
+            .find(|(name, _)| name.contains("Position3D"))
+            .map(|(_, c)| c)
+            .expect("a position column");
+        assert_eq!(store.num_rows, 1, "only frame 2 has a whole position");
+        assert_eq!(
+            position.get_row(0).expect("the one row"),
+            &[110.0, 201.0, 0.0],
+            "the row must be one frame's values, not a mix"
         );
     }
 }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -568,7 +568,14 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
 
     let mut rows: Vec<RrdRow> = Vec::new();
     for base in &base_paths {
-        let column = |field: &str| scalars.get(&format!("{base}/{field}"));
+        // A column with no values in it carries the field no further than having
+        // no column at all: an empty `Scalars` batch leaves one behind, and it
+        // would otherwise make a position-only recording look velocity-bearing.
+        let column = |field: &str| {
+            scalars
+                .get(&format!("{base}/{field}"))
+                .filter(|col| !col.is_empty())
+        };
         // Value of one field at one time index, or `None` when the recording
         // has no such column or no value there.
         let at = |col: Option<&Column>, key: RowKey| col?.get(&key).copied();
@@ -923,13 +930,11 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
         // whatever the rows are, so it gets no say in what they are. Its
         // remaining fields would otherwise narrow them: `x` and `z` recorded at
         // one time, with `y` absent from the file, cost a whole velocity its
-        // rows at every other time. An empty `Scalars` batch leaves a column
-        // behind with no values in it, which carries the field no further than
-        // having no column at all.
+        // rows at every other time.
         temporal.retain(|(_, fields)| {
-            fields.iter().all(|field| {
-                get_scalar_data(&scalars, base, field).is_some_and(|col| !col.is_empty())
-            })
+            fields
+                .iter()
+                .all(|field| get_scalar_data(&scalars, base, field).is_some())
         });
 
         // One row-key set for the whole entity. `EntityStore` keeps a single
@@ -1099,6 +1104,9 @@ const KNOWN_COMPONENTS: &[(&str, &[&str])] = &[
 ];
 
 /// Look up scalar data, trying both with and without leading slash.
+///
+/// A column with no values in it comes back as `None`: an empty `Scalars` batch
+/// leaves one behind, and it carries the field no further than having no column.
 fn get_scalar_data<'a>(
     scalars: &'a BTreeMap<String, Column>,
     base: &str,
@@ -1107,6 +1115,7 @@ fn get_scalar_data<'a>(
     scalars
         .get(&format!("{base}/{field}"))
         .or_else(|| scalars.get(&format!("/{base}/{field}")))
+        .filter(|col| !col.is_empty())
 }
 
 fn to_rerun_path(path: &EntityPath) -> String {
@@ -2655,5 +2664,56 @@ mod tests {
             .expect("a velocity column");
         assert_eq!(velocity.get_row(0).expect("row 0"), &[1.0, 2.0, 3.0]);
         assert_eq!(velocity.get_row(1).expect("row 1"), &[4.0, 2.0, 3.0]);
+    }
+
+    /// An empty velocity column leaves a position-only recording position-only.
+    ///
+    /// An empty `Scalars` batch leaves a column behind with no values in it,
+    /// which made the recording look velocity-bearing: every row then wanted a
+    /// whole velocity triple and none had one, so the positions that are there
+    /// were all dropped.
+    #[test]
+    fn an_empty_velocity_column_does_not_drop_the_positions() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_emptyvel_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("emptyvel.rrd");
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-empty-velocity-test")
+                .save(&path)
+                .expect("recording stream");
+            for (t, x) in [(0.0f64, 100.0f64), (10.0, 110.0)] {
+                rec.set_duration_secs("sim_time", t);
+                for (field, value) in [("x", x), ("y", 1.0), ("z", 2.0)] {
+                    rec.log(
+                        format!("/world/sat/emptyvel/{field}"),
+                        &re_sdk_types::archetypes::Scalars::new([value]),
+                    )
+                    .expect("log");
+                }
+                rec.log(
+                    "/world/sat/emptyvel/vx",
+                    &re_sdk_types::archetypes::Scalars::new(Vec::<f64>::new()),
+                )
+                .expect("log empty vx");
+            }
+            rec.flush_blocking().expect("flush");
+        }
+
+        let data = load_rrd_data(path.to_str().unwrap()).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(data.rows.len(), 2, "{:?}", data.rows);
+        for (row, x) in data.rows.iter().zip([100.0, 110.0]) {
+            assert_eq!((row.x, row.y, row.z), (x, 1.0, 2.0));
+            assert_eq!(
+                (row.vx, row.vy, row.vz),
+                (0.0, 0.0, 0.0),
+                "a velocity with no values reports zero, as a position-only row does"
+            );
+        }
     }
 }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -213,17 +213,16 @@ pub struct RrdData {
 /// yields rows in `step` order.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum RowKey {
-    /// A recording time index: `sim_time` \[ns\] and the `step` sequence
-    /// number, each present only when the recording has that timeline.
+    /// A recording time index: `sim_time` \[ns\], the `step` sequence number,
+    /// and the value on the recording's own named axis, each present only when
+    /// the recording carries that timeline. Held in separate slots, so a
+    /// `frame` of 1 is never the `step` 1 of a recording that has both.
     Timed {
         time_ns: Option<i64>,
         step: Option<i64>,
+        axis: Option<i64>,
         repeat: u32,
     },
-    /// A recording indexed by a timeline of its own naming: the value the row
-    /// sits at on that axis. Apart from `Timed` so that a `frame` of 1 is never
-    /// the `step` 1 of a recording that carries both.
-    Axis { value: i64, repeat: u32 },
     /// Neither timeline is present: fall back to the column-local index. Rows
     /// keyed this way carry no time information and all report `t = 0`.
     Index(usize),
@@ -236,7 +235,7 @@ impl RowKey {
             RowKey::Timed {
                 time_ns: Some(ns), ..
             } => ns as f64 / 1e9,
-            RowKey::Timed { time_ns: None, .. } | RowKey::Axis { .. } | RowKey::Index(_) => 0.0,
+            RowKey::Timed { time_ns: None, .. } | RowKey::Index(_) => 0.0,
         }
     }
 
@@ -244,12 +243,17 @@ impl RowKey {
     /// and comes back unchanged.
     fn at_repeat(self, repeat: u32) -> RowKey {
         match self {
-            RowKey::Timed { time_ns, step, .. } => RowKey::Timed {
+            RowKey::Timed {
                 time_ns,
                 step,
+                axis,
+                ..
+            } => RowKey::Timed {
+                time_ns,
+                step,
+                axis,
                 repeat,
             },
-            RowKey::Axis { value, .. } => RowKey::Axis { value, repeat },
             RowKey::Index(_) => self,
         }
     }
@@ -286,13 +290,6 @@ fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<Chun
     };
     let sim_time = timeline("sim_time");
     let step = timeline("step");
-    if sim_time.is_some() || step.is_some() {
-        return Some(ChunkKeys {
-            sim_time,
-            step,
-            axis: None,
-        });
-    }
 
     let mut named: Vec<_> = chunk
         .timelines()
@@ -303,36 +300,43 @@ fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<Chun
     // from run to run.
     named.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
 
-    let on = |times: Vec<i64>| {
+    // More axes than the key can hold: nothing here says which of them makes a
+    // row, and guessing is the mis-join this decode removes.
+    if named.len() > 1 {
+        return None;
+    }
+
+    let keys = |axis: Option<Vec<i64>>| {
         Some(ChunkKeys {
-            sim_time: None,
-            step: None,
-            axis: Some(times),
-        })
-    };
-    // A chunk carrying no timeline of its own either: its keys come from the
-    // column-local position, which never joins with a timed key.
-    let untimed = || {
-        Some(ChunkKeys {
-            sim_time: None,
-            step: None,
-            axis: None,
+            sim_time: sim_time.clone(),
+            step: step.clone(),
+            axis,
         })
     };
 
-    match axis {
-        None => match named.first() {
-            Some((name, col)) => {
-                *axis = Some(name.as_str().to_string());
-                on(col.times_raw().to_vec())
+    match (&axis, named.first()) {
+        // The recording's axis, settled by the first chunk to carry one.
+        (None, Some((name, col))) => {
+            let times = col.times_raw().to_vec();
+            *axis = Some(name.as_str().to_string());
+            keys(Some(times))
+        }
+        (Some(chosen), Some((name, col))) if name.as_str() == chosen.as_str() => {
+            keys(Some(col.times_raw().to_vec()))
+        }
+        // An axis that is not the recording's. A chunk that also carries
+        // `sim_time` or `step` still has a place among the rows; one that does
+        // not has nothing to place it by.
+        (Some(_), Some(_)) => {
+            if sim_time.is_some() || step.is_some() {
+                keys(None)
+            } else {
+                None
             }
-            None => untimed(),
-        },
-        Some(chosen) => match named.iter().find(|(name, _)| name.as_str() == chosen) {
-            Some((_, col)) => on(col.times_raw().to_vec()),
-            None if named.is_empty() => untimed(),
-            None => None,
-        },
+        }
+        // No axis of its own: the two names above place the row, or its
+        // column-local position does, which never joins with a timed key.
+        (_, None) => keys(None),
     }
 }
 
@@ -371,9 +375,8 @@ enum RowIndex {
     Timed {
         time_ns: Option<i64>,
         step: Option<i64>,
+        axis: Option<i64>,
     },
-    /// The row sits at this value on the recording's own named axis.
-    Axis(i64),
     /// The chunk carries no timeline; keys come from the column-local position.
     Untimed,
     /// A timeline the chunk does carry has no value for this row — skip it.
@@ -382,20 +385,18 @@ enum RowIndex {
 
 impl ChunkKeys {
     fn row(&self, row_idx: usize) -> RowIndex {
-        if let Some(axis) = &self.axis {
-            return match axis.get(row_idx) {
-                Some(&value) => RowIndex::Axis(value),
-                None => RowIndex::Missing,
-            };
-        }
         // A timeline the chunk carries must have a value for this row.
         let index = |times: &Option<Vec<i64>>| match times {
             Some(times) => times.get(row_idx).copied().map(Some).ok_or(()),
             None => Ok(None),
         };
-        match (index(&self.sim_time), index(&self.step)) {
-            (Ok(None), Ok(None)) => RowIndex::Untimed,
-            (Ok(time_ns), Ok(step)) => RowIndex::Timed { time_ns, step },
+        match (index(&self.sim_time), index(&self.step), index(&self.axis)) {
+            (Ok(None), Ok(None), Ok(None)) => RowIndex::Untimed,
+            (Ok(time_ns), Ok(step), Ok(axis)) => RowIndex::Timed {
+                time_ns,
+                step,
+                axis,
+            },
             _ => RowIndex::Missing,
         }
     }
@@ -492,12 +493,16 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
                         continue;
                     };
                     let moment = match keys.row(row_idx) {
-                        RowIndex::Timed { time_ns, step } => Some(RowKey::Timed {
+                        RowIndex::Timed {
                             time_ns,
                             step,
+                            axis,
+                        } => Some(RowKey::Timed {
+                            time_ns,
+                            step,
+                            axis,
                             repeat: 0,
                         }),
-                        RowIndex::Axis(value) => Some(RowKey::Axis { value, repeat: 0 }),
                         RowIndex::Untimed => None,
                         RowIndex::Missing => continue,
                     };
@@ -774,12 +779,16 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
                         continue;
                     };
                     let moment = match keys.row(row_idx) {
-                        RowIndex::Timed { time_ns, step } => Some(RowKey::Timed {
+                        RowIndex::Timed {
                             time_ns,
                             step,
+                            axis,
+                        } => Some(RowKey::Timed {
+                            time_ns,
+                            step,
+                            axis,
                             repeat: 0,
                         }),
-                        RowIndex::Axis(value) => Some(RowKey::Axis { value, repeat: 0 }),
                         RowIndex::Untimed => None,
                         RowIndex::Missing => continue,
                     };
@@ -2457,5 +2466,67 @@ mod tests {
             .expect("a velocity column");
         assert_eq!(velocity.get_row(0).expect("row 0"), &[1.0, 2.0, 3.0]);
         assert_eq!(velocity.get_row(1).expect("row 1"), &[4.0, 5.0, 6.0]);
+    }
+
+    /// An axis beside `sim_time` is part of what identifies a row.
+    ///
+    /// A chunk carrying `sim_time` had its other axis dropped from the key, so
+    /// rows sharing a `sim_time` but sitting at different `frame`s became
+    /// repeats of one moment and paired by arrival order. Measured with `x` at
+    /// frames 1 and 2 and `y`/`z` at frames 2 and 3, all at t=0:
+    /// `Position3D` came back as `[100.0, 201.0, 201.0]`, the frame-1 `x`
+    /// beside the frame-2 `y`. Only frame 2 is whole, so it is the one row.
+    #[test]
+    fn an_axis_beside_sim_time_identifies_the_row() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_xaxis_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("extra.rrd");
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-extra-axis-test")
+                .save(&path)
+                .expect("recording stream");
+            rec.set_duration_secs("sim_time", 0.0);
+            for (frame, x) in [(1i64, 100.0f64), (2, 110.0)] {
+                rec.set_time_sequence("frame", frame);
+                rec.log(
+                    "/world/sat/extra/x",
+                    &re_sdk_types::archetypes::Scalars::new([x]),
+                )
+                .expect("log x");
+            }
+            for (frame, v) in [(2i64, 201.0f64), (3, 202.0)] {
+                rec.set_time_sequence("frame", frame);
+                for field in ["y", "z"] {
+                    rec.log(
+                        format!("/world/sat/extra/{field}"),
+                        &re_sdk_types::archetypes::Scalars::new([v]),
+                    )
+                    .expect("log");
+                }
+            }
+            rec.flush_blocking().expect("flush");
+        }
+
+        let loaded = load_as_recording(path.to_str().unwrap()).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        let entity = EntityPath::parse("/world/sat/extra");
+        let store = loaded.entity(&entity).expect("entity");
+        let position = store
+            .columns
+            .iter()
+            .find(|(name, _)| name.contains("Position3D"))
+            .map(|(_, c)| c)
+            .expect("a position column");
+        assert_eq!(store.num_rows, 1, "frame 2 is the only whole position");
+        assert_eq!(
+            position.get_row(0).expect("the one row"),
+            &[110.0, 201.0, 201.0],
+            "every axis of the row must be frame 2's"
+        );
     }
 }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -220,6 +220,10 @@ enum RowKey {
         step: Option<i64>,
         repeat: u32,
     },
+    /// A recording indexed by a timeline of its own naming: the value the row
+    /// sits at on that axis. Apart from `Timed` so that a `frame` of 1 is never
+    /// the `step` 1 of a recording that carries both.
+    Axis { value: i64, repeat: u32 },
     /// Neither timeline is present: fall back to the column-local index. Rows
     /// keyed this way carry no time information and all report `t = 0`.
     Index(usize),
@@ -232,7 +236,29 @@ impl RowKey {
             RowKey::Timed {
                 time_ns: Some(ns), ..
             } => ns as f64 / 1e9,
-            RowKey::Timed { time_ns: None, .. } | RowKey::Index(_) => 0.0,
+            RowKey::Timed { time_ns: None, .. } | RowKey::Axis { .. } | RowKey::Index(_) => 0.0,
+        }
+    }
+
+    /// This key with its repeat number replaced. An `Index` key carries none
+    /// and comes back unchanged.
+    fn at_repeat(self, repeat: u32) -> RowKey {
+        match self {
+            RowKey::Timed { time_ns, step, .. } => RowKey::Timed {
+                time_ns,
+                step,
+                repeat,
+            },
+            RowKey::Axis { value, .. } => RowKey::Axis { value, repeat },
+            RowKey::Index(_) => self,
+        }
+    }
+
+    /// The moment this key sits on, or `None` for a key that carries no time.
+    fn moment(self) -> Option<Moment> {
+        match self {
+            RowKey::Index(_) => None,
+            _ => Some(self.at_repeat(0)),
         }
     }
 }
@@ -261,7 +287,11 @@ fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<Chun
     let sim_time = timeline("sim_time");
     let step = timeline("step");
     if sim_time.is_some() || step.is_some() {
-        return Some(ChunkKeys { sim_time, step });
+        return Some(ChunkKeys {
+            sim_time,
+            step,
+            axis: None,
+        });
     }
 
     let mut named: Vec<_> = chunk
@@ -276,7 +306,8 @@ fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<Chun
     let on = |times: Vec<i64>| {
         Some(ChunkKeys {
             sim_time: None,
-            step: Some(times),
+            step: None,
+            axis: Some(times),
         })
     };
     // A chunk carrying no timeline of its own either: its keys come from the
@@ -285,6 +316,7 @@ fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<Chun
         Some(ChunkKeys {
             sim_time: None,
             step: None,
+            axis: None,
         })
     };
 
@@ -309,35 +341,29 @@ type Column = BTreeMap<RowKey, f64>;
 
 /// The non-repeat part of a [`RowKey::Timed`]: one moment on the recording's
 /// timelines.
-type TimeKey = (Option<i64>, Option<i64>);
+/// One moment of a recording: a [`RowKey`] with its repeat number cleared, so
+/// that every value logged at that moment ranges within it.
+type Moment = RowKey;
 
 /// Next repeat ordinal to assign, per column and moment.
 ///
 /// A counter rather than a scan of the column: counting the existing repeats on
 /// every value made decoding quadratic in the length of a recording, even one
 /// with no repeats at all.
-type RepeatCounters = BTreeMap<String, BTreeMap<TimeKey, u32>>;
+type RepeatCounters = BTreeMap<String, BTreeMap<Moment, u32>>;
 
-/// How many values `column` holds at `time`, over every repeat.
-fn repeats_at(column: &Column, time: TimeKey) -> usize {
-    let (time_ns, step) = time;
-    let lo = RowKey::Timed {
-        time_ns,
-        step,
-        repeat: 0,
-    };
-    let hi = RowKey::Timed {
-        time_ns,
-        step,
-        repeat: u32::MAX,
-    };
-    column.range(lo..=hi).count()
+/// How many values `column` holds at `moment`, over every repeat.
+fn repeats_at(column: &Column, moment: Moment) -> usize {
+    column.range(moment..=moment.at_repeat(u32::MAX)).count()
 }
 
 /// Time index of every row in one chunk, per timeline the chunk carries.
 struct ChunkKeys {
     sim_time: Option<Vec<i64>>,
     step: Option<Vec<i64>>,
+    /// The recording's own named axis, carried only by a chunk that has
+    /// neither of the two above.
+    axis: Option<Vec<i64>>,
 }
 
 /// Where one chunk row sits on the recording's timelines.
@@ -348,6 +374,8 @@ enum RowIndex {
         time_ns: Option<i64>,
         step: Option<i64>,
     },
+    /// The row sits at this value on the recording's own named axis.
+    Axis(i64),
     /// The chunk carries no timeline; keys come from the column-local position.
     Untimed,
     /// A timeline the chunk does carry has no value for this row — skip it.
@@ -356,6 +384,12 @@ enum RowIndex {
 
 impl ChunkKeys {
     fn row(&self, row_idx: usize) -> RowIndex {
+        if let Some(axis) = &self.axis {
+            return match axis.get(row_idx) {
+                Some(&value) => RowIndex::Axis(value),
+                None => RowIndex::Missing,
+            };
+        }
         // A timeline the chunk carries must have a value for this row.
         let index = |times: &Option<Vec<i64>>| match times {
             Some(times) => times.get(row_idx).copied().map(Some).ok_or(()),
@@ -459,8 +493,13 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
                     let Some(Ok(scalar_vec)) = batch else {
                         continue;
                     };
-                    let timed = match keys.row(row_idx) {
-                        RowIndex::Timed { time_ns, step } => Some((time_ns, step)),
+                    let moment = match keys.row(row_idx) {
+                        RowIndex::Timed { time_ns, step } => Some(RowKey::Timed {
+                            time_ns,
+                            step,
+                            repeat: 0,
+                        }),
+                        RowIndex::Axis(value) => Some(RowKey::Axis { value, repeat: 0 }),
                         RowIndex::Untimed => None,
                         RowIndex::Missing => continue,
                     };
@@ -469,22 +508,18 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
                     // consecutive repeats rather than being dropped. The
                     // ordinal comes from a counter, so a long recording does
                     // not pay a scan of the column per value.
-                    let counter = timed.map(|time| {
+                    let counter = moment.map(|moment| {
                         repeat_counters
                             .entry(entity_path.clone())
                             .or_default()
-                            .entry(time)
+                            .entry(moment)
                             .or_insert(0)
                     });
                     let mut next_repeat = counter.as_ref().map_or(0, |c| **c);
                     for value in scalar_vec.iter() {
-                        let key = match timed {
-                            Some((time_ns, step)) => {
-                                let key = RowKey::Timed {
-                                    time_ns,
-                                    step,
-                                    repeat: next_repeat,
-                                };
+                        let key = match moment {
+                            Some(moment) => {
+                                let key = moment.at_repeat(next_repeat);
                                 next_repeat += 1;
                                 key
                             }
@@ -575,14 +610,13 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
         // Counted once per moment, not once per repeat: a `Scalars` batch puts
         // k values at one timestamp, and re-counting for each of them would
         // make reconstruction quadratic in k.
-        let mut ambiguous: BTreeSet<TimeKey> = BTreeSet::new();
-        let mut checked: BTreeSet<TimeKey> = BTreeSet::new();
+        let mut ambiguous: BTreeSet<Moment> = BTreeSet::new();
+        let mut checked: BTreeSet<Moment> = BTreeSet::new();
         for &key in x_col.keys() {
-            let RowKey::Timed { time_ns, step, .. } = key else {
+            let Some(moment) = key.moment() else {
                 continue;
             };
-            let time = (time_ns, step);
-            if !checked.insert(time) {
+            if !checked.insert(moment) {
                 continue;
             }
             // Every column that has values at this moment must have the same
@@ -593,17 +627,18 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
             // two is just as unpairable as the other way round.
             let counts: Vec<usize> = present
                 .iter()
-                .map(|c| repeats_at(c, time))
+                .map(|c| repeats_at(c, moment))
                 .filter(|&n| n != 0)
                 .collect();
             if counts.iter().any(|&n| n != counts[0]) {
-                ambiguous.insert(time);
+                ambiguous.insert(moment);
             }
         }
 
         for &key in x_col.keys() {
-            if let RowKey::Timed { time_ns, step, .. } = key
-                && ambiguous.contains(&(time_ns, step))
+            if key
+                .moment()
+                .is_some_and(|moment| ambiguous.contains(&moment))
             {
                 continue;
             }
@@ -740,27 +775,28 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
                     let Some(Ok(scalar_vec)) = batch else {
                         continue;
                     };
-                    let timed = match keys.row(row_idx) {
-                        RowIndex::Timed { time_ns, step } => Some((time_ns, step)),
+                    let moment = match keys.row(row_idx) {
+                        RowIndex::Timed { time_ns, step } => Some(RowKey::Timed {
+                            time_ns,
+                            step,
+                            repeat: 0,
+                        }),
+                        RowIndex::Axis(value) => Some(RowKey::Axis { value, repeat: 0 }),
                         RowIndex::Untimed => None,
                         RowIndex::Missing => continue,
                     };
-                    let counter = timed.map(|time| {
+                    let counter = moment.map(|moment| {
                         repeat_counters
                             .entry(entity_path.clone())
                             .or_default()
-                            .entry(time)
+                            .entry(moment)
                             .or_insert(0)
                     });
                     let mut next_repeat = counter.as_ref().map_or(0, |c| **c);
                     for value in scalar_vec.iter() {
-                        let key = match timed {
-                            Some((time_ns, step)) => {
-                                let key = RowKey::Timed {
-                                    time_ns,
-                                    step,
-                                    repeat: next_repeat,
-                                };
+                        let key = match moment {
+                            Some(moment) => {
+                                let key = moment.at_repeat(next_repeat);
                                 next_repeat += 1;
                                 key
                             }
@@ -918,26 +954,25 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
             // numbers are per field, so with two samples at one time of which
             // the first omits `y`, repeat 0 would pair the first sample's `x`
             // with the second's `y`, the cross-sample mix this join removes.
-            let mut ambiguous: BTreeSet<TimeKey> = BTreeSet::new();
-            let mut checked: BTreeSet<TimeKey> = BTreeSet::new();
+            let mut ambiguous: BTreeSet<Moment> = BTreeSet::new();
+            let mut checked: BTreeSet<Moment> = BTreeSet::new();
             for col in &all_columns {
                 for &key in col.keys() {
-                    let RowKey::Timed { time_ns, step, .. } = key else {
+                    let Some(moment) = key.moment() else {
                         continue;
                     };
-                    let time = (time_ns, step);
                     // Counting once per moment: per repeat it would be
                     // quadratic in the size of a multi-value batch.
-                    if !checked.insert(time) {
+                    if !checked.insert(moment) {
                         continue;
                     }
                     let counts: Vec<usize> = all_columns
                         .iter()
-                        .map(|c| repeats_at(c, time))
+                        .map(|c| repeats_at(c, moment))
                         .filter(|&n| n != 0)
                         .collect();
                     if counts.iter().any(|&n| n != counts[0]) {
-                        ambiguous.insert(time);
+                        ambiguous.insert(moment);
                     }
                 }
             }
@@ -950,19 +985,19 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
                     .collect(),
                 None => Vec::new(),
             };
-            keys.retain(|key| match key {
-                RowKey::Timed { time_ns, step, .. } => !ambiguous.contains(&(*time_ns, *step)),
-                RowKey::Index(_) => true,
+            keys.retain(|key| {
+                !key.moment()
+                    .is_some_and(|moment| ambiguous.contains(&moment))
             });
             keys
         };
-        // TODO: the keys also carry the step a row sits on, and only `SimTime`
-        // is filled from them, so a recording indexed by `step` alone comes back
-        // with every row at 0 s and its step timeline gone. Writing the steps
-        // under `TimelineName::Step` needs the name the recording used, which
-        // `RowKey` does not keep, and `Recording`'s CSV path reads `SimTime`
-        // only. Left as it stands on main until the step round-trip is settled
-        // with the writer.
+        // TODO: the keys also carry the step, or the named axis, a row sits on,
+        // and only `SimTime` is filled from them. So a recording indexed by
+        // `step` alone comes back with every row at 0 s and its step timeline
+        // gone, and one on an axis of its own loses that axis. `Recording`'s
+        // CSV path reads `SimTime` only, so filling the others changes what
+        // `orts convert` reports. Left as it stands on main until the step
+        // round-trip is settled with the writer.
         let entity_times: Vec<TimeIndex> = row_keys
             .iter()
             .map(|k| TimeIndex::Seconds(k.t_secs()))
@@ -2282,6 +2317,54 @@ mod tests {
         assert_eq!(
             rows, 0,
             "two states beside three attitudes cannot be paired, so neither is reported"
+        );
+    }
+
+    /// A named axis is never a step of the same value.
+    ///
+    /// The fallback put the axis value in the same slot as a real `step`, so a
+    /// `frame` of 1 and a `step` of 1 became one key. Measured with `x` and `z`
+    /// at `step = 1` and `y` at `frame = 1`: `Position3D` came back as
+    /// `[100.0, 999.0, 300.0]`, a position assembled across the two.
+    #[test]
+    fn a_named_axis_is_not_a_step_of_the_same_value() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_coll_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("collide.rrd");
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-axis-step-test")
+                .save(&path)
+                .expect("recording stream");
+            rec.set_time_sequence("step", 1i64);
+            for (field, value) in [("x", 100.0f64), ("z", 300.0)] {
+                rec.log(
+                    format!("/world/sat/coll/{field}"),
+                    &re_sdk_types::archetypes::Scalars::new([value]),
+                )
+                .expect("log");
+            }
+            rec.disable_timeline("step");
+            rec.set_time_sequence("frame", 1i64);
+            rec.log(
+                "/world/sat/coll/y",
+                &re_sdk_types::archetypes::Scalars::new([999.0f64]),
+            )
+            .expect("log");
+            rec.flush_blocking().expect("flush");
+        }
+
+        let loaded = load_as_recording(path.to_str().unwrap()).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        let entity = EntityPath::parse("/world/sat/coll");
+        let rows = loaded.entity(&entity).map_or(0, |store| store.num_rows);
+        assert_eq!(
+            rows, 0,
+            "neither the step nor the frame carries a whole position"
         );
     }
 }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -776,11 +776,51 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
         // The keys come from the union of every field's own keys, so a moment
         // any field records is a row. A component absent at that moment gets
         // zeros in that row, which is what `ComponentColumn` can express.
+        //
+        // A moment whose fields disagree on how many values they recorded is
+        // left out entirely, as in the other two decoders: the repeat numbers
+        // are per field, so with two samples at one time of which the first
+        // omits `y`, repeat 0 would pair the first sample's `x` with the
+        // second's `y` — the cross-sample mix this join exists to remove.
         let row_keys: Vec<RowKey> = {
+            let present: Vec<&Column> = field_names
+                .iter()
+                .filter_map(|field| get_scalar_data(&scalars, base, field))
+                .collect();
+
+            let mut ambiguous: BTreeSet<TimeKey> = BTreeSet::new();
+            let mut checked: BTreeSet<TimeKey> = BTreeSet::new();
+            for col in &present {
+                for &key in col.keys() {
+                    let RowKey::Timed { time_ns, step, .. } = key else {
+                        continue;
+                    };
+                    let time = (time_ns, step);
+                    // Counting once per moment: per repeat it would be
+                    // quadratic in the size of a multi-value batch.
+                    if !checked.insert(time) {
+                        continue;
+                    }
+                    let counts: Vec<usize> = present
+                        .iter()
+                        .map(|c| repeats_at(c, time))
+                        .filter(|&n| n != 0)
+                        .collect();
+                    if counts.iter().any(|&n| n != counts[0]) {
+                        ambiguous.insert(time);
+                    }
+                }
+            }
+
             let mut keys: BTreeSet<RowKey> = BTreeSet::new();
-            for field in &field_names {
-                if let Some(col) = get_scalar_data(&scalars, base, field) {
-                    keys.extend(col.keys().copied());
+            for col in &present {
+                for &key in col.keys() {
+                    if let RowKey::Timed { time_ns, step, .. } = key
+                        && ambiguous.contains(&(time_ns, step))
+                    {
+                        continue;
+                    }
+                    keys.insert(key);
                 }
             }
             keys.into_iter().collect()
@@ -1764,5 +1804,55 @@ mod tests {
             .expect("a velocity column");
         assert_eq!(position.get_row(1).expect("row 1"), &[110.0, 201.0, 0.0]);
         assert_eq!(velocity.get_row(1).expect("row 1"), &[4.0, 5.0, 6.0]);
+    }
+
+    /// A moment whose fields disagree on repeat count yields no row.
+    ///
+    /// Repeat numbers are per field, so two samples at one time of which the
+    /// first omits `y` made repeat 0 the first sample's `x` beside the second's
+    /// `y`: measured as `Position3D = [100.0, 201.0, 0.0]`. That moment is left
+    /// out entirely, as in the other two decoders.
+    #[test]
+    fn load_as_recording_drops_a_time_whose_fields_disagree_on_repeats() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_lar_rep_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("repeats.rrd");
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-lar-repeat-test")
+                .save(&path)
+                .expect("recording stream");
+            rec.set_duration_secs("sim_time", 0.0);
+            for sample in [
+                // The first sample at t=0 omits `y`.
+                vec![("x", 100.0f64), ("z", 0.0)],
+                vec![("x", 110.0), ("y", 201.0), ("z", 0.0)],
+            ] {
+                for (field, value) in sample {
+                    rec.log(
+                        format!("/world/sat/loader/{field}"),
+                        &re_sdk_types::archetypes::Scalars::new([value]),
+                    )
+                    .expect("log");
+                }
+            }
+            rec.flush_blocking().expect("flush");
+        }
+
+        let loaded = load_as_recording(path.to_str().unwrap()).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        let entity = loaded.entity_paths().next().cloned().expect("one entity");
+        let store = loaded.entity(&entity).expect("entity");
+        assert_eq!(
+            store.num_rows, 0,
+            "the one moment is unpairable, so it yields no row"
+        );
+        for (name, col) in &store.columns {
+            assert_eq!(col.num_rows(), 0, "{name} must be empty too");
+        }
     }
 }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -237,6 +237,73 @@ impl RowKey {
     }
 }
 
+/// Where a chunk's rows sit, or `None` when nothing places them.
+///
+/// `sim_time` and `step` are the names `orts` writes. A recording from another
+/// tool names its own timeline, and reading that as no timeline at all would
+/// join its columns by position, the mix this decode replaces. One such name
+/// serves the whole recording, held in `axis`: two axes are separate
+/// dimensions, so a `frame` of 1 and an `iteration` of 1 are not one moment. A
+/// chunk indexed only by some other axis has no place among the rest and is
+/// left out.
+///
+/// `log_time` and `log_tick`, which rerun adds to every log call, say when a
+/// value was logged rather than when it happened: two fields of one state carry
+/// different ones and could never pair.
+fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<ChunkKeys> {
+    let timeline = |wanted: &str| {
+        chunk
+            .timelines()
+            .iter()
+            .find(|(name, _)| name.as_str() == wanted)
+            .map(|(_, col)| col.times_raw().to_vec())
+    };
+    let sim_time = timeline("sim_time");
+    let step = timeline("step");
+    if sim_time.is_some() || step.is_some() {
+        return Some(ChunkKeys { sim_time, step });
+    }
+
+    let mut named: Vec<_> = chunk
+        .timelines()
+        .iter()
+        .filter(|(name, _)| !matches!(name.as_str(), "sim_time" | "step" | "log_time" | "log_tick"))
+        .collect();
+    // The timelines arrive as a set, so choose by name to stay reproducible
+    // from run to run.
+    named.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+
+    let on = |times: Vec<i64>| {
+        Some(ChunkKeys {
+            sim_time: None,
+            step: Some(times),
+        })
+    };
+    // A chunk carrying no timeline of its own either: its keys come from the
+    // column-local position, which never joins with a timed key.
+    let untimed = || {
+        Some(ChunkKeys {
+            sim_time: None,
+            step: None,
+        })
+    };
+
+    match axis {
+        None => match named.first() {
+            Some((name, col)) => {
+                *axis = Some(name.as_str().to_string());
+                on(col.times_raw().to_vec())
+            }
+            None => untimed(),
+        },
+        Some(chosen) => match named.iter().find(|(name, _)| name.as_str() == chosen) {
+            Some((_, col)) => on(col.times_raw().to_vec()),
+            None if named.is_empty() => untimed(),
+            None => None,
+        },
+    }
+}
+
 /// One decoded scalar field: its value at each time index of the recording.
 type Column = BTreeMap<RowKey, f64>;
 
@@ -331,6 +398,10 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
     // Collect text metadata
     let mut meta_texts: BTreeMap<String, String> = BTreeMap::new();
 
+    // The one timeline of the recording's own naming, settled by the first
+    // chunk that carries neither `sim_time` nor `step` and kept for the rest.
+    let mut recording_axis: Option<String> = None;
+
     for msg in DecoderApp::decode_lazy(reader) {
         let msg = msg?;
         let LogMsg::ArrowMsg(_, arrow_msg) = msg else {
@@ -374,37 +445,9 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
             continue;
         }
 
-        let timeline = |wanted: &str| {
-            chunk
-                .timelines()
-                .iter()
-                .find(|(name, _)| name.as_str() == wanted)
-                .map(|(_, col)| col.times_raw().to_vec())
+        let Some(keys) = chunk_keys(&chunk, &mut recording_axis) else {
+            continue;
         };
-        let sim_time = timeline("sim_time");
-        let step = timeline("step").or_else(|| {
-            // A recording written by another tool names its own timeline, and
-            // that timeline is what says which values belong together; joining
-            // such a file on column position is the mix this decode exists to
-            // avoid. `log_time` and `log_tick`, which rerun adds to every log
-            // call, say when a value was logged rather than when it happened,
-            // so two fields of one state carry different ones and cannot pair.
-            if sim_time.is_some() {
-                return None;
-            }
-            let mut named: Vec<_> = chunk
-                .timelines()
-                .iter()
-                .filter(|(name, _)| {
-                    !matches!(name.as_str(), "sim_time" | "step" | "log_time" | "log_tick")
-                })
-                .collect();
-            // The timelines arrive as a set, so choose by name to stay
-            // reproducible from run to run.
-            named.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
-            named.first().map(|(_, col)| col.times_raw().to_vec())
-        });
-        let keys = ChunkKeys { sim_time, step };
 
         for comp_id in chunk.components_identifiers() {
             let comp_name = comp_id.as_str();
@@ -639,6 +682,10 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
     let mut meta_scalars: BTreeMap<String, f64> = BTreeMap::new();
     let mut meta_texts: BTreeMap<String, String> = BTreeMap::new();
 
+    // The one timeline of the recording's own naming, settled by the first
+    // chunk that carries neither `sim_time` nor `step` and kept for the rest.
+    let mut recording_axis: Option<String> = None;
+
     for msg in DecoderApp::decode_lazy(reader) {
         let msg = msg?;
         let LogMsg::ArrowMsg(_, arrow_msg) = msg else {
@@ -679,37 +726,9 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
             continue;
         }
 
-        let timeline = |wanted: &str| {
-            chunk
-                .timelines()
-                .iter()
-                .find(|(name, _)| name.as_str() == wanted)
-                .map(|(_, col)| col.times_raw().to_vec())
+        let Some(keys) = chunk_keys(&chunk, &mut recording_axis) else {
+            continue;
         };
-        let sim_time = timeline("sim_time");
-        let step = timeline("step").or_else(|| {
-            // A recording written by another tool names its own timeline, and
-            // that timeline is what says which values belong together; joining
-            // such a file on column position is the mix this decode exists to
-            // avoid. `log_time` and `log_tick`, which rerun adds to every log
-            // call, say when a value was logged rather than when it happened,
-            // so two fields of one state carry different ones and cannot pair.
-            if sim_time.is_some() {
-                return None;
-            }
-            let mut named: Vec<_> = chunk
-                .timelines()
-                .iter()
-                .filter(|(name, _)| {
-                    !matches!(name.as_str(), "sim_time" | "step" | "log_time" | "log_tick")
-                })
-                .collect();
-            // The timelines arrive as a set, so choose by name to stay
-            // reproducible from run to run.
-            named.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
-            named.first().map(|(_, col)| col.times_raw().to_vec())
-        });
-        let keys = ChunkKeys { sim_time, step };
 
         for comp_id in chunk.components_identifiers() {
             let comp_name = comp_id.as_str();
@@ -881,11 +900,18 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
         };
 
         let row_keys: Vec<RowKey> = {
-            let anchor_columns: Vec<&Column> = anchors
-                .iter()
-                .flat_map(|(_, fields)| fields)
-                .filter_map(|field| get_scalar_data(&scalars, base, field))
-                .collect();
+            let columns_of = |groups: &[&(String, Vec<String>)]| -> Vec<&Column> {
+                groups
+                    .iter()
+                    .flat_map(|(_, fields)| fields)
+                    .filter_map(|field| get_scalar_data(&scalars, base, field))
+                    .collect()
+            };
+            let anchor_columns = columns_of(&anchors);
+            // The rows follow the anchors, but a disagreement anywhere in the
+            // entity makes the moment unpairable: three attitudes beside two
+            // states leave no way to say which attitude is which state's.
+            let all_columns = columns_of(&temporal.iter().collect::<Vec<_>>());
 
             // A moment whose fields disagree on how many values they recorded
             // is left out entirely, as in the other two decoders: the repeat
@@ -894,7 +920,7 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
             // with the second's `y`, the cross-sample mix this join removes.
             let mut ambiguous: BTreeSet<TimeKey> = BTreeSet::new();
             let mut checked: BTreeSet<TimeKey> = BTreeSet::new();
-            for col in &anchor_columns {
+            for col in &all_columns {
                 for &key in col.keys() {
                     let RowKey::Timed { time_ns, step, .. } = key else {
                         continue;
@@ -905,7 +931,7 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
                     if !checked.insert(time) {
                         continue;
                     }
-                    let counts: Vec<usize> = anchor_columns
+                    let counts: Vec<usize> = all_columns
                         .iter()
                         .map(|c| repeats_at(c, time))
                         .filter(|&n| n != 0)
@@ -2079,6 +2105,183 @@ mod tests {
             position.get_row(0).expect("the one row"),
             &[110.0, 201.0, 0.0],
             "the row must be one frame's values, not a mix"
+        );
+    }
+
+    /// Two axes of the recording's own naming do not share a row.
+    ///
+    /// A `frame` of 1 and an `iteration` of 1 are separate dimensions, but the
+    /// fallback kept only the raw value, so both became the same key. Measured
+    /// with `x` and `z` on `frame` and `y` on `iteration`: `Position3D` came
+    /// back as `[100.0, 999.0, 300.0]`, assembled from two axes. One axis serves
+    /// the whole recording, so neither half is a whole position and the entity
+    /// gets no row.
+    #[test]
+    fn a_second_named_axis_does_not_join_with_the_first() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_axis_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("axes.rrd");
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-two-axes-test")
+                .save(&path)
+                .expect("recording stream");
+            rec.set_time_sequence("frame", 1i64);
+            for (field, value) in [("x", 100.0f64), ("z", 300.0)] {
+                rec.log(
+                    format!("/world/sat/axes/{field}"),
+                    &re_sdk_types::archetypes::Scalars::new([value]),
+                )
+                .expect("log");
+            }
+            rec.disable_timeline("frame");
+            rec.set_time_sequence("iteration", 1i64);
+            rec.log(
+                "/world/sat/axes/y",
+                &re_sdk_types::archetypes::Scalars::new([999.0f64]),
+            )
+            .expect("log");
+            rec.flush_blocking().expect("flush");
+        }
+
+        let loaded = load_as_recording(path.to_str().unwrap()).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        // With no whole position on either axis the entity has no temporal
+        // component at all, so it may be absent rather than empty.
+        let entity = EntityPath::parse("/world/sat/axes");
+        let rows = loaded.entity(&entity).map_or(0, |store| store.num_rows);
+        assert_eq!(
+            rows, 0,
+            "no axis carries a whole position, so there is no row to report"
+        );
+    }
+
+    /// A component the file never carries costs only that component.
+    ///
+    /// The row keys come from the fields the anchors actually have a column
+    /// for. With a schema declaring `Position3D(x, y, z)` over a file that
+    /// never logged `y`, the rows follow velocity alone: position is left out,
+    /// since it is never whole, and the velocity that is there keeps its own
+    /// times rather than being discarded with it.
+    ///
+    /// This is also the schema path itself, which `meta/schema/<entity>` selects
+    /// over the field-name table.
+    #[test]
+    fn a_component_the_file_never_carries_costs_only_that_component() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_anchor_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("anchor.rrd");
+        let schema = r#"[
+            {"name":"orts.Position3D","fields":["x","y","z"]},
+            {"name":"orts.Velocity3D","fields":["vx","vy","vz"]}
+        ]"#;
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-anchor-test")
+                .save(&path)
+                .expect("recording stream");
+            rec.log_static(
+                "/meta/schema/world/sat/anchored",
+                &re_sdk_types::archetypes::TextDocument::new(schema),
+            )
+            .expect("log schema");
+            for (t, x, vx) in [(0.0f64, 100.0f64, 1.0f64), (10.0, 110.0, 4.0)] {
+                rec.set_duration_secs("sim_time", t);
+                // `y` is never logged, so `Position3D` has no whole row anywhere.
+                for (field, value) in [("x", x), ("z", 0.0), ("vx", vx), ("vy", 2.0), ("vz", 3.0)] {
+                    rec.log(
+                        format!("/world/sat/anchored/{field}"),
+                        &re_sdk_types::archetypes::Scalars::new([value]),
+                    )
+                    .expect("log");
+                }
+            }
+            rec.flush_blocking().expect("flush");
+        }
+
+        let loaded = load_as_recording(path.to_str().unwrap()).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        let entity = EntityPath::parse("/world/sat/anchored");
+        let store = loaded.entity(&entity).expect("entity");
+        assert!(
+            !store.columns.keys().any(|name| name.contains("Position3D")),
+            "a position that is never whole is not reported"
+        );
+        let velocity = store
+            .columns
+            .iter()
+            .find(|(name, _)| name.contains("Velocity3D"))
+            .map(|(_, c)| c)
+            .expect("the velocity the file does carry");
+        assert_eq!(store.num_rows, 2);
+        assert_eq!(
+            store.timelines.get(&TimelineName::SimTime),
+            Some(&vec![TimeIndex::Seconds(0.0), TimeIndex::Seconds(10.0)])
+        );
+        assert_eq!(velocity.get_row(0).expect("row 0"), &[1.0, 2.0, 3.0]);
+        assert_eq!(velocity.get_row(1).expect("row 1"), &[4.0, 2.0, 3.0]);
+    }
+
+    /// An optional component disagreeing on repeats leaves the moment out.
+    ///
+    /// The repeat count was checked across the anchor columns alone, so three
+    /// attitudes beside two states passed: the quaternion has keys for repeats
+    /// 0 and 1, and the first two attitudes were attached as if they were those
+    /// states'. Which attitude belongs to which state is unknowable, so the
+    /// moment yields no row.
+    #[test]
+    fn an_optional_component_disagreeing_on_repeats_leaves_the_moment_out() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_optrep_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("optrep.rrd");
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-optional-repeat-test")
+                .save(&path)
+                .expect("recording stream");
+            rec.set_duration_secs("sim_time", 0.0);
+            // Two whole states at one time.
+            for x in [100.0f64, 110.0] {
+                for (field, value) in [("x", x), ("y", 1.0), ("z", 2.0)] {
+                    rec.log(
+                        format!("/world/sat/optrep/{field}"),
+                        &re_sdk_types::archetypes::Scalars::new([value]),
+                    )
+                    .expect("log");
+                }
+            }
+            // Three attitudes at the same time.
+            for qw in [1.0f64, 0.9, 0.8] {
+                for (field, value) in [("qw", qw), ("qx", 0.0), ("qy", 0.0), ("qz", 0.0)] {
+                    rec.log(
+                        format!("/world/sat/optrep/{field}"),
+                        &re_sdk_types::archetypes::Scalars::new([value]),
+                    )
+                    .expect("log");
+                }
+            }
+            rec.flush_blocking().expect("flush");
+        }
+
+        let loaded = load_as_recording(path.to_str().unwrap()).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        let entity = EntityPath::parse("/world/sat/optrep");
+        let rows = loaded.entity(&entity).map_or(0, |store| store.num_rows);
+        assert_eq!(
+            rows, 0,
+            "two states beside three attitudes cannot be paired, so neither is reported"
         );
     }
 }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -488,6 +488,10 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
             let comp_name = comp_id.as_str();
             if comp_name.contains("Scalar") || comp_name.contains("scalars") {
                 let column = scalars.entry(entity_path.clone()).or_default();
+                // Resolved once for the whole component, as `column` is: the
+                // entity's name is owned to key the map, and doing that per
+                // value cost one allocation per field per row of a recording.
+                let counters = repeat_counters.entry(entity_path.clone()).or_default();
                 for row_idx in 0..n {
                     let batch =
                         chunk.component_batch::<re_sdk_types::components::Scalar>(comp_id, row_idx);
@@ -513,13 +517,7 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
                     // consecutive repeats rather than being dropped. The
                     // ordinal comes from a counter, so a long recording does
                     // not pay a scan of the column per value.
-                    let counter = moment.map(|moment| {
-                        repeat_counters
-                            .entry(entity_path.clone())
-                            .or_default()
-                            .entry(moment)
-                            .or_insert(0)
-                    });
+                    let counter = moment.map(|moment| counters.entry(moment).or_insert(0));
                     let mut next_repeat = counter.as_ref().map_or(0, |c| **c);
                     for value in scalar_vec.iter() {
                         let key = match moment {
@@ -781,6 +779,10 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
             let comp_name = comp_id.as_str();
             if comp_name.contains("Scalar") || comp_name.contains("scalars") {
                 let column = scalars.entry(entity_path.clone()).or_default();
+                // Resolved once for the whole component, as `column` is: the
+                // entity's name is owned to key the map, and doing that per
+                // value cost one allocation per field per row of a recording.
+                let counters = repeat_counters.entry(entity_path.clone()).or_default();
                 for row_idx in 0..n {
                     let batch =
                         chunk.component_batch::<re_sdk_types::components::Scalar>(comp_id, row_idx);
@@ -801,13 +803,7 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
                         RowIndex::Untimed => None,
                         RowIndex::Missing => continue,
                     };
-                    let counter = moment.map(|moment| {
-                        repeat_counters
-                            .entry(entity_path.clone())
-                            .or_default()
-                            .entry(moment)
-                            .or_insert(0)
-                    });
+                    let counter = moment.map(|moment| counters.entry(moment).or_insert(0));
                     let mut next_repeat = counter.as_ref().map_or(0, |c| **c);
                     for value in scalar_vec.iter() {
                         let key = match moment {

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -365,8 +365,8 @@ fn repeats_at(column: &Column, moment: Moment) -> usize {
 struct ChunkKeys {
     sim_time: Option<Vec<i64>>,
     step: Option<Vec<i64>>,
-    /// The recording's own named axis, carried only by a chunk that has
-    /// neither of the two above.
+    /// The recording's own named axis, which identifies a row beside the two
+    /// above rather than in place of them.
     axis: Option<Vec<i64>>,
 }
 
@@ -434,7 +434,7 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
     let mut meta_texts: BTreeMap<String, String> = BTreeMap::new();
 
     // The one timeline of the recording's own naming, settled by the first
-    // chunk that carries neither `sim_time` nor `step` and kept for the rest.
+    // chunk to carry one and kept for the rest, whatever else that chunk has.
     let mut recording_axis: Option<String> = None;
 
     for msg in DecoderApp::decode_lazy(reader) {
@@ -728,7 +728,7 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
     let mut meta_texts: BTreeMap<String, String> = BTreeMap::new();
 
     // The one timeline of the recording's own naming, settled by the first
-    // chunk that carries neither `sim_time` nor `step` and kept for the rest.
+    // chunk to carry one and kept for the rest, whatever else that chunk has.
     let mut recording_axis: Option<String> = None;
 
     for msg in DecoderApp::decode_lazy(reader) {

--- a/rrd-wasm/Cargo.toml
+++ b/rrd-wasm/Cargo.toml
@@ -35,6 +35,13 @@ wasm-bindgen = { version = "0.2", optional = true }
 wasm = ["wasm-bindgen", "serde-wasm-bindgen"]
 
 # Note: dev-dependencies do NOT affect wasm-pack builds (only used for `cargo test`)
-# orts is needed for generating test fixtures via the recording API
-# [dev-dependencies]
-# orts = { path = "../orts" }
+# `re_sdk` writes the .rrd files the decoder tests read back, including the
+# ragged recordings (a component logged at only some time steps) that no
+# committed fixture can express. It is the same writer `orts` uses, and it
+# brings `re_log_encoding`'s `encoder` feature that `save()` needs. `orts`
+# itself is deliberately not a dev-dependency here: the decoder must stay
+# testable against the RRD format, not against one producer's conventions.
+[dev-dependencies]
+re_sdk = "0.33"
+# A directory of its own per written .rrd, removed when the test returns.
+tempfile = "3"

--- a/rrd-wasm/src/lib.rs
+++ b/rrd-wasm/src/lib.rs
@@ -412,7 +412,14 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
 
     let mut rows: Vec<RrdRow> = Vec::new();
     for base in &base_paths {
-        let column = |field: &str| scalars.get(&format!("{base}/{field}"));
+        // A column with no values in it carries the field no further than having
+        // no column at all: an empty `Scalars` batch leaves one behind, and it
+        // would otherwise make a position-only recording look velocity-bearing.
+        let column = |field: &str| {
+            scalars
+                .get(&format!("{base}/{field}"))
+                .filter(|col| !col.is_empty())
+        };
         // Value of one field at one time index, or `None` when the recording
         // has no such column or no value there.
         let at = |col: Option<&Column>, key: RowKey| col?.get(&key).copied();
@@ -1099,5 +1106,29 @@ mod tests {
             "the `iteration` chunk cannot be placed among the rest: {:?}",
             parsed.rows
         );
+    }
+
+    /// An empty velocity column leaves a position-only recording position-only.
+    ///
+    /// An empty `Scalars` batch leaves a column behind with no values in it,
+    /// which made the recording look velocity-bearing: every row then wanted a
+    /// whole velocity triple and none had one, so the positions that are there
+    /// were all dropped.
+    #[test]
+    fn an_empty_velocity_column_does_not_drop_the_positions() {
+        let parsed = decode_written(|rec| {
+            for (t, x) in [(0.0f64, 100.0f64), (10.0, 110.0)] {
+                rec.set_duration_secs("sim_time", t);
+                log_scalars(rec, &[("x", x), ("y", 1.0), ("z", 2.0)]);
+                rec.log(
+                    format!("{ENTITY}/vx"),
+                    &re_sdk_types::archetypes::Scalars::new(Vec::<f64>::new()),
+                )
+                .expect("log empty vx");
+            }
+        });
+        assert_eq!(parsed.rows.len(), 2, "{:?}", parsed.rows);
+        assert_eq!(parsed.rows[0].x, 100.0);
+        assert_eq!(parsed.rows[1].x, 110.0);
     }
 }

--- a/rrd-wasm/src/lib.rs
+++ b/rrd-wasm/src/lib.rs
@@ -91,6 +91,73 @@ impl RowKey {
     }
 }
 
+/// Where a chunk's rows sit, or `None` when nothing places them.
+///
+/// `sim_time` and `step` are the names `orts` writes. A recording from another
+/// tool names its own timeline, and reading that as no timeline at all would
+/// join its columns by position, the mix this decode replaces. One such name
+/// serves the whole recording, held in `axis`: two axes are separate
+/// dimensions, so a `frame` of 1 and an `iteration` of 1 are not one moment. A
+/// chunk indexed only by some other axis has no place among the rest and is
+/// left out.
+///
+/// `log_time` and `log_tick`, which rerun adds to every log call, say when a
+/// value was logged rather than when it happened: two fields of one state carry
+/// different ones and could never pair.
+fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<ChunkKeys> {
+    let timeline = |wanted: &str| {
+        chunk
+            .timelines()
+            .iter()
+            .find(|(name, _)| name.as_str() == wanted)
+            .map(|(_, col)| col.times_raw().to_vec())
+    };
+    let sim_time = timeline("sim_time");
+    let step = timeline("step");
+    if sim_time.is_some() || step.is_some() {
+        return Some(ChunkKeys { sim_time, step });
+    }
+
+    let mut named: Vec<_> = chunk
+        .timelines()
+        .iter()
+        .filter(|(name, _)| !matches!(name.as_str(), "sim_time" | "step" | "log_time" | "log_tick"))
+        .collect();
+    // The timelines arrive as a set, so choose by name to stay reproducible
+    // from run to run.
+    named.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+
+    let on = |times: Vec<i64>| {
+        Some(ChunkKeys {
+            sim_time: None,
+            step: Some(times),
+        })
+    };
+    // A chunk carrying no timeline of its own either: its keys come from the
+    // column-local position, which never joins with a timed key.
+    let untimed = || {
+        Some(ChunkKeys {
+            sim_time: None,
+            step: None,
+        })
+    };
+
+    match axis {
+        None => match named.first() {
+            Some((name, col)) => {
+                *axis = Some(name.as_str().to_string());
+                on(col.times_raw().to_vec())
+            }
+            None => untimed(),
+        },
+        Some(chosen) => match named.iter().find(|(name, _)| name.as_str() == chosen) {
+            Some((_, col)) => on(col.times_raw().to_vec()),
+            None if named.is_empty() => untimed(),
+            None => None,
+        },
+    }
+}
+
 /// One decoded scalar field: its value at each time index of the recording.
 type Column = BTreeMap<RowKey, f64>;
 
@@ -182,6 +249,10 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
     let mut meta_scalars: BTreeMap<String, f64> = BTreeMap::new();
     let mut meta_texts: BTreeMap<String, String> = BTreeMap::new();
 
+    // The one timeline of the recording's own naming, settled by the first
+    // chunk that carries neither `sim_time` nor `step` and kept for the rest.
+    let mut recording_axis: Option<String> = None;
+
     for msg in DecoderApp::decode_lazy(reader) {
         let msg = msg?;
         let LogMsg::ArrowMsg(_, arrow_msg) = msg else {
@@ -222,37 +293,9 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
             continue;
         }
 
-        let timeline = |wanted: &str| {
-            chunk
-                .timelines()
-                .iter()
-                .find(|(name, _)| name.as_str() == wanted)
-                .map(|(_, col)| col.times_raw().to_vec())
+        let Some(keys) = chunk_keys(&chunk, &mut recording_axis) else {
+            continue;
         };
-        let sim_time = timeline("sim_time");
-        let step = timeline("step").or_else(|| {
-            // A recording written by another tool names its own timeline, and
-            // that timeline is what says which values belong together; joining
-            // such a file on column position is the mix this decode exists to
-            // avoid. `log_time` and `log_tick`, which rerun adds to every log
-            // call, say when a value was logged rather than when it happened,
-            // so two fields of one state carry different ones and cannot pair.
-            if sim_time.is_some() {
-                return None;
-            }
-            let mut named: Vec<_> = chunk
-                .timelines()
-                .iter()
-                .filter(|(name, _)| {
-                    !matches!(name.as_str(), "sim_time" | "step" | "log_time" | "log_tick")
-                })
-                .collect();
-            // The timelines arrive as a set, so choose by name to stay
-            // reproducible from run to run.
-            named.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
-            named.first().map(|(_, col)| col.times_raw().to_vec())
-        });
-        let keys = ChunkKeys { sim_time, step };
 
         for comp_id in chunk.components_identifiers() {
             let comp_name = comp_id.as_str();
@@ -917,5 +960,29 @@ mod tests {
             "the row is frame 2, the only frame with a whole position"
         );
         assert_eq!(parsed.rows[0].y, 201.0);
+    }
+
+    /// Two axes of the recording's own naming do not share a row.
+    ///
+    /// A `frame` of 1 and an `iteration` of 1 are separate dimensions, but the
+    /// fallback kept only the raw value, so both became the same key. Measured
+    /// with `x` and `z` on `frame` and `y` on `iteration`: one row came back as
+    /// x = 100.0 beside y = 999.0, a position assembled from two axes. One axis
+    /// serves the whole recording, so neither half is a whole position and the
+    /// recording yields no row.
+    #[test]
+    fn a_second_named_axis_does_not_join_with_the_first() {
+        let parsed = decode_written(|rec| {
+            rec.set_time_sequence("frame", 1i64);
+            log_scalars(rec, &[("x", 100.0), ("z", 300.0)]);
+            rec.disable_timeline("frame");
+            rec.set_time_sequence("iteration", 1i64);
+            log_scalars(rec, &[("y", 999.0)]);
+        });
+        assert!(
+            parsed.rows.is_empty(),
+            "no axis carries a whole position: {:?}",
+            parsed.rows
+        );
     }
 }

--- a/rrd-wasm/src/lib.rs
+++ b/rrd-wasm/src/lib.rs
@@ -229,10 +229,30 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
                 .find(|(name, _)| name.as_str() == wanted)
                 .map(|(_, col)| col.times_raw().to_vec())
         };
-        let keys = ChunkKeys {
-            sim_time: timeline("sim_time"),
-            step: timeline("step"),
-        };
+        let sim_time = timeline("sim_time");
+        let step = timeline("step").or_else(|| {
+            // A recording written by another tool names its own timeline, and
+            // that timeline is what says which values belong together; joining
+            // such a file on column position is the mix this decode exists to
+            // avoid. `log_time` and `log_tick`, which rerun adds to every log
+            // call, say when a value was logged rather than when it happened,
+            // so two fields of one state carry different ones and cannot pair.
+            if sim_time.is_some() {
+                return None;
+            }
+            let mut named: Vec<_> = chunk
+                .timelines()
+                .iter()
+                .filter(|(name, _)| {
+                    !matches!(name.as_str(), "sim_time" | "step" | "log_time" | "log_tick")
+                })
+                .collect();
+            // The timelines arrive as a set, so choose by name to stay
+            // reproducible from run to run.
+            named.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+            named.first().map(|(_, col)| col.times_raw().to_vec())
+        });
+        let keys = ChunkKeys { sim_time, step };
 
         for comp_id in chunk.components_identifiers() {
             let comp_name = comp_id.as_str();
@@ -875,5 +895,27 @@ mod tests {
         assert_eq!(parsed.rows.len(), 1, "{:?}", parsed.rows);
         assert_eq!(parsed.rows[0].x, 100.0);
         assert!(parsed.rows[0].quaternion.is_none());
+    }
+
+    /// A recording indexed by a timeline of its own naming still joins on it.
+    ///
+    /// `sim_time` and `step` are the names `orts` writes; another tool names its
+    /// own, and treating that as no timeline at all fell back to column
+    /// position. Measured with `y` logged at frame 2 alone: the one row came
+    /// back as x = 101.0, the frame-1 `x` beside the frame-2 `y`.
+    #[test]
+    fn a_recording_on_its_own_named_timeline_joins_on_it() {
+        let parsed = decode_written(|rec| {
+            rec.set_time_sequence("frame", 1i64);
+            log_scalars(rec, &[("x", 101.0), ("z", 0.0)]);
+            rec.set_time_sequence("frame", 2i64);
+            log_scalars(rec, &[("x", 102.0), ("y", 201.0), ("z", 0.0)]);
+        });
+        assert_eq!(parsed.rows.len(), 1, "{:?}", parsed.rows);
+        assert_eq!(
+            parsed.rows[0].x, 102.0,
+            "the row is frame 2, the only frame with a whole position"
+        );
+        assert_eq!(parsed.rows[0].y, 201.0);
     }
 }

--- a/rrd-wasm/src/lib.rs
+++ b/rrd-wasm/src/lib.rs
@@ -65,19 +65,18 @@ pub struct ParsedRrd {
 /// and the n-th repeat of one field joins the n-th repeat of the others.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 enum RowKey {
-    /// A recording time index: `sim_time` \[ns\] and the `step` sequence number,
-    /// each present only when the recording has that timeline. Ordered by time
-    /// first, so rows without a `sim_time` all report `t = 0` but stay in step
-    /// order.
+    /// A recording time index: `sim_time` \[ns\], the `step` sequence number,
+    /// and the value on the recording's own named axis, each present only when
+    /// the recording carries that timeline. Held in separate slots, so a
+    /// `frame` of 1 is never the `step` 1 of a recording that has both. Ordered
+    /// by time first, so rows without a `sim_time` all report `t = 0` but stay
+    /// in step order.
     Timed {
         time_ns: Option<i64>,
         step: Option<i64>,
+        axis: Option<i64>,
         repeat: u32,
     },
-    /// A recording indexed by a timeline of its own naming: the value the row
-    /// sits at on that axis. Apart from `Timed` so that a `frame` of 1 is never
-    /// the `step` 1 of a recording that carries both.
-    Axis { value: i64, repeat: u32 },
     /// Neither timeline is present: fall back to the column-local index. Rows
     /// keyed this way carry no time information and all report `t = 0`.
     Index(usize),
@@ -90,7 +89,7 @@ impl RowKey {
             RowKey::Timed {
                 time_ns: Some(ns), ..
             } => ns as f64 / 1e9,
-            RowKey::Timed { time_ns: None, .. } | RowKey::Axis { .. } | RowKey::Index(_) => 0.0,
+            RowKey::Timed { time_ns: None, .. } | RowKey::Index(_) => 0.0,
         }
     }
 
@@ -98,12 +97,17 @@ impl RowKey {
     /// and comes back unchanged.
     fn at_repeat(self, repeat: u32) -> RowKey {
         match self {
-            RowKey::Timed { time_ns, step, .. } => RowKey::Timed {
+            RowKey::Timed {
                 time_ns,
                 step,
+                axis,
+                ..
+            } => RowKey::Timed {
+                time_ns,
+                step,
+                axis,
                 repeat,
             },
-            RowKey::Axis { value, .. } => RowKey::Axis { value, repeat },
             RowKey::Index(_) => self,
         }
     }
@@ -140,13 +144,6 @@ fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<Chun
     };
     let sim_time = timeline("sim_time");
     let step = timeline("step");
-    if sim_time.is_some() || step.is_some() {
-        return Some(ChunkKeys {
-            sim_time,
-            step,
-            axis: None,
-        });
-    }
 
     let mut named: Vec<_> = chunk
         .timelines()
@@ -157,36 +154,43 @@ fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<Chun
     // from run to run.
     named.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
 
-    let on = |times: Vec<i64>| {
+    // More axes than the key can hold: nothing here says which of them makes a
+    // row, and guessing is the mis-join this decode removes.
+    if named.len() > 1 {
+        return None;
+    }
+
+    let keys = |axis: Option<Vec<i64>>| {
         Some(ChunkKeys {
-            sim_time: None,
-            step: None,
-            axis: Some(times),
-        })
-    };
-    // A chunk carrying no timeline of its own either: its keys come from the
-    // column-local position, which never joins with a timed key.
-    let untimed = || {
-        Some(ChunkKeys {
-            sim_time: None,
-            step: None,
-            axis: None,
+            sim_time: sim_time.clone(),
+            step: step.clone(),
+            axis,
         })
     };
 
-    match axis {
-        None => match named.first() {
-            Some((name, col)) => {
-                *axis = Some(name.as_str().to_string());
-                on(col.times_raw().to_vec())
+    match (&axis, named.first()) {
+        // The recording's axis, settled by the first chunk to carry one.
+        (None, Some((name, col))) => {
+            let times = col.times_raw().to_vec();
+            *axis = Some(name.as_str().to_string());
+            keys(Some(times))
+        }
+        (Some(chosen), Some((name, col))) if name.as_str() == chosen.as_str() => {
+            keys(Some(col.times_raw().to_vec()))
+        }
+        // An axis that is not the recording's. A chunk that also carries
+        // `sim_time` or `step` still has a place among the rows; one that does
+        // not has nothing to place it by.
+        (Some(_), Some(_)) => {
+            if sim_time.is_some() || step.is_some() {
+                keys(None)
+            } else {
+                None
             }
-            None => untimed(),
-        },
-        Some(chosen) => match named.iter().find(|(name, _)| name.as_str() == chosen) {
-            Some((_, col)) => on(col.times_raw().to_vec()),
-            None if named.is_empty() => untimed(),
-            None => None,
-        },
+        }
+        // No axis of its own: the two names above place the row, or its
+        // column-local position does, which never joins with a timed key.
+        (_, None) => keys(None),
     }
 }
 
@@ -226,9 +230,8 @@ enum RowIndex {
     Timed {
         time_ns: Option<i64>,
         step: Option<i64>,
+        axis: Option<i64>,
     },
-    /// The row sits at this value on the recording's own named axis.
-    Axis(i64),
     /// The chunk carries no timeline; keys come from the column-local position.
     Untimed,
     /// A timeline the chunk does carry has no value for this row — skip it.
@@ -237,20 +240,18 @@ enum RowIndex {
 
 impl ChunkKeys {
     fn row(&self, row_idx: usize) -> RowIndex {
-        if let Some(axis) = &self.axis {
-            return match axis.get(row_idx) {
-                Some(&value) => RowIndex::Axis(value),
-                None => RowIndex::Missing,
-            };
-        }
         // A timeline the chunk carries must have a value for this row.
         let index = |times: &Option<Vec<i64>>| match times {
             Some(times) => times.get(row_idx).copied().map(Some).ok_or(()),
             None => Ok(None),
         };
-        match (index(&self.sim_time), index(&self.step)) {
-            (Ok(None), Ok(None)) => RowIndex::Untimed,
-            (Ok(time_ns), Ok(step)) => RowIndex::Timed { time_ns, step },
+        match (index(&self.sim_time), index(&self.step), index(&self.axis)) {
+            (Ok(None), Ok(None), Ok(None)) => RowIndex::Untimed,
+            (Ok(time_ns), Ok(step), Ok(axis)) => RowIndex::Timed {
+                time_ns,
+                step,
+                axis,
+            },
             _ => RowIndex::Missing,
         }
     }
@@ -340,12 +341,16 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
                         continue;
                     };
                     let moment = match keys.row(row_idx) {
-                        RowIndex::Timed { time_ns, step } => Some(RowKey::Timed {
+                        RowIndex::Timed {
                             time_ns,
                             step,
+                            axis,
+                        } => Some(RowKey::Timed {
+                            time_ns,
+                            step,
+                            axis,
                             repeat: 0,
                         }),
-                        RowIndex::Axis(value) => Some(RowKey::Axis { value, repeat: 0 }),
                         RowIndex::Untimed => None,
                         RowIndex::Missing => continue,
                     };
@@ -1037,6 +1042,34 @@ mod tests {
             parsed.rows.is_empty(),
             "neither the step nor the frame carries a whole position: {:?}",
             parsed.rows
+        );
+    }
+
+    /// An axis beside `sim_time` is part of what identifies a row.
+    ///
+    /// A chunk carrying `sim_time` had its other axis dropped from the key, so
+    /// rows sharing a `sim_time` but sitting at different `frame`s became
+    /// repeats of one moment and paired by arrival order: the frame-1 `x` came
+    /// back beside the frame-2 `y`. Only frame 2 is whole, so it is the one row.
+    #[test]
+    fn an_axis_beside_sim_time_identifies_the_row() {
+        let parsed = decode_written(|rec| {
+            rec.set_duration_secs("sim_time", 0.0);
+            for (frame, x) in [(1i64, 100.0f64), (2, 110.0)] {
+                rec.set_time_sequence("frame", frame);
+                log_scalars(rec, &[("x", x)]);
+            }
+            for (frame, v) in [(2i64, 201.0f64), (3, 202.0)] {
+                rec.set_time_sequence("frame", frame);
+                log_scalars(rec, &[("y", v), ("z", v)]);
+            }
+        });
+        assert_eq!(parsed.rows.len(), 1, "{:?}", parsed.rows);
+        let row = &parsed.rows[0];
+        assert_eq!(
+            (row.x, row.y, row.z),
+            (110.0, 201.0, 201.0),
+            "every axis of the row must be frame 2's"
         );
     }
 }

--- a/rrd-wasm/src/lib.rs
+++ b/rrd-wasm/src/lib.rs
@@ -327,25 +327,45 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
         let has_velocity = vel_cols.0.is_some() || vel_cols.1.is_some() || vel_cols.2.is_some();
 
         // Repeat ordinals are assigned per column, so they only identify a row
-        // while every required column has the same number of values at that
+        // while every column present has the same number of values at that
         // moment. Where the counts disagree, which value pairs with which is
         // unknowable from the file: the moment is skipped rather than joined on
         // an ordinal that means different things in different columns.
-        let required: Vec<&Column> = [Some(x_col), pos_cols.1, pos_cols.2]
-            .into_iter()
-            .chain(if has_velocity {
-                [vel_cols.0, vel_cols.1, vel_cols.2]
-            } else {
-                [None, None, None]
-            })
-            .flatten()
-            .collect();
+        //
+        // The optional columns count too. Attitude logged for only the second of
+        // two states at one moment would otherwise attach to the first.
+        let present: Vec<&Column> = [
+            Some(x_col),
+            pos_cols.1,
+            pos_cols.2,
+            vel_cols.0,
+            vel_cols.1,
+            vel_cols.2,
+            quat_cols.0,
+            quat_cols.1,
+            quat_cols.2,
+            quat_cols.3,
+            omega_cols.0,
+            omega_cols.1,
+            omega_cols.2,
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
 
         for &key in x_col.keys() {
             if let RowKey::Timed { time_ns, step, .. } = key {
                 let time = (time_ns, step);
-                let counts: Vec<usize> = required.iter().map(|c| repeats_at(c, time)).collect();
-                if counts.iter().any(|&n| n != counts[0]) {
+                // Only a moment that actually repeats can be ambiguous: with one
+                // value per column the ordinal is 0 everywhere, and a column
+                // absent at that moment is simply absent from the row.
+                let x_count = repeats_at(x_col, time);
+                if x_count > 1
+                    && present
+                        .iter()
+                        .map(|c| repeats_at(c, time))
+                        .any(|n| n != 0 && n != x_count)
+                {
                     continue;
                 }
             }
@@ -793,5 +813,48 @@ mod tests {
         ]);
         let xs: Vec<f64> = parsed.rows.iter().map(|r| r.x).collect();
         assert_eq!(xs, vec![1.0, 2.0, 3.0], "steps out of order: {xs:?}");
+    }
+
+    /// The optional columns count toward the repeat check too.
+    ///
+    /// Two complete states at one moment with attitude on the second only: the
+    /// quaternion holds repeat 0, so joining on the ordinal attached it to the
+    /// first state and left the second without one.
+    #[test]
+    fn an_optional_column_disagreeing_on_repeats_yields_no_row() {
+        let parsed = decode_written(|rec| {
+            rec.set_duration_secs("sim_time", 0.0);
+            log_scalars(rec, &[("x", 100.0), ("y", 0.0), ("z", 0.0)]);
+            log_scalars(
+                rec,
+                &[
+                    ("x", 110.0),
+                    ("y", 0.0),
+                    ("z", 0.0),
+                    ("qw", 1.0),
+                    ("qx", 0.5),
+                    ("qy", 0.0),
+                    ("qz", 0.0),
+                ],
+            );
+        });
+        assert!(
+            parsed.rows.is_empty(),
+            "the quaternion cannot be assigned to either state; got {:?}",
+            parsed.rows
+        );
+    }
+
+    /// A moment with one value per column is never ambiguous, whichever
+    /// optional columns are absent.
+    #[test]
+    fn a_single_sample_with_absent_optional_columns_still_yields_a_row() {
+        let parsed = decode_written(|rec| {
+            rec.set_duration_secs("sim_time", 0.0);
+            log_scalars(rec, &[("x", 100.0), ("y", 200.0), ("z", 300.0)]);
+        });
+        assert_eq!(parsed.rows.len(), 1, "{:?}", parsed.rows);
+        assert_eq!(parsed.rows[0].x, 100.0);
+        assert!(parsed.rows[0].quaternion.is_none());
     }
 }

--- a/rrd-wasm/src/lib.rs
+++ b/rrd-wasm/src/lib.rs
@@ -366,16 +366,18 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
             if !checked.insert(time) {
                 continue;
             }
-            // Only a moment that actually repeats can be ambiguous: with one
-            // value per column the ordinal is 0 everywhere, and a column absent
-            // at that moment is simply absent from the row.
-            let x_count = repeats_at(x_col, time);
-            if x_count > 1
-                && present
-                    .iter()
-                    .map(|c| repeats_at(c, time))
-                    .any(|n| n != 0 && n != x_count)
-            {
+            // Every column that has values at this moment must have the same
+            // number of them. A count of zero is a column absent there, which
+            // is simply absent from the row; any other disagreement means the
+            // ordinal points at different samples in different columns. Checked
+            // whichever column repeats — `x` holding one value while `y` holds
+            // two is just as unpairable as the other way round.
+            let counts: Vec<usize> = present
+                .iter()
+                .map(|c| repeats_at(c, time))
+                .filter(|&n| n != 0)
+                .collect();
+            if counts.iter().any(|&n| n != counts[0]) {
                 ambiguous.insert(time);
             }
         }

--- a/rrd-wasm/src/lib.rs
+++ b/rrd-wasm/src/lib.rs
@@ -74,6 +74,10 @@ enum RowKey {
         step: Option<i64>,
         repeat: u32,
     },
+    /// A recording indexed by a timeline of its own naming: the value the row
+    /// sits at on that axis. Apart from `Timed` so that a `frame` of 1 is never
+    /// the `step` 1 of a recording that carries both.
+    Axis { value: i64, repeat: u32 },
     /// Neither timeline is present: fall back to the column-local index. Rows
     /// keyed this way carry no time information and all report `t = 0`.
     Index(usize),
@@ -86,7 +90,29 @@ impl RowKey {
             RowKey::Timed {
                 time_ns: Some(ns), ..
             } => ns as f64 / 1e9,
-            RowKey::Timed { time_ns: None, .. } | RowKey::Index(_) => 0.0,
+            RowKey::Timed { time_ns: None, .. } | RowKey::Axis { .. } | RowKey::Index(_) => 0.0,
+        }
+    }
+
+    /// This key with its repeat number replaced. An `Index` key carries none
+    /// and comes back unchanged.
+    fn at_repeat(self, repeat: u32) -> RowKey {
+        match self {
+            RowKey::Timed { time_ns, step, .. } => RowKey::Timed {
+                time_ns,
+                step,
+                repeat,
+            },
+            RowKey::Axis { value, .. } => RowKey::Axis { value, repeat },
+            RowKey::Index(_) => self,
+        }
+    }
+
+    /// The moment this key sits on, or `None` for a key that carries no time.
+    fn moment(self) -> Option<Moment> {
+        match self {
+            RowKey::Index(_) => None,
+            _ => Some(self.at_repeat(0)),
         }
     }
 }
@@ -115,7 +141,11 @@ fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<Chun
     let sim_time = timeline("sim_time");
     let step = timeline("step");
     if sim_time.is_some() || step.is_some() {
-        return Some(ChunkKeys { sim_time, step });
+        return Some(ChunkKeys {
+            sim_time,
+            step,
+            axis: None,
+        });
     }
 
     let mut named: Vec<_> = chunk
@@ -130,7 +160,8 @@ fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<Chun
     let on = |times: Vec<i64>| {
         Some(ChunkKeys {
             sim_time: None,
-            step: Some(times),
+            step: None,
+            axis: Some(times),
         })
     };
     // A chunk carrying no timeline of its own either: its keys come from the
@@ -139,6 +170,7 @@ fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<Chun
         Some(ChunkKeys {
             sim_time: None,
             step: None,
+            axis: None,
         })
     };
 
@@ -163,29 +195,20 @@ type Column = BTreeMap<RowKey, f64>;
 
 /// The non-repeat part of a [`RowKey::Timed`]: one moment on the recording's
 /// timelines.
-type TimeKey = (Option<i64>, Option<i64>);
+/// One moment of a recording: a [`RowKey`] with its repeat number cleared, so
+/// that every value logged at that moment ranges within it.
+type Moment = RowKey;
 
 /// Next repeat ordinal to assign, per column and moment.
 ///
 /// A counter rather than a scan of the column: counting the existing repeats on
 /// every value made decoding quadratic in the length of a recording, even one
 /// with no repeats at all.
-type RepeatCounters = BTreeMap<String, BTreeMap<TimeKey, u32>>;
+type RepeatCounters = BTreeMap<String, BTreeMap<Moment, u32>>;
 
-/// How many values `column` holds at `time`, over every repeat.
-fn repeats_at(column: &Column, time: TimeKey) -> usize {
-    let (time_ns, step) = time;
-    let lo = RowKey::Timed {
-        time_ns,
-        step,
-        repeat: 0,
-    };
-    let hi = RowKey::Timed {
-        time_ns,
-        step,
-        repeat: u32::MAX,
-    };
-    column.range(lo..=hi).count()
+/// How many values `column` holds at `moment`, over every repeat.
+fn repeats_at(column: &Column, moment: Moment) -> usize {
+    column.range(moment..=moment.at_repeat(u32::MAX)).count()
 }
 
 /// Time index of every row in one chunk, per timeline the chunk carries. With
@@ -193,6 +216,9 @@ fn repeats_at(column: &Column, time: TimeKey) -> usize {
 struct ChunkKeys {
     sim_time: Option<Vec<i64>>,
     step: Option<Vec<i64>>,
+    /// The recording's own named axis, carried only by a chunk that has
+    /// neither of the two above.
+    axis: Option<Vec<i64>>,
 }
 
 /// Where one chunk row sits on the recording's timelines.
@@ -203,6 +229,8 @@ enum RowIndex {
         time_ns: Option<i64>,
         step: Option<i64>,
     },
+    /// The row sits at this value on the recording's own named axis.
+    Axis(i64),
     /// The chunk carries no timeline; keys come from the column-local position.
     Untimed,
     /// A timeline the chunk does carry has no value for this row — skip it.
@@ -211,6 +239,12 @@ enum RowIndex {
 
 impl ChunkKeys {
     fn row(&self, row_idx: usize) -> RowIndex {
+        if let Some(axis) = &self.axis {
+            return match axis.get(row_idx) {
+                Some(&value) => RowIndex::Axis(value),
+                None => RowIndex::Missing,
+            };
+        }
         // A timeline the chunk carries must have a value for this row.
         let index = |times: &Option<Vec<i64>>| match times {
             Some(times) => times.get(row_idx).copied().map(Some).ok_or(()),
@@ -307,8 +341,13 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
                     let Some(Ok(scalar_vec)) = batch else {
                         continue;
                     };
-                    let timed = match keys.row(row_idx) {
-                        RowIndex::Timed { time_ns, step } => Some((time_ns, step)),
+                    let moment = match keys.row(row_idx) {
+                        RowIndex::Timed { time_ns, step } => Some(RowKey::Timed {
+                            time_ns,
+                            step,
+                            repeat: 0,
+                        }),
+                        RowIndex::Axis(value) => Some(RowKey::Axis { value, repeat: 0 }),
                         RowIndex::Untimed => None,
                         RowIndex::Missing => continue,
                     };
@@ -317,22 +356,18 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
                     // consecutive repeats rather than being dropped. The
                     // ordinal comes from a counter, so a long recording does
                     // not pay a scan of the column per value.
-                    let counter = timed.map(|time| {
+                    let counter = moment.map(|moment| {
                         repeat_counters
                             .entry(entity_path.clone())
                             .or_default()
-                            .entry(time)
+                            .entry(moment)
                             .or_insert(0)
                     });
                     let mut next_repeat = counter.as_ref().map_or(0, |c| **c);
                     for value in scalar_vec.iter() {
-                        let key = match timed {
-                            Some((time_ns, step)) => {
-                                let key = RowKey::Timed {
-                                    time_ns,
-                                    step,
-                                    repeat: next_repeat,
-                                };
+                        let key = match moment {
+                            Some(moment) => {
+                                let key = moment.at_repeat(next_repeat);
                                 next_repeat += 1;
                                 key
                             }
@@ -419,14 +454,13 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
         // Counted once per moment, not once per repeat: a `Scalars` batch puts
         // k values at one timestamp, and re-counting for each of them would
         // make reconstruction quadratic in k.
-        let mut ambiguous: BTreeSet<TimeKey> = BTreeSet::new();
-        let mut checked: BTreeSet<TimeKey> = BTreeSet::new();
+        let mut ambiguous: BTreeSet<Moment> = BTreeSet::new();
+        let mut checked: BTreeSet<Moment> = BTreeSet::new();
         for &key in x_col.keys() {
-            let RowKey::Timed { time_ns, step, .. } = key else {
+            let Some(moment) = key.moment() else {
                 continue;
             };
-            let time = (time_ns, step);
-            if !checked.insert(time) {
+            if !checked.insert(moment) {
                 continue;
             }
             // Every column that has values at this moment must have the same
@@ -437,17 +471,18 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
             // two is just as unpairable as the other way round.
             let counts: Vec<usize> = present
                 .iter()
-                .map(|c| repeats_at(c, time))
+                .map(|c| repeats_at(c, moment))
                 .filter(|&n| n != 0)
                 .collect();
             if counts.iter().any(|&n| n != counts[0]) {
-                ambiguous.insert(time);
+                ambiguous.insert(moment);
             }
         }
 
         for &key in x_col.keys() {
-            if let RowKey::Timed { time_ns, step, .. } = key
-                && ambiguous.contains(&(time_ns, step))
+            if key
+                .moment()
+                .is_some_and(|moment| ambiguous.contains(&moment))
             {
                 continue;
             }
@@ -982,6 +1017,27 @@ mod tests {
         assert!(
             parsed.rows.is_empty(),
             "no axis carries a whole position: {:?}",
+            parsed.rows
+        );
+    }
+
+    /// A named axis is never a step of the same value.
+    ///
+    /// The fallback put the axis value in the same slot as a real `step`, so a
+    /// `frame` of 1 and a `step` of 1 became one key and their halves were
+    /// assembled into one position.
+    #[test]
+    fn a_named_axis_is_not_a_step_of_the_same_value() {
+        let parsed = decode_written(|rec| {
+            rec.set_time_sequence("step", 1i64);
+            log_scalars(rec, &[("x", 100.0), ("z", 300.0)]);
+            rec.disable_timeline("step");
+            rec.set_time_sequence("frame", 1i64);
+            log_scalars(rec, &[("y", 999.0)]);
+        });
+        assert!(
+            parsed.rows.is_empty(),
+            "neither the step nor the frame carries a whole position: {:?}",
             parsed.rows
         );
     }

--- a/rrd-wasm/src/lib.rs
+++ b/rrd-wasm/src/lib.rs
@@ -47,14 +47,116 @@ pub struct ParsedRrd {
     pub rows: Vec<RrdRow>,
 }
 
+/// Join key identifying one logical row of a scalar column.
+///
+/// Every scalar field lives on its own entity path in an RRD (`<base>/x`,
+/// `<base>/y`, …), so a state row has to be reassembled from several columns.
+/// The key is the recording's own time index, not the position of a value
+/// inside its column — the two coincide only as long as every column happens to
+/// carry a value at every step. A chunk with no timeline at all has no time
+/// index to key on, and only there does the column-local position stand in.
+///
+/// Every timeline the recording carries takes part in the key: `orts` writes
+/// both `sim_time` and `step`, and two steps can share a `sim_time`, so keying
+/// on time alone would join values from different steps.
+///
+/// The trailing counter distinguishes several values logged at the *same* time
+/// index, so repeats are still separate rows instead of overwriting each other,
+/// and the n-th repeat of one field joins the n-th repeat of the others.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+enum RowKey {
+    /// A recording time index: `sim_time` \[ns\] and the `step` sequence number,
+    /// each present only when the recording has that timeline. Ordered by time
+    /// first, so rows without a `sim_time` all report `t = 0` but stay in step
+    /// order.
+    Timed {
+        time_ns: Option<i64>,
+        step: Option<i64>,
+        repeat: u32,
+    },
+    /// Neither timeline is present: fall back to the column-local index. Rows
+    /// keyed this way carry no time information and all report `t = 0`.
+    Index(usize),
+}
+
+impl RowKey {
+    /// Simulation time of this row \[s\], or 0 when the recording carries none.
+    fn t_secs(self) -> f64 {
+        match self {
+            RowKey::Timed {
+                time_ns: Some(ns), ..
+            } => ns as f64 / 1e9,
+            RowKey::Timed { time_ns: None, .. } | RowKey::Index(_) => 0.0,
+        }
+    }
+}
+
+/// One decoded scalar field: its value at each time index of the recording.
+type Column = BTreeMap<RowKey, f64>;
+
+/// How many values `column` already holds at one time index. `key` builds the
+/// key for the n-th repeat at that time, so the count is the next free slot.
+fn repeats(column: &Column, key: impl Fn(u32) -> RowKey) -> u32 {
+    column.range(key(0)..=key(u32::MAX)).count() as u32
+}
+
+/// Time index of every row in one chunk, per timeline the chunk carries. With
+/// neither timeline, keys are assigned per column from its current length.
+struct ChunkKeys {
+    sim_time: Option<Vec<i64>>,
+    step: Option<Vec<i64>>,
+}
+
+/// Where one chunk row sits on the recording's timelines.
+#[derive(Clone, Copy)]
+enum RowIndex {
+    /// The chunk's timelines place the row at this time index.
+    Timed {
+        time_ns: Option<i64>,
+        step: Option<i64>,
+    },
+    /// The chunk carries no timeline; keys come from the column-local position.
+    Untimed,
+    /// A timeline the chunk does carry has no value for this row — skip it.
+    Missing,
+}
+
+impl ChunkKeys {
+    fn row(&self, row_idx: usize) -> RowIndex {
+        // A timeline the chunk carries must have a value for this row.
+        let index = |times: &Option<Vec<i64>>| match times {
+            Some(times) => times.get(row_idx).copied().map(Some).ok_or(()),
+            None => Ok(None),
+        };
+        match (index(&self.sim_time), index(&self.step)) {
+            (Ok(None), Ok(None)) => RowIndex::Untimed,
+            (Ok(time_ns), Ok(step)) => RowIndex::Timed { time_ns, step },
+            _ => RowIndex::Missing,
+        }
+    }
+}
+
 /// Decode an RRD stream into orbital data.
 ///
 /// Accepts any `impl Read` — works with both `File` and `Cursor<&[u8]>`.
+///
+/// Columns are joined on the recording's time index, so a component that is
+/// logged at only some of the time steps (or not at all) never shifts the
+/// remaining components onto the wrong row. A row is emitted only when the
+/// whole position triple — and, when the recording has velocity columns, the
+/// whole velocity triple — is present at that exact time; incomplete rows are
+/// dropped rather than padded with zeros.
+///
+/// That guarantee needs a time index to join on, which every recording orts
+/// writes carries (`sim_time`, `step`, or both). A chunk with neither timeline
+/// has no join key available, so its values are keyed by position within their
+/// own column — the arrangement this join replaced, and one a sparse column
+/// still shifts. Such a recording does not come from orts.
 pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Error>> {
     let reader = std::io::BufReader::new(reader);
 
-    // Collect f64 scalars: entity_path -> Vec<(time_ns, f64)>
-    let mut scalars: BTreeMap<String, Vec<(i64, f64)>> = BTreeMap::new();
+    // Collect f64 scalars: entity_path -> (time index -> value)
+    let mut scalars: BTreeMap<String, Column> = BTreeMap::new();
     let mut meta_scalars: BTreeMap<String, f64> = BTreeMap::new();
     let mut meta_texts: BTreeMap<String, String> = BTreeMap::new();
 
@@ -98,29 +200,60 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
             continue;
         }
 
-        let sim_time_col = chunk
-            .timelines()
-            .iter()
-            .find(|(name, _)| name.as_str() == "sim_time");
-        let times: Vec<i64> = if let Some((_, col)) = sim_time_col {
-            col.times_raw().to_vec()
-        } else {
-            vec![0; n]
+        let timeline = |wanted: &str| {
+            chunk
+                .timelines()
+                .iter()
+                .find(|(name, _)| name.as_str() == wanted)
+                .map(|(_, col)| col.times_raw().to_vec())
+        };
+        let keys = ChunkKeys {
+            sim_time: timeline("sim_time"),
+            step: timeline("step"),
         };
 
         for comp_id in chunk.components_identifiers() {
             let comp_name = comp_id.as_str();
             if comp_name.contains("Scalar") || comp_name.contains("scalars") {
-                for (row_idx, &t) in times.iter().enumerate() {
+                let column = scalars.entry(entity_path.clone()).or_default();
+                for row_idx in 0..n {
                     let batch =
                         chunk.component_batch::<re_sdk_types::components::Scalar>(comp_id, row_idx);
-                    if let Some(Ok(scalar_vec)) = batch {
-                        for s in scalar_vec {
-                            scalars
-                                .entry(entity_path.clone())
-                                .or_default()
-                                .push((t, s.0.0));
-                        }
+                    let Some(Ok(scalar_vec)) = batch else {
+                        continue;
+                    };
+                    let timed = match keys.row(row_idx) {
+                        RowIndex::Timed { time_ns, step } => Some((time_ns, step)),
+                        RowIndex::Untimed => None,
+                        RowIndex::Missing => continue,
+                    };
+                    // A batch usually holds one value per row, but `Scalars`
+                    // takes a slice: several values at one time index become
+                    // consecutive repeats rather than being dropped. The repeat
+                    // counter is scanned once for the row and advanced locally,
+                    // so a wide batch costs one scan of the column, not one per
+                    // value.
+                    let mut next_repeat = timed.map_or(0, |(time_ns, step)| {
+                        repeats(column, |repeat| RowKey::Timed {
+                            time_ns,
+                            step,
+                            repeat,
+                        })
+                    });
+                    for value in scalar_vec.iter() {
+                        let key = match timed {
+                            Some((time_ns, step)) => {
+                                let key = RowKey::Timed {
+                                    time_ns,
+                                    step,
+                                    repeat: next_repeat,
+                                };
+                                next_repeat += 1;
+                                key
+                            }
+                            None => RowKey::Index(column.len()),
+                        };
+                        column.insert(key, value.0.0);
                     }
                 }
             }
@@ -151,48 +284,55 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
 
     let mut rows: Vec<RrdRow> = Vec::new();
     for base in &base_paths {
-        let x_data = scalars.get(&format!("{base}/x"));
-        let y_data = scalars.get(&format!("{base}/y"));
-        let z_data = scalars.get(&format!("{base}/z"));
-        let vx_data = scalars.get(&format!("{base}/vx"));
-        let vy_data = scalars.get(&format!("{base}/vy"));
-        let vz_data = scalars.get(&format!("{base}/vz"));
+        let column = |field: &str| scalars.get(&format!("{base}/{field}"));
+        // Value of one field at one time index, or `None` when the recording
+        // has no such column or no value there.
+        let at = |col: Option<&Column>, key: RowKey| col?.get(&key).copied();
 
-        let Some(x_data) = x_data else { continue };
+        // A row is a position, so the whole triple has to be there.
+        let Some(x_col) = column("x") else { continue };
+        let pos_cols = (Some(x_col), column("y"), column("z"));
+        let vel_cols = (column("vx"), column("vy"), column("vz"));
+        let quat_cols = (column("qw"), column("qx"), column("qy"), column("qz"));
+        let omega_cols = (column("wx"), column("wy"), column("wz"));
 
-        let qw_data = scalars.get(&format!("{base}/qw"));
-        let qx_data = scalars.get(&format!("{base}/qx"));
-        let qy_data = scalars.get(&format!("{base}/qy"));
-        let qz_data = scalars.get(&format!("{base}/qz"));
-        let wx_data = scalars.get(&format!("{base}/wx"));
-        let wy_data = scalars.get(&format!("{base}/wy"));
-        let wz_data = scalars.get(&format!("{base}/wz"));
+        // A recording with no velocity column at all is position-only; one that
+        // has velocity columns must supply all three at a time for the row to be
+        // a state vector.
+        let has_velocity = vel_cols.0.is_some() || vel_cols.1.is_some() || vel_cols.2.is_some();
 
-        for (i, (t_ns, x)) in x_data.iter().enumerate() {
-            let t_sec = *t_ns as f64 / 1e9;
+        for &key in x_col.keys() {
+            let triple = |cols: (Option<&Column>, Option<&Column>, Option<&Column>)| {
+                Some([at(cols.0, key)?, at(cols.1, key)?, at(cols.2, key)?])
+            };
 
-            let quaternion = qw_data.and_then(|qw| {
-                let qw = qw.get(i)?.1;
-                let qx = qx_data?.get(i)?.1;
-                let qy = qy_data?.get(i)?.1;
-                let qz = qz_data?.get(i)?.1;
-                Some([qw, qx, qy, qz])
-            });
-            let angular_velocity = wx_data.and_then(|wx| {
-                let wx = wx.get(i)?.1;
-                let wy = wy_data?.get(i)?.1;
-                let wz = wz_data?.get(i)?.1;
-                Some([wx, wy, wz])
-            });
+            let Some([x, y, z]) = triple(pos_cols) else {
+                continue;
+            };
+            let velocity = triple(vel_cols);
+            if has_velocity && velocity.is_none() {
+                continue;
+            }
+            let [vx, vy, vz] = velocity.unwrap_or([0.0; 3]);
+
+            let quaternion = (|| {
+                Some([
+                    at(quat_cols.0, key)?,
+                    at(quat_cols.1, key)?,
+                    at(quat_cols.2, key)?,
+                    at(quat_cols.3, key)?,
+                ])
+            })();
+            let angular_velocity = triple(omega_cols);
 
             rows.push(RrdRow {
-                t: t_sec,
-                x: *x,
-                y: y_data.and_then(|v| v.get(i)).map(|v| v.1).unwrap_or(0.0),
-                z: z_data.and_then(|v| v.get(i)).map(|v| v.1).unwrap_or(0.0),
-                vx: vx_data.and_then(|v| v.get(i)).map(|v| v.1).unwrap_or(0.0),
-                vy: vy_data.and_then(|v| v.get(i)).map(|v| v.1).unwrap_or(0.0),
-                vz: vz_data.and_then(|v| v.get(i)).map(|v| v.1).unwrap_or(0.0),
+                t: key.t_secs(),
+                x,
+                y,
+                z,
+                vx,
+                vy,
+                vz,
                 entity_path: Some(base.clone()),
                 quaternion,
                 angular_velocity,
@@ -276,5 +416,262 @@ mod tests {
             "body_radius should be positive"
         );
         assert!(m.epoch_jd.is_some(), "epoch_jd should be set");
+    }
+
+    const ENTITY: &str = "/world/sat/ragged";
+
+    /// One logged sample: `(sim_time [s], [(field, value)])`. A field absent
+    /// from a sample is simply not logged at that time, which is how a ragged
+    /// recording arises in practice (a component logged conditionally).
+    type Sample<'a> = (f64, Vec<(&'a str, f64)>);
+    /// A sample tagged with its `step` sequence number.
+    type SteppedSample<'a> = (f64, i64, Vec<(&'a str, f64)>);
+    /// A sample whose fields each carry several values in one logged row.
+    type BatchSample<'a> = (f64, Vec<(&'a str, Vec<f64>)>);
+
+    /// Write an .rrd with `write`, then decode it back. The recording lives in
+    /// a directory of its own that is removed when the call returns, so no two
+    /// calls — including tests running in parallel — can meet on one path.
+    fn decode_written(write: impl FnOnce(&re_sdk::RecordingStream)) -> ParsedRrd {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("test.rrd");
+        let rec = re_sdk::RecordingStreamBuilder::new("rrd-wasm-test")
+            .save(&path)
+            .expect("recording stream");
+        write(&rec);
+        rec.flush_blocking().expect("flush");
+        drop(rec);
+        let bytes = std::fs::read(&path).expect("written rrd");
+        decode_rrd(std::io::Cursor::new(&bytes)).expect("rrd should decode")
+    }
+
+    /// Log one scalar per field at the stream's current time.
+    fn log_scalars(rec: &re_sdk::RecordingStream, fields: &[(&str, f64)]) {
+        for (field, value) in fields {
+            rec.log(
+                format!("{ENTITY}/{field}"),
+                &re_sdk_types::archetypes::Scalars::new([*value]),
+            )
+            .expect("log scalar");
+        }
+    }
+
+    /// Decode an .rrd whose scalar columns carry exactly the given samples.
+    fn decode_samples(samples: &[Sample]) -> ParsedRrd {
+        decode_written(|rec| {
+            for (t, fields) in samples {
+                rec.set_duration_secs("sim_time", *t);
+                log_scalars(rec, fields);
+            }
+        })
+    }
+
+    /// Decode an .rrd carrying both timelines, so one `sim_time` can span
+    /// several `step`s the way it can in an `orts` recording.
+    fn decode_stepped_samples(samples: &[SteppedSample]) -> ParsedRrd {
+        decode_written(|rec| {
+            for (t, step, fields) in samples {
+                rec.set_duration_secs("sim_time", *t);
+                rec.set_time_sequence("step", *step);
+                log_scalars(rec, fields);
+            }
+        })
+    }
+
+    /// Decode an .rrd whose `Scalars` batches carry several values per logged
+    /// row — one row of the recording, many values of the column.
+    fn decode_batched_samples(samples: &[BatchSample]) -> ParsedRrd {
+        decode_written(|rec| {
+            for (t, fields) in samples {
+                rec.set_duration_secs("sim_time", *t);
+                for (field, values) in fields {
+                    rec.log(
+                        format!("{ENTITY}/{field}"),
+                        &re_sdk_types::archetypes::Scalars::new(values.clone()),
+                    )
+                    .expect("log scalars");
+                }
+            }
+        })
+    }
+
+    fn state(x: f64) -> Vec<(&'static str, f64)> {
+        vec![
+            ("x", x),
+            ("y", x + 1.0),
+            ("z", x + 2.0),
+            ("vx", x + 3.0),
+            ("vy", x + 4.0),
+            ("vz", x + 5.0),
+        ]
+    }
+
+    /// The states of `xs`, each component collected into one batch per field.
+    fn state_batch(xs: &[f64]) -> Vec<(&'static str, Vec<f64>)> {
+        let fields = ["x", "y", "z", "vx", "vy", "vz"];
+        fields
+            .iter()
+            .enumerate()
+            .map(|(k, field)| (*field, xs.iter().map(|x| x + k as f64).collect()))
+            .collect()
+    }
+
+    /// Dense, aligned columns: every logged value must come back on the row of
+    /// the time it was logged at. All six components differ from each other and
+    /// from step to step, so any reshuffling of rows or columns shows up.
+    #[test]
+    fn dense_columns_keep_every_value_on_its_own_time() {
+        let data = decode_samples(&[
+            (0.0, state(100.0)),
+            (10.0, state(200.0)),
+            (20.0, state(300.0)),
+        ]);
+
+        assert_eq!(data.rows.len(), 3, "expected one row per time step");
+        for (row, x) in data.rows.iter().zip([100.0, 200.0, 300.0]) {
+            assert_eq!(
+                (row.t, row.x, row.y, row.z, row.vx, row.vy, row.vz),
+                (
+                    (x - 100.0) / 10.0,
+                    x,
+                    x + 1.0,
+                    x + 2.0,
+                    x + 3.0,
+                    x + 4.0,
+                    x + 5.0
+                ),
+                "row {row:?} does not match the state logged at its time"
+            );
+        }
+    }
+
+    /// Two states logged at the same time index are two rows, not one: the
+    /// repeat must not overwrite the earlier value, and the n-th repeat of each
+    /// component must stay with the n-th repeat of the others.
+    #[test]
+    fn repeated_time_index_keeps_both_rows() {
+        let data = decode_samples(&[
+            (0.0, state(100.0)),
+            (0.0, state(200.0)),
+            (10.0, state(300.0)),
+        ]);
+
+        assert_eq!(data.rows.len(), 3, "got {:?}", data.rows);
+        assert_eq!(
+            data.rows
+                .iter()
+                .map(|r| (r.t, r.x, r.y))
+                .collect::<Vec<_>>(),
+            vec![
+                (0.0, 100.0, 101.0),
+                (0.0, 200.0, 201.0),
+                (10.0, 300.0, 301.0)
+            ]
+        );
+    }
+
+    /// `sim_time` alone is not a row identity: an `orts` recording carries a
+    /// `step` timeline as well, and several steps can share one `sim_time`.
+    /// Keying on time alone pairs the n-th value of each column, so a component
+    /// missing at one of those steps drags the next step's value onto the row.
+    #[test]
+    fn steps_sharing_a_sim_time_stay_separate_rows() {
+        let mut middle = state(200.0);
+        middle.retain(|(field, _)| *field != "y");
+        let data = decode_stepped_samples(&[
+            (0.0, 10, state(100.0)),
+            (0.0, 11, middle),
+            (0.0, 12, state(300.0)),
+        ]);
+
+        // step 11 has no y, so it is not a position row. Steps 10 and 12 keep
+        // their own values instead of borrowing step 12's y for step 11.
+        assert_eq!(data.rows.len(), 2, "got {:?}", data.rows);
+        assert_eq!(
+            data.rows
+                .iter()
+                .map(|r| (r.x, r.y, r.vz))
+                .collect::<Vec<_>>(),
+            vec![(100.0, 101.0, 105.0), (300.0, 301.0, 305.0)]
+        );
+    }
+
+    /// A `Scalars` batch can hold several values at one time index. All of them
+    /// are values of the recording, not just the first.
+    #[test]
+    fn every_value_of_a_scalar_batch_is_decoded() {
+        let data = decode_batched_samples(&[(0.0, state_batch(&[100.0, 200.0]))]);
+
+        assert_eq!(data.rows.len(), 2, "got {:?}", data.rows);
+        assert_eq!(
+            data.rows
+                .iter()
+                .map(|r| (r.x, r.y, r.vz))
+                .collect::<Vec<_>>(),
+            vec![(100.0, 101.0, 105.0), (200.0, 201.0, 205.0)]
+        );
+    }
+
+    /// A component missing at one time step must not slide the later values of
+    /// that column onto the earlier rows.
+    #[test]
+    fn sparse_position_column_is_joined_by_time() {
+        let mut first = state(100.0);
+        first.retain(|(field, _)| *field != "y");
+        let data = decode_samples(&[(0.0, first), (10.0, state(200.0))]);
+
+        // t=0 has no y at all, so it is not a position — the only complete row
+        // is t=10, and it must carry *its own* y (201), not t=0's row index.
+        assert_eq!(
+            data.rows.len(),
+            1,
+            "incomplete position must be dropped, got {:?}",
+            data.rows
+        );
+        assert_eq!((data.rows[0].t, data.rows[0].y), (10.0, 201.0));
+    }
+
+    /// Velocity logged for only part of a run must not be reported as zero
+    /// velocity on the remaining rows.
+    #[test]
+    fn row_missing_a_velocity_component_is_dropped() {
+        let mut second = state(200.0);
+        second.retain(|(field, _)| *field != "vz");
+        let data = decode_samples(&[(0.0, state(100.0)), (10.0, second)]);
+
+        assert_eq!(
+            data.rows.len(),
+            1,
+            "incomplete velocity must be dropped, got {:?}",
+            data.rows
+        );
+        assert_eq!((data.rows[0].t, data.rows[0].vz), (0.0, 105.0));
+    }
+
+    /// Attitude logged at only some steps must attach to those steps.
+    #[test]
+    fn attitude_attaches_to_the_time_it_was_logged_at() {
+        let mut attitude_step = state(200.0);
+        attitude_step.extend([
+            ("qw", 1.0),
+            ("qx", 0.2),
+            ("qy", 0.3),
+            ("qz", 0.4),
+            ("wx", 0.01),
+            ("wy", 0.02),
+            ("wz", 0.03),
+        ]);
+        let data = decode_samples(&[
+            (0.0, state(100.0)),
+            (10.0, attitude_step),
+            (20.0, state(300.0)),
+        ]);
+
+        assert_eq!(data.rows.len(), 3);
+        assert_eq!(data.rows[0].quaternion, None, "t=0 logged no attitude");
+        assert_eq!(data.rows[1].quaternion, Some([1.0, 0.2, 0.3, 0.4]));
+        assert_eq!(data.rows[1].angular_velocity, Some([0.01, 0.02, 0.03]));
+        assert_eq!(data.rows[2].quaternion, None, "t=20 logged no attitude");
+        assert_eq!(data.rows[2].angular_velocity, None);
     }
 }

--- a/rrd-wasm/src/lib.rs
+++ b/rrd-wasm/src/lib.rs
@@ -336,6 +336,10 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
             let comp_name = comp_id.as_str();
             if comp_name.contains("Scalar") || comp_name.contains("scalars") {
                 let column = scalars.entry(entity_path.clone()).or_default();
+                // Resolved once for the whole component, as `column` is: the
+                // entity's name is owned to key the map, and doing that per
+                // value cost one allocation per field per row of a recording.
+                let counters = repeat_counters.entry(entity_path.clone()).or_default();
                 for row_idx in 0..n {
                     let batch =
                         chunk.component_batch::<re_sdk_types::components::Scalar>(comp_id, row_idx);
@@ -361,13 +365,7 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
                     // consecutive repeats rather than being dropped. The
                     // ordinal comes from a counter, so a long recording does
                     // not pay a scan of the column per value.
-                    let counter = moment.map(|moment| {
-                        repeat_counters
-                            .entry(entity_path.clone())
-                            .or_default()
-                            .entry(moment)
-                            .or_insert(0)
-                    });
+                    let counter = moment.map(|moment| counters.entry(moment).or_insert(0));
                     let mut next_repeat = counter.as_ref().map_or(0, |c| **c);
                     for value in scalar_vec.iter() {
                         let key = match moment {

--- a/rrd-wasm/src/lib.rs
+++ b/rrd-wasm/src/lib.rs
@@ -94,10 +94,31 @@ impl RowKey {
 /// One decoded scalar field: its value at each time index of the recording.
 type Column = BTreeMap<RowKey, f64>;
 
-/// How many values `column` already holds at one time index. `key` builds the
-/// key for the n-th repeat at that time, so the count is the next free slot.
-fn repeats(column: &Column, key: impl Fn(u32) -> RowKey) -> u32 {
-    column.range(key(0)..=key(u32::MAX)).count() as u32
+/// The non-repeat part of a [`RowKey::Timed`]: one moment on the recording's
+/// timelines.
+type TimeKey = (Option<i64>, Option<i64>);
+
+/// Next repeat ordinal to assign, per column and moment.
+///
+/// A counter rather than a scan of the column: counting the existing repeats on
+/// every value made decoding quadratic in the length of a recording, even one
+/// with no repeats at all.
+type RepeatCounters = BTreeMap<String, BTreeMap<TimeKey, u32>>;
+
+/// How many values `column` holds at `time`, over every repeat.
+fn repeats_at(column: &Column, time: TimeKey) -> usize {
+    let (time_ns, step) = time;
+    let lo = RowKey::Timed {
+        time_ns,
+        step,
+        repeat: 0,
+    };
+    let hi = RowKey::Timed {
+        time_ns,
+        step,
+        repeat: u32::MAX,
+    };
+    column.range(lo..=hi).count()
 }
 
 /// Time index of every row in one chunk, per timeline the chunk carries. With
@@ -157,6 +178,7 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
 
     // Collect f64 scalars: entity_path -> (time index -> value)
     let mut scalars: BTreeMap<String, Column> = BTreeMap::new();
+    let mut repeat_counters: RepeatCounters = BTreeMap::new();
     let mut meta_scalars: BTreeMap<String, f64> = BTreeMap::new();
     let mut meta_texts: BTreeMap<String, String> = BTreeMap::new();
 
@@ -229,17 +251,17 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
                     };
                     // A batch usually holds one value per row, but `Scalars`
                     // takes a slice: several values at one time index become
-                    // consecutive repeats rather than being dropped. The repeat
-                    // counter is scanned once for the row and advanced locally,
-                    // so a wide batch costs one scan of the column, not one per
-                    // value.
-                    let mut next_repeat = timed.map_or(0, |(time_ns, step)| {
-                        repeats(column, |repeat| RowKey::Timed {
-                            time_ns,
-                            step,
-                            repeat,
-                        })
+                    // consecutive repeats rather than being dropped. The
+                    // ordinal comes from a counter, so a long recording does
+                    // not pay a scan of the column per value.
+                    let counter = timed.map(|time| {
+                        repeat_counters
+                            .entry(entity_path.clone())
+                            .or_default()
+                            .entry(time)
+                            .or_insert(0)
                     });
+                    let mut next_repeat = counter.as_ref().map_or(0, |c| **c);
                     for value in scalar_vec.iter() {
                         let key = match timed {
                             Some((time_ns, step)) => {
@@ -254,6 +276,9 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
                             None => RowKey::Index(column.len()),
                         };
                         column.insert(key, value.0.0);
+                    }
+                    if let Some(counter) = counter {
+                        *counter = next_repeat;
                     }
                 }
             }
@@ -301,7 +326,30 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
         // a state vector.
         let has_velocity = vel_cols.0.is_some() || vel_cols.1.is_some() || vel_cols.2.is_some();
 
+        // Repeat ordinals are assigned per column, so they only identify a row
+        // while every required column has the same number of values at that
+        // moment. Where the counts disagree, which value pairs with which is
+        // unknowable from the file: the moment is skipped rather than joined on
+        // an ordinal that means different things in different columns.
+        let required: Vec<&Column> = [Some(x_col), pos_cols.1, pos_cols.2]
+            .into_iter()
+            .chain(if has_velocity {
+                [vel_cols.0, vel_cols.1, vel_cols.2]
+            } else {
+                [None, None, None]
+            })
+            .flatten()
+            .collect();
+
         for &key in x_col.keys() {
+            if let RowKey::Timed { time_ns, step, .. } = key {
+                let time = (time_ns, step);
+                let counts: Vec<usize> = required.iter().map(|c| repeats_at(c, time)).collect();
+                if counts.iter().any(|&n| n != counts[0]) {
+                    continue;
+                }
+            }
+
             let triple = |cols: (Option<&Column>, Option<&Column>, Option<&Column>)| {
                 Some([at(cols.0, key)?, at(cols.1, key)?, at(cols.2, key)?])
             };
@@ -673,5 +721,77 @@ mod tests {
         assert_eq!(data.rows[1].angular_velocity, Some([0.01, 0.02, 0.03]));
         assert_eq!(data.rows[2].quaternion, None, "t=20 logged no attitude");
         assert_eq!(data.rows[2].angular_velocity, None);
+    }
+
+    /// A moment whose columns hold different numbers of values yields no row.
+    ///
+    /// Repeat ordinals are assigned per column, so they identify a row only
+    /// while every required column has the same count at that moment. With two
+    /// samples at t=0 where the first omits `y`, `x` holds repeats 0 and 1
+    /// while `y` holds only repeat 0 — joining on the ordinal paired the first
+    /// `x` with the second sample's `y` and dropped the second row, which is
+    /// the same shift this join set out to remove, one level in.
+    #[test]
+    fn a_time_whose_columns_disagree_on_repeats_yields_no_row() {
+        let parsed = decode_written(|rec| {
+            rec.set_duration_secs("sim_time", 0.0);
+            log_scalars(rec, &[("x", 100.0), ("z", 0.0)]);
+            log_scalars(rec, &[("x", 110.0), ("y", 201.0), ("z", 0.0)]);
+        });
+        assert!(
+            parsed.rows.is_empty(),
+            "ordinals cannot pair these values; expected no rows, got {:?}",
+            parsed.rows
+        );
+    }
+
+    /// Matching repeat counts still yield one row each, in order.
+    #[test]
+    fn matching_repeats_at_one_time_yield_a_row_each() {
+        let parsed = decode_written(|rec| {
+            rec.set_duration_secs("sim_time", 0.0);
+            log_scalars(rec, &[("x", 100.0), ("y", 1.0), ("z", 0.0)]);
+            log_scalars(rec, &[("x", 110.0), ("y", 2.0), ("z", 0.0)]);
+        });
+        assert_eq!(parsed.rows.len(), 2, "{:?}", parsed.rows);
+        assert_eq!(parsed.rows[0].x, 100.0);
+        assert_eq!(parsed.rows[0].y, 1.0);
+        assert_eq!(parsed.rows[1].x, 110.0);
+        assert_eq!(parsed.rows[1].y, 2.0);
+    }
+
+    /// A recording with no timeline at all still decodes, keyed by position.
+    ///
+    /// Nothing `orts` writes lands here — every recording it produces carries
+    /// `sim_time`, `step` or both — but a file from elsewhere can, and the
+    /// fallback has to stay reachable. Rows keyed this way report `t = 0`.
+    #[test]
+    fn a_recording_with_no_timeline_falls_back_to_column_order() {
+        let parsed = decode_written(|rec| {
+            // No `set_duration_secs` and no `set_time_sequence`.
+            log_scalars(rec, &[("x", 100.0), ("y", 200.0), ("z", 300.0)]);
+            log_scalars(rec, &[("x", 110.0), ("y", 210.0), ("z", 310.0)]);
+        });
+        assert_eq!(parsed.rows.len(), 2, "{:?}", parsed.rows);
+        for row in &parsed.rows {
+            assert_eq!(row.t, 0.0, "an untimed row reports t = 0");
+        }
+        assert_eq!(parsed.rows[0].x, 100.0);
+        assert_eq!(parsed.rows[1].x, 110.0);
+    }
+
+    /// Rows sharing a `t` keep the recording's own order.
+    ///
+    /// `sort_by` is stable and the rows are built in `RowKey` order, so several
+    /// `step`s at one `sim_time` come out in step order rather than arbitrarily.
+    #[test]
+    fn rows_sharing_a_sim_time_keep_step_order() {
+        let parsed = decode_stepped_samples(&[
+            (5.0, 10, vec![("x", 1.0), ("y", 0.0), ("z", 0.0)]),
+            (5.0, 11, vec![("x", 2.0), ("y", 0.0), ("z", 0.0)]),
+            (5.0, 12, vec![("x", 3.0), ("y", 0.0), ("z", 0.0)]),
+        ]);
+        let xs: Vec<f64> = parsed.rows.iter().map(|r| r.x).collect();
+        assert_eq!(xs, vec![1.0, 2.0, 3.0], "steps out of order: {xs:?}");
     }
 }

--- a/rrd-wasm/src/lib.rs
+++ b/rrd-wasm/src/lib.rs
@@ -220,8 +220,8 @@ fn repeats_at(column: &Column, moment: Moment) -> usize {
 struct ChunkKeys {
     sim_time: Option<Vec<i64>>,
     step: Option<Vec<i64>>,
-    /// The recording's own named axis, carried only by a chunk that has
-    /// neither of the two above.
+    /// The recording's own named axis, which identifies a row beside the two
+    /// above rather than in place of them.
     axis: Option<Vec<i64>>,
 }
 
@@ -285,7 +285,7 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
     let mut meta_texts: BTreeMap<String, String> = BTreeMap::new();
 
     // The one timeline of the recording's own naming, settled by the first
-    // chunk that carries neither `sim_time` nor `step` and kept for the rest.
+    // chunk to carry one and kept for the rest, whatever else that chunk has.
     let mut recording_axis: Option<String> = None;
 
     for msg in DecoderApp::decode_lazy(reader) {

--- a/rrd-wasm/src/lib.rs
+++ b/rrd-wasm/src/lib.rs
@@ -4,7 +4,7 @@
 //! Designed to be compiled to WASM for use in the viewer's Web Worker.
 //! Does NOT compute Keplerian elements — that is done by arika WASM.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Read;
 
 use re_chunk::Chunk;
@@ -353,21 +353,38 @@ pub fn decode_rrd(reader: impl Read) -> Result<ParsedRrd, Box<dyn std::error::Er
         .flatten()
         .collect();
 
+        // Counted once per moment, not once per repeat: a `Scalars` batch puts
+        // k values at one timestamp, and re-counting for each of them would
+        // make reconstruction quadratic in k.
+        let mut ambiguous: BTreeSet<TimeKey> = BTreeSet::new();
+        let mut checked: BTreeSet<TimeKey> = BTreeSet::new();
         for &key in x_col.keys() {
-            if let RowKey::Timed { time_ns, step, .. } = key {
-                let time = (time_ns, step);
-                // Only a moment that actually repeats can be ambiguous: with one
-                // value per column the ordinal is 0 everywhere, and a column
-                // absent at that moment is simply absent from the row.
-                let x_count = repeats_at(x_col, time);
-                if x_count > 1
-                    && present
-                        .iter()
-                        .map(|c| repeats_at(c, time))
-                        .any(|n| n != 0 && n != x_count)
-                {
-                    continue;
-                }
+            let RowKey::Timed { time_ns, step, .. } = key else {
+                continue;
+            };
+            let time = (time_ns, step);
+            if !checked.insert(time) {
+                continue;
+            }
+            // Only a moment that actually repeats can be ambiguous: with one
+            // value per column the ordinal is 0 everywhere, and a column absent
+            // at that moment is simply absent from the row.
+            let x_count = repeats_at(x_col, time);
+            if x_count > 1
+                && present
+                    .iter()
+                    .map(|c| repeats_at(c, time))
+                    .any(|n| n != 0 && n != x_count)
+            {
+                ambiguous.insert(time);
+            }
+        }
+
+        for &key in x_col.keys() {
+            if let RowKey::Timed { time_ns, step, .. } = key
+                && ambiguous.contains(&(time_ns, step))
+            {
+                continue;
             }
 
             let triple = |cols: (Option<&Column>, Option<&Column>, Option<&Column>)| {

--- a/rrd-wasm/src/lib.rs
+++ b/rrd-wasm/src/lib.rs
@@ -134,6 +134,12 @@ impl RowKey {
 /// `log_time` and `log_tick`, which rerun adds to every log call, say when a
 /// value was logged rather than when it happened: two fields of one state carry
 /// different ones and could never pair.
+///
+/// The axis is settled by the first chunk of the file to carry one, so a
+/// recording whose earlier chunks have none keys those without it and they no
+/// longer join with the later ones. Deciding it up front would mean decoding
+/// the file twice; the rows are lost rather than mixed, which is the failure
+/// this decode prefers.
 fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<ChunkKeys> {
     let timeline = |wanted: &str| {
         chunk
@@ -178,16 +184,12 @@ fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<Chun
         (Some(chosen), Some((name, col))) if name.as_str() == chosen.as_str() => {
             keys(Some(col.times_raw().to_vec()))
         }
-        // An axis that is not the recording's. A chunk that also carries
-        // `sim_time` or `step` still has a place among the rows; one that does
-        // not has nothing to place it by.
-        (Some(_), Some(_)) => {
-            if sim_time.is_some() || step.is_some() {
-                keys(None)
-            } else {
-                None
-            }
-        }
+        // An axis that is not the recording's. Keying on `sim_time` and `step`
+        // alone would drop it, and the row would then join fields that sit at
+        // no value of it at all: `x` at `sim_time = 0` beside a `y` at
+        // `sim_time = 0, iteration = 7`. The key holds one axis, so a chunk on
+        // another is left out rather than projected onto fewer dimensions.
+        (Some(_), Some(_)) => None,
         // No axis of its own: the two names above place the row, or its
         // column-local position does, which never joins with a timed key.
         (_, None) => keys(None),
@@ -1070,6 +1072,32 @@ mod tests {
             (row.x, row.y, row.z),
             (110.0, 201.0, 201.0),
             "every axis of the row must be frame 2's"
+        );
+    }
+
+    /// No row is assembled across two axes of the recording's own naming.
+    ///
+    /// Keying a chunk on `sim_time` and `step` alone drops the axis it does
+    /// carry, and the row can then join fields that sit at no value of it: `x`
+    /// and `z` at `sim_time = 0` beside a `y` at `sim_time = 0, iteration = 7`.
+    /// Which of two axes a file settles on depends on the order its chunks
+    /// arrive, so this holds the outcome rather than reproducing one ordering:
+    /// either way the position is never whole.
+    #[test]
+    fn no_row_is_assembled_across_two_named_axes() {
+        let parsed = decode_written(|rec| {
+            rec.set_duration_secs("sim_time", 0.0);
+            rec.set_time_sequence("frame", 1i64);
+            log_scalars(rec, &[("x", 100.0)]);
+            rec.disable_timeline("frame");
+            log_scalars(rec, &[("z", 300.0)]);
+            rec.set_time_sequence("iteration", 7i64);
+            log_scalars(rec, &[("y", 999.0)]);
+        });
+        assert!(
+            parsed.rows.is_empty(),
+            "the `iteration` chunk cannot be placed among the rest: {:?}",
+            parsed.rows
         );
     }
 }

--- a/rrd-wasm/src/lib.rs
+++ b/rrd-wasm/src/lib.rs
@@ -193,8 +193,6 @@ fn chunk_keys(chunk: &re_chunk::Chunk, axis: &mut Option<String>) -> Option<Chun
 /// One decoded scalar field: its value at each time index of the recording.
 type Column = BTreeMap<RowKey, f64>;
 
-/// The non-repeat part of a [`RowKey::Timed`]: one moment on the recording's
-/// timelines.
 /// One moment of a recording: a [`RowKey`] with its repeat number cleared, so
 /// that every value logged at that moment ranges within it.
 type Moment = RowKey;


### PR DESCRIPTION
RRD の読み出しが疎な列を配列 index で結合しており、別の時刻の値を同じ行に混ぜていた。**同じ欠陥が 3 つの decoder にあり、すべてを直す。**

| decoder | 通る経路 |
|---|---|
| `rrd-wasm` の `decode_rrd` | viewer が `.rrd` を直接開く |
| `orts` の `load_rrd_data` | `orts replay`、`orts serve` の history 読み戻し |
| `orts` の `load_as_recording` | `orts convert` |

3 つはコードを共有せず独立に decode するので、1 つを直しても他は残る。

## 症状

.rrd では scalar の各成分が独立した entity path（`<base>/x`, `<base>/y`, …）に載るので、状態行は複数の列から組み立てる。どの decoder も各成分を「値がある step だけ」の列に集め、最後に `x` 列の index `i` で全列を引いていた（欠損は `0.0` 埋め）。これが時刻と一致するのは、全列が全 step で値を持つ間だけ。

```rust
// orts/src/record/rerun_export.rs（変更前）
for (i, (t_ns, x)) in x_data.iter().enumerate() {
    let qw = qw.get(i)?.1;
```

`re_sdk` で `y` を t=10 にだけ書いた recording を読み直した実測:

| | t=0 の行 | t=10 の行 |
|---|---|---|
| 変更前 | `y = 201.0`（t=10 の値） | `y = 0.0` |
| 変更後 | 落ちる（position が揃わない） | `y = 201.0` |

attitude を 2 step 目以降に書くと、その最初の値が 1 行目に付く挙動も同じ原因。

## 変更内容

recording 自身の時刻 index でキーづけして join する。

- key は recording が持つ timeline すべて（`sim_time` と `step`）を含める。orts は両方を書き、同じ `sim_time` に複数の step が載りうるので、時刻だけでは別 step の値が同じ行に入る
- `sim_time` と `step` は orts が書く名前なので、どちらも無い recording では recording 自身の timeline を使う。それ以外の名前をすべて timeline なしとして扱うと、外部の .rrd が列の位置で結合されてしまう（実測: `y` を frame 2 にだけ書くと `Position3D` が `[100.0, 201.0, 0.0]`、frame 1 の `x` と frame 2 の `y` の組）。`log_time` と `log_tick` は除く。rerun が log 呼び出しごとに付けるもので、いつ起きたかでなくいつ logging したかを表すため、1 つの状態の 2 つの field が別の値を持ち対にならない
- その名前は recording 全体で 1 つ。軸が 2 つあれば別の次元なので、`frame` の 1 と `iteration` の 1 は同じ瞬間ではない（実測: `x` と `z` を `frame`、`y` を `iteration` に書くと `Position3D` が `[100.0, 999.0, 300.0]`、2 つの次元から組み立てた位置）。他の軸だけで index された chunk は、他の行と並べる根拠がないので落とす
- 独自の軸は `sim_time` と `step` の代わりでなく、それらと並ぶ 3 つめの slot として key に入れる。`step` と同じ slot にすると `frame` の 1 と `step` の 1 が同じ key になり（実測: `x`/`z` を `step = 1`、`y` を `frame = 1` に書くと `Position3D` が `[100.0, 999.0, 300.0]`）、`sim_time` がある chunk で軸を落とすと、同じ `sim_time` で `frame` が違う行が 1 つの瞬間の repeat になって到着順で組になる（実測: `x` を frame 1,2、`y`/`z` を frame 2,3 に t=0 で書くと `Position3D` が `[100.0, 201.0, 201.0]`。値数は一致するので repeat 検査には掛からない）
- 独自の軸を 2 本以上持つ chunk は key で表せないので落とす。recording の軸でない軸を持つ chunk も落とす。`sim_time` と `step` だけで key を作るとその軸が落ちて、その軸の値を一切持たない field と組になる（`sim_time = 0` の `x`/`z` と `sim_time = 0, iteration = 7` の `y`）
- 値が 1 つも入っていない列は、列が無いのと同じ扱いにする。空の `Scalars` バッチは列だけ残す。判定は列を引くところ（`column` と `get_scalar_data`）に置いたので、全 field に効く（実測: 空の `y` があると position が「揃わない state component」として行を 0 個に絞り、揃っている velocity の 2 行まで消える。空の `vx` があると position のみの recording が velocity 持ちに見え、揃っている position 2 行がすべて消える）

軸の名前はファイル中で最初に軸を持つ chunk が決める。前の方の chunk が軸を持たない recording では、それらは軸なしで key づけされ、後の chunk と結合しなくなる。先に決めるにはファイルを 2 度 decode する必要がある。行は混ざるのでなく失われる側に倒しており、doc コメントに書いた。
- key は repeat counter を持ち、同一時刻に複数回 logging された値は上書きせず別の行として復元する。1 行に複数値を持つ `Scalars` バッチも各値に連番を与えて全値を復元する
- 行を出すのは position 3 成分（recording が velocity 列を持つ場合は velocity 3 成分も）がその時刻に揃ったときで、揃わない行は落とす。`RrdRow` に欠損を表す手段がなく、ゼロは位置として意味を持ってしまうため

`load_as_recording` は `RrdRow` ではなく `Recording` を作るので、行の決め方も別に書く。`EntityStore` は entity の全 component 列で 1 つの timeline を共有するため、列ごとに「値がある時刻だけ」へ詰めると列同士が行 0 の意味で食い違う（実測: timeline が `[10.0]` なのに `num_rows` が 2、行 0 に t=10 の position と t=0 の velocity が並ぶ）。行の key は entity で 1 つに決める。

- `ComponentColumn` には「この行に値がない」を表す手段がないので、行を出すのは position と velocity が揃った時刻。一部の時刻にしか記録されていない component（attitude など）はゼロ埋めせず列ごと落とす。`orts convert` の CSV はこの値から軌道要素を計算するため、埋めたゼロが実測値と区別できなくなる
- key を作るのは entity 直下の field だけ。timeline を持たない static field と、独自の時刻を持つ子 entity を入れると、上位 entity が記録していない行が増える（実測: 2 行のはずが 5 行、うち 3 行が記録のない `[0.0, 0.0, 0.0]`）
- repeat 数が食い違う時刻を落とす検査も入れる。repeat 番号は field ごとなので、同一時刻の 2 サンプルのうち 1 つ目が `y` を欠くと、repeat 0 が 1 つ目の `x` と 2 つ目の `y` の組になる（実測 `Position3D = [100.0, 201.0, 0.0]`）

同一時刻に複数の値がある場合（`Scalars` の多値バッチ、同じ時刻への複数回の logging）は repeat 番号で区別する。ただし repeat 番号は列ごとに振るので、その時刻に存在する列の値数が食い違うと、どの値がどれと対になるか決められない。その時刻は行を出さない。検査は entity の全 temporal 列で行う。行を決めるのは position と velocity だが、entity のどこかで食い違えばその瞬間は対にならない（実測: 2 つの状態と 3 つの attitude を同じ時刻に書くと 2 行返り、先頭 2 つの attitude がその状態のものとして付く）。

```
t=0 に 2 サンプル、1 つ目が y を欠く場合:
  ordinal で結合すると x=100.0（1 つ目）と y=201.0（2 つ目）が組になり、2 つ目が消える
  → その時刻は 0 行にする
```

任意列（attitude、角速度）も同じ検査に含める。2 サンプル目にだけ付けた quaternion が 1 サンプル目に付いていた。

値数は時刻ごとに 1 度だけ数える。repeat ごとに数え直すと、多値バッチの大きさに対して二乗になる。「時刻」は `RowKey` から repeat 番号を落としたもので表す。`(Option<i64>, Option<i64>)` では `Timed` な key しか表せなかった。

`RowKey` / `Column` / `ChunkKeys` は両 crate に複製した。互いに依存関係がないため、共通化には新しい crate が必要になる。重複の解消は別途。

## 影響範囲

`orts run --format rrd` は 1 回の run のすべての step で同じ component を logging するので、その出力は古い経路を通らない（同梱 fixture のデコード結果は main と 11 行すべて値まで一致）。この経路に入るのは外部で書かれた .rrd。

`orts serve` の history segment は attitude が state ごとに optional なので疎になりうるが、`save_as_rrd` が component の row `i` を entity の timeline の row `i` に書くため、どちらの decoder が読む前にファイルの時点で既に誤った時刻にある。こちらは writer の修正が先に必要。

## テスト

**`rrd-wasm` 19 本**。dev-dependency に `re_sdk`（orts が .rrd を書くのに使っているのと同じ writer）を入れ、疎な recording を書いて読み直す。index join に戻すと 3 本が落ち、`y = 201.0` が t=0 の行に載ることを実測で確認した。

既存の round-trip テストは同じ状態を 5 回書いていたので index を入れ替えても通っていた。密な recording は全 6 成分・全 step の値を相異なるものにして、「値が自分の時刻の行に載る」ことを固定した。

同一時刻に 2 回書いた状態が 2 行として復元されること、同一 `sim_time` の別 step（key から `step` を外すと step 11 の x に step 12 の `y` が付く）、1 行に複数値を持つ `Scalars` バッチも、それぞれ別テストで固定した。

**`orts` 22 本**。こちらも `re_sdk` で直接書く。`save_as_rrd` を経由しないのは、`ComponentColumn` が timeline 行を持たないため、疎な component を誤った時刻で書き出すから。それを通したテストは loader ではなく writer を測ることになる。`load_as_recording` の分は、`Position3D` の行が 2 つの時刻の混合にならないこと、全 component 列の行数が entity の timeline と一致すること、repeat 数が食い違う時刻が 0 行になること、static field と子 entity が行を増やさないこと、一部の時刻にしか記録されていない component が落ちて position の行は残ること、ファイルに列が一切ない component の分だけが落ちて他の component の行は残ること、その component の残りの field が疎でも他の component の行を狭めないこと（どちらも schema 経路）を固定する。

timeline を一切持たない recording が列の順序で復元されることも両側で固定した。orts が書く recording は必ず `sim_time` か `step` を持つので、この経路に入るのは外部で書かれた .rrd だけ。

index join に戻すと rrd-wasm 3 本・orts 2 本が落ち、任意列を検査から外すと 1 本落ちる。既存の round-trip テストは通る。

`cargo test -p rrd-wasm` 23 件、`cargo test -p orts --lib rerun_export` 30 件 pass。同梱 fixture を `orts convert --format csv` に通した出力は 11 行で main と一致する（全列が全 step で値を持つため）。`cargo clippy --locked --workspace -- -D warnings` と `cargo deny check advisories` がどちらも 0 件。

## 残る制約

`load_as_recording` は key が持つ step と独自の軸を `Recording` に戻さず、`SimTime` だけを埋める。`step` だけで index された recording は全行 0 秒になり step timeline は再書き出しで失われ、独自の軸で index されたものはその軸を失う。main と同じ挙動で、`Recording` の CSV 経路は `SimTime` しか読まないため、他を埋めると `orts convert` の出力が変わる。コードに TODO を置いた。

## 関連

`save_as_rrd` は `ComponentColumn`（flat な `Vec<f64>`）を entity 単位の timeline と別に持つので、疎な component の値を誤った時刻で書き出す。上記の実測はこれを避けて `re_sdk` で直接書いている。writer 側は #379 が列単位の送信に置き換えるところで、時刻の対応そのものは変えていない。`Recording` の column に timeline 行を持たせる修正として別途扱う。











