### PR TITLE
fix(plugin-sdk): make the example control laws do what their READMEs claim

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -243,6 +243,31 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   なし) のため、`orts_plugin!` の callback 型 guest は影響なし。手書きの
   `impl Guest` guest は binding を再生成し新規 host import をリンクする必要がある。([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
+#### Fixed
+- `detumble-nadir` の Nadir モードが nadir を指向するようになった。star tracker の
+  body→inertial 姿勢をそのまま誤差クォータニオンとして扱っていたため、目標は
+  慣性 identity 姿勢・目標角速度 0 だった。`input.spacecraft.orbit` を参照せず、
+  LVLH 目標も軌道角速度 (LEO で ~1.1e-3 rad/s) も計算していない。nadir 指向が
+  成立している状態に対して 1.0 N·m の wheel torque を指令し、その間
+  `current_mode()` は "nadir" を返していた。([#367](https://github.com/sksat/orts/pull/367))
+- 指令を組めない tick が、そのモードが駆動するアクチュエータに明示的なゼロを
+  指令するようになった。WIT の `command` 契約では `None` は「コマンドなし =
+  前回値を保持」でゼロではないため、detumble 最後の磁気モーメントが nadir フェーズ中
+  ずっと通電し続け、センサ欠損時には wheel torque 指令が残って wheel が飽和へ
+  加速し続けていた。([#367](https://github.com/sksat/orts/pull/367))
+- `transfer-burn-with-tcm` と `constellation-phasing` が apogee で円化するように
+  なった。transfer ellipse の半周期は *perigee* からの時間だが、両 example は
+  そのタイマーを有限時間の first burn の**終了時**から起動していたため、burn が
+  張った弧の分だけ apogee を過ぎてから点火していた。同梱の 5000 N / 500 kg では
+  1.66° のずれで、推力が下がるほど弧が広がりずれは無限に大きくなりうる。apogee は
+  径方向速度 `r·v` の符号反転で検出し、タイマーは watchdog に降格した。
+  ([#367](https://github.com/sksat/orts/pull/367))
+- 両 example の同梱設定・bench スクリプト・README が `target/wasm32-wasip2/` を
+  指していた。host が読むのは component で、それを出す `cargo component build` の
+  出力先は `wasm32-wasip1` なので、手順どおりに実行しても plugin が見つからなかった。
+  `detumble-nadir` にはそもそも設定が無く一度も end-to-end で動かされていなかったので、
+  追加した。([#367](https://github.com/sksat/orts/pull/367))
+
 ### `arika` (Rust, crates.io)
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,6 +270,33 @@ section is subdivided by package.
   guests using `orts_plugin!` are unaffected; hand-written `impl Guest` guests
   must regenerate bindings and link the two new host imports. ([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
+#### Fixed
+- `detumble-nadir`'s Nadir mode points at nadir. It read the star tracker's
+  body→inertial attitude as the error quaternion, so its target was the inertial
+  identity attitude with zero rate — it never read `input.spacecraft.orbit`, and
+  computed neither the LVLH target nor the orbital rate (~1.1e-3 rad/s in LEO).
+  Given a spacecraft already holding nadir it commanded 1.0 N·m of wheel torque
+  while `current_mode()` reported "nadir". ([#367](https://github.com/sksat/orts/pull/367))
+- A tick that cannot build a command now zeroes the actuator its mode drives.
+  The WIT `command` contract reads `None` as "no command — hold the previous
+  value", not zero, so the last detumble magnetic moment stayed energised through
+  the whole nadir phase, and a missing sensor reading left a wheel torque command
+  in place, accelerating the wheel toward saturation.
+  ([#367](https://github.com/sksat/orts/pull/367))
+- `transfer-burn-with-tcm` and `constellation-phasing` circularize at apogee. The
+  transfer ellipse's half period runs from *perigee*, but both examples started
+  that timer when the finite first burn *ended*, so they lit up as far past
+  apogee as the burn's arc. At the bundled 5000 N / 500 kg the miss is 1.66°; the
+  lower the thrust, the wider the arc and the larger the miss, without bound.
+  Apogee is now detected from the sign change of the radial velocity `r·v`, with
+  the timer kept as a watchdog. ([#367](https://github.com/sksat/orts/pull/367))
+- The bundled configs, bench scripts and READMEs of both examples pointed at
+  `target/wasm32-wasip2/`, where nothing is built: the host loads a component,
+  and `cargo component build` writes those under `wasm32-wasip1`. Following the
+  documented steps could not find the plugin. `detumble-nadir` had no config at
+  all and had never been run end to end; it has one now.
+  ([#367](https://github.com/sksat/orts/pull/367))
+
 ### `arika` (Rust, crates.io)
 
 #### Added

--- a/plugin-sdk/examples/constellation-phasing/README.md
+++ b/plugin-sdk/examples/constellation-phasing/README.md
@@ -79,7 +79,7 @@ stateDiagram-v2
     [*] --> FirstBurn : raise_delay_s = 0
     Parked --> FirstBurn : t ≥ raise_delay_s
     FirstBurn --> Coast : SMA ≥ transfer_SMA
-    Coast --> SecondBurn : elapsed ≥ T_transfer / 2
+    Coast --> SecondBurn : r·v が上昇 → 非上昇 (apogee)
     SecondBurn --> Trim : SMA ≥ target_r
     Trim --> Trim : SMA ≥ target_r − deadband
     Trim --> Trim : SMA < target_r − deadband<br>(throttle = 1, TCM)
@@ -95,8 +95,8 @@ stateDiagram-v2
 
 ```bash
 cd plugin-sdk/examples/constellation-phasing
-cargo build --target wasm32-wasip2 --release
-# -> ../target/wasm32-wasip2/release/orts_example_plugin_constellation_phasing.wasm
+cargo +1.91.0 component build --release
+# -> ../target/wasm32-wasip1/release/orts_example_plugin_constellation_phasing.wasm
 ```
 
 以下のコマンド例は `orts` CLI が PATH に入っている前提。

--- a/plugin-sdk/examples/constellation-phasing/README.md
+++ b/plugin-sdk/examples/constellation-phasing/README.md
@@ -95,7 +95,7 @@ stateDiagram-v2
 
 ```bash
 cd plugin-sdk/examples/constellation-phasing
-cargo +1.91.0 component build --release
+cargo component build --release
 # -> ../target/wasm32-wasip1/release/orts_example_plugin_constellation_phasing.wasm
 ```
 

--- a/plugin-sdk/examples/constellation-phasing/bench.sh
+++ b/plugin-sdk/examples/constellation-phasing/bench.sh
@@ -8,7 +8,7 @@
 # - quick mode: N = 1, 8, 64 with --warmup 1 --runs 3 (dev iteration)
 #
 # Prereq:
-#   cargo +1.91.0 component build --release        # (in this directory)
+#   cargo component build --release        # (in this directory)
 #   hyperfine (github.com/sharkdp/hyperfine)
 #   python3
 

--- a/plugin-sdk/examples/constellation-phasing/bench.sh
+++ b/plugin-sdk/examples/constellation-phasing/bench.sh
@@ -8,7 +8,7 @@
 # - quick mode: N = 1, 8, 64 with --warmup 1 --runs 3 (dev iteration)
 #
 # Prereq:
-#   cargo build --target wasm32-wasip2 --release   # (in this directory)
+#   cargo +1.91.0 component build --release        # (in this directory)
 #   hyperfine (github.com/sharkdp/hyperfine)
 #   python3
 

--- a/plugin-sdk/examples/constellation-phasing/gen_bench_config.py
+++ b/plugin-sdk/examples/constellation-phasing/gen_bench_config.py
@@ -25,7 +25,7 @@ OUTPUT_INTERVAL = 100.0  # sparse to limit CSV-size scaling with N
 _SCRIPT_DIR = Path(__file__).resolve().parent
 WASM_PATH = str(
     _SCRIPT_DIR.parent
-    / "target/wasm32-wasip2/release/orts_example_plugin_constellation_phasing.wasm"
+    / "target/wasm32-wasip1/release/orts_example_plugin_constellation_phasing.wasm"
 )
 
 

--- a/plugin-sdk/examples/constellation-phasing/orts.toml
+++ b/plugin-sdk/examples/constellation-phasing/orts.toml
@@ -45,7 +45,7 @@ initial_angular_velocity = [0.0, 0.0, 0.0]
 
 [satellites.controller]
 type = "wasm"
-path = "../target/wasm32-wasip2/release/orts_example_plugin_constellation_phasing.wasm"
+path = "../target/wasm32-wasip1/release/orts_example_plugin_constellation_phasing.wasm"
 
 [satellites.controller.config]
 target_altitude_km = 550.0
@@ -90,7 +90,7 @@ initial_angular_velocity = [0.0, 0.0, 0.0]
 
 [satellites.controller]
 type = "wasm"
-path = "../target/wasm32-wasip2/release/orts_example_plugin_constellation_phasing.wasm"
+path = "../target/wasm32-wasip1/release/orts_example_plugin_constellation_phasing.wasm"
 
 [satellites.controller.config]
 target_altitude_km = 550.0
@@ -135,7 +135,7 @@ initial_angular_velocity = [0.0, 0.0, 0.0]
 
 [satellites.controller]
 type = "wasm"
-path = "../target/wasm32-wasip2/release/orts_example_plugin_constellation_phasing.wasm"
+path = "../target/wasm32-wasip1/release/orts_example_plugin_constellation_phasing.wasm"
 
 [satellites.controller.config]
 target_altitude_km = 550.0
@@ -180,7 +180,7 @@ initial_angular_velocity = [0.0, 0.0, 0.0]
 
 [satellites.controller]
 type = "wasm"
-path = "../target/wasm32-wasip2/release/orts_example_plugin_constellation_phasing.wasm"
+path = "../target/wasm32-wasip1/release/orts_example_plugin_constellation_phasing.wasm"
 
 [satellites.controller.config]
 target_altitude_km = 550.0

--- a/plugin-sdk/examples/constellation-phasing/src/lib.rs
+++ b/plugin-sdk/examples/constellation-phasing/src/lib.rs
@@ -23,6 +23,20 @@ use orts_plugin_sdk::{Plugin, orts_plugin};
 
 const EARTH_RADIUS_KM: f64 = 6378.137;
 
+/// Coast の watchdog 期限 \[s\]: `sma` の軌道 1 周期後（+10% の余裕）。
+///
+/// apogee はどの点から数えても 1 周期以内に来るので、これを過ぎても `r·v` の
+/// 符号反転を観測できないのは state stream 側の異常。余裕は摂動と有限
+/// sample_period のぶん。楕円でない状態（`sma <= 0` や非有限）では watchdog を
+/// 張らない（時間だけを根拠に噴かせない）。
+fn coast_watchdog_t(t: f64, sma: f64, mu: f64) -> Option<f64> {
+    if !sma.is_finite() || sma <= 0.0 {
+        return None;
+    }
+    let period = 2.0 * std::f64::consts::PI * (sma.powi(3) / mu).sqrt();
+    Some(t + 1.1 * period)
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Phase {
     Parked,
@@ -55,12 +69,19 @@ struct ConstellationPhasing {
     kd: f64,
     sample_period: f64,
     transfer_sma_km: Option<f64>,
-    transfer_half_period_s: Option<f64>,
-    coast_start_t: Option<f64>,
+    /// Coast → SecondBurn の watchdog 期限 \[s\]。主判定は `r·v` の符号反転
+    /// （= apogee）で、これは「apogee を検出できないまま coast 軌道 1 周期が
+    /// 過ぎた」場合に Coast から抜けるための保険。Coast 遷移時の実測 SMA から
+    /// 求める（nominal transfer SMA だと finite-burn の overshoot 分だけ実周期を
+    /// 下回り、本来の apogee より先に発火しうる）。
+    coast_watchdog_t: Option<f64>,
     phase: Phase,
     /// Last SMA [km] seen by `update()`. Used by SecondBurn/Trim to predict
     /// the next step's SMA change and throttle back to avoid overshoot.
     prev_sma_km: Option<f64>,
+    /// 前 tick の径方向速度 `r·v` \[km²/s\]。apogee（上昇 → 非上昇）の
+    /// 符号反転を見るために保持する。
+    prev_radial_rate: Option<f64>,
 }
 
 impl Plugin<TickInput, Command> for ConstellationPhasing {
@@ -111,10 +132,10 @@ impl Plugin<TickInput, Command> for ConstellationPhasing {
             kd: cfg.kd,
             sample_period: cfg.sample_period,
             transfer_sma_km: None,
-            transfer_half_period_s: None,
-            coast_start_t: None,
+            coast_watchdog_t: None,
             phase: initial_phase,
             prev_sma_km: None,
+            prev_radial_rate: None,
         })
     }
 
@@ -157,10 +178,7 @@ impl Plugin<TickInput, Command> for ConstellationPhasing {
                     self.phase = Phase::FirstBurn;
                     // FirstBurn に入ったら transfer orbit のパラメータをキャッシュする
                     // （parking 軌道の現 r を起点に計算）。
-                    let transfer_sma = (r + self.target_r_km) / 2.0;
-                    self.transfer_sma_km = Some(transfer_sma);
-                    self.transfer_half_period_s =
-                        Some(std::f64::consts::PI * (transfer_sma.powi(3) / self.mu_km3_s2).sqrt());
+                    self.transfer_sma_km = Some((r + self.target_r_km) / 2.0);
                     1.0
                 } else {
                     0.0
@@ -170,21 +188,28 @@ impl Plugin<TickInput, Command> for ConstellationPhasing {
                 let transfer_sma = *self
                     .transfer_sma_km
                     .get_or_insert((r + self.target_r_km) / 2.0);
-                let _ = self.transfer_half_period_s.get_or_insert(
-                    std::f64::consts::PI * (transfer_sma.powi(3) / self.mu_km3_s2).sqrt(),
-                );
                 if sma >= transfer_sma {
                     self.phase = Phase::Coast;
-                    self.coast_start_t = Some(input.t);
+                    self.coast_watchdog_t = coast_watchdog_t(input.t, sma, self.mu_km3_s2);
                     0.0
                 } else {
                     1.0
                 }
             }
             Phase::Coast => {
-                let half_period = self.transfer_half_period_s.unwrap_or(0.0);
-                let coast_elapsed = input.t - self.coast_start_t.unwrap_or(input.t);
-                if coast_elapsed >= half_period {
+                // apogee は状態量で判定する: 径方向速度 r·v が正（上昇）から
+                // 非正に変わる点が apogee。降下中に Coast へ入った場合は、
+                // まず上昇に転じるのを待つ。
+                //
+                // 時間ベースの判定を主にしてはいけない: transfer ellipse の
+                // 半周期は *perigee* 起点の時間なので、有限時間の FirstBurn の
+                // 終了時刻から測ると、burn 中に飛んだ弧の分だけ apogee を過ぎて
+                // から噴く。時間はここでは watchdog（apogee を 1 周期検出でき
+                // なかった場合の脱出）にだけ使う。
+                let radial_rate = r_vec.dot(&v_vec);
+                let was_ascending = self.prev_radial_rate.unwrap_or(radial_rate) > 0.0;
+                let watchdog_expired = self.coast_watchdog_t.is_some_and(|tw| input.t >= tw);
+                if (was_ascending && radial_rate <= 0.0) || watchdog_expired {
                     self.phase = Phase::SecondBurn;
                     1.0
                 } else {
@@ -232,6 +257,7 @@ impl Plugin<TickInput, Command> for ConstellationPhasing {
             }
         };
         self.prev_sma_km = Some(sma);
+        self.prev_radial_rate = Some(r_vec.dot(&v_vec));
 
         // 姿勢 target: body-Y を velocity 方向、body-Z を orbit normal に向ける。
         // Parked 中でも attitude tracking は有効にしておく（姿勢が安定していないと
@@ -319,5 +345,172 @@ impl Default for Config {
             kd: 20.0,
             sample_period: 1.0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MU: f64 = 398_600.441_8;
+
+    /// 近点通過から `dt` 秒後の 2 体問題の状態（軌道面 = x-y）。
+    /// Kepler 方程式を Newton 法で解くだけの self-contained な伝播。
+    fn kepler_state(a: f64, e: f64, dt: f64) -> (Vector3<f64>, Vector3<f64>) {
+        let n = (MU / (a * a * a)).sqrt();
+        let m = n * dt;
+        let mut ecc = m;
+        for _ in 0..60 {
+            let step = (ecc - e * ecc.sin() - m) / (1.0 - e * ecc.cos());
+            ecc -= step;
+            if step.abs() < 1e-14 {
+                break;
+            }
+        }
+        let b = a * (1.0 - e * e).sqrt();
+        let ecc_dot = n / (1.0 - e * ecc.cos());
+        (
+            Vector3::new(a * (ecc.cos() - e), b * ecc.sin(), 0.0),
+            Vector3::new(-a * ecc.sin() * ecc_dot, b * ecc.cos() * ecc_dot, 0.0),
+        )
+    }
+
+    fn tick(t: f64, r: Vector3<f64>, v: Vector3<f64>) -> TickInput {
+        TickInput {
+            t,
+            spacecraft: SpacecraftState {
+                orbit: OrbitalState {
+                    position: PositionEciKm {
+                        x: r.x,
+                        y: r.y,
+                        z: r.z,
+                    },
+                    velocity: VelocityEciKms {
+                        x: v.x,
+                        y: v.y,
+                        z: v.z,
+                    },
+                },
+                attitude: AttitudeState {
+                    orientation: Quat {
+                        w: 1.0,
+                        x: 0.0,
+                        y: 0.0,
+                        z: 0.0,
+                    },
+                    angular_velocity: Vec3 {
+                        x: 0.0,
+                        y: 0.0,
+                        z: 0.0,
+                    },
+                },
+                mass: 500.0,
+            },
+            epoch: None,
+            sensors: Sensors {
+                magnetometers: vec![],
+                gyroscopes: vec![],
+                star_trackers: vec![],
+                sun_sensors: vec![],
+            },
+            actuators: ActuatorTelemetry { rw: None },
+        }
+    }
+
+    const R_PARK: f64 = EARTH_RADIUS_KM + 350.0;
+    const R_TARGET: f64 = EARTH_RADIUS_KM + 550.0;
+    const CONFIG: &str = r#"{"target_altitude_km":550.0,"raise_delay_s":0.0,"sample_period":1.0}"#;
+
+    fn transfer_half_period() -> f64 {
+        let a = (R_PARK + R_TARGET) / 2.0;
+        std::f64::consts::PI * (a.powi(3) / MU).sqrt()
+    }
+
+    /// FirstBurn 終了を transfer ellipse 上の `burn_end`（perigee 通過からの
+    /// 経過時間）に置き、そこから 1 s 刻みで伝播して SecondBurn に入る tick を
+    /// 返す。戻り値は `(遷移時刻, r, v, 1 sample 前の r·v)`。
+    fn coast_until_second_burn(burn_end: f64) -> (f64, Vector3<f64>, Vector3<f64>, f64) {
+        let a = (R_PARK + R_TARGET) / 2.0;
+        let e = (R_TARGET - R_PARK) / (R_TARGET + R_PARK);
+        let half_period = transfer_half_period();
+
+        let mut ctrl = ConstellationPhasing::init(CONFIG).expect("config");
+
+        // t=0: parking 円軌道。ここで transfer_sma がキャッシュされる。
+        let v_circ = (MU / R_PARK).sqrt();
+        ctrl.update(&tick(
+            0.0,
+            Vector3::new(R_PARK, 0.0, 0.0),
+            Vector3::new(0.0, v_circ, 0.0),
+        ))
+        .expect("no error");
+        assert_eq!(ctrl.current_mode(), Some("first_burn"));
+
+        // transfer ellipse 上を 1 s 刻みで伝播する。sma を確実に
+        // transfer_sma 以上にするため a をごくわずか大きくとる。
+        let a_prop = a * (1.0 + 1e-9);
+        let mut prev_radial_rate = f64::NAN;
+        let mut t = burn_end;
+        while t < burn_end + 4.0 * half_period {
+            let (r, v) = kepler_state(a_prop, e, t);
+            ctrl.update(&tick(t, r, v)).expect("no error");
+            if ctrl.current_mode() == Some("second_burn") {
+                return (t, r, v, prev_radial_rate);
+            }
+            prev_radial_rate = r.dot(&v);
+            t += 1.0;
+        }
+        panic!("Coast から SecondBurn へ遷移するはず");
+    }
+
+    fn assert_switched_at_apogee(t_switch: f64, r: Vector3<f64>, v: Vector3<f64>, prev: f64) {
+        assert!(
+            prev > 0.0,
+            "apogee の 1 sample 前はまだ上昇中のはず: r·v = {prev}"
+        );
+        assert!(
+            r.dot(&v) <= 0.0,
+            "遷移 tick では下降に転じているはず: r·v = {}",
+            r.dot(&v)
+        );
+        let flight_path = r.dot(&v) / (r.norm() * v.norm());
+        assert!(
+            flight_path.abs() < 1e-3,
+            "SecondBurn は apogee で始まるはず: sin(fpa) = {flight_path:.3e} at t = {t_switch}"
+        );
+    }
+
+    /// SecondBurn は apogee で始まらなければならない。
+    ///
+    /// FirstBurn 終了時刻から半周期を数えると、burn 中に飛んだ弧の分だけ
+    /// apogee を過ぎてから噴く（同梱設定では 2808 s の半周期に対し burn
+    /// 5.6 s、ここでは低推力を模して 300 s）。
+    #[test]
+    fn second_burn_starts_at_apogee() {
+        let half_period = transfer_half_period();
+        let (t_switch, r, v, prev) = coast_until_second_burn(300.0);
+
+        assert_switched_at_apogee(t_switch, r, v, prev);
+        assert!(
+            (t_switch - half_period).abs() <= 1.0,
+            "apogee は t = {half_period:.1} s、遷移は t = {t_switch:.1} s"
+        );
+    }
+
+    /// 降下中に Coast へ入った場合（apogee を過ぎてから burn が終わった等）は、
+    /// その場で噴かずに次の apogee を待つ。`r·v <= 0` を単発で見ると、遷移直後の
+    /// 任意の点で噴いてしまう。
+    #[test]
+    fn coast_entered_while_descending_waits_for_the_next_apogee() {
+        let half_period = transfer_half_period();
+        // apogee の 500 s 後（降下中）で FirstBurn を終える。
+        let (t_switch, r, v, prev) = coast_until_second_burn(half_period + 500.0);
+
+        assert_switched_at_apogee(t_switch, r, v, prev);
+        let next_apogee = 3.0 * half_period;
+        assert!(
+            (t_switch - next_apogee).abs() <= 1.0,
+            "次の apogee は t = {next_apogee:.1} s、遷移は t = {t_switch:.1} s"
+        );
     }
 }

--- a/plugin-sdk/examples/constellation-phasing/src/lib.rs
+++ b/plugin-sdk/examples/constellation-phasing/src/lib.rs
@@ -207,7 +207,10 @@ impl Plugin<TickInput, Command> for ConstellationPhasing {
                 // から噴く。時間はここでは watchdog（apogee を 1 周期検出でき
                 // なかった場合の脱出）にだけ使う。
                 let radial_rate = r_vec.dot(&v_vec);
-                let was_ascending = self.prev_radial_rate.unwrap_or(radial_rate) > 0.0;
+                // `>= 0.0`: a previous rate of exactly zero is apogee reached, not
+                // apogee missed. Entering Coast already descending stays
+                // `prev < 0`, so the watchdog remains that case's way out.
+                let was_ascending = self.prev_radial_rate.unwrap_or(radial_rate) >= 0.0;
                 let watchdog_expired = self.coast_watchdog_t.is_some_and(|tw| input.t >= tw);
                 if (was_ascending && radial_rate <= 0.0) || watchdog_expired {
                     self.phase = Phase::SecondBurn;

--- a/plugin-sdk/examples/constellation-phasing/src/lib.rs
+++ b/plugin-sdk/examples/constellation-phasing/src/lib.rs
@@ -487,7 +487,7 @@ mod tests {
     ///
     /// FirstBurn 終了時刻から半周期を数えると、burn 中に飛んだ弧の分だけ
     /// apogee を過ぎてから噴く（同梱設定では 2808 s の半周期に対し burn
-    /// 5.6 s、ここでは低推力を模して 300 s）。
+    /// 6.0 s、ここでは低推力を模して 300 s）。
     #[test]
     fn second_burn_starts_at_apogee() {
         let half_period = transfer_half_period();

--- a/plugin-sdk/examples/detumble-nadir/orts.toml
+++ b/plugin-sdk/examples/detumble-nadir/orts.toml
@@ -1,0 +1,59 @@
+body = "earth"
+dt = 0.1
+output_interval = 10.0
+duration = 8000.0
+epoch = "2024-01-01T00:00:00Z"
+
+# Detumble → nadir pointing のモード遷移デモ。
+#
+# - Detumble: B-dot 則で MTQ を駆動し、|ω| < omega_threshold まで落とす
+#   (初期 |ω| = 0.015 rad/s から ~4,100 s)。
+# - Nadir: LVLH 目標姿勢を軌道状態から作り、RW で追従する。MTQ には
+#   明示的にゼロを指令する (WIT の `none` は「前回値を ZOH 保持」なので、
+#   detumble 最後の磁気モーメントが残らないようにする)。
+#
+# 収束後は body-Z が nadir を向き、body は LVLH と一緒に軌道角速度
+# n = √(μ/a³) ≈ 1.1e-3 rad/s で回り続ける。
+#
+# 実行:
+#   cd plugin-sdk/examples && cargo +1.91.0 component build --release
+#   cd detumble-nadir && orts run --config orts.toml --format csv --output out.csv
+
+[[satellites]]
+id = "detumble-nadir-demo"
+sensors = ["magnetometer", "gyroscope", "star_tracker"]
+
+[satellites.orbit]
+type = "circular"
+altitude = 500
+inclination = 51.6
+
+[satellites.attitude]
+inertia_diag = [1, 1, 1]
+mass = 50
+initial_quaternion = [1, 0, 0, 0]
+initial_angular_velocity = [0.0087, 0.0087, -0.0087]
+
+[satellites.controller]
+type = "wasm"
+path = "../target/wasm32-wasip1/release/orts_example_plugin_detumble_nadir.wasm"
+
+[satellites.controller.config]
+sample_period = 1.0
+detumble_gain = 1e5
+max_moment = 10.0
+omega_threshold = 0.01
+# inertia_diag = 1 kg·m² に対する PD ゲイン: ω_n = √(kp/I) = 0.05 rad/s、
+# ζ = kd / (2√(kp·I)) = 1.0 (臨界減衰)。要求トルクは max_torque 以下に収まる。
+nadir_kp = 0.0025
+nadir_kd = 0.1
+
+[satellites.magnetorquers]
+type = "three_axis"
+max_moment = 10.0
+
+[satellites.reaction_wheels]
+type = "three_axis"
+inertia = 0.05
+max_momentum = 10.0
+max_torque = 0.1

--- a/plugin-sdk/examples/detumble-nadir/orts.toml
+++ b/plugin-sdk/examples/detumble-nadir/orts.toml
@@ -16,7 +16,7 @@ epoch = "2024-01-01T00:00:00Z"
 # n = √(μ/a³) ≈ 1.1e-3 rad/s で回り続ける。
 #
 # 実行:
-#   cd plugin-sdk/examples && cargo +1.91.0 component build --release
+#   cd plugin-sdk/examples && cargo component build --release
 #   cd detumble-nadir && orts run --config orts.toml --format csv --output out.csv
 
 [[satellites]]

--- a/plugin-sdk/examples/detumble-nadir/src/lib.rs
+++ b/plugin-sdk/examples/detumble-nadir/src/lib.rs
@@ -1,9 +1,15 @@
 //! Detumble → nadir pointing モード遷移デモ — コールバック型。
 //!
 //! enum でモードを表現し、収束条件で遷移する。
+//!
+//! - **Detumble**: B-dot 則 `m = +k (ω × B)` で MTQ を駆動し `|ω|` を落とす。
+//! - **Nadir**: 軌道状態から LVLH フレームを組んで目標姿勢とし、誤差
+//!   クォータニオンと軌道角速度に対する PD を RW トルクとして出す。
+//!   `orts::attitude::control::{NadirPointing, TrackingPdController}` と
+//!   同じ定義・同じ誤差規約を使う。
 
+use nalgebra::{Matrix3, Rotation3, UnitQuaternion, Vector3};
 use orts_plugin_sdk::bindings::orts::plugin::types::*;
-use nalgebra::{UnitQuaternion, Vector3};
 use orts_plugin_sdk::{Plugin, orts_plugin};
 
 enum Mode {
@@ -67,7 +73,7 @@ impl Plugin<TickInput, Command> for Controller {
             } => {
                 let omega = match input.sensors.gyroscopes.first() {
                     Some(g) => Vector3::new(g.x, g.y, g.z),
-                    None => return Ok(None),
+                    None => return Ok(Some(stop_detumble())),
                 };
 
                 if omega.norm() < *omega_threshold {
@@ -75,15 +81,18 @@ impl Plugin<TickInput, Command> for Controller {
                         kp: self.nadir_kp,
                         kd: self.nadir_kd,
                     };
-                    return Ok(None);
+                    // MTQ は明示的にゼロを指令する。`mtq: None` は「コマンド
+                    // なし = 前回値を ZOH 保持」なので、detumble 最後の磁気
+                    // モーメントが nadir フェーズ中ずっと通電し続けてしまう。
+                    return Ok(Some(stop_detumble()));
                 }
 
                 let b = match input.sensors.magnetometers.first() {
                     Some(m) => Vector3::new(m.x, m.y, m.z),
-                    None => return Ok(None),
+                    None => return Ok(Some(stop_detumble())),
                 };
                 if b.norm_squared() < 1e-60 {
-                    return Ok(None);
+                    return Ok(Some(stop_detumble()));
                 }
 
                 // B-dot law: m = -k dB/dt, and in the body frame
@@ -107,24 +116,39 @@ impl Plugin<TickInput, Command> for Controller {
             Mode::Nadir { kp, kd } => {
                 let att = match input.sensors.star_trackers.first() {
                     Some(a) => a,
-                    None => return Ok(None),
+                    None => return Ok(Some(stop_nadir())),
                 };
                 let omega = match input.sensors.gyroscopes.first() {
                     Some(g) => Vector3::new(g.x, g.y, g.z),
-                    None => return Ok(None),
+                    None => return Ok(Some(stop_nadir())),
                 };
 
-                let q = UnitQuaternion::from_quaternion(nalgebra::Quaternion::new(
+                // star tracker は body→inertial 姿勢を返す。nadir 指向の
+                // 誤差はこれを LVLH 目標姿勢と比べて初めて得られる。
+                let q_measured = UnitQuaternion::from_quaternion(nalgebra::Quaternion::new(
                     att.w, att.x, att.y, att.z,
                 ));
-                let q = if q.w < 0.0 {
-                    UnitQuaternion::from_quaternion(-q.into_inner())
-                } else {
-                    q
+
+                let Some((q_target, omega_target)) = lvlh_target(&input.spacecraft.orbit) else {
+                    // 半径 0 または r ∥ v（純径方向軌道）では LVLH が定義でき
+                    // ない。目標が無いままトルク指令を残すと wheel が飽和する。
+                    return Ok(Some(stop_nadir()));
                 };
 
-                let theta = 2.0 * q.vector();
-                let tau = -*kp * theta - *kd * omega;
+                // 左不変誤差 q_err = q_target⁻¹ q_measured（body frame の誤差）。
+                let q_err = q_target.inverse() * q_measured;
+                // 半球選択（最短経路）。
+                let q_err = if q_err.w < 0.0 {
+                    UnitQuaternion::from_quaternion(-q_err.into_inner())
+                } else {
+                    q_err
+                };
+                let theta = 2.0 * q_err.vector();
+
+                // omega_target は目標(LVLH)フレーム成分なので、現 body frame へ
+                // 移してから角速度誤差を取る。q_err は current→target なので逆変換。
+                let omega_error = omega - q_err.inverse() * omega_target;
+                let tau = -*kp * theta - *kd * omega_error;
 
                 // Per-wheel motor torque (Newton's 3rd law for orthogonal 3-axis)
                 Ok(Some(Command {
@@ -139,6 +163,68 @@ impl Plugin<TickInput, Command> for Controller {
     fn current_mode(&self) -> Option<&str> {
         Some((&self.mode).into())
     }
+}
+
+/// Detumble が駆動するアクチュエータ（MTQ）を止める指令。
+///
+/// WIT の `command` 契約では、指令を省く（`mtq: None`）のは「前回値を ZOH
+/// 保持」であってゼロではない。センサが欠けて B-dot を組めないときに指令を
+/// 返さないと、直前の磁気モーメントが通電し続ける。制御できない間は切る。
+fn stop_detumble() -> Command {
+    Command {
+        mtq: Some(MtqCommand::Moments(vec![0.0; 3])),
+        rw: None,
+        thruster: None,
+    }
+}
+
+/// Nadir が駆動するアクチュエータ（RW）を止める指令。
+///
+/// こちらは ZOH 保持の害がさらに大きい: トルク指令が残り続けると wheel は
+/// 飽和へ向かって加速し続ける。姿勢・角速度・軌道のいずれかが使えない間は
+/// トルク 0 を指令し、wheel を現在の角運動量で惰走させる。
+fn stop_nadir() -> Command {
+    Command {
+        rw: Some(RwCommand::Torques(vec![0.0; 3])),
+        mtq: None,
+        thruster: None,
+    }
+}
+
+/// LVLH (nadir 指向) 目標姿勢と目標角速度を軌道状態から求める。
+///
+/// `orts::attitude::control::NadirPointing` と同じ定義:
+///
+/// - `z_lvlh = -r̂`（nadir）
+/// - `y_lvlh = -ĥ`（軌道法線の逆、`h = r × v`）
+/// - `x_lvlh = y_lvlh × z_lvlh`（円軌道なら概ね速度方向）
+///
+/// 戻り値は `(q_target, omega_target)`。`q_target` は body→inertial、
+/// `omega_target` は LVLH フレーム成分の `[0, -n, 0]`（`n = |h|/r²` \[rad/s\]）。
+/// `r` または `h` が退化している場合は `None`。
+fn lvlh_target(orbit: &OrbitalState) -> Option<(UnitQuaternion<f64>, Vector3<f64>)> {
+    let r = Vector3::new(orbit.position.x, orbit.position.y, orbit.position.z);
+    let v = Vector3::new(orbit.velocity.x, orbit.velocity.y, orbit.velocity.z);
+    let h = r.cross(&v);
+    let r_mag = r.norm();
+    let h_mag = h.norm();
+    // 0 除算を floor で弾く（`arika::rsw_quaternion` と同じ方針）。非有限
+    // 入力も同時に落とす: NaN は比較が全て false になるため明示的に検査する。
+    const DEGENERATE: f64 = 1e-10;
+    let well_posed =
+        r_mag.is_finite() && h_mag.is_finite() && r_mag > DEGENERATE && h_mag > DEGENERATE;
+    if !well_posed {
+        return None;
+    }
+
+    let z_lvlh = -r / r_mag;
+    let y_lvlh = -h / h_mag;
+    let x_lvlh = y_lvlh.cross(&z_lvlh);
+    let rot = Matrix3::from_columns(&[x_lvlh, y_lvlh, z_lvlh]);
+    let q_target = UnitQuaternion::from_rotation_matrix(&Rotation3::from_matrix_unchecked(rot));
+
+    let n = h_mag / (r_mag * r_mag);
+    Some((q_target, Vector3::new(0.0, -n, 0.0)))
 }
 
 orts_plugin!(Controller, mode);
@@ -164,5 +250,370 @@ impl Default for Config {
             nadir_kp: 1.0,
             nadir_kd: 2.0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MU: f64 = 398_600.441_8;
+    const R_CIRC: f64 = 6_878.137;
+
+    /// 赤道円軌道の状態（x 軸上、+y 方向へ prograde）。
+    fn circular_orbit() -> (Vector3<f64>, Vector3<f64>) {
+        (
+            Vector3::new(R_CIRC, 0.0, 0.0),
+            Vector3::new(0.0, (MU / R_CIRC).sqrt(), 0.0),
+        )
+    }
+
+    fn tick_input(
+        r: Vector3<f64>,
+        v: Vector3<f64>,
+        q: UnitQuaternion<f64>,
+        omega: Vector3<f64>,
+    ) -> TickInput {
+        TickInput {
+            t: 0.0,
+            spacecraft: SpacecraftState {
+                orbit: OrbitalState {
+                    position: PositionEciKm {
+                        x: r.x,
+                        y: r.y,
+                        z: r.z,
+                    },
+                    velocity: VelocityEciKms {
+                        x: v.x,
+                        y: v.y,
+                        z: v.z,
+                    },
+                },
+                attitude: AttitudeState {
+                    orientation: Quat {
+                        w: q.w,
+                        x: q.i,
+                        y: q.j,
+                        z: q.k,
+                    },
+                    angular_velocity: Vec3 {
+                        x: omega.x,
+                        y: omega.y,
+                        z: omega.z,
+                    },
+                },
+                mass: 100.0,
+            },
+            epoch: None,
+            sensors: Sensors {
+                magnetometers: vec![MagneticFieldBody {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 3e-5,
+                }],
+                gyroscopes: vec![AngularVelocityBody {
+                    x: omega.x,
+                    y: omega.y,
+                    z: omega.z,
+                }],
+                star_trackers: vec![AttitudeBodyToInertial {
+                    w: q.w,
+                    x: q.i,
+                    y: q.j,
+                    z: q.k,
+                }],
+                sun_sensors: vec![],
+            },
+            actuators: ActuatorTelemetry { rw: None },
+        }
+    }
+
+    fn nadir_controller() -> Controller {
+        let mut c = Controller::init("").expect("default config");
+        c.mode = Mode::Nadir {
+            kp: c.nadir_kp,
+            kd: c.nadir_kd,
+        };
+        c
+    }
+
+    fn rw_torques(cmd: &Command) -> Vec<f64> {
+        match cmd.rw.as_ref().expect("nadir mode must command the wheels") {
+            RwCommand::Torques(t) => t.clone(),
+            other => panic!("expected wheel torques, got {other:?}"),
+        }
+    }
+
+    /// LVLH 目標姿勢の定義そのものを固定する（`orts` の
+    /// `nadir_z_axis_points_toward_earth` と同じ不変量）。
+    #[test]
+    fn lvlh_target_points_body_z_at_nadir() {
+        let (r, v) = circular_orbit();
+        let input = tick_input(r, v, UnitQuaternion::identity(), Vector3::zeros());
+        let (q_target, omega_target) = lvlh_target(&input.spacecraft.orbit).expect("well-posed");
+
+        let z_body = q_target * Vector3::z();
+        assert!(
+            (z_body - (-r.normalize())).norm() < 1e-14,
+            "body +Z must point nadir, got {z_body:?}"
+        );
+        let h_hat = r.cross(&v).normalize();
+        let y_body = q_target * Vector3::y();
+        assert!(
+            (y_body - (-h_hat)).norm() < 1e-14,
+            "body +Y must point along -h, got {y_body:?}"
+        );
+
+        // 円軌道の軌道角速度 n = v/r（LVLH 成分で -Y 周り）。
+        let n = v.norm() / r.norm();
+        assert!((omega_target - Vector3::new(0.0, -n, 0.0)).norm() < 1e-15);
+        assert!(n > 1e-3, "LEO の軌道角速度は ~1.1e-3 rad/s のはず: {n}");
+    }
+
+    /// 姿勢と角速度が LVLH 目標に一致していればトルクは 0。
+    /// 慣性 identity 保持則ならここで大きなトルクを出す。
+    #[test]
+    fn nadir_commands_no_torque_while_tracking() {
+        let (r, v) = circular_orbit();
+        let (q_target, omega_target) = lvlh_target(&OrbitalState {
+            position: PositionEciKm {
+                x: r.x,
+                y: r.y,
+                z: r.z,
+            },
+            velocity: VelocityEciKms {
+                x: v.x,
+                y: v.y,
+                z: v.z,
+            },
+        })
+        .expect("well-posed");
+
+        let mut ctrl = nadir_controller();
+        let cmd = ctrl
+            .update(&tick_input(r, v, q_target, omega_target))
+            .expect("no error")
+            .expect("command");
+
+        let torques = rw_torques(&cmd);
+        let mag = torques.iter().fold(0.0_f64, |m, t| m.max(t.abs()));
+        assert!(
+            mag < 1e-12,
+            "tracking the LVLH target must need no torque, got {torques:?}"
+        );
+    }
+
+    /// nadir 周りの yaw 誤差に対して復元トルクを出す（大きさは kp·θ）。
+    #[test]
+    fn nadir_torque_restores_a_yaw_offset() {
+        let (r, v) = circular_orbit();
+        let (q_target, omega_target) = lvlh_target(
+            &tick_input(r, v, UnitQuaternion::identity(), Vector3::zeros())
+                .spacecraft
+                .orbit,
+        )
+        .expect("well-posed");
+
+        let offset = 5.0_f64.to_radians();
+        let q_err = UnitQuaternion::from_axis_angle(&Vector3::z_axis(), offset);
+        let q_measured = q_target * q_err;
+        // 角速度誤差 0 になるよう、目標角速度を現 body frame に写して与える。
+        let omega = q_err.inverse() * omega_target;
+
+        let mut ctrl = nadir_controller();
+        let cmd = ctrl
+            .update(&tick_input(r, v, q_measured, omega))
+            .expect("no error")
+            .expect("command");
+        let torques = rw_torques(&cmd);
+
+        // wheel torque = -body torque。body への復元トルクは -Z 周り。
+        assert!(
+            torques[2] > 0.0,
+            "wheel torque about +Z must absorb the -Z restoring torque, got {torques:?}"
+        );
+        let expected = ctrl.nadir_kp * offset;
+        let rel_err = ((torques[2] - expected) / expected).abs();
+        assert!(
+            rel_err < 0.01,
+            "|tau_z| ~ kp*theta = {expected:.5}, got {:.5}",
+            torques[2]
+        );
+        for (axis, tau) in [("x", torques[0]), ("y", torques[1])] {
+            assert!(
+                tau.abs() < 1e-12,
+                "pure yaw offset must not torque {axis}: {tau}"
+            );
+        }
+    }
+
+    /// r ∥ v（純径方向）では LVLH が定義できない。目標が無いので PD は組めない
+    /// が、指令を省くと直前の RW トルクが ZOH で残り wheel が飽和へ向かうので、
+    /// トルク 0 を明示的に指令する。
+    #[test]
+    fn nadir_stops_the_wheels_on_a_degenerate_orbit() {
+        let r = Vector3::new(R_CIRC, 0.0, 0.0);
+        let v = Vector3::new(1.0, 0.0, 0.0);
+        assert!(
+            lvlh_target(
+                &tick_input(r, v, UnitQuaternion::identity(), Vector3::zeros())
+                    .spacecraft
+                    .orbit
+            )
+            .is_none()
+        );
+
+        let mut ctrl = nadir_controller();
+        let cmd = ctrl
+            .update(&tick_input(
+                r,
+                v,
+                UnitQuaternion::identity(),
+                Vector3::zeros(),
+            ))
+            .expect("no error")
+            .expect("a degenerate orbit must still stop the wheels");
+        let torques = rw_torques(&cmd);
+        assert!(
+            torques.iter().all(|t| *t == 0.0),
+            "expected zero wheel torque, got {torques:?}"
+        );
+    }
+
+    /// センサが欠けて B-dot を組めない tick でも、指令を省かずゼロを出す。
+    /// 省くと直前の磁気モーメントが ZOH で通電し続ける。
+    #[test]
+    fn detumble_without_a_magnetometer_zeroes_the_mtq() {
+        let (r, v) = circular_orbit();
+        let mut ctrl = Controller::init("").expect("default config");
+
+        // |omega| = 0.1 rad/s は遷移閾値 (1e-2) より大きいので detumble のまま。
+        let mut input = tick_input(
+            r,
+            v,
+            UnitQuaternion::identity(),
+            Vector3::new(0.1, 0.0, 0.0),
+        );
+        input.sensors.magnetometers.clear();
+
+        let cmd = ctrl
+            .update(&input)
+            .expect("no error")
+            .expect("a missing magnetometer must still stop the MTQ");
+        assert_eq!(ctrl.current_mode(), Some("detumble"));
+        match cmd.mtq {
+            Some(MtqCommand::Moments(ref m)) => assert!(
+                m.iter().all(|v| *v == 0.0),
+                "expected zero magnetic moment, got {m:?}"
+            ),
+            other => panic!("expected an explicit zero MTQ command, got {other:?}"),
+        }
+    }
+
+    /// detumble → nadir の遷移 tick で MTQ を明示的に 0 にする。
+    /// `mtq: None` は「前回値を ZOH 保持」なので、最後の磁気モーメントが
+    /// nadir フェーズ中ずっと残ってしまう。
+    #[test]
+    fn transition_to_nadir_zeroes_the_mtq() {
+        let (r, v) = circular_orbit();
+        let mut ctrl = Controller::init("").expect("default config");
+        assert_eq!(ctrl.current_mode(), Some("detumble"));
+
+        // |omega| = 1e-3 < omega_threshold (1e-2) で遷移条件を満たす。
+        let input = tick_input(
+            r,
+            v,
+            UnitQuaternion::identity(),
+            Vector3::new(1e-3, 0.0, 0.0),
+        );
+        let cmd = ctrl
+            .update(&input)
+            .expect("no error")
+            .expect("transition tick must command something");
+
+        assert_eq!(ctrl.current_mode(), Some("nadir"));
+        match cmd.mtq {
+            Some(MtqCommand::Moments(ref m)) => assert!(
+                m.iter().all(|v| *v == 0.0),
+                "transition must zero the MTQ, got {m:?}"
+            ),
+            other => panic!("expected an explicit zero MTQ command, got {other:?}"),
+        }
+    }
+    /// 傾斜円軌道上の状態を時刻 `t` で返す（`R_CIRC` 半径、軌道面は X 軸周りに
+    /// `inc_rad` 傾ける）。
+    fn inclined_circular_orbit(inc_rad: f64, t: f64) -> (Vector3<f64>, Vector3<f64>) {
+        let n = (MU / R_CIRC.powi(3)).sqrt();
+        let u = Vector3::new(1.0, 0.0, 0.0);
+        let w = Vector3::new(0.0, inc_rad.cos(), inc_rad.sin());
+        let (s, c) = (n * t).sin_cos();
+        (R_CIRC * (c * u + s * w), R_CIRC * n * (-s * u + c * w))
+    }
+
+    /// 剛体 + 理想 wheel の閉ループで、body +Z が nadir に乗り、そのまま
+    /// **回り続ける**ことを確認する。
+    ///
+    /// 慣性固定則は「収束後は静止」なので、姿勢誤差の瞬間値ではなく軌道弧に
+    /// わたる追従で区別できる。収束後の body 角速度は軌道角速度に一致する
+    /// はずで、ゼロに落ちるならそれは慣性固定。
+    #[test]
+    fn nadir_tracks_the_rotating_lvlh_frame_over_an_orbit_arc() {
+        // 等方慣性なのでジャイロ項 ω × (Iω) が消え、プラントは I dω/dt = τ。
+        const INERTIA_KGM2: f64 = 10.0;
+        const INC_RAD: f64 = 0.5;
+        const DT: f64 = 0.1;
+        const SAMPLE_PERIOD: f64 = 0.5;
+        const DURATION: f64 = 1500.0; // 軌道弧 ~95°
+        // これ以降は追従が確立していること。
+        const SETTLED_AFTER: f64 = 400.0;
+
+        let mut ctrl = nadir_controller();
+        let mut q = UnitQuaternion::identity();
+        let mut omega = Vector3::zeros();
+        let mut torque = Vector3::zeros();
+        let mut next_tick = 0.0;
+        let mut worst_settled_cos = f64::INFINITY;
+
+        let mut t = 0.0;
+        while t < DURATION {
+            let (r, v) = inclined_circular_orbit(INC_RAD, t);
+
+            if t + 1e-9 >= next_tick {
+                let cmd = ctrl
+                    .update(&tick_input(r, v, q, omega))
+                    .expect("no error")
+                    .expect("nadir mode always commands the wheels");
+                // wheel torque の反作用が body トルク（`RwAssemblyCore::
+                // reaction_torque` と同じ符号）。
+                let wheel = rw_torques(&cmd);
+                torque = -Vector3::new(wheel[0], wheel[1], wheel[2]);
+                next_tick += SAMPLE_PERIOD;
+            }
+
+            if t >= SETTLED_AFTER {
+                let z_body = q * Vector3::z();
+                worst_settled_cos = worst_settled_cos.min(z_body.dot(&(-r.normalize())));
+            }
+
+            omega += torque / INERTIA_KGM2 * DT;
+            q *= UnitQuaternion::from_scaled_axis(omega * DT);
+            t += DT;
+        }
+
+        assert!(
+            worst_settled_cos > 0.999,
+            "body +Z must stay on nadir over the whole arc; worst cos = \
+             {worst_settled_cos:.6} ({:.2}° off)",
+            worst_settled_cos.clamp(-1.0, 1.0).acos().to_degrees()
+        );
+
+        let orbital_rate = (MU / R_CIRC.powi(3)).sqrt();
+        let rate_error = (omega.norm() - orbital_rate).abs() / orbital_rate;
+        assert!(
+            rate_error < 0.05,
+            "converged body rate {:.4e} rad/s must match the orbital rate \
+             {orbital_rate:.4e} rad/s (an inertial hold converges to zero)",
+            omega.norm()
+        );
     }
 }

--- a/plugin-sdk/examples/transfer-burn-with-tcm/README.md
+++ b/plugin-sdk/examples/transfer-burn-with-tcm/README.md
@@ -96,12 +96,12 @@ uv run plot.py   # → transfer_burn_with_tcm.png
   FirstBurn が初期軌道接線方向で点火され、Coast (transfer ellipse) を半周後、
   反対側で SecondBurn が発火して目標円軌道に載っている様子が読める。
 - **右上 (Altitude)**: 500 → 2000 km の単調上昇。burn 区間 (赤シェード) で
-  FirstBurn (t ≈ 0 – 37 s) が一瞬ジャンプ、Coast 中に transfer ellipse の
-  apogee へ向けて滑らかに上昇、t ≈ 3315 s（transfer 半周期 = apogee）の SecondBurn で circularize。
+  FirstBurn (t ≈ 0 – 34 s) が一瞬ジャンプ、Coast 中に transfer ellipse の
+  apogee へ向けて滑らかに上昇、t ≈ 3329 s（apogee、transfer 半周期 3315 s + FirstBurn 中に飛んだ弧）の SecondBurn で circularize。
   各 burn の Δalt 値が注釈付き。
 - **右下 (Orbital speed)**: burn 区間 (赤シェード) と **Δv 注釈** 付き。
-  FirstBurn で 7.613 → 7.98 km/s に加速、Coast 中は vis-viva により altitude
-  上昇と引き換えに 7.98 → 6.55 km/s に減速、SecondBurn で 6.55 → 6.90 km/s
+  FirstBurn で 7.613 → 7.979 km/s に加速、Coast 中は vis-viva により altitude
+  上昇と引き換えに 7.979 → 6.565 km/s に減速、SecondBurn で 6.565 → 6.914 km/s
   に再加速して target 円軌道の速度へ。教科書 Hohmann の 2-impulse 特性そのもの。
 
 burn 区間の検出は `orts` が CSV に出力する `throttle_0` / `throttle_1` /

--- a/plugin-sdk/examples/transfer-burn-with-tcm/README.md
+++ b/plugin-sdk/examples/transfer-burn-with-tcm/README.md
@@ -97,7 +97,8 @@ uv run plot.py   # → transfer_burn_with_tcm.png
   反対側で SecondBurn が発火して目標円軌道に載っている様子が読める。
 - **右上 (Altitude)**: 500 → 2000 km の単調上昇。burn 区間 (赤シェード) で
   FirstBurn (t ≈ 0 – 34 s) が一瞬ジャンプ、Coast 中に transfer ellipse の
-  apogee へ向けて滑らかに上昇、t ≈ 3329 s（apogee、transfer 半周期 3315 s + FirstBurn 中に飛んだ弧）の SecondBurn で circularize。
+  apogee へ向けて滑らかに上昇、SecondBurn で circularize。SecondBurn の発火は
+  径方向速度 `r·v` の符号反転で決まり、同梱設定では t ≈ 3329 s（実測）。
   各 burn の Δalt 値が注釈付き。
 - **右下 (Orbital speed)**: burn 区間 (赤シェード) と **Δv 注釈** 付き。
   FirstBurn で 7.613 → 7.979 km/s に加速、Coast 中は vis-viva により altitude

--- a/plugin-sdk/examples/transfer-burn-with-tcm/README.md
+++ b/plugin-sdk/examples/transfer-burn-with-tcm/README.md
@@ -71,7 +71,7 @@ SecondBurn でも姿勢整合が取れる（この姿勢トラッキングがな
 
 ```sh
 cd plugin-sdk/examples
-cargo +1.91.0 component build -p orts-example-plugin-transfer-burn-with-tcm --release
+cargo component build -p orts-example-plugin-transfer-burn-with-tcm --release
 ```
 
 出力: `target/wasm32-wasip1/release/orts_example_plugin_transfer_burn_with_tcm.wasm`

--- a/plugin-sdk/examples/transfer-burn-with-tcm/README.md
+++ b/plugin-sdk/examples/transfer-burn-with-tcm/README.md
@@ -24,14 +24,14 @@ stateDiagram-v2
     direction LR
     [*] --> FirstBurn
     FirstBurn --> Coast: sma ≥ (r₁+r₂)/2
-    Coast --> SecondBurn: coast_elapsed ≥ T_transfer/2
+    Coast --> SecondBurn: r·v が上昇 → 非上昇 (apogee)
     SecondBurn --> Trim: sma ≥ r_target
     Trim --> Trim: sma < r_target − deadband<br/>→ throttle = 1
     note right of FirstBurn
         prograde 連続噴射で<br/>transfer ellipse まで上昇
     end note
     note right of Coast
-        throttle = 0<br/>半周期タイマで apogee 検出
+        throttle = 0<br/>r·v の符号反転で apogee 検出
     end note
     note right of SecondBurn
         apogee で再び prograde<br/>SMA を target まで上げて円化
@@ -43,9 +43,11 @@ stateDiagram-v2
 
 - **FirstBurn**: prograde 連続噴射で SMA を transfer ellipse の値
   `(r_initial + r_target)/2` まで上げる。
-- **Coast**: throttle=0。transfer ellipse 上を慣性飛行。半周期タイマで
-  apogee 到達を判定（finite-burn 損失で `r` がぴったり届かない場合でも
-  ロバスト、実機の maneuver 計画でも一般的）。
+- **Coast**: throttle=0。transfer ellipse 上を慣性飛行。apogee は径方向速度
+  `r·v` が正（上昇）から非正に変わる点として検出する（finite-burn 損失で `r` が
+  ぴったり届かない場合でも apogee そのものを捉える）。時間ベースにすると
+  transfer 半周期は perigee 起点なので、FirstBurn 終了時刻から測った分だけ
+  遅れる。1 transfer 周期を超えても検出できない場合だけ watchdog として遷移。
 - **SecondBurn**: target SMA まで prograde 噴射で円化。
 - **Trim (TCM)**: drag や初期 burn 誤差で SMA が deadband 分下がったら
   補正 burn。instantaneous の `r` で判定すると楕円軌道 perigee で毎周期
@@ -63,16 +65,16 @@ stateDiagram-v2
 `τ = -Kp·θ - Kd·ω` を RW トルクとして発行。結果として body-Y の推力
 ベクトルは常に prograde を向き、低推力・長時間 burn や apogee での
 SecondBurn でも姿勢整合が取れる（この姿勢トラッキングがないと
-半周期後の SecondBurn は retrograde になって軌道が崩壊する）。
+半周後の SecondBurn は retrograde になって軌道が崩壊する）。
 
 ## ビルド
 
 ```sh
 cd plugin-sdk/examples
-cargo build -p orts-example-plugin-transfer-burn-with-tcm --target wasm32-wasip2 --release
+cargo +1.91.0 component build -p orts-example-plugin-transfer-burn-with-tcm --release
 ```
 
-出力: `target/wasm32-wasip2/release/orts_example_plugin_transfer_burn_with_tcm.wasm`
+出力: `target/wasm32-wasip1/release/orts_example_plugin_transfer_burn_with_tcm.wasm`
 
 ## シミュレーション実行
 
@@ -95,7 +97,7 @@ uv run plot.py   # → transfer_burn_with_tcm.png
   反対側で SecondBurn が発火して目標円軌道に載っている様子が読める。
 - **右上 (Altitude)**: 500 → 2000 km の単調上昇。burn 区間 (赤シェード) で
   FirstBurn (t ≈ 0 – 37 s) が一瞬ジャンプ、Coast 中に transfer ellipse の
-  apogee へ向けて滑らかに上昇、t ≈ 3350 s の SecondBurn で circularize。
+  apogee へ向けて滑らかに上昇、t ≈ 3315 s（transfer 半周期 = apogee）の SecondBurn で circularize。
   各 burn の Δalt 値が注釈付き。
 - **右下 (Orbital speed)**: burn 区間 (赤シェード) と **Δv 注釈** 付き。
   FirstBurn で 7.613 → 7.98 km/s に加速、Coast 中は vis-viva により altitude
@@ -152,8 +154,8 @@ direction_body = [0.0, 1.0, 0.0]  # +Y body
   できず plugin は FirstBurn 開始時に Err を返す。
 - FirstBurn の Δv は sample_period 粒度で決まるため、精密な軌道制御には
   sample_period を小さくするか、finite-burn 計画と closed-loop 合流を
-  組むとよい（今回の demo は時間ベース半周期タイマで apogee を外さない
-  ロバスト設計）。
+  組むとよい（apogee 判定自体は状態量 `r·v` から取るので、burn が長引いても
+  点火位置は apogee に留まる）。
 
 ## 関連テスト
 

--- a/plugin-sdk/examples/transfer-burn-with-tcm/orts.toml
+++ b/plugin-sdk/examples/transfer-burn-with-tcm/orts.toml
@@ -36,7 +36,7 @@ initial_angular_velocity = [0.0, 0.0, 0.0]
 
 [satellites.controller]
 type = "wasm"
-path = "../target/wasm32-wasip2/release/orts_example_plugin_transfer_burn_with_tcm.wasm"
+path = "../target/wasm32-wasip1/release/orts_example_plugin_transfer_burn_with_tcm.wasm"
 
 [satellites.controller.config]
 target_altitude_km = 2000.0

--- a/plugin-sdk/examples/transfer-burn-with-tcm/orts.toml
+++ b/plugin-sdk/examples/transfer-burn-with-tcm/orts.toml
@@ -11,9 +11,9 @@ atmosphere = "none"
 # 司令するので、body-Y が常に velocity 方向を向いた状態で burn できる
 # （教科書通りの 2-burn Hohmann になる）。
 #
-# - FirstBurn: t≈0 から ~37 s。Δv ≈ 366 m/s を prograde に投入。
+# - FirstBurn: t≈0 から ~34 s。Δv ≈ 366 m/s を prograde に投入。
 #   transfer ellipse (perigee 500 km / apogee 2000 km、SMA 7628 km) を形成。
-# - Coast: t≈37 s から ~3314 s (transfer 半周期)。ballistic に apogee へ。
+# - Coast: t≈34 s から ~3329 s (apogee)。ballistic に apogee へ。
 # - SecondBurn: apogee で再び prograde burn、SMA を target まで上げて円化。
 # - Trim: SMA が deadband 分だけ下回ったら TCM 補正 burn (drag 等に対抗)。
 #

--- a/plugin-sdk/examples/transfer-burn-with-tcm/src/lib.rs
+++ b/plugin-sdk/examples/transfer-burn-with-tcm/src/lib.rs
@@ -212,7 +212,10 @@ impl Plugin<TickInput, Command> for TransferBurnWithTcm {
                 // 1.7°、flight path angle 0.18° 残り）。時間はここでは
                 // watchdog（apogee を 1 周期検出できなかった場合の脱出）にだけ使う。
                 let radial_rate = r_vec.dot(&v_vec);
-                let was_ascending = self.prev_radial_rate.unwrap_or(radial_rate) > 0.0;
+                // `>= 0.0`: a previous rate of exactly zero is apogee reached, not
+                // apogee missed. Entering Coast already descending stays
+                // `prev < 0`, so the watchdog remains that case's way out.
+                let was_ascending = self.prev_radial_rate.unwrap_or(radial_rate) >= 0.0;
                 let watchdog_expired = self.coast_watchdog_t.is_some_and(|tw| input.t >= tw);
                 if (was_ascending && radial_rate <= 0.0) || watchdog_expired {
                     self.phase = Phase::SecondBurn;

--- a/plugin-sdk/examples/transfer-burn-with-tcm/src/lib.rs
+++ b/plugin-sdk/examples/transfer-burn-with-tcm/src/lib.rs
@@ -208,8 +208,8 @@ impl Plugin<TickInput, Command> for TransferBurnWithTcm {
                 // 時間ベースの判定を主にしてはいけない: transfer ellipse の
                 // 半周期は *perigee* からの時間なので、有限時間の FirstBurn の
                 // 終了時刻を起点にすると、既に飛んだ弧の分だけ apogee を過ぎて
-                // から噴く（同梱設定では 3315 s に対し burn 37 s、apogee から
-                // 1.7°、flight path angle 0.18° 残り）。時間はここでは
+                // から噴く（同梱設定では半周期 3315 s に対し burn 33.5 s、
+                // apogee から 1.5°、flight path angle 0.16° 残り）。時間はここでは
                 // watchdog（apogee を 1 周期検出できなかった場合の脱出）にだけ使う。
                 let radial_rate = r_vec.dot(&v_vec);
                 // `>= 0.0`: a previous rate of exactly zero is apogee reached, not
@@ -473,7 +473,7 @@ mod tests {
     ///
     /// FirstBurn 終了時刻から半周期を数えると、burn 中に飛んだ弧の分だけ
     /// apogee を過ぎてから噴く（同梱設定では 3315 s の半周期に対し burn
-    /// 37 s、ここでは低推力を模して 300 s）。
+    /// 33.5 s、ここでは低推力を模して 300 s）。
     #[test]
     fn second_burn_starts_at_apogee() {
         let half_period = transfer_half_period();

--- a/plugin-sdk/examples/transfer-burn-with-tcm/src/lib.rs
+++ b/plugin-sdk/examples/transfer-burn-with-tcm/src/lib.rs
@@ -17,7 +17,7 @@
 //! # State Machine
 //!
 //! ```text
-//!                 sma >= (r1+r2)/2        coast_elapsed >= T_transfer/2
+//!                 sma >= (r1+r2)/2        r·v: + → 0 以下 (apogee)
 //!      FirstBurn ────────────────▶ Coast ───────────────────────────▶ SecondBurn
 //!                                                                           │
 //!                                                                   sma >= r_target
@@ -29,10 +29,12 @@
 //!                                                          で再度 throttle = 1 (TCM)
 //! ```
 //!
-//! - **Coast → SecondBurn**: apogee 到達を時間ベース（transfer ellipse の
-//!   半周期経過）で判定する。finite-burn 損失で `r` が `target` にぴったり
-//!   届かない場合でもロバストに遷移する。実機の maneuver 計画でも
-//!   半周期タイマーで apogee を打つのが一般的。
+//! - **Coast → SecondBurn**: apogee 到達を径方向速度 `r·v` の符号反転
+//!   （上昇 → 非上昇）で判定する。finite-burn 損失で `r` が `target` に
+//!   ぴったり届かない場合でも apogee そのものを捉える。時間ベースにすると、
+//!   transfer ellipse の半周期は perigee 起点の時間なので FirstBurn 終了時刻から
+//!   測った分だけ遅れる。時間は「coast 軌道 1 周期経っても apogee を検出できない」
+//!   場合の watchdog にだけ使う。
 //! - **Trim (TCM)**: drag や初期 burn 誤差で SMA が目標を下回ったときのみ
 //!   補正 burn。instantaneous の `r` で判定すると楕円軌道の perigee で
 //!   毎周期発火してしまうので、軌道サイズ (SMA) ベースで判定する。
@@ -62,6 +64,20 @@ use orts_plugin_sdk::bindings::orts::plugin::types::*;
 use orts_plugin_sdk::{Plugin, orts_plugin};
 
 const EARTH_RADIUS_KM: f64 = 6378.137;
+
+/// Coast の watchdog 期限 \[s\]: `sma` の軌道 1 周期後（+10% の余裕）。
+///
+/// apogee はどの点から数えても 1 周期以内に来るので、これを過ぎても `r·v` の
+/// 符号反転を観測できないのは state stream 側の異常。余裕は摂動と有限
+/// sample_period のぶん。楕円でない状態（`sma <= 0` や非有限）では watchdog を
+/// 張らない（時間だけを根拠に噴かせない）。
+fn coast_watchdog_t(t: f64, sma: f64, mu: f64) -> Option<f64> {
+    if !sma.is_finite() || sma <= 0.0 {
+        return None;
+    }
+    let period = 2.0 * std::f64::consts::PI * (sma.powi(3) / mu).sqrt();
+    Some(t + 1.1 * period)
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Phase {
@@ -93,12 +109,15 @@ struct TransferBurnWithTcm {
     sample_period: f64,
     // derived (lazy from first update)
     transfer_sma_km: Option<f64>,
-    /// transfer ellipse 半周期 [s] — Coast → SecondBurn の切り替えに使う。
-    /// finite burn 損失があるため、apogee を `r` ベースで検出するよりも
-    /// 時間ベースの方がロバスト（実機の maneuver 計画でも一般的）。
-    transfer_half_period_s: Option<f64>,
-    /// Coast フェーズに入った時刻 [s]。
-    coast_start_t: Option<f64>,
+    /// Coast → SecondBurn の watchdog 期限 \[s\]。主判定は `r·v` の符号反転
+    /// （= apogee）で、これは「apogee を検出できないまま coast 軌道 1 周期が
+    /// 過ぎた」場合に Coast から抜けるための保険。Coast 遷移時の実測 SMA から
+    /// 求める（nominal transfer SMA だと finite-burn の overshoot 分だけ実周期を
+    /// 下回り、本来の apogee より先に発火しうる）。
+    coast_watchdog_t: Option<f64>,
+    /// 前 tick の径方向速度 `r·v` \[km²/s\]。apogee（上昇 → 非上昇）の
+    /// 符号反転を見るために保持する。
+    prev_radial_rate: Option<f64>,
     phase: Phase,
 }
 
@@ -141,8 +160,8 @@ impl Plugin<TickInput, Command> for TransferBurnWithTcm {
             kd: cfg.kd,
             sample_period: cfg.sample_period,
             transfer_sma_km: None,
-            transfer_half_period_s: None,
-            coast_start_t: None,
+            coast_watchdog_t: None,
+            prev_radial_rate: None,
             phase: Phase::FirstBurn,
         })
     }
@@ -171,26 +190,31 @@ impl Plugin<TickInput, Command> for TransferBurnWithTcm {
             ));
         }
 
-        // transfer 半周期を一度だけ計算してキャッシュ。
-        let half_period = *self
-            .transfer_half_period_s
-            .get_or_insert(std::f64::consts::PI * (transfer_sma.powi(3) / self.mu_km3_s2).sqrt());
-
         let throttle = match self.phase {
             Phase::FirstBurn => {
                 if sma >= transfer_sma {
                     self.phase = Phase::Coast;
-                    self.coast_start_t = Some(input.t);
+                    self.coast_watchdog_t = coast_watchdog_t(input.t, sma, self.mu_km3_s2);
                     0.0
                 } else {
                     1.0
                 }
             }
             Phase::Coast => {
-                // 時間ベースで apogee 到達を判定（finite-burn 損失で r が
-                // target に届かない場合でも確実に SecondBurn へ遷移する）。
-                let coast_elapsed = input.t - self.coast_start_t.unwrap_or(input.t);
-                if coast_elapsed >= half_period {
+                // apogee は状態量で判定する: 径方向速度 r·v が正（上昇）から
+                // 非正に変わる点が apogee。降下中に Coast へ入った場合（初期
+                // 軌道が円でない等）は、まず上昇に転じるのを待つ。
+                //
+                // 時間ベースの判定を主にしてはいけない: transfer ellipse の
+                // 半周期は *perigee* からの時間なので、有限時間の FirstBurn の
+                // 終了時刻を起点にすると、既に飛んだ弧の分だけ apogee を過ぎて
+                // から噴く（同梱設定では 3315 s に対し burn 37 s、apogee から
+                // 1.7°、flight path angle 0.18° 残り）。時間はここでは
+                // watchdog（apogee を 1 周期検出できなかった場合の脱出）にだけ使う。
+                let radial_rate = r_vec.dot(&v_vec);
+                let was_ascending = self.prev_radial_rate.unwrap_or(radial_rate) > 0.0;
+                let watchdog_expired = self.coast_watchdog_t.is_some_and(|tw| input.t >= tw);
+                if (was_ascending && radial_rate <= 0.0) || watchdog_expired {
                     self.phase = Phase::SecondBurn;
                     1.0
                 } else {
@@ -216,6 +240,7 @@ impl Plugin<TickInput, Command> for TransferBurnWithTcm {
                 }
             }
         };
+        self.prev_radial_rate = Some(r_vec.dot(&v_vec));
 
         // 2. 姿勢 target: body-Y を velocity 方向に、body-Z を orbit 法線に
         let y_target = v_vec.normalize();
@@ -227,9 +252,8 @@ impl Plugin<TickInput, Command> for TransferBurnWithTcm {
 
         // 3. PD on attitude error → RW torque
         let att = &input.spacecraft.attitude.orientation;
-        let q_current = UnitQuaternion::from_quaternion(nalgebra::Quaternion::new(
-            att.w, att.x, att.y, att.z,
-        ));
+        let q_current =
+            UnitQuaternion::from_quaternion(nalgebra::Quaternion::new(att.w, att.x, att.y, att.z));
         let q_err = q_target.inverse() * q_current;
         // 半球選択（最短経路）。
         let q_err = if q_err.w < 0.0 {
@@ -268,7 +292,10 @@ impl Plugin<TickInput, Command> for TransferBurnWithTcm {
         Ok(Some(Command {
             rw: Some(RwCommand::Torques(rw_torques)),
             mtq: None,
-            thruster: Some(ThrusterCommand::Throttles(vec![throttle; self.num_thrusters])),
+            thruster: Some(ThrusterCommand::Throttles(vec![
+                throttle;
+                self.num_thrusters
+            ])),
         }))
     }
 
@@ -304,5 +331,172 @@ impl Default for Config {
             kd: 20.0,
             sample_period: 1.0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MU: f64 = 398_600.441_8;
+
+    /// 近点通過から `dt` 秒後の 2 体問題の状態（軌道面 = x-y）。
+    /// Kepler 方程式を Newton 法で解くだけの self-contained な伝播。
+    fn kepler_state(a: f64, e: f64, dt: f64) -> (Vector3<f64>, Vector3<f64>) {
+        let n = (MU / (a * a * a)).sqrt();
+        let m = n * dt;
+        let mut ecc = m;
+        for _ in 0..60 {
+            let step = (ecc - e * ecc.sin() - m) / (1.0 - e * ecc.cos());
+            ecc -= step;
+            if step.abs() < 1e-14 {
+                break;
+            }
+        }
+        let b = a * (1.0 - e * e).sqrt();
+        let ecc_dot = n / (1.0 - e * ecc.cos());
+        (
+            Vector3::new(a * (ecc.cos() - e), b * ecc.sin(), 0.0),
+            Vector3::new(-a * ecc.sin() * ecc_dot, b * ecc.cos() * ecc_dot, 0.0),
+        )
+    }
+
+    fn tick(t: f64, r: Vector3<f64>, v: Vector3<f64>) -> TickInput {
+        TickInput {
+            t,
+            spacecraft: SpacecraftState {
+                orbit: OrbitalState {
+                    position: PositionEciKm {
+                        x: r.x,
+                        y: r.y,
+                        z: r.z,
+                    },
+                    velocity: VelocityEciKms {
+                        x: v.x,
+                        y: v.y,
+                        z: v.z,
+                    },
+                },
+                attitude: AttitudeState {
+                    orientation: Quat {
+                        w: 1.0,
+                        x: 0.0,
+                        y: 0.0,
+                        z: 0.0,
+                    },
+                    angular_velocity: Vec3 {
+                        x: 0.0,
+                        y: 0.0,
+                        z: 0.0,
+                    },
+                },
+                mass: 500.0,
+            },
+            epoch: None,
+            sensors: Sensors {
+                magnetometers: vec![],
+                gyroscopes: vec![],
+                star_trackers: vec![],
+                sun_sensors: vec![],
+            },
+            actuators: ActuatorTelemetry { rw: None },
+        }
+    }
+
+    const R_PARK: f64 = EARTH_RADIUS_KM + 500.0;
+    const R_TARGET: f64 = EARTH_RADIUS_KM + 2000.0;
+    const CONFIG: &str = r#"{"target_altitude_km":2000.0,"sample_period":1.0}"#;
+
+    /// FirstBurn 終了を transfer ellipse 上の `burn_end`（perigee 通過からの
+    /// 経過時間）に置き、そこから 1 s 刻みで伝播して SecondBurn に入る tick を
+    /// 返す。戻り値は `(遷移時刻, r, v, 1 sample 前の r·v)`。
+    fn coast_until_second_burn(burn_end: f64) -> (f64, Vector3<f64>, Vector3<f64>, f64) {
+        let a = (R_PARK + R_TARGET) / 2.0;
+        let e = (R_TARGET - R_PARK) / (R_TARGET + R_PARK);
+        let half_period = std::f64::consts::PI * (a.powi(3) / MU).sqrt();
+
+        let mut ctrl = TransferBurnWithTcm::init(CONFIG).expect("config");
+
+        // t=0: parking 円軌道。ここで transfer_sma がキャッシュされる。
+        let v_circ = (MU / R_PARK).sqrt();
+        ctrl.update(&tick(
+            0.0,
+            Vector3::new(R_PARK, 0.0, 0.0),
+            Vector3::new(0.0, v_circ, 0.0),
+        ))
+        .expect("no error");
+        assert_eq!(ctrl.current_mode(), Some("first_burn"));
+
+        // transfer ellipse 上を 1 s 刻みで伝播する。sma を確実に
+        // transfer_sma 以上にするため a をごくわずか大きくとる。
+        let a_prop = a * (1.0 + 1e-9);
+        let mut prev_radial_rate = f64::NAN;
+        let mut t = burn_end;
+        while t < burn_end + 4.0 * half_period {
+            let (r, v) = kepler_state(a_prop, e, t);
+            ctrl.update(&tick(t, r, v)).expect("no error");
+            if ctrl.current_mode() == Some("second_burn") {
+                return (t, r, v, prev_radial_rate);
+            }
+            prev_radial_rate = r.dot(&v);
+            t += 1.0;
+        }
+        panic!("Coast から SecondBurn へ遷移するはず");
+    }
+
+    fn assert_switched_at_apogee(t_switch: f64, r: Vector3<f64>, v: Vector3<f64>, prev: f64) {
+        assert!(
+            prev > 0.0,
+            "apogee の 1 sample 前はまだ上昇中のはず: r·v = {prev}"
+        );
+        assert!(
+            r.dot(&v) <= 0.0,
+            "遷移 tick では下降に転じているはず: r·v = {}",
+            r.dot(&v)
+        );
+        let flight_path = r.dot(&v) / (r.norm() * v.norm());
+        assert!(
+            flight_path.abs() < 1e-3,
+            "SecondBurn は apogee で始まるはず: sin(fpa) = {flight_path:.3e} at t = {t_switch}"
+        );
+    }
+
+    fn transfer_half_period() -> f64 {
+        let a = (R_PARK + R_TARGET) / 2.0;
+        std::f64::consts::PI * (a.powi(3) / MU).sqrt()
+    }
+
+    /// SecondBurn は apogee で始まらなければならない。
+    ///
+    /// FirstBurn 終了時刻から半周期を数えると、burn 中に飛んだ弧の分だけ
+    /// apogee を過ぎてから噴く（同梱設定では 3315 s の半周期に対し burn
+    /// 37 s、ここでは低推力を模して 300 s）。
+    #[test]
+    fn second_burn_starts_at_apogee() {
+        let half_period = transfer_half_period();
+        let (t_switch, r, v, prev) = coast_until_second_burn(300.0);
+
+        assert_switched_at_apogee(t_switch, r, v, prev);
+        assert!(
+            (t_switch - half_period).abs() <= 1.0,
+            "apogee は t = {half_period:.1} s、遷移は t = {t_switch:.1} s"
+        );
+    }
+
+    /// 降下中に Coast へ入った場合（apogee を過ぎてから burn が終わった等）は、
+    /// その場で噴かずに次の apogee を待つ。`r·v <= 0` を単発で見ると、遷移直後の
+    /// 任意の点で噴いてしまう。
+    #[test]
+    fn coast_entered_while_descending_waits_for_the_next_apogee() {
+        let half_period = transfer_half_period();
+        // apogee の 500 s 後（降下中）で FirstBurn を終える。
+        let (t_switch, r, v, prev) = coast_until_second_burn(half_period + 500.0);
+
+        assert_switched_at_apogee(t_switch, r, v, prev);
+        let next_apogee = 3.0 * half_period;
+        assert!(
+            (t_switch - next_apogee).abs() <= 1.0,
+            "次の apogee は t = {next_apogee:.1} s、遷移は t = {t_switch:.1} s"
+        );
     }
 }


### PR DESCRIPTION
plugin-sdk の example が、README の説明と違う制御をしていた。4 件を直す。

## Nadir モードが nadir を計算していない

`detumble-nadir` の `Mode::Nadir` の制御則が、star tracker の読み値（body→inertial 姿勢）をそのまま誤差クォータニオンにしていた。つまり目標は慣性 identity 姿勢・目標角速度 0 で、`input.spacecraft.orbit` を見ておらず、LVLH 目標も軌道角速度（LEO で ~1.1e-3 rad/s）も計算していない。

nadir 指向が完全に成立している状態（star tracker = LVLH 目標姿勢、gyro = 軌道角速度）を与えると、wheel torque `[-1.0, -1.002, 1.0]` N·m を指令する。あるべき値は 0 で、その間 `current_mode()` は "nadir" を返す。

目標姿勢を軌道状態から組むようにした。定義は `orts::attitude::control::NadirPointing` と同じ（z = -r̂, y = -ĥ, x = y × z）、誤差規約は `TrackingPdController` と同じ（左不変 q_err、目標角速度 `[0, -n, 0]` を現 body frame へ回して角速度誤差を取る）。半径 0 / r ∥ v / 非有限入力では NaN 姿勢を作らない。

同梱設定（500 km 円軌道、8000 s）を両方の制御則で走らせた実測。

| | nadir 角（収束後 2000 s） | nadir 角（最終 1 周） | body 角速度 |
|---|---|---|---|
| 変更前 | 106.5°〜141.6° | 38.7°〜178.5° | 0.0 rad/s |
| 変更後 | 0.000°〜0.152° | 0.000°〜178.5° | 1.107e-3〜1.110e-3 rad/s |

変更前は body 角速度が厳密に 0 で、慣性空間に貼り付いたまま `current_mode()` が "nadir" を返す。地球が下を通り過ぎるので nadir 角が 1 周で 38.7°〜178.5° を掃き、178.5°（camera が天頂を向く）に達する瞬間がある。

変更後は軌道角速度 √(μ/a³) = 1.108e-3 rad/s で回り、0.152° 以内で追従する。最終 1 周の最大値 178.5° は detumble から nadir に切り替わった直後（t = 4110 s）の捕捉過渡で、収束後の 2000 s では 0.152° 以内。

## 指令を組めない tick で前回の指令が保持され続ける

WIT の `command` 契約では `None` は「コマンドなし」で、前回値が ZOH で保持される。ゼロ指令とは別。

モード遷移では detumble 最後の磁気モーメントが nadir フェーズ中ずっと出続ける（遷移条件 |ω| < 0.01 rad/s から |m| ~ 3e-3 A·m²）。センサ欠損時も同じで、gyro / magnetometer / star tracker が無い tick、磁場読み値が 0 の tick、LVLH が定義できない軌道の tick はいずれも指令を返さない。RW では影響が大きく、トルク指令が残ると wheel が飽和へ加速し続ける。

指令を組めない tick は、そのモードが駆動するアクチュエータ（Detumble なら MTQ、Nadir なら RW）に明示的なゼロを指令する。モード遷移 tick も同じ経路を通る。

## 2 回目の燃焼が apogee を過ぎてから始まる

`transfer-burn-with-tcm` と `constellation-phasing`。transfer ellipse の半周期は *perigee* から apogee までの時間だが、両 example はそのタイマーを有限時間 FirstBurn の**終了時**から起動していた。すでに飛んだ弧の分だけ apogee を過ぎて点火する。

同梱設定（500 km → 2000 km、5000 N / 500 kg）では半周期 3315.2 s に対し burn 36.5 s なので、apogee を 1.66°・flight path angle 0.18° 過ぎた点で円化を始める。推力が下がるほど FirstBurn 中に進む角度が大きくなるので、ずれに上限はない。

apogee を径方向速度 `r·v` の符号反転（上昇 → 非上昇）で検出する。単に `r·v <= 0` を見ず前 tick の符号を保持するのは、降下中に Coast へ入った場合（parking 軌道が円でない、burn が apogee を過ぎて終わった）にその場で噴かず次の apogee まで待つため。時間ベースの判定は watchdog として残し、期限は Coast 遷移時の実測 SMA から求めた coast 軌道 1 周期 +10% にした（nominal SMA から求めると finite burn の overshoot 分だけ実周期を下回り、本来の apogee より先に発火しうる）。

| thrust | 点火時の真近点角 | 円化後の離心率 | 近地点 × 遠地点 |
|---|---|---|---|
| 5000 N 変更前 | 181.0° | 3.1e-3 | 1976.8 × 2028.8 km |
| 5000 N 変更後 | 180.1° | 1.4e-3 | 1990.7 × 2014.8 km |
| 300 N 変更前 | 192.8° | 4.1e-2 | 1651.8 × 2346.8 km |
| 300 N 変更後 | 180.4° | 1.9e-2 | 1843.0 × 2156.4 km |

## 同梱設定が存在しない artifact path を指していた

両 example の `orts.toml` / bench config 生成スクリプト / bench.sh / README が `target/wasm32-wasip2/` を指していた。host が読むのは component で、それを出す `cargo component build` の出力先は `wasm32-wasip1`。手順どおりに実行しても plugin が見つからない。

`detumble-nadir` にはそもそも設定が無く、一度も end-to-end で動かされていなかった。Nadir が慣性姿勢を保持していても気づけなかった理由がこれ。追加した設定は 500 km 円軌道 (i = 51.6°)、等方 1 kg·m²、初期 |ω| = 0.015 rad/s、PD ゲインはその慣性に合わせて ω_n = 0.05 rad/s / 臨界減衰（要求トルクが wheel の `max_torque` 内に収まる）。

## テスト

`plugin-sdk/examples` の 10 crate はいずれもテストを持たない cdylib で、CI もビルドだけをしている。符号や目標を誤った制御則が誰にも気づかれなかったのはこのため。crate 構成は変えずに `#[cfg(test)]` を追加した（cdylib のままでも `cargo test` はユニットテストを実行できる）。3 crate で 11 件 pass。

**`detumble-nadir`（6 本）** — LVLH 目標の不変量（body +Z が -r̂、body +Y が -ĥ、`n = |h|/r²`）、目標一致時のトルク 0、yaw 誤差 5° への復元トルクが `kp·θ`、退化した軌道での RW トルク 0、遷移 tick と magnetometer 欠損時の MTQ 0。慣性 identity 保持則に戻すと 4 本、ゼロ指令を `None` に戻すと 2 本落ちる。

**閉ループ 1 本** — 理想剛体 + 理想 wheel で軌道弧 ~95° を回し、body +Z が nadir に乗り続けること（cos > 0.999）と、収束後の body 角速度が軌道角速度に一致することを見る。慣性 identity 保持則も「収束後はトルク 0」になるので、弧にわたる追従で区別する。目標を identity に戻すと 118.65° 外れて落ちる。

**Hohmann 2 本** — Kepler 方程式を解く self-contained な伝播で 1 s 刻みに進め、`second_burn` に入る tick で `r·v` が符号を変えていること・`|r·v|/(|r||v|) < 1e-3`・遷移時刻が apogee から 1 sample 以内であることを見る。半周期タイマーに戻すと、低推力を模した設定（FirstBurn 終了を perigee + 300 s）で 1 sample 前の `r·v` が -1388 km²/s（apogee を大きく過ぎている）で落ちる。降下中（apogee + 500 s）に Coast へ入るケースは別テストで、次の apogee（3T/2）まで待つことを固定した。符号反転の latch を外すと遷移直後の降下点で噴いて落ちる。

examples は独立した workspace なので、実行には `--manifest-path plugin-sdk/examples/Cargo.toml` が必要。

## 関連

CI の examples ビルドジョブへのテスト追加、`plugin-sdk/examples/Cargo.lock` の stale（`cargo build --locked` が拒否する）、`pd-rw-control` / `pd-rw-unloading` に残る `cargo fmt` 差分（examples workspace は CI の fmt check 対象外）、`cli/tests/thruster_plugin_e2e.rs` が `wasm32-wasip2` を探して常に skip される件は、それぞれ別 PR で扱う。
