### PR TITLE
fix: keep `duration` off the orbital period

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -173,11 +173,6 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   `back = {}` は `two_sided = true` と同じ)。面積 / `cd` / 圧力中心はどちらでも
   同じ板として共有する。`two_sided = false` と `back` の同時指定は矛盾なので
   reject する。パネルを書くと
-  (`area`, `normal`, `cd`, `specular`, `diffuse`, `cp_offset`, `back`
-  ([#395](https://github.com/sksat/orts/pull/395)))。パネルは片面なので、薄板
-  (太陽電池パドル) の裏面を作るのが `back` である。面積 / `cd` / 圧力中心は同じ板
-  として共有し、反射率は裏面が独自に持つ。空の table (`back = {}`) なら表と同じに
-  なる。パネルを書くと
   SRP と大気抵抗が姿勢依存になり、圧力中心が重心から外れていればそれが姿勢外乱に
   なる。等方面の `srp_area_to_mass` / `ballistic_coeff` では表せない部分である。
   パネルは `attitude` を要求し、等方面のパラメータとの同時指定は reject する

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -30,6 +30,26 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - WIT v0 plugin interface に msg-io / stream-io チャネルを追加。([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
+- `SatelliteParams` が `SpacecraftShape` を optional で持ち、
+  `build_spacecraft_dynamics` がそれを見て等方面の `SolarRadiationPressure` /
+  `AtmosphericDrag` の代わりに `PanelSrp` / `PanelDrag` を install するように
+  した。機体の外形は一つなので、パネルは片方ではなく両方の力を担う。
+  `build_orbital_system` はどちらも install しない (パネルの力は姿勢を要求する)。
+  `SurfacePanel` に `with_cp_offset` を追加した。パネルの力を姿勢外乱にするのは
+  この offset である。([#386](https://github.com/sksat/orts/pull/386))
+- `SurfacePanel::back_face` で薄板の反対面を作れるようにした。法線を反転し、面積 /
+  `cd` / 圧力中心は引き継ぎ、光学係数は引数で受ける (パドルの両面は性質が違う)。
+  パネルは片面で、両モデルとも太陽や流れと逆を向いた面を落とすので、板を 1 枚として
+  書くとその衛星が取る姿勢の半分で力がゼロになり、重心から外れた圧力中心が作る
+  トルクも出ない。閉じた形状の面には使わない (反対側は既に別のパネルである)。([#395](https://github.com/sksat/orts/pull/395))
+- 外乱トルクの登録を `orts::setup` に集約し、どれを解くかを `SatelliteParams` の
+  `DisturbanceTorques` で選ぶようにした。`build_spacecraft_dynamics` がそれを見て
+  gravity gradient トルクを install する。`build_orbital_system` は install しない
+  (軌道のみの系にはトルクが作用する姿勢が無く、`torque_body` を捨てる)。
+  呼び出し側は環境モデルを登録しなくなった。CLI はこのトルクを 2 つの entry point
+  で同一行に書いていて、両者が食い違わない保証が無かった。actuator (RW, MTQ,
+  thruster) の登録は呼び出し側に残る。搭載する actuator は機体のハードウェア記述で
+  決まる。([#382](https://github.com/sksat/orts/pull/382))
 - `SurfacePanel` が lumped な `cr` の代わりに `optics: PanelOptics { specular,
   diffuse }` を持つようになった。吸収率は `1 - specular - diffuse` として導出する。
   単一係数は face-on の SRP 力の大きさを決めるだけで、斜入射での向きが決まらない
@@ -105,6 +125,9 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   あるとき `r × ŝ` と `r × n̂` は別方向を向くので、`Cr` をどう選んでも正しい答えには
   ならない。太陽電池パドル相当 (ρ_s ≈ 0.2, ρ_d ≈ 0.1) では 45° 入射で欠けていた項が
   力の ~30% を占める。model の導入時から存在し、0.2.0 も該当する。
+  図解: [光子の行き先](docs/src/assets/srp-flat-panel/photon-fates.svg)、
+  [2 成分の合成](docs/src/assets/srp-flat-panel/force-composition.svg)、
+  [トルクの向き](docs/src/assets/srp-flat-panel/torque-direction.svg)。
   ([#377](https://github.com/sksat/orts/pull/377))
 - `AttitudeState::q_dot` が、和を計算した後でなく積を作る前に角速度を半分にする
   ようになった。結果が有限な入力で overflow しなくなる: `q = [0, 1/√2, 1/√2, 0]`、
@@ -150,6 +173,11 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   `back = {}` は `two_sided = true` と同じ)。面積 / `cd` / 圧力中心はどちらでも
   同じ板として共有する。`two_sided = false` と `back` の同時指定は矛盾なので
   reject する。パネルを書くと
+  (`area`, `normal`, `cd`, `specular`, `diffuse`, `cp_offset`, `back`
+  ([#395](https://github.com/sksat/orts/pull/395)))。パネルは片面なので、薄板
+  (太陽電池パドル) の裏面を作るのが `back` である。面積 / `cd` / 圧力中心は同じ板
+  として共有し、反射率は裏面が独自に持つ。空の table (`back = {}`) なら表と同じに
+  なる。パネルを書くと
   SRP と大気抵抗が姿勢依存になり、圧力中心が重心から外れていればそれが姿勢外乱に
   なる。等方面の `srp_area_to_mass` / `ballistic_coeff` では表せない部分である。
   パネルは `attitude` を要求し、等方面のパラメータとの同時指定は reject する
@@ -206,6 +234,10 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   追加。よく使う・agent に関係する経路を端末内で発見できるようにした。([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
+- `orts run` の downlink log レコードの level を info/debug から debug/trace へ
+  下げた。衛星 × outbound message × control tick ごとに出るため、logger が
+  実際に動く状態では info だと fleet 規模の実行で他の診断が読めなくなり、
+  積分ループ内で stderr のロックを取る書き込みが増える。 ([#390](https://github.com/sksat/orts/pull/390))
 - `--tle` を再び TLE 専用 (2LE/3LE、`-` で stdin) とし、新規 `--omm` と
   対にした。要素セットのパースは削除した `orts::tle` でなく
   `arika::tle` / `arika::omm` を使用 (従来は `--tle` が OMM も自動受理)。([#87](https://github.com/sksat/orts/pull/87))
@@ -215,6 +247,30 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   は併用不可。`--tle-line1` / `--tle-line2` は両方指定が必須。([#87](https://github.com/sksat/orts/pull/87))
 - TLE epoch の day-of-year を (閏考慮の) 年日数で検証。不正値はそのまま別の
   年に繰り上がらず拒否される。([#87](https://github.com/sksat/orts/pull/87))
+- config ファイル、`orts config validate`、WebSocket の `start_simulation`
+  payload は、シミュレーションが実行できない入力を別の値に読み替えず拒否する:
+  未知の `[integrator] type` / `atmosphere` (従来は dp45 / exponential
+  モデル)、id が 1 つの recording entity を指す 2 機 (id の文字列でなく entity で
+  比較するので、recording と同じく `a` と `/a` は衝突する。従来は recording
+  entity と CSV section を共有し、id 文字列まで同じなら `[[command]]` の宛先も
+  共有していた)、
+  どの剛体もとりえない attitude ブロック (正定値でない、または主慣性モーメントで
+  `I1 + I2 >= I3` を破る慣性テンソル、`mass <= 0`、正規化できない
+  `initial_quaternion`)。config が受理する `integrator` / `atmosphere` の綴りは、
+  対応する CLI フラグが受理する集合と厳密に一致する。
+
+  どのフィールドも読まないキーは、拒否せずキー名を warning として表示する。実行は
+  続くので新しい `orts` 向けに書いた config も古い `orts` で実行でき、`duraton = 100`
+  が黙って 1 周期分実行されることはなくなった。`orts config validate` は `warnings`
+  にキーのパスを出力し、`run` と `serve` は `log::warn!` で報告する。server は client の
+  `start_simulation` や `add_satellite` に含まれるものを表示する。`type` タグ付きの
+  block (`[satellites.orbit]`、`[satellites.controller]`、reaction wheel、磁気トルカ)
+  だけは拒否する。`serde_ignored` は internally tagged enum の内部を見られず報告
+  できないため、`inclinaton = 51.6` が無視されると軌道が赤道面のままになる。特異な
+  慣性テンソルは従来
+  `SpacecraftDynamics::new` で panic し、`orts serve --config` では spawn された
+  manager task の中で起きるため、server は listen したままシミュレーションも
+  client への error も無い状態になっていた。([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
 - `duration` が各衛星の軌道周期を置き換えなくなった。`duration` は run の終了時刻だが
@@ -229,6 +285,39 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   なった。`serve` は無摂動の orbit-only 衛星を周期の境界ごとに初期軌道へ戻すが、
   新規追加した衛星の境界は fleet の**直前**のエントリから読んでいた (最初の追加では
   5554 s のハードコード)。([#368](https://github.com/sksat/orts/pull/368))
+- `orts` が診断ログを stderr に出力するようになった。logger を初期化していな
+  かったため `log::` の呼び出しは全て破棄されており、stream-io stdio plug の
+  displaced、stream の socket error、`serve` 中のシミュレーション停止、
+  WASM plugin が WIT `host-env.log` 経由で出力した行が、どれも表示されなかった。
+  `.rrd` を書く際に rerun の crate が出す診断も同じ出力に含まれる。level は
+  `RUST_LOG` で選び、既定は `warn,orts=info` (orts は info、依存は warn)。
+  `NO_COLOR` 指定時と stderr が terminal でない場合は装飾を付けない。どちらも
+  `orts --help` に記載がある。stdout は従来どおりコマンドの出力 (CSV、`--json`
+  サマリ、`serve --stream-stdio` の protocol) だけ。 ([#390](https://github.com/sksat/orts/pull/390))
+- `tle` / `norad` 軌道を Earth 以外の中心天体で使う config を、
+  `orts config validate` と `orts serve --config` が拒否する。SGP4 は Earth 専用で、
+  `SimParams::from_config` はこの規則に panic 経由で到達していたため、config は valid
+  と判定された上で `orts run --config` が panic していた。([#351](https://github.com/sksat/orts/pull/351))
+- どの mode でも実行できない fleet を `orts config validate` と
+  `orts serve --config` が拒否する。`[satellites.attitude]` や
+  `[satellites.controller]` を一部の衛星にだけ書いた config と、全衛星に controller
+  があって attitude がどこにもない config。engine は元からこれらを拒否していたが、
+  `orts serve` は engine を spawn した manager task 内で構築するため、config は valid
+  と判定され banner も表示された上で、指定した config が実行されないまま server が
+  idle 状態で待機していた。`serve` は listening と表示せずエラー終了する。([#351](https://github.com/sksat/orts/pull/351))
+- WebSocket の `add_satellite` が、実行中の fleet の衛星と同じ entity path
+  (`/world/sat/<id>`) になる id を拒否する。従来は同じ path の 2 機を受理し、
+  `[[command]]` は後から追加した方にしか配送されなかった。`id` 省略時の
+  `sat-<現在の機数>` も同様に衝突する。([#351](https://github.com/sksat/orts/pull/351))
+- `orts serve` が、`ClientMessage` に deserialize できなかったメッセージに
+  `{"type":"error"}` を返す。従来は error を破棄していたため、client は応答が
+  返らないまま待ち続けた。deserialize が失敗するのは `type` タグ付き block に未知の
+  キーがある場合。([#351](https://github.com/sksat/orts/pull/351))
+- `orts serve` が `Server listening` / `WebSocket endpoint` の banner を、
+  `--config` ファイルを受理した後にだけ出すようになった。先に出していたため、
+  banner を起動完了として待つ呼び出し側 (`cli/tests/ws_e2e.rs`、Playwright の
+  spec) には、拒否された config が error message ではなく接続失敗として
+  届いていた。([#351](https://github.com/sksat/orts/pull/351))
 - `orts run --format csv --output <path>` が CSV を `<path>` に書き込むように
   なった。従来は `--format csv` の実行が `--output` に関わらず常に stdout へ
   出力し、指定パスを黙って無視していた。([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -30,26 +30,6 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - WIT v0 plugin interface に msg-io / stream-io チャネルを追加。([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
-- `SatelliteParams` が `SpacecraftShape` を optional で持ち、
-  `build_spacecraft_dynamics` がそれを見て等方面の `SolarRadiationPressure` /
-  `AtmosphericDrag` の代わりに `PanelSrp` / `PanelDrag` を install するように
-  した。機体の外形は一つなので、パネルは片方ではなく両方の力を担う。
-  `build_orbital_system` はどちらも install しない (パネルの力は姿勢を要求する)。
-  `SurfacePanel` に `with_cp_offset` を追加した。パネルの力を姿勢外乱にするのは
-  この offset である。([#386](https://github.com/sksat/orts/pull/386))
-- `SurfacePanel::back_face` で薄板の反対面を作れるようにした。法線を反転し、面積 /
-  `cd` / 圧力中心は引き継ぎ、光学係数は引数で受ける (パドルの両面は性質が違う)。
-  パネルは片面で、両モデルとも太陽や流れと逆を向いた面を落とすので、板を 1 枚として
-  書くとその衛星が取る姿勢の半分で力がゼロになり、重心から外れた圧力中心が作る
-  トルクも出ない。閉じた形状の面には使わない (反対側は既に別のパネルである)。([#395](https://github.com/sksat/orts/pull/395))
-- 外乱トルクの登録を `orts::setup` に集約し、どれを解くかを `SatelliteParams` の
-  `DisturbanceTorques` で選ぶようにした。`build_spacecraft_dynamics` がそれを見て
-  gravity gradient トルクを install する。`build_orbital_system` は install しない
-  (軌道のみの系にはトルクが作用する姿勢が無く、`torque_body` を捨てる)。
-  呼び出し側は環境モデルを登録しなくなった。CLI はこのトルクを 2 つの entry point
-  で同一行に書いていて、両者が食い違わない保証が無かった。actuator (RW, MTQ,
-  thruster) の登録は呼び出し側に残る。搭載する actuator は機体のハードウェア記述で
-  決まる。([#382](https://github.com/sksat/orts/pull/382))
 - `SurfacePanel` が lumped な `cr` の代わりに `optics: PanelOptics { specular,
   diffuse }` を持つようになった。吸収率は `1 - specular - diffuse` として導出する。
   単一係数は face-on の SRP 力の大きさを決めるだけで、斜入射での向きが決まらない
@@ -125,9 +105,6 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   あるとき `r × ŝ` と `r × n̂` は別方向を向くので、`Cr` をどう選んでも正しい答えには
   ならない。太陽電池パドル相当 (ρ_s ≈ 0.2, ρ_d ≈ 0.1) では 45° 入射で欠けていた項が
   力の ~30% を占める。model の導入時から存在し、0.2.0 も該当する。
-  図解: [光子の行き先](docs/src/assets/srp-flat-panel/photon-fates.svg)、
-  [2 成分の合成](docs/src/assets/srp-flat-panel/force-composition.svg)、
-  [トルクの向き](docs/src/assets/srp-flat-panel/torque-direction.svg)。
   ([#377](https://github.com/sksat/orts/pull/377))
 - `AttitudeState::q_dot` が、和を計算した後でなく積を作る前に角速度を半分にする
   ようになった。結果が有限な入力で overflow しなくなる: `q = [0, 1/√2, 1/√2, 0]`、
@@ -229,10 +206,6 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   追加。よく使う・agent に関係する経路を端末内で発見できるようにした。([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
-- `orts run` の downlink log レコードの level を info/debug から debug/trace へ
-  下げた。衛星 × outbound message × control tick ごとに出るため、logger が
-  実際に動く状態では info だと fleet 規模の実行で他の診断が読めなくなり、
-  積分ループ内で stderr のロックを取る書き込みが増える。 ([#390](https://github.com/sksat/orts/pull/390))
 - `--tle` を再び TLE 専用 (2LE/3LE、`-` で stdin) とし、新規 `--omm` と
   対にした。要素セットのパースは削除した `orts::tle` でなく
   `arika::tle` / `arika::omm` を使用 (従来は `--tle` が OMM も自動受理)。([#87](https://github.com/sksat/orts/pull/87))
@@ -242,65 +215,20 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   は併用不可。`--tle-line1` / `--tle-line2` は両方指定が必須。([#87](https://github.com/sksat/orts/pull/87))
 - TLE epoch の day-of-year を (閏考慮の) 年日数で検証。不正値はそのまま別の
   年に繰り上がらず拒否される。([#87](https://github.com/sksat/orts/pull/87))
-- config ファイル、`orts config validate`、WebSocket の `start_simulation`
-  payload は、シミュレーションが実行できない入力を別の値に読み替えず拒否する:
-  未知の `[integrator] type` / `atmosphere` (従来は dp45 / exponential
-  モデル)、id が 1 つの recording entity を指す 2 機 (id の文字列でなく entity で
-  比較するので、recording と同じく `a` と `/a` は衝突する。従来は recording
-  entity と CSV section を共有し、id 文字列まで同じなら `[[command]]` の宛先も
-  共有していた)、
-  どの剛体もとりえない attitude ブロック (正定値でない、または主慣性モーメントで
-  `I1 + I2 >= I3` を破る慣性テンソル、`mass <= 0`、正規化できない
-  `initial_quaternion`)。config が受理する `integrator` / `atmosphere` の綴りは、
-  対応する CLI フラグが受理する集合と厳密に一致する。
-
-  どのフィールドも読まないキーは、拒否せずキー名を warning として表示する。実行は
-  続くので新しい `orts` 向けに書いた config も古い `orts` で実行でき、`duraton = 100`
-  が黙って 1 周期分実行されることはなくなった。`orts config validate` は `warnings`
-  にキーのパスを出力し、`run` と `serve` は `log::warn!` で報告する。server は client の
-  `start_simulation` や `add_satellite` に含まれるものを表示する。`type` タグ付きの
-  block (`[satellites.orbit]`、`[satellites.controller]`、reaction wheel、磁気トルカ)
-  だけは拒否する。`serde_ignored` は internally tagged enum の内部を見られず報告
-  できないため、`inclinaton = 51.6` が無視されると軌道が赤道面のままになる。特異な
-  慣性テンソルは従来
-  `SpacecraftDynamics::new` で panic し、`orts serve --config` では spawn された
-  manager task の中で起きるため、server は listen したままシミュレーションも
-  client への error も無い状態になっていた。([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
-- `orts` が診断ログを stderr に出力するようになった。logger を初期化していな
-  かったため `log::` の呼び出しは全て破棄されており、stream-io stdio plug の
-  displaced、stream の socket error、`serve` 中のシミュレーション停止、
-  WASM plugin が WIT `host-env.log` 経由で出力した行が、どれも表示されなかった。
-  `.rrd` を書く際に rerun の crate が出す診断も同じ出力に含まれる。level は
-  `RUST_LOG` で選び、既定は `warn,orts=info` (orts は info、依存は warn)。
-  `NO_COLOR` 指定時と stderr が terminal でない場合は装飾を付けない。どちらも
-  `orts --help` に記載がある。stdout は従来どおりコマンドの出力 (CSV、`--json`
-  サマリ、`serve --stream-stdio` の protocol) だけ。 ([#390](https://github.com/sksat/orts/pull/390))
-- `tle` / `norad` 軌道を Earth 以外の中心天体で使う config を、
-  `orts config validate` と `orts serve --config` が拒否する。SGP4 は Earth 専用で、
-  `SimParams::from_config` はこの規則に panic 経由で到達していたため、config は valid
-  と判定された上で `orts run --config` が panic していた。([#351](https://github.com/sksat/orts/pull/351))
-- どの mode でも実行できない fleet を `orts config validate` と
-  `orts serve --config` が拒否する。`[satellites.attitude]` や
-  `[satellites.controller]` を一部の衛星にだけ書いた config と、全衛星に controller
-  があって attitude がどこにもない config。engine は元からこれらを拒否していたが、
-  `orts serve` は engine を spawn した manager task 内で構築するため、config は valid
-  と判定され banner も表示された上で、指定した config が実行されないまま server が
-  idle 状態で待機していた。`serve` は listening と表示せずエラー終了する。([#351](https://github.com/sksat/orts/pull/351))
-- WebSocket の `add_satellite` が、実行中の fleet の衛星と同じ entity path
-  (`/world/sat/<id>`) になる id を拒否する。従来は同じ path の 2 機を受理し、
-  `[[command]]` は後から追加した方にしか配送されなかった。`id` 省略時の
-  `sat-<現在の機数>` も同様に衝突する。([#351](https://github.com/sksat/orts/pull/351))
-- `orts serve` が、`ClientMessage` に deserialize できなかったメッセージに
-  `{"type":"error"}` を返す。従来は error を破棄していたため、client は応答が
-  返らないまま待ち続けた。deserialize が失敗するのは `type` タグ付き block に未知の
-  キーがある場合。([#351](https://github.com/sksat/orts/pull/351))
-- `orts serve` が `Server listening` / `WebSocket endpoint` の banner を、
-  `--config` ファイルを受理した後にだけ出すようになった。先に出していたため、
-  banner を起動完了として待つ呼び出し側 (`cli/tests/ws_e2e.rs`、Playwright の
-  spec) には、拒否された config が error message ではなく接続失敗として
-  届いていた。([#351](https://github.com/sksat/orts/pull/351))
+- `duration` が各衛星の軌道周期を置き換えなくなった。`duration` は run の終了時刻だが
+  両方が 1 つの field に載っていたため、`--duration 120` は CSV header・RRD の
+  `meta/sim/period`・WebSocket の `SatelliteInfo` のすべてに、5553.6 s かかる軌道の
+  周期として 120 s を載せていた。全衛星に同じ duration が入るので fleet の周期も
+  1 つの値に潰れていた。horizon が必要な箇所は `duration.unwrap_or(period)` から
+  終了時刻を取る。`duration` 未指定なら、orbit-only と spacecraft の run は従来どおり
+  各衛星の 1 周分を回り、controlled の run は従来どおり最初の衛星の周期を fleet 全体の
+  終了時刻にする。([#TBD](https://github.com/sksat/orts/pull/TBD))
+- 走っている `orts serve` に追加した衛星が、自分自身の周期で軌道を再設定するように
+  なった。`serve` は無摂動の orbit-only 衛星を周期の境界ごとに初期軌道へ戻すが、
+  新規追加した衛星の境界は fleet の**直前**のエントリから読んでいた (最初の追加では
+  5554 s のハードコード)。([#TBD](https://github.com/sksat/orts/pull/TBD))
 - `orts run --format csv --output <path>` が CSV を `<path>` に書き込むように
   なった。従来は `--format csv` の実行が `--output` に関わらず常に stdout へ
   出力し、指定パスを黙って無視していた。([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -224,11 +224,11 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   1 つの値に潰れていた。horizon が必要な箇所は `duration.unwrap_or(period)` から
   終了時刻を取る。`duration` 未指定なら、orbit-only と spacecraft の run は従来どおり
   各衛星の 1 周分を回り、controlled の run は従来どおり最初の衛星の周期を fleet 全体の
-  終了時刻にする。([#TBD](https://github.com/sksat/orts/pull/TBD))
+  終了時刻にする。([#368](https://github.com/sksat/orts/pull/368))
 - 走っている `orts serve` に追加した衛星が、自分自身の周期で軌道を再設定するように
   なった。`serve` は無摂動の orbit-only 衛星を周期の境界ごとに初期軌道へ戻すが、
   新規追加した衛星の境界は fleet の**直前**のエントリから読んでいた (最初の追加では
-  5554 s のハードコード)。([#TBD](https://github.com/sksat/orts/pull/TBD))
+  5554 s のハードコード)。([#368](https://github.com/sksat/orts/pull/368))
 - `orts run --format csv --output <path>` が CSV を `<path>` に書き込むように
   なった。従来は `--format csv` の実行が `--output` に関わらず常に stdout へ
   出力し、指定パスを黙って無視していた。([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,29 @@ section is subdivided by package.
 - WIT v0 plugin interface extended with the msg-io and stream-io channels. ([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
+- `SatelliteParams` carries an optional `SpacecraftShape`, and
+  `build_spacecraft_dynamics` installs `PanelSrp` and `PanelDrag` from it in
+  place of the isotropic `SolarRadiationPressure` and `AtmosphericDrag`. The
+  outer shape is one object, so panels drive both forces rather than one of
+  them. `build_orbital_system` installs neither: panel forces need an attitude.
+  `SurfacePanel` gains `with_cp_offset`, which is what turns a panel force into
+  an attitude disturbance. ([#386](https://github.com/sksat/orts/pull/386))
+- `SurfacePanel::back_face` builds the other side of a thin plate: the normal is
+  negated, the area, `cd` and centre of pressure carry over, and the optics are
+  given, since the two sides of an array differ. A panel is one face and both
+  force models drop a face pointing away from the Sun or the flow, so a plate
+  written as one panel produces nothing for half of the attitudes it sees — and
+  the torque about an off-centre pressure point goes with it. Not for a face of
+  a closed body, whose far side is already another panel. ([#395](https://github.com/sksat/orts/pull/395))
+- `orts::setup` registers disturbance torques, and `SatelliteParams` carries a
+  `DisturbanceTorques` selection to say which. `build_spacecraft_dynamics`
+  installs the gravity-gradient torque from it; `build_orbital_system` installs
+  none, since an orbit-only system has no orientation for a torque to act on and
+  discards `torque_body`. Callers no longer register environmental models
+  themselves — the CLI had been adding this torque on the same line in two entry
+  points, with nothing keeping the two in step. Actuators (RW, MTQ, thrusters)
+  stay with the caller, since they come from the spacecraft's own hardware
+  description. ([#382](https://github.com/sksat/orts/pull/382))
 - `SurfacePanel` carries `optics: PanelOptics { specular, diffuse }` in place of
   a lumped `cr`, with the absorbed fraction derived as `1 - specular - diffuse`.
   A single coefficient fixes the SRP force magnitude face-on but leaves its
@@ -121,6 +144,10 @@ section is subdivided by package.
   different ways, so no choice of `Cr` recovers the right answer. For a solar
   array (ρ_s ≈ 0.2, ρ_d ≈ 0.1) the missing term carries ~30% of the force at 45°
   incidence. Present since the model was introduced, 0.2.0 included.
+  Japanese-labeled diagrams of the law, the two force components and the torque
+  direction: [photon fates](docs/src/assets/srp-flat-panel/photon-fates.svg),
+  [force composition](docs/src/assets/srp-flat-panel/force-composition.svg),
+  [torque direction](docs/src/assets/srp-flat-panel/torque-direction.svg).
   ([#377](https://github.com/sksat/orts/pull/377))
 - `AttitudeState::q_dot` halves the angular velocity before forming the
   products rather than the sum afterwards, so it no longer overflows where its
@@ -173,6 +200,11 @@ section is subdivided by package.
   empty `back = {}` says the same as the flag). Either way the area, `cd` and
   centre of pressure are shared, and `two_sided = false` beside `back` is
   rejected as a contradiction. Writing panels
+  `area`, `normal`, `cd`, `specular`, `diffuse`, `cp_offset` and `back` ([#395](https://github.com/sksat/orts/pull/395)).
+  A panel is one face, so `back` is what gives a thin plate — a solar array —
+  its far side: the area, `cd` and centre of pressure are shared and the
+  reflectivities are its own, with an empty table (`back = {}`) copying the
+  front's. Writing panels
   makes SRP and drag attitude-dependent, and an off-centre centre of pressure
   turns them into attitude disturbances — which is what the isotropic
   `srp_area_to_mass` / `ballistic_coeff` cannot express. Panels require
@@ -237,6 +269,10 @@ section is subdivided by package.
   are discoverable without leaving the terminal. ([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
+- `orts run`'s downlink log records moved from info/debug to debug/trace. They
+  fire per satellite per outbound message per control tick, so with a backend
+  installed, info would bury every other diagnostic on a fleet-sized run and add
+  a locked stderr write inside the integration loop. ([#390](https://github.com/sksat/orts/pull/390))
 - `--tle` is TLE-only again (2LE/3LE; `-` for stdin) and pairs with the new
   `--omm`; element-set parsing is now backed by `arika::tle` / `arika::omm`
   instead of the removed `orts::tle`. (Previously `--tle` also auto-accepted OMM.) ([#87](https://github.com/sksat/orts/pull/87))
@@ -246,6 +282,32 @@ section is subdivided by package.
   `--tle-line2`; and `--tle-line1` / `--tle-line2` must be given together. ([#87](https://github.com/sksat/orts/pull/87))
 - TLE epoch day-of-year is validated against the (leap-aware) year length, so a
   malformed field is rejected rather than rolling into another year. ([#87](https://github.com/sksat/orts/pull/87))
+- Config files, `orts config validate` and the WebSocket `start_simulation`
+  payload reject input the simulation cannot honor, instead of resolving it to
+  something else: an unknown `[integrator] type` or `atmosphere` (previously
+  dp45 / the exponential model), two
+  satellites whose ids name one recording entity (previously one entity and one
+  CSV section for both; compared on the entity, so `a` and `/a` collide as they
+  do in the recording, while the same id string twice shared its `[[command]]`
+  target as well), and an attitude block no
+  rigid body could have — an inertia tensor that is not positive definite or
+  violates `I1 + I2 >= I3` on its principal moments, `mass <= 0`, or an
+  `initial_quaternion` that cannot be normalized. The `integrator` /
+  `atmosphere` spellings a config accepts are now exactly the ones the
+  equivalent CLI flag accepts.
+
+  A key nothing reads is named rather than refused: the run goes ahead, so a
+  config written for a newer `orts` still works here, and `duraton = 100` no
+  longer runs for one orbital period in silence. `orts config validate` carries
+  the paths in its `warnings`, `run` and `serve` report them at warn level, and
+  the server names the ones in a client's `start_simulation` or `add_satellite`. A `type`-tagged
+  block — `[satellites.orbit]`, `[satellites.controller]`, the reaction wheels
+  and the magnetorquers — refuses instead: `serde_ignored` cannot see inside an
+  internally tagged enum, so there is nothing to name there, and a dropped
+  `inclinaton = 51.6` would leave the orbit equatorial. A singular inertia tensor previously panicked in
+  `SpacecraftDynamics::new`; under `orts serve --config` that happened inside
+  the spawned manager task, leaving the server listening with no simulation and
+  no error to the client. ([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
 - `duration` no longer replaces each satellite's orbital period. It is the
@@ -263,6 +325,41 @@ section is subdivided by package.
   period boundary, and the boundary for a newly added satellite was read from
   the *previous* entry in the fleet (or a hardcoded 5554 s when it was the
   first). ([#368](https://github.com/sksat/orts/pull/368))
+- `orts` now writes its diagnostics to stderr. With no `log` backend installed
+  every `log::` call was discarded, so a displaced stream-io stdio plug, a stream
+  socket error, a halted `serve` simulation, and every line a WASM plugin logged
+  through the WIT `host-env.log` import all went unreported. The diagnostics the
+  rerun crates emit while writing an `.rrd` now appear in the same output.
+  `RUST_LOG` selects the level — default `warn,orts=info`, ours at info and
+  dependencies at warn — and `NO_COLOR`, or a stderr that is not a terminal,
+  drops the styling; `orts --help` documents both. stdout is unchanged: the CSV,
+  the `--json` summary, or the `serve --stream-stdio` protocol and nothing else. ([#390](https://github.com/sksat/orts/pull/390))
+- `orts config validate` and `orts serve --config` refuse a `tle` or `norad`
+  orbit about any body but Earth. SGP4 is Earth's, and `SimParams::from_config`
+  reached that rule through a panic, so such a config validated clean and then
+  took down `orts run --config`. ([#351](https://github.com/sksat/orts/pull/351))
+- `orts config validate` and `orts serve --config` refuse a fleet no
+  simulation mode can run: `[satellites.attitude]` or
+  `[satellites.controller]` on some satellites but not all, or a controller on
+  every satellite with attitude on none. The engine already refused these, but
+  `orts serve` builds it inside the spawned manager, so the config validated
+  clean, the startup banner printed, and the server sat idle with the given
+  config never running. `serve` now exits with the error instead of announcing
+  a listening server. ([#351](https://github.com/sksat/orts/pull/351))
+- The WebSocket `add_satellite` refuses an id whose entity path
+  (`/world/sat/<id>`) already belongs to a satellite in the running fleet. Two
+  satellites on one path meant `[[command]]` reached only the one added last. An
+  omitted `id` takes `sat-<current fleet size>`, which collides the same
+  way. ([#351](https://github.com/sksat/orts/pull/351))
+- `orts serve` answers a message that does not deserialize into `ClientMessage`
+  with a `{"type":"error"}` frame. The error used to be discarded, leaving the
+  client waiting for a response that never came. An unknown key in a
+  `type`-tagged block is what fails. ([#351](https://github.com/sksat/orts/pull/351))
+- `orts serve` prints its `Server listening` / `WebSocket endpoint` banner only
+  after the `--config` file is accepted. Printing it first made a rejected
+  config reach a caller that waits on the banner — `cli/tests/ws_e2e.rs`, the
+  Playwright specs — as a refused connection rather than as its own error
+  message. ([#351](https://github.com/sksat/orts/pull/351))
 - `orts run --format csv --output <path>` now writes the CSV to `<path>`.
   Previously every `--format csv` run wrote to stdout regardless of `--output`,
   silently ignoring the given path. ([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,29 +33,6 @@ section is subdivided by package.
 - WIT v0 plugin interface extended with the msg-io and stream-io channels. ([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
-- `SatelliteParams` carries an optional `SpacecraftShape`, and
-  `build_spacecraft_dynamics` installs `PanelSrp` and `PanelDrag` from it in
-  place of the isotropic `SolarRadiationPressure` and `AtmosphericDrag`. The
-  outer shape is one object, so panels drive both forces rather than one of
-  them. `build_orbital_system` installs neither: panel forces need an attitude.
-  `SurfacePanel` gains `with_cp_offset`, which is what turns a panel force into
-  an attitude disturbance. ([#386](https://github.com/sksat/orts/pull/386))
-- `SurfacePanel::back_face` builds the other side of a thin plate: the normal is
-  negated, the area, `cd` and centre of pressure carry over, and the optics are
-  given, since the two sides of an array differ. A panel is one face and both
-  force models drop a face pointing away from the Sun or the flow, so a plate
-  written as one panel produces nothing for half of the attitudes it sees — and
-  the torque about an off-centre pressure point goes with it. Not for a face of
-  a closed body, whose far side is already another panel. ([#395](https://github.com/sksat/orts/pull/395))
-- `orts::setup` registers disturbance torques, and `SatelliteParams` carries a
-  `DisturbanceTorques` selection to say which. `build_spacecraft_dynamics`
-  installs the gravity-gradient torque from it; `build_orbital_system` installs
-  none, since an orbit-only system has no orientation for a torque to act on and
-  discards `torque_body`. Callers no longer register environmental models
-  themselves — the CLI had been adding this torque on the same line in two entry
-  points, with nothing keeping the two in step. Actuators (RW, MTQ, thrusters)
-  stay with the caller, since they come from the spacecraft's own hardware
-  description. ([#382](https://github.com/sksat/orts/pull/382))
 - `SurfacePanel` carries `optics: PanelOptics { specular, diffuse }` in place of
   a lumped `cr`, with the absorbed fraction derived as `1 - specular - diffuse`.
   A single coefficient fixes the SRP force magnitude face-on but leaves its
@@ -144,10 +121,6 @@ section is subdivided by package.
   different ways, so no choice of `Cr` recovers the right answer. For a solar
   array (ρ_s ≈ 0.2, ρ_d ≈ 0.1) the missing term carries ~30% of the force at 45°
   incidence. Present since the model was introduced, 0.2.0 included.
-  Japanese-labeled diagrams of the law, the two force components and the torque
-  direction: [photon fates](docs/src/assets/srp-flat-panel/photon-fates.svg),
-  [force composition](docs/src/assets/srp-flat-panel/force-composition.svg),
-  [torque direction](docs/src/assets/srp-flat-panel/torque-direction.svg).
   ([#377](https://github.com/sksat/orts/pull/377))
 - `AttitudeState::q_dot` halves the angular velocity before forming the
   products rather than the sum afterwards, so it no longer overflows where its
@@ -264,10 +237,6 @@ section is subdivided by package.
   are discoverable without leaving the terminal. ([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
-- `orts run`'s downlink log records moved from info/debug to debug/trace. They
-  fire per satellite per outbound message per control tick, so with a backend
-  installed, info would bury every other diagnostic on a fleet-sized run and add
-  a locked stderr write inside the integration loop. ([#390](https://github.com/sksat/orts/pull/390))
 - `--tle` is TLE-only again (2LE/3LE; `-` for stdin) and pairs with the new
   `--omm`; element-set parsing is now backed by `arika::tle` / `arika::omm`
   instead of the removed `orts::tle`. (Previously `--tle` also auto-accepted OMM.) ([#87](https://github.com/sksat/orts/pull/87))
@@ -277,69 +246,23 @@ section is subdivided by package.
   `--tle-line2`; and `--tle-line1` / `--tle-line2` must be given together. ([#87](https://github.com/sksat/orts/pull/87))
 - TLE epoch day-of-year is validated against the (leap-aware) year length, so a
   malformed field is rejected rather than rolling into another year. ([#87](https://github.com/sksat/orts/pull/87))
-- Config files, `orts config validate` and the WebSocket `start_simulation`
-  payload reject input the simulation cannot honor, instead of resolving it to
-  something else: an unknown `[integrator] type` or `atmosphere` (previously
-  dp45 / the exponential model), two
-  satellites whose ids name one recording entity (previously one entity and one
-  CSV section for both; compared on the entity, so `a` and `/a` collide as they
-  do in the recording, while the same id string twice shared its `[[command]]`
-  target as well), and an attitude block no
-  rigid body could have — an inertia tensor that is not positive definite or
-  violates `I1 + I2 >= I3` on its principal moments, `mass <= 0`, or an
-  `initial_quaternion` that cannot be normalized. The `integrator` /
-  `atmosphere` spellings a config accepts are now exactly the ones the
-  equivalent CLI flag accepts.
-
-  A key nothing reads is named rather than refused: the run goes ahead, so a
-  config written for a newer `orts` still works here, and `duraton = 100` no
-  longer runs for one orbital period in silence. `orts config validate` carries
-  the paths in its `warnings`, `run` and `serve` report them at warn level, and
-  the server names the ones in a client's `start_simulation` or `add_satellite`. A `type`-tagged
-  block — `[satellites.orbit]`, `[satellites.controller]`, the reaction wheels
-  and the magnetorquers — refuses instead: `serde_ignored` cannot see inside an
-  internally tagged enum, so there is nothing to name there, and a dropped
-  `inclinaton = 51.6` would leave the orbit equatorial. A singular inertia tensor previously panicked in
-  `SpacecraftDynamics::new`; under `orts serve --config` that happened inside
-  the spawned manager task, leaving the server listening with no simulation and
-  no error to the client. ([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
-- `orts` now writes its diagnostics to stderr. With no `log` backend installed
-  every `log::` call was discarded, so a displaced stream-io stdio plug, a stream
-  socket error, a halted `serve` simulation, and every line a WASM plugin logged
-  through the WIT `host-env.log` import all went unreported. The diagnostics the
-  rerun crates emit while writing an `.rrd` now appear in the same output.
-  `RUST_LOG` selects the level — default `warn,orts=info`, ours at info and
-  dependencies at warn — and `NO_COLOR`, or a stderr that is not a terminal,
-  drops the styling; `orts --help` documents both. stdout is unchanged: the CSV,
-  the `--json` summary, or the `serve --stream-stdio` protocol and nothing else. ([#390](https://github.com/sksat/orts/pull/390))
-- `orts config validate` and `orts serve --config` refuse a `tle` or `norad`
-  orbit about any body but Earth. SGP4 is Earth's, and `SimParams::from_config`
-  reached that rule through a panic, so such a config validated clean and then
-  took down `orts run --config`. ([#351](https://github.com/sksat/orts/pull/351))
-- `orts config validate` and `orts serve --config` refuse a fleet no
-  simulation mode can run: `[satellites.attitude]` or
-  `[satellites.controller]` on some satellites but not all, or a controller on
-  every satellite with attitude on none. The engine already refused these, but
-  `orts serve` builds it inside the spawned manager, so the config validated
-  clean, the startup banner printed, and the server sat idle with the given
-  config never running. `serve` now exits with the error instead of announcing
-  a listening server. ([#351](https://github.com/sksat/orts/pull/351))
-- The WebSocket `add_satellite` refuses an id whose entity path
-  (`/world/sat/<id>`) already belongs to a satellite in the running fleet. Two
-  satellites on one path meant `[[command]]` reached only the one added last. An
-  omitted `id` takes `sat-<current fleet size>`, which collides the same
-  way. ([#351](https://github.com/sksat/orts/pull/351))
-- `orts serve` answers a message that does not deserialize into `ClientMessage`
-  with a `{"type":"error"}` frame. The error used to be discarded, leaving the
-  client waiting for a response that never came. An unknown key in a
-  `type`-tagged block is what fails. ([#351](https://github.com/sksat/orts/pull/351))
-- `orts serve` prints its `Server listening` / `WebSocket endpoint` banner only
-  after the `--config` file is accepted. Printing it first made a rejected
-  config reach a caller that waits on the banner — `cli/tests/ws_e2e.rs`, the
-  Playwright specs — as a refused connection rather than as its own error
-  message. ([#351](https://github.com/sksat/orts/pull/351))
+- `duration` no longer replaces each satellite's orbital period. It is the
+  run's end time, but both were carried in one field, so `--duration 120` left
+  the CSV header, the RRD `meta/sim/period` and the WebSocket `SatelliteInfo`
+  all reporting 120 s as the period of an orbit that takes 5553.6 s — and
+  flattened a fleet onto one value, since every satellite was assigned the same
+  duration. The end time now comes from `duration.unwrap_or(period)` where a
+  horizon is wanted; with no `duration`, an orbit-only or spacecraft run still
+  covers one orbit of each satellite, and a controlled run still takes the
+  first satellite's period for the whole fleet.
+  ([#TBD](https://github.com/sksat/orts/pull/TBD))
+- A satellite added to a running `orts serve` re-anchors its orbit on its own
+  period. `serve` restarts an unperturbed orbit-only satellite's orbit at every
+  period boundary, and the boundary for a newly added satellite was read from
+  the *previous* entry in the fleet (or a hardcoded 5554 s when it was the
+  first). ([#TBD](https://github.com/sksat/orts/pull/TBD))
 - `orts run --format csv --output <path>` now writes the CSV to `<path>`.
   Previously every `--format csv` run wrote to stdout regardless of `--output`,
   silently ignoring the given path. ([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,11 +200,6 @@ section is subdivided by package.
   empty `back = {}` says the same as the flag). Either way the area, `cd` and
   centre of pressure are shared, and `two_sided = false` beside `back` is
   rejected as a contradiction. Writing panels
-  `area`, `normal`, `cd`, `specular`, `diffuse`, `cp_offset` and `back` ([#395](https://github.com/sksat/orts/pull/395)).
-  A panel is one face, so `back` is what gives a thin plate — a solar array —
-  its far side: the area, `cd` and centre of pressure are shared and the
-  reflectivities are its own, with an empty table (`back = {}`) copying the
-  front's. Writing panels
   makes SRP and drag attitude-dependent, and an off-centre centre of pressure
   turns them into attitude disturbances — which is what the isotropic
   `srp_area_to_mass` / `ballistic_coeff` cannot express. Panels require

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,12 +257,12 @@ section is subdivided by package.
   horizon is wanted; with no `duration`, an orbit-only or spacecraft run still
   covers one orbit of each satellite, and a controlled run still takes the
   first satellite's period for the whole fleet.
-  ([#TBD](https://github.com/sksat/orts/pull/TBD))
+  ([#368](https://github.com/sksat/orts/pull/368))
 - A satellite added to a running `orts serve` re-anchors its orbit on its own
   period. `serve` restarts an unperturbed orbit-only satellite's orbit at every
   period boundary, and the boundary for a newly added satellite was read from
   the *previous* entry in the fleet (or a hardcoded 5554 s when it was the
-  first). ([#TBD](https://github.com/sksat/orts/pull/TBD))
+  first). ([#368](https://github.com/sksat/orts/pull/368))
 - `orts run --format csv --output <path>` now writes the CSV to `<path>`.
   Previously every `--format csv` run wrote to stdout regardless of `--output`,
   silently ignoring the given path. ([#214](https://github.com/sksat/orts/pull/214))

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -233,7 +233,8 @@ pub struct SimArgs {
     #[arg(long)]
     pub space_weather: Option<String>,
 
-    /// Total simulation duration in seconds (overrides orbital period)
+    /// Total simulation duration in seconds. Omit to cover one orbit
+    /// (`orts run`); `orts serve` streams without end either way.
     #[arg(long)]
     pub duration: Option<f64>,
 

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -140,6 +140,10 @@ enum DataSink<'a> {
 }
 
 /// `-` is the canonical stdout sentinel; `stdout` is kept as a legacy alias.
+fn is_stdout_sentinel(s: &str) -> bool {
+    s == "-" || s == "stdout"
+}
+
 /// How far to propagate one satellite [s].
 ///
 /// `duration` is the run's end time and applies to the whole fleet; with none
@@ -156,10 +160,6 @@ enum DataSink<'a> {
 /// a pre-existing difference between the modes, left as it is here.
 fn end_time_of(params: &SimParams, sat: &crate::satellite::SatelliteSpec) -> f64 {
     params.duration.unwrap_or(sat.period)
-}
-
-fn is_stdout_sentinel(s: &str) -> bool {
-    s == "-" || s == "stdout"
 }
 
 /// Decide where the simulation data goes. With no `--output`, CSV defaults to

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -140,6 +140,24 @@ enum DataSink<'a> {
 }
 
 /// `-` is the canonical stdout sentinel; `stdout` is kept as a legacy alias.
+/// How far to propagate one satellite [s].
+///
+/// `duration` is the run's end time and applies to the whole fleet; with none
+/// given, each satellite is propagated for one of its own orbits. The two used
+/// to be folded together by writing `duration` into
+/// [`SatelliteSpec::period`](crate::satellite::SatelliteSpec::period), which
+/// left every reader of the period — the CSV header, the RRD `meta/sim/period`,
+/// the WebSocket `SatelliteInfo` — reporting the end time as the orbital
+/// period.
+///
+/// Used by the orbit-only and spacecraft paths, which end each satellite
+/// separately. `run_controlled_simulation` steps the whole fleet on one clock,
+/// so it takes `duration` or the *first* satellite's period for all of them —
+/// a pre-existing difference between the modes, left as it is here.
+fn end_time_of(params: &SimParams, sat: &crate::satellite::SatelliteSpec) -> f64 {
+    params.duration.unwrap_or(sat.period)
+}
+
 fn is_stdout_sentinel(s: &str) -> bool {
     s == "-" || s == "stdout"
 }
@@ -546,7 +564,8 @@ pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
             .initial_state(params.mu, params.epoch)
             .map_err(|e| CmdError::failure(format!("satellite '{}': {e}", sat.id)))?;
 
-        group = group.add_satellite_until(sat.id.as_str(), initial, sat.period, system);
+        group =
+            group.add_satellite_until(sat.id.as_str(), initial, end_time_of(params, sat), system);
     }
 
     propagate_and_record(params, group, |rec, entity, tp, state| {
@@ -596,7 +615,8 @@ pub fn run_spacecraft_simulation(params: &SimParams) -> Result<Recording, CmdErr
             mass: att.mass,
         };
         let initial = dynamics.initial_augmented_state(plant);
-        group = group.add_satellite_until(sat.id.as_str(), initial, sat.period, dynamics);
+        group =
+            group.add_satellite_until(sat.id.as_str(), initial, end_time_of(params, sat), dynamics);
     }
 
     propagate_and_record(params, group, |rec, entity, tp, state| {
@@ -663,17 +683,17 @@ where
     }
 
     // Propagate in output_interval steps
-    let max_period = params
+    let last_end_time = params
         .satellites
         .iter()
-        .map(|s| s.period)
+        .map(|s| end_time_of(params, s))
         .fold(0.0_f64, f64::max);
     let mut t = 0.0_f64;
 
     while !group.all_finished() {
         t += params.output_interval;
-        if t > max_period {
-            t = max_period;
+        if t > last_end_time {
+            t = last_end_time;
         }
 
         // Propagation errors are reported, not unwrapped: an invalid step size

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -283,7 +283,11 @@ pub(super) fn push_terminated_capped(events: &mut VecDeque<String>, msg: String)
 /// Per-satellite metadata for serve mode.
 struct SatMeta {
     spec: SatelliteSpec,
-    orbit_end_t: f64,
+    /// When this satellite's orbit is next re-anchored on its initial state
+    /// [s]. `serve` streams without end, so for an unperturbed orbit-only
+    /// satellite it restarts the orbit every period rather than stopping —
+    /// this is a recurring boundary, not a horizon.
+    next_orbit_reset_t: f64,
     next_save_t: f64,
 }
 
@@ -454,7 +458,7 @@ impl ServeEngine {
                     controlled_sats.push(sat);
                     metas.push(SatMeta {
                         spec: spec.clone(),
-                        orbit_end_t: spec.period,
+                        next_orbit_reset_t: spec.period,
                         next_save_t: params.output_interval,
                     });
                 }
@@ -506,7 +510,7 @@ impl ServeEngine {
                 sc_group = sc_group.add_satellite(spec.id.as_str(), initial, dynamics);
                 metas.push(SatMeta {
                     spec: spec.clone(),
-                    orbit_end_t: spec.period,
+                    next_orbit_reset_t: spec.period,
                     next_save_t: params.output_interval,
                 });
             }
@@ -547,7 +551,7 @@ impl ServeEngine {
                 orbit_group = orbit_group.add_satellite(spec.id.as_str(), initial, system);
                 metas.push(SatMeta {
                     spec: spec.clone(),
-                    orbit_end_t: spec.period,
+                    next_orbit_reset_t: spec.period,
                     next_save_t: params.output_interval,
                 });
             }
@@ -784,7 +788,7 @@ impl ServeEngine {
                 let resets: Vec<(SatId, OrbitalState)> = (0..n)
                     .filter_map(|i| {
                         if !self.group.is_terminated(i)
-                            && self.current_t >= self.metas[i].orbit_end_t - 1e-9
+                            && self.current_t >= self.metas[i].next_orbit_reset_t - 1e-9
                         {
                             Some((
                                 self.group.sat_id(i),
@@ -812,7 +816,8 @@ impl ServeEngine {
                         .iter()
                         .position(|m| m.spec.id.as_str() == AsRef::<str>::as_ref(id))
                     {
-                        self.metas[i].orbit_end_t = self.current_t + self.metas[i].spec.period;
+                        self.metas[i].next_orbit_reset_t =
+                            self.current_t + self.metas[i].spec.period;
                     }
                 }
             }
@@ -1051,9 +1056,13 @@ impl ServeEngine {
         let t = self.current_t;
         let sat_entity_path = spec.entity_path();
 
+        let next_orbit_reset_t = self.current_t + spec.period;
         self.metas.push(SatMeta {
             spec,
-            orbit_end_t: self.current_t + self.metas.last().map_or(5554.0, |m| m.spec.period),
+            // The satellite's own period. This used to read the *previous*
+            // entry in `metas` (or a hardcoded 5554 s for the first add), so a
+            // satellite added to a fleet re-anchored on someone else's orbit.
+            next_orbit_reset_t,
             next_save_t: self.current_t + self.params.output_interval,
         });
         // Keep `sat_streams` index-aligned with `metas` (dynamic adds cannot
@@ -1179,7 +1188,7 @@ impl ServeEngine {
 
         self.metas.push(SatMeta {
             spec,
-            orbit_end_t: self.current_t + sat_info.period,
+            next_orbit_reset_t: self.current_t + sat_info.period,
             next_save_t: self.current_t + self.params.output_interval,
         });
         // Keep `sat_streams` index-aligned with `metas` (dynamic adds cannot
@@ -1429,6 +1438,43 @@ orbit = { type = "circular", altitude = 50 }
                 .broadcasts
                 .iter()
                 .any(|m| m.contains("satellite_added"))
+        );
+    }
+
+    /// A satellite added at runtime re-anchors on its own orbit.
+    ///
+    /// `serve` restarts an unperturbed orbit-only satellite at every period
+    /// boundary. The boundary for a newly added one was read from the previous
+    /// entry in `metas` — the 500 km `sat-a` here — so a satellite added to a
+    /// fleet was re-anchored on someone else's orbit.
+    #[test]
+    fn an_added_satellite_resets_on_its_own_period() {
+        let mut init = engine_from_toml(ORBIT_ONLY).expect("engine builds");
+        let existing = init.engine.metas[0].spec.period;
+
+        let cfg: SatelliteConfig = serde_json::from_str(
+            r#"{ "id": "sat-b", "orbit": { "type": "circular", "altitude": 1500 } }"#,
+        )
+        .expect("valid satellite config");
+        init.engine.add_satellite(cfg).expect("orbit-only add ok");
+
+        let added = init
+            .engine
+            .metas
+            .iter()
+            .find(|m| m.spec.id == "sat-b")
+            .expect("the added satellite is in metas");
+        assert!(
+            added.spec.period > existing + 500.0,
+            "the fixture needs two clearly different periods: {} vs {existing}",
+            added.spec.period
+        );
+        assert!(
+            (added.next_orbit_reset_t - added.spec.period).abs() < 1e-9,
+            "reset boundary {} should be the added satellite's own period {}, \
+             not the existing {existing}",
+            added.next_orbit_reset_t,
+            added.spec.period
         );
     }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1481,9 +1481,12 @@ impl SatelliteConfig {
 ///
 /// Each value is load-bearing:
 /// - `dt` drives `while t < t_end`, so zero never advances.
-/// - `output_interval` drives `t += output_interval` in `run`, so zero never
-///   reaches the time the fleet stops at (`duration` when given, otherwise the
-///   longest satellite period).
+/// - `output_interval` drives `t += output_interval` in the orbit-only and
+///   spacecraft `run` loops, so zero never reaches the time they stop at
+///   (`duration` when given, otherwise the longest satellite period). The
+///   controlled loop advances on controller ticks instead and only compares
+///   `output_interval` to decide when to log, so zero there means logging every
+///   tick rather than a clock that cannot move.
 /// - `stream_interval` is a divisor in the serve loop's pacing, where zero
 ///   yields `0 * inf = NaN` and panics `Duration::from_secs_f64`.
 /// - `duration` is how far `run` propagates the fleet.

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1482,10 +1482,10 @@ impl SatelliteConfig {
 /// Each value is load-bearing:
 /// - `dt` drives `while t < t_end`, so zero never advances.
 /// - `output_interval` drives `t += output_interval` in `run`, so zero never
-///   reaches `max_period`.
+///   reaches the last satellite's end time.
 /// - `stream_interval` is a divisor in the serve loop's pacing, where zero
 ///   yields `0 * inf = NaN` and panics `Duration::from_secs_f64`.
-/// - `duration` becomes each satellite's propagation period.
+/// - `duration` is how far `run` propagates the fleet.
 ///
 /// `output_interval < dt` is rejected too: `SimParams` clamps
 /// `stream_interval` into `[dt, output_interval]`, which panics outright on
@@ -2666,7 +2666,7 @@ altitude = -100.0
         assert!(config.validate().is_ok(), "RK4 ignores tolerances");
     }
 
-    /// `output_interval = 0` never reaches `max_period` in `run`;
+    /// `output_interval = 0` never reaches the fleet's end time in `run`;
     /// `stream_interval = 0` is a divisor in the serve loop's pacing, where it
     /// produces `NaN` and panics `Duration::from_secs_f64`.
     #[test]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1482,7 +1482,8 @@ impl SatelliteConfig {
 /// Each value is load-bearing:
 /// - `dt` drives `while t < t_end`, so zero never advances.
 /// - `output_interval` drives `t += output_interval` in `run`, so zero never
-///   reaches the last satellite's end time.
+///   reaches the time the fleet stops at (`duration` when given, otherwise the
+///   longest satellite period).
 /// - `stream_interval` is a divisor in the serve loop's pacing, where zero
 ///   yields `0 * inf = NaN` and panics `Duration::from_secs_f64`.
 /// - `duration` is how far `run` propagates the fleet.

--- a/cli/src/satellite.rs
+++ b/cli/src/satellite.rs
@@ -36,7 +36,16 @@ pub struct SatelliteSpec {
     pub name: Option<String>,
     /// Orbit specification.
     pub orbit: OrbitSpec,
-    /// Orbital period for this satellite.
+    /// Orbital period of this satellite [s], from its own orbit: `2π√(r³/μ)`
+    /// for a circular orbit, the element set's mean motion for a TLE / OMM.
+    ///
+    /// A property of the orbit, so nothing on the command line moves it —
+    /// `duration` is the run's end time and lives on
+    /// [`SimParams`](crate::sim::params::SimParams). Where an end time is what
+    /// is wanted, the two combine as `duration.unwrap_or(period)`: with no
+    /// `duration`, an orbit-only or spacecraft run covers one orbit of each
+    /// satellite. A controlled run steps the fleet on one clock and takes the
+    /// first satellite's period for all of them.
     pub period: f64,
     /// Explicit ballistic coefficient Cd*A/(2m) [m²/kg] for drag.
     pub ballistic_coeff: Option<f64>,

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -308,19 +308,6 @@ impl SimParams {
             .unwrap_or(output_interval)
             .clamp(args.dt.min(output_interval), output_interval);
 
-        // Apply --duration override: replace each satellite's period with the user-specified duration
-        let satellites = if let Some(dur) = args.duration {
-            satellites
-                .into_iter()
-                .map(|mut s| {
-                    s.period = dur;
-                    s
-                })
-                .collect()
-        } else {
-            satellites
-        };
-
         // Resolve the deferred epoch: an explicit `--epoch` wins; otherwise it
         // defaults to the first TLE/OMM's element-set epoch (tsince = 0 for
         // that satellite only — see `element_set_epoch`); otherwise "now".
@@ -386,18 +373,6 @@ impl SimParams {
             .stream_interval
             .unwrap_or(output_interval)
             .clamp(config.dt.min(output_interval), output_interval);
-
-        let satellites = if let Some(dur) = config.duration {
-            satellites
-                .into_iter()
-                .map(|mut s| {
-                    s.period = dur;
-                    s
-                })
-                .collect()
-        } else {
-            satellites
-        };
 
         let epoch = epoch
             .or_else(|| element_set_epoch(&satellites))
@@ -615,6 +590,123 @@ impl SimParams {
 mod tests {
     use super::*;
     use crate::satellite::OrbitSpec;
+
+    /// `duration` is the run's end time, not the satellite's orbital period.
+    ///
+    /// The two used to share `SatelliteSpec::period`, so `--duration 120` left
+    /// every consumer of the period — the CSV header, the RRD `meta/sim/period`
+    /// and the WebSocket `SatelliteInfo` — reporting 120 s for an orbit that
+    /// takes 5553.6 s. The period is a property of the orbit and nothing on the
+    /// command line moves it.
+    #[test]
+    fn duration_does_not_overwrite_the_orbital_period() {
+        // 2π√(r³/μ) at r = 6778.137 km, the circular orbit 400 km up.
+        const PERIOD_400KM: f64 = 5553.6;
+
+        let mut args = sim_args_for_period_tests();
+        args.sats = vec!["altitude=400".to_string()];
+
+        let without = SimParams::from_sim_args(&args, false);
+        assert!(
+            (without.satellites[0].period - PERIOD_400KM).abs() < 1.0,
+            "period without --duration: {}",
+            without.satellites[0].period
+        );
+
+        args.duration = Some(120.0);
+        let with = SimParams::from_sim_args(&args, false);
+        assert!(
+            (with.satellites[0].period - PERIOD_400KM).abs() < 1.0,
+            "--duration 120 changed the orbital period to {}",
+            with.satellites[0].period
+        );
+        assert_eq!(
+            with.duration,
+            Some(120.0),
+            "the end time still has to reach SimParams"
+        );
+    }
+
+    /// Same for the config path, which resolves `duration` separately.
+    #[test]
+    fn config_duration_does_not_overwrite_the_orbital_period() {
+        const PERIOD_400KM: f64 = 5553.6;
+
+        let config: crate::config::SimConfig = toml::from_str(
+            r#"
+body = "earth"
+dt = 10.0
+duration = 120.0
+
+[[satellites]]
+id = "a"
+orbit = { type = "circular", altitude = 400 }
+"#,
+        )
+        .expect("the fixture config parses");
+        let params = SimParams::from_config(&config);
+
+        assert!(
+            (params.satellites[0].period - PERIOD_400KM).abs() < 1.0,
+            "config duration changed the orbital period to {}",
+            params.satellites[0].period
+        );
+        assert_eq!(params.duration, Some(120.0));
+    }
+
+    /// A fleet keeps each satellite's own period under `--duration`.
+    ///
+    /// Overwriting the period flattened the fleet onto one value, which is what
+    /// made the collision invisible: both satellites reported the same period
+    /// because both had been assigned the same duration.
+    #[test]
+    fn duration_leaves_each_satellite_its_own_period() {
+        let mut args = sim_args_for_period_tests();
+        args.sats = vec![
+            "altitude=400,id=low".to_string(),
+            "altitude=800,id=high".to_string(),
+        ];
+        args.duration = Some(120.0);
+        let params = SimParams::from_sim_args(&args, false);
+
+        let (low, high) = (&params.satellites[0], &params.satellites[1]);
+        assert!(
+            high.period > low.period + 400.0,
+            "800 km must orbit slower than 400 km: {} vs {}",
+            high.period,
+            low.period
+        );
+    }
+
+    /// A `SimArgs` with every field at its default, for the tests above to
+    /// vary one field at a time.
+    fn sim_args_for_period_tests() -> SimArgs {
+        SimArgs {
+            body: "earth".to_string(),
+            dt: 10.0,
+            output_interval: None,
+            stream_interval: None,
+            epoch: None,
+            tle: None,
+            omm: None,
+            tle_line1: None,
+            tle_line2: None,
+            norad_id: None,
+            sats: vec![],
+            integrator: IntegratorChoice::Dp45,
+            atol: 1e-10,
+            rtol: 1e-8,
+            atmosphere: AtmosphereChoice::Exponential,
+            f107: 150.0,
+            ap: 15.0,
+            space_weather: None,
+            duration: None,
+            config: None,
+            plugin_backend: PluginBackendChoice::Auto,
+            plugin_backend_threshold: None,
+            plugin_backend_async_mode: PluginAsyncModeChoice::Deterministic,
+        }
+    }
 
     #[test]
     fn sim_params_stream_interval_defaults_to_output_interval() {

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -860,163 +860,129 @@ fn test_cli_json_and_data_stdout_conflict() {
     );
 }
 
-/// Two satellites resolving to the same id used to run: both wrote rows under
-/// one recording entity path / CSV section, so the fleet silently became one
-/// mislabeled satellite. The second entry here has no `id`, so it defaults to
-/// `sat-1` and collides with the first entry's explicit id — the collision is
-/// invisible in the file.
-#[test]
-fn test_cli_config_rejects_duplicate_satellite_ids() {
-    let dir = std::env::temp_dir().join(format!("orts-e2e-dup-id-{}", std::process::id()));
-    std::fs::create_dir_all(&dir).unwrap();
-    let config_path = dir.join("dup.toml");
-    std::fs::write(
-        &config_path,
-        "dt = 10.0\nduration = 60.0\n\n\
-         [[satellites]]\nid = \"sat-1\"\n[satellites.orbit]\ntype = \"circular\"\naltitude = 400\n\n\
-         [[satellites]]\n[satellites.orbit]\ntype = \"circular\"\naltitude = 800\n",
-    )
-    .unwrap();
+/// The circular orbit 400 km up: `2π√(r³/μ)` at r = 6778.137 km.
+const PERIOD_400KM_S: f64 = 5553.624;
+/// The circular orbit 800 km up.
+const PERIOD_800KM_S: f64 = 6052.414;
 
-    let output = run_cli_with_config(config_path.to_str().unwrap());
-    assert!(
-        !output.status.success(),
-        "duplicate satellite ids must fail the run, stdout={}",
-        String::from_utf8_lossy(&output.stdout)
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("duplicate satellite id 'sat-1'"),
-        "error should name the colliding id, got: {stderr}"
-    );
-    std::fs::remove_dir_all(&dir).ok();
+/// Return the last `t` reached in each satellite's CSV section.
+///
+/// Reads the section markers rather than the rows, because the single- and
+/// multi-satellite CSVs differ in shape: only the multi-satellite one prefixes
+/// each row with the id.
+fn final_t_per_section(csv: &str) -> Vec<(String, f64)> {
+    let mut out: Vec<(String, f64)> = Vec::new();
+    let mut multi = false;
+    for line in csv.lines() {
+        if let Some(rest) = line.strip_prefix("# --- ") {
+            let id = rest.trim_end_matches(" ---").to_string();
+            out.push((id, f64::NAN));
+            continue;
+        }
+        if line.starts_with("# satellite_id,") {
+            multi = true;
+            continue;
+        }
+        if line.starts_with('#') || line.trim().is_empty() || line.starts_with("t[") {
+            continue;
+        }
+        let cols: Vec<&str> = line.split(',').collect();
+        let t: f64 = cols[usize::from(multi)]
+            .parse()
+            .expect("a numeric t column");
+        match out.last_mut() {
+            Some(entry) => entry.1 = t,
+            None => out.push((String::from("(single)"), t)),
+        }
+    }
+    out
 }
 
-/// An inertia tensor that cannot be inverted reached
-/// `SpacecraftDynamics::new`, which aborts the process (`expect`) once the
-/// attitude config is honored. It is an input error, so it must be reported as
-/// one, with the satellite named.
-#[test]
-fn test_cli_config_rejects_singular_inertia() {
-    let dir = std::env::temp_dir().join(format!("orts-e2e-inertia-{}", std::process::id()));
-    std::fs::create_dir_all(&dir).unwrap();
-    let config_path = dir.join("singular.toml");
-    std::fs::write(
-        &config_path,
-        "dt = 10.0\nduration = 60.0\n\n\
-         [[satellites]]\nid = \"sat-a\"\n[satellites.orbit]\ntype = \"circular\"\naltitude = 400\n\n\
-         [satellites.attitude]\ninertia_diag = [0.0, 0.0, 0.0]\nmass = 100.0\n",
-    )
-    .unwrap();
-
-    let output = run_cli_with_config(config_path.to_str().unwrap());
-    assert!(
-        !output.status.success(),
-        "a singular inertia tensor must fail the run"
-    );
-    assert_eq!(
-        output.status.code(),
-        Some(1),
-        "bad input is a reported failure (`CmdError::failure`), not a panic (101): stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("satellites[0]")
-            && stderr.contains("attitude:")
-            && stderr.contains("inertia tensor"),
-        "error should name the entry, the block and the constraint, got: {stderr}"
-    );
-    std::fs::remove_dir_all(&dir).ok();
-}
-
-/// `--atmosphere nrlmsise0` is rejected by clap; the same typo in a config
-/// file used to run the exponential model instead, with nothing in the output
-/// naming the model that was actually integrated.
-#[test]
-fn test_cli_config_rejects_unknown_atmosphere() {
-    let dir = std::env::temp_dir().join(format!("orts-e2e-atmo-{}", std::process::id()));
-    std::fs::create_dir_all(&dir).unwrap();
-    let config_path = dir.join("atmo.toml");
-    std::fs::write(
-        &config_path,
-        "dt = 10.0\nduration = 60.0\natmosphere = \"nrlmsise0\"\n\n\
-         [[satellites]]\nid = \"a\"\nballistic_coeff = 0.01\n\
-         [satellites.orbit]\ntype = \"circular\"\naltitude = 300\n",
-    )
-    .unwrap();
-
-    let output = run_cli_with_config(config_path.to_str().unwrap());
-    assert!(
-        !output.status.success(),
-        "an unknown atmosphere model must fail the run"
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("nrlmsise0") && stderr.contains("nrlmsise00"),
-        "error should name the typo and the legal spelling, got: {stderr}"
-    );
-    std::fs::remove_dir_all(&dir).ok();
-}
-
-/// A misspelled key was dropped without a word, which is indistinguishable from
-/// a key that was never written: `duraton = 60` ran for one full orbital period
-/// and reported success. The run still goes ahead — that is what lets a config
-/// written for a newer `orts` work here — but the key is named.
-#[test]
-fn test_cli_config_names_an_unread_key() {
-    let dir = std::env::temp_dir().join(format!("orts-e2e-unknown-key-{}", std::process::id()));
-    std::fs::create_dir_all(&dir).unwrap();
-    let config_path = dir.join("typo.toml");
-    std::fs::write(
-        &config_path,
-        "dt = 10.0\nduraton = 60.0\n\n\
-         [[satellites]]\nid = \"a\"\n[satellites.orbit]\ntype = \"circular\"\naltitude = 400\n",
-    )
-    .unwrap();
-
-    let output = run_cli_with_config(config_path.to_str().unwrap());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        output.status.success(),
-        "the run goes ahead, ignoring the key: {stderr}"
-    );
-    assert!(
-        stderr.contains("duraton"),
-        "the warning should name the unread key, got: {stderr}"
-    );
-    std::fs::remove_dir_all(&dir).ok();
-}
-
-/// The same collision from the CLI side: `--sat id=a` twice built a two-entry
-/// fleet whose entries shared one entity path and one command target.
-#[test]
-fn test_cli_repeated_sat_id_is_rejected() {
+fn run_csv(args: &[&str]) -> String {
     let binary = env!("CARGO_BIN_EXE_orts");
     let output = Command::new(binary)
-        .args([
-            "run",
-            "--sat",
-            "altitude=400,id=a",
-            "--sat",
-            "altitude=800,id=a",
-            "--duration",
-            "60",
-            "--output",
-            "-",
-            "--format",
-            "csv",
-        ])
+        .args(["run", "--output", "stdout", "--format", "csv"])
+        .args(args)
         .output()
         .expect("failed to execute orts");
     assert!(
-        !output.status.success(),
-        "a repeated --sat id must fail the run, stdout={}",
-        String::from_utf8_lossy(&output.stdout)
+        output.status.success(),
+        "orts run {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// `--duration` sets how long the run covers; the reported period stays the
+/// orbit's own.
+///
+/// The two used to share one field, so `--duration 120` made the CSV header
+/// (and the RRD `meta/sim/period`, and the WebSocket `SatelliteInfo`) call
+/// 120 s the orbital period of an orbit that takes 5553.6 s.
+#[test]
+fn duration_sets_the_end_time_and_leaves_the_period_alone() {
+    let csv = run_csv(&["--sat", "altitude=400", "--duration", "120"]);
+
     assert!(
-        stderr.contains("duplicate satellite id 'a'"),
-        "error should name the repeated id, got: {stderr}"
+        csv.contains(&format!("# Period = {PERIOD_400KM_S:.1} s")),
+        "header should report the orbital period, got:\n{}",
+        csv.lines().take(10).collect::<Vec<_>>().join("\n")
     );
+
+    let finals = final_t_per_section(&csv);
+    assert_eq!(finals.len(), 1, "one satellite, one section: {finals:?}");
+    assert!(
+        (finals[0].1 - 120.0).abs() < 1e-9,
+        "the run should still end at the requested duration, got {finals:?}"
+    );
+}
+
+/// Without `--duration`, each satellite is propagated for one of its own
+/// orbits — which is what made the shared field look consistent.
+#[test]
+fn a_fleet_without_duration_ends_each_satellite_at_its_own_period() {
+    let csv = run_csv(&[
+        "--sat",
+        "altitude=400,id=low",
+        "--sat",
+        "altitude=800,id=high",
+    ]);
+
+    let finals = final_t_per_section(&csv);
+    assert_eq!(finals.len(), 2, "two sections expected: {finals:?}");
+    let low = finals.iter().find(|(id, _)| id == "low").expect("low");
+    let high = finals.iter().find(|(id, _)| id == "high").expect("high");
+    assert!(
+        (low.1 - PERIOD_400KM_S).abs() < 1.0,
+        "low should end at its own period, got {}",
+        low.1
+    );
+    assert!(
+        (high.1 - PERIOD_800KM_S).abs() < 1.0,
+        "high should end at its own period, got {}",
+        high.1
+    );
+}
+
+/// `--duration` is a property of the run, so it applies to the whole fleet
+/// while each satellite keeps its own period.
+#[test]
+fn duration_applies_to_every_satellite_in_a_fleet() {
+    let csv = run_csv(&[
+        "--sat",
+        "altitude=400,id=low",
+        "--sat",
+        "altitude=800,id=high",
+        "--duration",
+        "120",
+    ]);
+
+    let finals = final_t_per_section(&csv);
+    assert_eq!(finals.len(), 2, "two sections expected: {finals:?}");
+    for (id, t) in &finals {
+        assert!(
+            (t - 120.0).abs() < 1e-9,
+            "satellite '{id}' should end at the run's duration, got {t}"
+        );
+    }
 }

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -937,6 +937,81 @@ fn duration_sets_the_end_time_and_leaves_the_period_alone() {
     );
 }
 
+/// A satellite with an attitude config ends at `duration` too.
+///
+/// The spacecraft path is a separate `add_satellite_until` call from the
+/// orbit-only one, so it took its end time from a separate expression.
+/// Measured: putting `sat.period` back there left every other test passing,
+/// because the E2E cases above are orbit-only and the `SimParams` tests stop
+/// before propagation.
+#[test]
+fn duration_sets_the_end_time_for_a_spacecraft_run() {
+    let dir = std::env::temp_dir().join(format!("orts_e2e_att_dur_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let config_path = dir.join("attitude_duration.toml");
+    std::fs::write(
+        &config_path,
+        r#"
+dt = 1.0
+duration = 120.0
+output_interval = 30.0
+
+[[satellites]]
+id = "att"
+[satellites.orbit]
+type = "circular"
+altitude = 400.0
+
+[satellites.attitude]
+inertia_diag = [10.0, 10.0, 10.0]
+mass = 100.0
+initial_angular_velocity = [0.0, 0.0, 0.01]
+"#,
+    )
+    .expect("write config");
+
+    let binary = env!("CARGO_BIN_EXE_orts");
+    let output = Command::new(binary)
+        .args([
+            "run",
+            "--output",
+            "stdout",
+            "--format",
+            "csv",
+            "--config",
+            config_path.to_str().expect("utf-8 path"),
+        ])
+        .output()
+        .expect("failed to execute orts");
+    assert!(
+        output.status.success(),
+        "orts run --config failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let csv = String::from_utf8_lossy(&output.stdout).into_owned();
+
+    // The attitude columns are what make this the spacecraft path.
+    assert!(
+        csv.contains("qw") || csv.contains("quaternion"),
+        "the run should carry attitude columns, got header:\n{}",
+        csv.lines().take(6).collect::<Vec<_>>().join("\n")
+    );
+    assert!(
+        csv.contains(&format!("# Period = {PERIOD_400KM_S:.1} s")),
+        "header should report the orbital period, got:\n{}",
+        csv.lines().take(10).collect::<Vec<_>>().join("\n")
+    );
+
+    let finals = final_t_per_section(&csv);
+    assert_eq!(finals.len(), 1, "one satellite, one section: {finals:?}");
+    assert!(
+        (finals[0].1 - 120.0).abs() < 1e-9,
+        "the spacecraft run should end at the requested duration, got {finals:?}"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
 /// Without `--duration`, each satellite is propagated for one of its own
 /// orbits — which is what made the shared field look consistent.
 #[test]

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -986,3 +986,163 @@ fn duration_applies_to_every_satellite_in_a_fleet() {
         );
     }
 }
+/// Two satellites resolving to the same id used to run: both wrote rows under
+/// one recording entity path / CSV section, so the fleet silently became one
+/// mislabeled satellite. The second entry here has no `id`, so it defaults to
+/// `sat-1` and collides with the first entry's explicit id — the collision is
+/// invisible in the file.
+#[test]
+fn test_cli_config_rejects_duplicate_satellite_ids() {
+    let dir = std::env::temp_dir().join(format!("orts-e2e-dup-id-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let config_path = dir.join("dup.toml");
+    std::fs::write(
+        &config_path,
+        "dt = 10.0\nduration = 60.0\n\n\
+         [[satellites]]\nid = \"sat-1\"\n[satellites.orbit]\ntype = \"circular\"\naltitude = 400\n\n\
+         [[satellites]]\n[satellites.orbit]\ntype = \"circular\"\naltitude = 800\n",
+    )
+    .unwrap();
+
+    let output = run_cli_with_config(config_path.to_str().unwrap());
+    assert!(
+        !output.status.success(),
+        "duplicate satellite ids must fail the run, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("duplicate satellite id 'sat-1'"),
+        "error should name the colliding id, got: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// An inertia tensor that cannot be inverted reached
+/// `SpacecraftDynamics::new`, which aborts the process (`expect`) once the
+/// attitude config is honored. It is an input error, so it must be reported as
+/// one, with the satellite named.
+#[test]
+fn test_cli_config_rejects_singular_inertia() {
+    let dir = std::env::temp_dir().join(format!("orts-e2e-inertia-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let config_path = dir.join("singular.toml");
+    std::fs::write(
+        &config_path,
+        "dt = 10.0\nduration = 60.0\n\n\
+         [[satellites]]\nid = \"sat-a\"\n[satellites.orbit]\ntype = \"circular\"\naltitude = 400\n\n\
+         [satellites.attitude]\ninertia_diag = [0.0, 0.0, 0.0]\nmass = 100.0\n",
+    )
+    .unwrap();
+
+    let output = run_cli_with_config(config_path.to_str().unwrap());
+    assert!(
+        !output.status.success(),
+        "a singular inertia tensor must fail the run"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "bad input is a reported failure (`CmdError::failure`), not a panic (101): stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("satellites[0]")
+            && stderr.contains("attitude:")
+            && stderr.contains("inertia tensor"),
+        "error should name the entry, the block and the constraint, got: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// `--atmosphere nrlmsise0` is rejected by clap; the same typo in a config
+/// file used to run the exponential model instead, with nothing in the output
+/// naming the model that was actually integrated.
+#[test]
+fn test_cli_config_rejects_unknown_atmosphere() {
+    let dir = std::env::temp_dir().join(format!("orts-e2e-atmo-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let config_path = dir.join("atmo.toml");
+    std::fs::write(
+        &config_path,
+        "dt = 10.0\nduration = 60.0\natmosphere = \"nrlmsise0\"\n\n\
+         [[satellites]]\nid = \"a\"\nballistic_coeff = 0.01\n\
+         [satellites.orbit]\ntype = \"circular\"\naltitude = 300\n",
+    )
+    .unwrap();
+
+    let output = run_cli_with_config(config_path.to_str().unwrap());
+    assert!(
+        !output.status.success(),
+        "an unknown atmosphere model must fail the run"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("nrlmsise0") && stderr.contains("nrlmsise00"),
+        "error should name the typo and the legal spelling, got: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// A misspelled key was dropped without a word, which is indistinguishable from
+/// a key that was never written: `duraton = 60` ran for one full orbital period
+/// and reported success. The run still goes ahead — that is what lets a config
+/// written for a newer `orts` work here — but the key is named.
+#[test]
+fn test_cli_config_names_an_unread_key() {
+    let dir = std::env::temp_dir().join(format!("orts-e2e-unknown-key-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let config_path = dir.join("typo.toml");
+    std::fs::write(
+        &config_path,
+        "dt = 10.0\nduraton = 60.0\n\n\
+         [[satellites]]\nid = \"a\"\n[satellites.orbit]\ntype = \"circular\"\naltitude = 400\n",
+    )
+    .unwrap();
+
+    let output = run_cli_with_config(config_path.to_str().unwrap());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "the run goes ahead, ignoring the key: {stderr}"
+    );
+    assert!(
+        stderr.contains("duraton"),
+        "the warning should name the unread key, got: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// The same collision from the CLI side: `--sat id=a` twice built a two-entry
+/// fleet whose entries shared one entity path and one command target.
+#[test]
+fn test_cli_repeated_sat_id_is_rejected() {
+    let binary = env!("CARGO_BIN_EXE_orts");
+    let output = Command::new(binary)
+        .args([
+            "run",
+            "--sat",
+            "altitude=400,id=a",
+            "--sat",
+            "altitude=800,id=a",
+            "--duration",
+            "60",
+            "--output",
+            "-",
+            "--format",
+            "csv",
+        ])
+        .output()
+        .expect("failed to execute orts");
+    assert!(
+        !output.status.success(),
+        "a repeated --sat id must fail the run, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("duplicate satellite id 'a'"),
+        "error should name the repeated id, got: {stderr}"
+    );
+}


### PR DESCRIPTION
`--duration` は「何秒ぶん計算するか」を指定する引数。軌道周期は高度から決まる物理量で、400 km 円軌道なら 5553.6 s。この 2 つは本来無関係だが、`--duration` を付けると出力に載る軌道周期がその値に化ける。

```
$ orts run --sat altitude=400 --duration 120 --format csv
# Period = 120.0 s (2.0 min)
```

軌道長半径 `a = 6778.137 km` は正しく出るので、化けるのは周期だけ。CSV header、RRD の `meta/sim/period`、WebSocket の `SatelliteInfo.period` の 3 か所に同じ値が載る。README Quick Start が `--duration` を使うので、既定で踏む。

## 原因

`SatelliteSpec::period` が 2 つの意味を兼ねていた。1 つは衛星の軌道周期で、上の 3 か所に載る値。もう 1 つはその衛星をどこまで積分するかという終了時刻。`--duration` と config の `duration` は終了時刻を指定する引数だが、実装は軌道周期の側を書き換えていた（CLI 経路と config 経路の両方）。

編隊でも同じ値が全機に入るので、400 km と 800 km の 2 機が同じ周期を報告する。

終了時刻を、必要な箇所で `duration.unwrap_or(period)` として組むようにした。`run` の `add_satellite_until` 2 箇所と伝播ループの打ち切り時刻（旧 `max_period` を `last_end_time` に改名）に通し、`period` は軌道由来の値のまま据え置く。

`duration` 未指定の挙動は変わらない。orbit-only と spacecraft の run は各衛星の 1 周分、controlled の run は最初の衛星の周期を 編隊全体の終了時刻にする。mode 間のこの差は変更していない。

| 引数 | header の Period | 各衛星の最終 t |
|---|---|---|
| `--sat altitude=400 --duration 120` | 5553.6 s | 120.000 |
| 400km + 800km、`--duration 120` | 5553.6 s | 両方 120.0 |
| 400km + 800km、duration 未指定 | 5553.6 s | 5553.624 / 6052.414 |

## 追加した衛星が他機の周期で軌道を巻き戻す

`serve` は無摂動の orbit-only 衛星を、ある時刻で初期軌道に戻してストリームを続ける。その境界を持つ `SatMeta.orbit_end_t` は終了時刻ではなく繰り返しの境界なので、`next_orbit_reset_t` に改名した。

同じ場所に別の不具合があった。走っている `serve` に衛星を追加したときの境界が、直前のエントリの period を読んでいた。500 km の fleet に 1500 km の衛星を追加すると、追加した衛星が 500 km の周期で巻き戻る。fleet が空のときは 5554 s のハードコードだった。

## テスト

`params.rs` 3 本 — CLI 経路と config 経路で period が軌道の値のまま `SimParams.duration` に終了時刻が載ること、編隊の各機が自分の周期を保つこと。

`cli/tests/e2e.rs` 3 本 — `--duration` の CSV header と最終 t、duration 未指定の編隊が各自の周期で終わること、`--duration` が編隊全体に適用されること。`--duration` の E2E は今回追加したものが最初。

`serve/engine.rs` 1 本 — 追加した衛星の再設定境界が自分の period であること。既存の衛星と 500 s 以上離れた周期を選んで、他の衛星の周期を読んでいたら落ちるようにしてある。

CLI 経路の上書きを戻すと 3 本落ちることを実測した。`cargo test -p orts-cli` 303 件 pass。

## 関連

`orts serve` は今も無期限にストリームし続けるので、CLI-orbit 経路の `serve --sat ... --duration 120` は duration を受理して無視する。これを拒否する話は #350 が扱う。

複数衛星の RRD メタデータは先頭衛星の `altitude` と `period` だけを書き、viewer がそれを全 entity path に複製する。`SimMetadata` が単一の値しか持てないので、entity ごとの schema と RRD writer/reader の変更が必要になる。



