### PR TITLE
fix: tick each controller on its own sample period

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -30,26 +30,6 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - WIT v0 plugin interface に msg-io / stream-io チャネルを追加。([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
-- `SatelliteParams` が `SpacecraftShape` を optional で持ち、
-  `build_spacecraft_dynamics` がそれを見て等方面の `SolarRadiationPressure` /
-  `AtmosphericDrag` の代わりに `PanelSrp` / `PanelDrag` を install するように
-  した。機体の外形は一つなので、パネルは片方ではなく両方の力を担う。
-  `build_orbital_system` はどちらも install しない (パネルの力は姿勢を要求する)。
-  `SurfacePanel` に `with_cp_offset` を追加した。パネルの力を姿勢外乱にするのは
-  この offset である。([#386](https://github.com/sksat/orts/pull/386))
-- `SurfacePanel::back_face` で薄板の反対面を作れるようにした。法線を反転し、面積 /
-  `cd` / 圧力中心は引き継ぎ、光学係数は引数で受ける (パドルの両面は性質が違う)。
-  パネルは片面で、両モデルとも太陽や流れと逆を向いた面を落とすので、板を 1 枚として
-  書くとその衛星が取る姿勢の半分で力がゼロになり、重心から外れた圧力中心が作る
-  トルクも出ない。閉じた形状の面には使わない (反対側は既に別のパネルである)。([#395](https://github.com/sksat/orts/pull/395))
-- 外乱トルクの登録を `orts::setup` に集約し、どれを解くかを `SatelliteParams` の
-  `DisturbanceTorques` で選ぶようにした。`build_spacecraft_dynamics` がそれを見て
-  gravity gradient トルクを install する。`build_orbital_system` は install しない
-  (軌道のみの系にはトルクが作用する姿勢が無く、`torque_body` を捨てる)。
-  呼び出し側は環境モデルを登録しなくなった。CLI はこのトルクを 2 つの entry point
-  で同一行に書いていて、両者が食い違わない保証が無かった。actuator (RW, MTQ,
-  thruster) の登録は呼び出し側に残る。搭載する actuator は機体のハードウェア記述で
-  決まる。([#382](https://github.com/sksat/orts/pull/382))
 - `SurfacePanel` が lumped な `cr` の代わりに `optics: PanelOptics { specular,
   diffuse }` を持つようになった。吸収率は `1 - specular - diffuse` として導出する。
   単一係数は face-on の SRP 力の大きさを決めるだけで、斜入射での向きが決まらない
@@ -125,9 +105,6 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   あるとき `r × ŝ` と `r × n̂` は別方向を向くので、`Cr` をどう選んでも正しい答えには
   ならない。太陽電池パドル相当 (ρ_s ≈ 0.2, ρ_d ≈ 0.1) では 45° 入射で欠けていた項が
   力の ~30% を占める。model の導入時から存在し、0.2.0 も該当する。
-  図解: [光子の行き先](docs/src/assets/srp-flat-panel/photon-fates.svg)、
-  [2 成分の合成](docs/src/assets/srp-flat-panel/force-composition.svg)、
-  [トルクの向き](docs/src/assets/srp-flat-panel/torque-direction.svg)。
   ([#377](https://github.com/sksat/orts/pull/377))
 - `AttitudeState::q_dot` が、和を計算した後でなく積を作る前に角速度を半分にする
   ようになった。結果が有限な入力で overflow しなくなる: `q = [0, 1/√2, 1/√2, 0]`、
@@ -236,10 +213,6 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   追加。よく使う・agent に関係する経路を端末内で発見できるようにした。([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
-- `orts run` の downlink log レコードの level を info/debug から debug/trace へ
-  下げた。衛星 × outbound message × control tick ごとに出るため、logger が
-  実際に動く状態では info だと fleet 規模の実行で他の診断が読めなくなり、
-  積分ループ内で stderr のロックを取る書き込みが増える。 ([#390](https://github.com/sksat/orts/pull/390))
 - `--tle` を再び TLE 専用 (2LE/3LE、`-` で stdin) とし、新規 `--omm` と
   対にした。要素セットのパースは削除した `orts::tle` でなく
   `arika::tle` / `arika::omm` を使用 (従来は `--tle` が OMM も自動受理)。([#87](https://github.com/sksat/orts/pull/87))
@@ -249,30 +222,6 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   は併用不可。`--tle-line1` / `--tle-line2` は両方指定が必須。([#87](https://github.com/sksat/orts/pull/87))
 - TLE epoch の day-of-year を (閏考慮の) 年日数で検証。不正値はそのまま別の
   年に繰り上がらず拒否される。([#87](https://github.com/sksat/orts/pull/87))
-- config ファイル、`orts config validate`、WebSocket の `start_simulation`
-  payload は、シミュレーションが実行できない入力を別の値に読み替えず拒否する:
-  未知の `[integrator] type` / `atmosphere` (従来は dp45 / exponential
-  モデル)、id が 1 つの recording entity を指す 2 機 (id の文字列でなく entity で
-  比較するので、recording と同じく `a` と `/a` は衝突する。従来は recording
-  entity と CSV section を共有し、id 文字列まで同じなら `[[command]]` の宛先も
-  共有していた)、
-  どの剛体もとりえない attitude ブロック (正定値でない、または主慣性モーメントで
-  `I1 + I2 >= I3` を破る慣性テンソル、`mass <= 0`、正規化できない
-  `initial_quaternion`)。config が受理する `integrator` / `atmosphere` の綴りは、
-  対応する CLI フラグが受理する集合と厳密に一致する。
-
-  どのフィールドも読まないキーは、拒否せずキー名を warning として表示する。実行は
-  続くので新しい `orts` 向けに書いた config も古い `orts` で実行でき、`duraton = 100`
-  が黙って 1 周期分実行されることはなくなった。`orts config validate` は `warnings`
-  にキーのパスを出力し、`run` と `serve` は `log::warn!` で報告する。server は client の
-  `start_simulation` や `add_satellite` に含まれるものを表示する。`type` タグ付きの
-  block (`[satellites.orbit]`、`[satellites.controller]`、reaction wheel、磁気トルカ)
-  だけは拒否する。`serde_ignored` は internally tagged enum の内部を見られず報告
-  できないため、`inclinaton = 51.6` が無視されると軌道が赤道面のままになる。特異な
-  慣性テンソルは従来
-  `SpacecraftDynamics::new` で panic し、`orts serve --config` では spawn された
-  manager task の中で起きるため、server は listen したままシミュレーションも
-  client への error も無い状態になっていた。([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
 - `duration` が各衛星の軌道周期を置き換えなくなった。`duration` は run の終了時刻だが
@@ -320,6 +269,16 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   banner を起動完了として待つ呼び出し側 (`cli/tests/ws_e2e.rs`、Playwright の
   spec) には、拒否された config が error message ではなく接続失敗として
   届いていた。([#351](https://github.com/sksat/orts/pull/351))
+- 各 controller が自分の `sample_period` で動くようになった。2 つの loop がこれを
+  動かしていた。非 realtime の `orts serve` は `stream_interval` で timeline を切り、
+  切るたびに controller を 1 回呼んでいた。README quick start の config は
+  `output_interval` と `stream_interval` を `dt = 0.01` のままにし、`pd-rw-control` は
+  0.1 s を要求するので、10 Hz の controller が 100 Hz で回り、各コマンドの保持時間が
+  意図の 1/10 になっていた (実測: sim 時間 1 s あたり 10 回でなく 100 回)。`orts run` は
+  fleet の最短周期で全衛星を回すので、0.1 s の controller と並ぶ 1.0 s の controller が
+  毎秒 10 回 tick していた。どちらの loop も、保持中のコマンドのまま必要な境界まで
+  積分し、その時刻に due な衛星だけを tick する。
+  ([#TBD](https://github.com/sksat/orts/pull/TBD))
 - `orts run --format csv --output <path>` が CSV を `<path>` に書き込むように
   なった。従来は `--format csv` の実行が `--output` に関わらず常に stdout へ
   出力し、指定パスを黙って無視していた。([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -278,7 +278,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   fleet の最短周期で全衛星を回すので、0.1 s の controller と並ぶ 1.0 s の controller が
   毎秒 10 回 tick していた。どちらの loop も、保持中のコマンドのまま必要な境界まで
   積分し、その時刻に due な衛星だけを tick する。
-  ([#TBD](https://github.com/sksat/orts/pull/TBD))
+  ([#369](https://github.com/sksat/orts/pull/369))
 - `orts run --format csv --output <path>` が CSV を `<path>` に書き込むように
   なった。従来は `--format csv` の実行が `--output` に関わらず常に stdout へ
   出力し、指定パスを黙って無視していた。([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -287,39 +287,6 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   なった。`serve` は無摂動の orbit-only 衛星を周期の境界ごとに初期軌道へ戻すが、
   新規追加した衛星の境界は fleet の**直前**のエントリから読んでいた (最初の追加では
   5554 s のハードコード)。([#368](https://github.com/sksat/orts/pull/368))
-- `orts` が診断ログを stderr に出力するようになった。logger を初期化していな
-  かったため `log::` の呼び出しは全て破棄されており、stream-io stdio plug の
-  displaced、stream の socket error、`serve` 中のシミュレーション停止、
-  WASM plugin が WIT `host-env.log` 経由で出力した行が、どれも表示されなかった。
-  `.rrd` を書く際に rerun の crate が出す診断も同じ出力に含まれる。level は
-  `RUST_LOG` で選び、既定は `warn,orts=info` (orts は info、依存は warn)。
-  `NO_COLOR` 指定時と stderr が terminal でない場合は装飾を付けない。どちらも
-  `orts --help` に記載がある。stdout は従来どおりコマンドの出力 (CSV、`--json`
-  サマリ、`serve --stream-stdio` の protocol) だけ。 ([#390](https://github.com/sksat/orts/pull/390))
-- `tle` / `norad` 軌道を Earth 以外の中心天体で使う config を、
-  `orts config validate` と `orts serve --config` が拒否する。SGP4 は Earth 専用で、
-  `SimParams::from_config` はこの規則に panic 経由で到達していたため、config は valid
-  と判定された上で `orts run --config` が panic していた。([#351](https://github.com/sksat/orts/pull/351))
-- どの mode でも実行できない fleet を `orts config validate` と
-  `orts serve --config` が拒否する。`[satellites.attitude]` や
-  `[satellites.controller]` を一部の衛星にだけ書いた config と、全衛星に controller
-  があって attitude がどこにもない config。engine は元からこれらを拒否していたが、
-  `orts serve` は engine を spawn した manager task 内で構築するため、config は valid
-  と判定され banner も表示された上で、指定した config が実行されないまま server が
-  idle 状態で待機していた。`serve` は listening と表示せずエラー終了する。([#351](https://github.com/sksat/orts/pull/351))
-- WebSocket の `add_satellite` が、実行中の fleet の衛星と同じ entity path
-  (`/world/sat/<id>`) になる id を拒否する。従来は同じ path の 2 機を受理し、
-  `[[command]]` は後から追加した方にしか配送されなかった。`id` 省略時の
-  `sat-<現在の機数>` も同様に衝突する。([#351](https://github.com/sksat/orts/pull/351))
-- `orts serve` が、`ClientMessage` に deserialize できなかったメッセージに
-  `{"type":"error"}` を返す。従来は error を破棄していたため、client は応答が
-  返らないまま待ち続けた。deserialize が失敗するのは `type` タグ付き block に未知の
-  キーがある場合。([#351](https://github.com/sksat/orts/pull/351))
-- `orts serve` が `Server listening` / `WebSocket endpoint` の banner を、
-  `--config` ファイルを受理した後にだけ出すようになった。先に出していたため、
-  banner を起動完了として待つ呼び出し側 (`cli/tests/ws_e2e.rs`、Playwright の
-  spec) には、拒否された config が error message ではなく接続失敗として
-  届いていた。([#351](https://github.com/sksat/orts/pull/351))
 - 各 controller が自分の `sample_period` で動くようになった。2 つの loop がこれを
   動かしていた。非 realtime の `orts serve` は `stream_interval` で timeline を切り、
   切るたびに controller を 1 回呼んでいた。README quick start の config は

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -30,6 +30,26 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - WIT v0 plugin interface に msg-io / stream-io チャネルを追加。([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
+- `SatelliteParams` が `SpacecraftShape` を optional で持ち、
+  `build_spacecraft_dynamics` がそれを見て等方面の `SolarRadiationPressure` /
+  `AtmosphericDrag` の代わりに `PanelSrp` / `PanelDrag` を install するように
+  した。機体の外形は一つなので、パネルは片方ではなく両方の力を担う。
+  `build_orbital_system` はどちらも install しない (パネルの力は姿勢を要求する)。
+  `SurfacePanel` に `with_cp_offset` を追加した。パネルの力を姿勢外乱にするのは
+  この offset である。([#386](https://github.com/sksat/orts/pull/386))
+- `SurfacePanel::back_face` で薄板の反対面を作れるようにした。法線を反転し、面積 /
+  `cd` / 圧力中心は引き継ぎ、光学係数は引数で受ける (パドルの両面は性質が違う)。
+  パネルは片面で、両モデルとも太陽や流れと逆を向いた面を落とすので、板を 1 枚として
+  書くとその衛星が取る姿勢の半分で力がゼロになり、重心から外れた圧力中心が作る
+  トルクも出ない。閉じた形状の面には使わない (反対側は既に別のパネルである)。([#395](https://github.com/sksat/orts/pull/395))
+- 外乱トルクの登録を `orts::setup` に集約し、どれを解くかを `SatelliteParams` の
+  `DisturbanceTorques` で選ぶようにした。`build_spacecraft_dynamics` がそれを見て
+  gravity gradient トルクを install する。`build_orbital_system` は install しない
+  (軌道のみの系にはトルクが作用する姿勢が無く、`torque_body` を捨てる)。
+  呼び出し側は環境モデルを登録しなくなった。CLI はこのトルクを 2 つの entry point
+  で同一行に書いていて、両者が食い違わない保証が無かった。actuator (RW, MTQ,
+  thruster) の登録は呼び出し側に残る。搭載する actuator は機体のハードウェア記述で
+  決まる。([#382](https://github.com/sksat/orts/pull/382))
 - `SurfacePanel` が lumped な `cr` の代わりに `optics: PanelOptics { specular,
   diffuse }` を持つようになった。吸収率は `1 - specular - diffuse` として導出する。
   単一係数は face-on の SRP 力の大きさを決めるだけで、斜入射での向きが決まらない
@@ -105,6 +125,9 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   あるとき `r × ŝ` と `r × n̂` は別方向を向くので、`Cr` をどう選んでも正しい答えには
   ならない。太陽電池パドル相当 (ρ_s ≈ 0.2, ρ_d ≈ 0.1) では 45° 入射で欠けていた項が
   力の ~30% を占める。model の導入時から存在し、0.2.0 も該当する。
+  図解: [光子の行き先](docs/src/assets/srp-flat-panel/photon-fates.svg)、
+  [2 成分の合成](docs/src/assets/srp-flat-panel/force-composition.svg)、
+  [トルクの向き](docs/src/assets/srp-flat-panel/torque-direction.svg)。
   ([#377](https://github.com/sksat/orts/pull/377))
 - `AttitudeState::q_dot` が、和を計算した後でなく積を作る前に角速度を半分にする
   ようになった。結果が有限な入力で overflow しなくなる: `q = [0, 1/√2, 1/√2, 0]`、
@@ -157,6 +180,11 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   `back = {}` は `two_sided = true` と同じ)。面積 / `cd` / 圧力中心はどちらでも
   同じ板として共有する。`two_sided = false` と `back` の同時指定は矛盾なので
   reject する。パネルを書くと
+  (`area`, `normal`, `cd`, `specular`, `diffuse`, `cp_offset`, `back`
+  ([#395](https://github.com/sksat/orts/pull/395)))。パネルは片面なので、薄板
+  (太陽電池パドル) の裏面を作るのが `back` である。面積 / `cd` / 圧力中心は同じ板
+  として共有し、反射率は裏面が独自に持つ。空の table (`back = {}`) なら表と同じに
+  なる。パネルを書くと
   SRP と大気抵抗が姿勢依存になり、圧力中心が重心から外れていればそれが姿勢外乱に
   なる。等方面の `srp_area_to_mass` / `ballistic_coeff` では表せない部分である。
   パネルは `attitude` を要求し、等方面のパラメータとの同時指定は reject する
@@ -213,6 +241,10 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   追加。よく使う・agent に関係する経路を端末内で発見できるようにした。([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
+- `orts run` の downlink log レコードの level を info/debug から debug/trace へ
+  下げた。衛星 × outbound message × control tick ごとに出るため、logger が
+  実際に動く状態では info だと fleet 規模の実行で他の診断が読めなくなり、
+  積分ループ内で stderr のロックを取る書き込みが増える。 ([#390](https://github.com/sksat/orts/pull/390))
 - `--tle` を再び TLE 専用 (2LE/3LE、`-` で stdin) とし、新規 `--omm` と
   対にした。要素セットのパースは削除した `orts::tle` でなく
   `arika::tle` / `arika::omm` を使用 (従来は `--tle` が OMM も自動受理)。([#87](https://github.com/sksat/orts/pull/87))
@@ -222,6 +254,30 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   は併用不可。`--tle-line1` / `--tle-line2` は両方指定が必須。([#87](https://github.com/sksat/orts/pull/87))
 - TLE epoch の day-of-year を (閏考慮の) 年日数で検証。不正値はそのまま別の
   年に繰り上がらず拒否される。([#87](https://github.com/sksat/orts/pull/87))
+- config ファイル、`orts config validate`、WebSocket の `start_simulation`
+  payload は、シミュレーションが実行できない入力を別の値に読み替えず拒否する:
+  未知の `[integrator] type` / `atmosphere` (従来は dp45 / exponential
+  モデル)、id が 1 つの recording entity を指す 2 機 (id の文字列でなく entity で
+  比較するので、recording と同じく `a` と `/a` は衝突する。従来は recording
+  entity と CSV section を共有し、id 文字列まで同じなら `[[command]]` の宛先も
+  共有していた)、
+  どの剛体もとりえない attitude ブロック (正定値でない、または主慣性モーメントで
+  `I1 + I2 >= I3` を破る慣性テンソル、`mass <= 0`、正規化できない
+  `initial_quaternion`)。config が受理する `integrator` / `atmosphere` の綴りは、
+  対応する CLI フラグが受理する集合と厳密に一致する。
+
+  どのフィールドも読まないキーは、拒否せずキー名を warning として表示する。実行は
+  続くので新しい `orts` 向けに書いた config も古い `orts` で実行でき、`duraton = 100`
+  が黙って 1 周期分実行されることはなくなった。`orts config validate` は `warnings`
+  にキーのパスを出力し、`run` と `serve` は `log::warn!` で報告する。server は client の
+  `start_simulation` や `add_satellite` に含まれるものを表示する。`type` タグ付きの
+  block (`[satellites.orbit]`、`[satellites.controller]`、reaction wheel、磁気トルカ)
+  だけは拒否する。`serde_ignored` は internally tagged enum の内部を見られず報告
+  できないため、`inclinaton = 51.6` が無視されると軌道が赤道面のままになる。特異な
+  慣性テンソルは従来
+  `SpacecraftDynamics::new` で panic し、`orts serve --config` では spawn された
+  manager task の中で起きるため、server は listen したままシミュレーションも
+  client への error も無い状態になっていた。([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
 - `duration` が各衛星の軌道周期を置き換えなくなった。`duration` は run の終了時刻だが
@@ -279,6 +335,39 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   毎秒 10 回 tick していた。どちらの loop も、保持中のコマンドのまま必要な境界まで
   積分し、その時刻に due な衛星だけを tick する。
   ([#369](https://github.com/sksat/orts/pull/369))
+- `orts` が診断ログを stderr に出力するようになった。logger を初期化していな
+  かったため `log::` の呼び出しは全て破棄されており、stream-io stdio plug の
+  displaced、stream の socket error、`serve` 中のシミュレーション停止、
+  WASM plugin が WIT `host-env.log` 経由で出力した行が、どれも表示されなかった。
+  `.rrd` を書く際に rerun の crate が出す診断も同じ出力に含まれる。level は
+  `RUST_LOG` で選び、既定は `warn,orts=info` (orts は info、依存は warn)。
+  `NO_COLOR` 指定時と stderr が terminal でない場合は装飾を付けない。どちらも
+  `orts --help` に記載がある。stdout は従来どおりコマンドの出力 (CSV、`--json`
+  サマリ、`serve --stream-stdio` の protocol) だけ。 ([#390](https://github.com/sksat/orts/pull/390))
+- `tle` / `norad` 軌道を Earth 以外の中心天体で使う config を、
+  `orts config validate` と `orts serve --config` が拒否する。SGP4 は Earth 専用で、
+  `SimParams::from_config` はこの規則に panic 経由で到達していたため、config は valid
+  と判定された上で `orts run --config` が panic していた。([#351](https://github.com/sksat/orts/pull/351))
+- どの mode でも実行できない fleet を `orts config validate` と
+  `orts serve --config` が拒否する。`[satellites.attitude]` や
+  `[satellites.controller]` を一部の衛星にだけ書いた config と、全衛星に controller
+  があって attitude がどこにもない config。engine は元からこれらを拒否していたが、
+  `orts serve` は engine を spawn した manager task 内で構築するため、config は valid
+  と判定され banner も表示された上で、指定した config が実行されないまま server が
+  idle 状態で待機していた。`serve` は listening と表示せずエラー終了する。([#351](https://github.com/sksat/orts/pull/351))
+- WebSocket の `add_satellite` が、実行中の fleet の衛星と同じ entity path
+  (`/world/sat/<id>`) になる id を拒否する。従来は同じ path の 2 機を受理し、
+  `[[command]]` は後から追加した方にしか配送されなかった。`id` 省略時の
+  `sat-<現在の機数>` も同様に衝突する。([#351](https://github.com/sksat/orts/pull/351))
+- `orts serve` が、`ClientMessage` に deserialize できなかったメッセージに
+  `{"type":"error"}` を返す。従来は error を破棄していたため、client は応答が
+  返らないまま待ち続けた。deserialize が失敗するのは `type` タグ付き block に未知の
+  キーがある場合。([#351](https://github.com/sksat/orts/pull/351))
+- `orts serve` が `Server listening` / `WebSocket endpoint` の banner を、
+  `--config` ファイルを受理した後にだけ出すようになった。先に出していたため、
+  banner を起動完了として待つ呼び出し側 (`cli/tests/ws_e2e.rs`、Playwright の
+  spec) には、拒否された config が error message ではなく接続失敗として
+  届いていた。([#351](https://github.com/sksat/orts/pull/351))
 - `orts run --format csv --output <path>` が CSV を `<path>` に書き込むように
   なった。従来は `--format csv` の実行が `--output` に関わらず常に stdout へ
   出力し、指定パスを黙って無視していた。([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -180,11 +180,6 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   `back = {}` は `two_sided = true` と同じ)。面積 / `cd` / 圧力中心はどちらでも
   同じ板として共有する。`two_sided = false` と `back` の同時指定は矛盾なので
   reject する。パネルを書くと
-  (`area`, `normal`, `cd`, `specular`, `diffuse`, `cp_offset`, `back`
-  ([#395](https://github.com/sksat/orts/pull/395)))。パネルは片面なので、薄板
-  (太陽電池パドル) の裏面を作るのが `back` である。面積 / `cd` / 圧力中心は同じ板
-  として共有し、反射率は裏面が独自に持つ。空の table (`back = {}`) なら表と同じに
-  なる。パネルを書くと
   SRP と大気抵抗が姿勢依存になり、圧力中心が重心から外れていればそれが姿勢外乱に
   なる。等方面の `srp_area_to_mass` / `ballistic_coeff` では表せない部分である。
   パネルは `attitude` を要求し、等方面のパラメータとの同時指定は reject する

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,29 @@ section is subdivided by package.
 - WIT v0 plugin interface extended with the msg-io and stream-io channels. ([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
+- `SatelliteParams` carries an optional `SpacecraftShape`, and
+  `build_spacecraft_dynamics` installs `PanelSrp` and `PanelDrag` from it in
+  place of the isotropic `SolarRadiationPressure` and `AtmosphericDrag`. The
+  outer shape is one object, so panels drive both forces rather than one of
+  them. `build_orbital_system` installs neither: panel forces need an attitude.
+  `SurfacePanel` gains `with_cp_offset`, which is what turns a panel force into
+  an attitude disturbance. ([#386](https://github.com/sksat/orts/pull/386))
+- `SurfacePanel::back_face` builds the other side of a thin plate: the normal is
+  negated, the area, `cd` and centre of pressure carry over, and the optics are
+  given, since the two sides of an array differ. A panel is one face and both
+  force models drop a face pointing away from the Sun or the flow, so a plate
+  written as one panel produces nothing for half of the attitudes it sees — and
+  the torque about an off-centre pressure point goes with it. Not for a face of
+  a closed body, whose far side is already another panel. ([#395](https://github.com/sksat/orts/pull/395))
+- `orts::setup` registers disturbance torques, and `SatelliteParams` carries a
+  `DisturbanceTorques` selection to say which. `build_spacecraft_dynamics`
+  installs the gravity-gradient torque from it; `build_orbital_system` installs
+  none, since an orbit-only system has no orientation for a torque to act on and
+  discards `torque_body`. Callers no longer register environmental models
+  themselves — the CLI had been adding this torque on the same line in two entry
+  points, with nothing keeping the two in step. Actuators (RW, MTQ, thrusters)
+  stay with the caller, since they come from the spacecraft's own hardware
+  description. ([#382](https://github.com/sksat/orts/pull/382))
 - `SurfacePanel` carries `optics: PanelOptics { specular, diffuse }` in place of
   a lumped `cr`, with the absorbed fraction derived as `1 - specular - diffuse`.
   A single coefficient fixes the SRP force magnitude face-on but leaves its
@@ -121,6 +144,10 @@ section is subdivided by package.
   different ways, so no choice of `Cr` recovers the right answer. For a solar
   array (ρ_s ≈ 0.2, ρ_d ≈ 0.1) the missing term carries ~30% of the force at 45°
   incidence. Present since the model was introduced, 0.2.0 included.
+  Japanese-labeled diagrams of the law, the two force components and the torque
+  direction: [photon fates](docs/src/assets/srp-flat-panel/photon-fates.svg),
+  [force composition](docs/src/assets/srp-flat-panel/force-composition.svg),
+  [torque direction](docs/src/assets/srp-flat-panel/torque-direction.svg).
   ([#377](https://github.com/sksat/orts/pull/377))
 - `AttitudeState::q_dot` halves the angular velocity before forming the
   products rather than the sum afterwards, so it no longer overflows where its
@@ -180,6 +207,11 @@ section is subdivided by package.
   empty `back = {}` says the same as the flag). Either way the area, `cd` and
   centre of pressure are shared, and `two_sided = false` beside `back` is
   rejected as a contradiction. Writing panels
+  `area`, `normal`, `cd`, `specular`, `diffuse`, `cp_offset` and `back` ([#395](https://github.com/sksat/orts/pull/395)).
+  A panel is one face, so `back` is what gives a thin plate — a solar array —
+  its far side: the area, `cd` and centre of pressure are shared and the
+  reflectivities are its own, with an empty table (`back = {}`) copying the
+  front's. Writing panels
   makes SRP and drag attitude-dependent, and an off-centre centre of pressure
   turns them into attitude disturbances — which is what the isotropic
   `srp_area_to_mass` / `ballistic_coeff` cannot express. Panels require
@@ -244,6 +276,10 @@ section is subdivided by package.
   are discoverable without leaving the terminal. ([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
+- `orts run`'s downlink log records moved from info/debug to debug/trace. They
+  fire per satellite per outbound message per control tick, so with a backend
+  installed, info would bury every other diagnostic on a fleet-sized run and add
+  a locked stderr write inside the integration loop. ([#390](https://github.com/sksat/orts/pull/390))
 - `--tle` is TLE-only again (2LE/3LE; `-` for stdin) and pairs with the new
   `--omm`; element-set parsing is now backed by `arika::tle` / `arika::omm`
   instead of the removed `orts::tle`. (Previously `--tle` also auto-accepted OMM.) ([#87](https://github.com/sksat/orts/pull/87))
@@ -253,6 +289,32 @@ section is subdivided by package.
   `--tle-line2`; and `--tle-line1` / `--tle-line2` must be given together. ([#87](https://github.com/sksat/orts/pull/87))
 - TLE epoch day-of-year is validated against the (leap-aware) year length, so a
   malformed field is rejected rather than rolling into another year. ([#87](https://github.com/sksat/orts/pull/87))
+- Config files, `orts config validate` and the WebSocket `start_simulation`
+  payload reject input the simulation cannot honor, instead of resolving it to
+  something else: an unknown `[integrator] type` or `atmosphere` (previously
+  dp45 / the exponential model), two
+  satellites whose ids name one recording entity (previously one entity and one
+  CSV section for both; compared on the entity, so `a` and `/a` collide as they
+  do in the recording, while the same id string twice shared its `[[command]]`
+  target as well), and an attitude block no
+  rigid body could have — an inertia tensor that is not positive definite or
+  violates `I1 + I2 >= I3` on its principal moments, `mass <= 0`, or an
+  `initial_quaternion` that cannot be normalized. The `integrator` /
+  `atmosphere` spellings a config accepts are now exactly the ones the
+  equivalent CLI flag accepts.
+
+  A key nothing reads is named rather than refused: the run goes ahead, so a
+  config written for a newer `orts` still works here, and `duraton = 100` no
+  longer runs for one orbital period in silence. `orts config validate` carries
+  the paths in its `warnings`, `run` and `serve` report them at warn level, and
+  the server names the ones in a client's `start_simulation` or `add_satellite`. A `type`-tagged
+  block — `[satellites.orbit]`, `[satellites.controller]`, the reaction wheels
+  and the magnetorquers — refuses instead: `serde_ignored` cannot see inside an
+  internally tagged enum, so there is nothing to name there, and a dropped
+  `inclinaton = 51.6` would leave the orbit equatorial. A singular inertia tensor previously panicked in
+  `SpacecraftDynamics::new`; under `orts serve --config` that happened inside
+  the spawned manager task, leaving the server listening with no simulation and
+  no error to the client. ([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
 - `duration` no longer replaces each satellite's orbital period. It is the
@@ -315,6 +377,41 @@ section is subdivided by package.
   so a 1.0 s controller beside a 0.1 s one ticked 10 times a second. Both loops
   now propagate to whatever boundary they need under the held command and tick
   only the satellites due there. ([#369](https://github.com/sksat/orts/pull/369))
+- `orts` now writes its diagnostics to stderr. With no `log` backend installed
+  every `log::` call was discarded, so a displaced stream-io stdio plug, a stream
+  socket error, a halted `serve` simulation, and every line a WASM plugin logged
+  through the WIT `host-env.log` import all went unreported. The diagnostics the
+  rerun crates emit while writing an `.rrd` now appear in the same output.
+  `RUST_LOG` selects the level — default `warn,orts=info`, ours at info and
+  dependencies at warn — and `NO_COLOR`, or a stderr that is not a terminal,
+  drops the styling; `orts --help` documents both. stdout is unchanged: the CSV,
+  the `--json` summary, or the `serve --stream-stdio` protocol and nothing else. ([#390](https://github.com/sksat/orts/pull/390))
+- `orts config validate` and `orts serve --config` refuse a `tle` or `norad`
+  orbit about any body but Earth. SGP4 is Earth's, and `SimParams::from_config`
+  reached that rule through a panic, so such a config validated clean and then
+  took down `orts run --config`. ([#351](https://github.com/sksat/orts/pull/351))
+- `orts config validate` and `orts serve --config` refuse a fleet no
+  simulation mode can run: `[satellites.attitude]` or
+  `[satellites.controller]` on some satellites but not all, or a controller on
+  every satellite with attitude on none. The engine already refused these, but
+  `orts serve` builds it inside the spawned manager, so the config validated
+  clean, the startup banner printed, and the server sat idle with the given
+  config never running. `serve` now exits with the error instead of announcing
+  a listening server. ([#351](https://github.com/sksat/orts/pull/351))
+- The WebSocket `add_satellite` refuses an id whose entity path
+  (`/world/sat/<id>`) already belongs to a satellite in the running fleet. Two
+  satellites on one path meant `[[command]]` reached only the one added last. An
+  omitted `id` takes `sat-<current fleet size>`, which collides the same
+  way. ([#351](https://github.com/sksat/orts/pull/351))
+- `orts serve` answers a message that does not deserialize into `ClientMessage`
+  with a `{"type":"error"}` frame. The error used to be discarded, leaving the
+  client waiting for a response that never came. An unknown key in a
+  `type`-tagged block is what fails. ([#351](https://github.com/sksat/orts/pull/351))
+- `orts serve` prints its `Server listening` / `WebSocket endpoint` banner only
+  after the `--config` file is accepted. Printing it first made a rejected
+  config reach a caller that waits on the banner — `cli/tests/ws_e2e.rs`, the
+  Playwright specs — as a refused connection rather than as its own error
+  message. ([#351](https://github.com/sksat/orts/pull/351))
 - `orts run --format csv --output <path>` now writes the CSV to `<path>`.
   Previously every `--format csv` run wrote to stdout regardless of `--output`,
   silently ignoring the given path. ([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,29 +33,6 @@ section is subdivided by package.
 - WIT v0 plugin interface extended with the msg-io and stream-io channels. ([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
-- `SatelliteParams` carries an optional `SpacecraftShape`, and
-  `build_spacecraft_dynamics` installs `PanelSrp` and `PanelDrag` from it in
-  place of the isotropic `SolarRadiationPressure` and `AtmosphericDrag`. The
-  outer shape is one object, so panels drive both forces rather than one of
-  them. `build_orbital_system` installs neither: panel forces need an attitude.
-  `SurfacePanel` gains `with_cp_offset`, which is what turns a panel force into
-  an attitude disturbance. ([#386](https://github.com/sksat/orts/pull/386))
-- `SurfacePanel::back_face` builds the other side of a thin plate: the normal is
-  negated, the area, `cd` and centre of pressure carry over, and the optics are
-  given, since the two sides of an array differ. A panel is one face and both
-  force models drop a face pointing away from the Sun or the flow, so a plate
-  written as one panel produces nothing for half of the attitudes it sees — and
-  the torque about an off-centre pressure point goes with it. Not for a face of
-  a closed body, whose far side is already another panel. ([#395](https://github.com/sksat/orts/pull/395))
-- `orts::setup` registers disturbance torques, and `SatelliteParams` carries a
-  `DisturbanceTorques` selection to say which. `build_spacecraft_dynamics`
-  installs the gravity-gradient torque from it; `build_orbital_system` installs
-  none, since an orbit-only system has no orientation for a torque to act on and
-  discards `torque_body`. Callers no longer register environmental models
-  themselves — the CLI had been adding this torque on the same line in two entry
-  points, with nothing keeping the two in step. Actuators (RW, MTQ, thrusters)
-  stay with the caller, since they come from the spacecraft's own hardware
-  description. ([#382](https://github.com/sksat/orts/pull/382))
 - `SurfacePanel` carries `optics: PanelOptics { specular, diffuse }` in place of
   a lumped `cr`, with the absorbed fraction derived as `1 - specular - diffuse`.
   A single coefficient fixes the SRP force magnitude face-on but leaves its
@@ -144,10 +121,6 @@ section is subdivided by package.
   different ways, so no choice of `Cr` recovers the right answer. For a solar
   array (ρ_s ≈ 0.2, ρ_d ≈ 0.1) the missing term carries ~30% of the force at 45°
   incidence. Present since the model was introduced, 0.2.0 included.
-  Japanese-labeled diagrams of the law, the two force components and the torque
-  direction: [photon fates](docs/src/assets/srp-flat-panel/photon-fates.svg),
-  [force composition](docs/src/assets/srp-flat-panel/force-composition.svg),
-  [torque direction](docs/src/assets/srp-flat-panel/torque-direction.svg).
   ([#377](https://github.com/sksat/orts/pull/377))
 - `AttitudeState::q_dot` halves the angular velocity before forming the
   products rather than the sum afterwards, so it no longer overflows where its
@@ -271,10 +244,6 @@ section is subdivided by package.
   are discoverable without leaving the terminal. ([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
-- `orts run`'s downlink log records moved from info/debug to debug/trace. They
-  fire per satellite per outbound message per control tick, so with a backend
-  installed, info would bury every other diagnostic on a fleet-sized run and add
-  a locked stderr write inside the integration loop. ([#390](https://github.com/sksat/orts/pull/390))
 - `--tle` is TLE-only again (2LE/3LE; `-` for stdin) and pairs with the new
   `--omm`; element-set parsing is now backed by `arika::tle` / `arika::omm`
   instead of the removed `orts::tle`. (Previously `--tle` also auto-accepted OMM.) ([#87](https://github.com/sksat/orts/pull/87))
@@ -284,32 +253,6 @@ section is subdivided by package.
   `--tle-line2`; and `--tle-line1` / `--tle-line2` must be given together. ([#87](https://github.com/sksat/orts/pull/87))
 - TLE epoch day-of-year is validated against the (leap-aware) year length, so a
   malformed field is rejected rather than rolling into another year. ([#87](https://github.com/sksat/orts/pull/87))
-- Config files, `orts config validate` and the WebSocket `start_simulation`
-  payload reject input the simulation cannot honor, instead of resolving it to
-  something else: an unknown `[integrator] type` or `atmosphere` (previously
-  dp45 / the exponential model), two
-  satellites whose ids name one recording entity (previously one entity and one
-  CSV section for both; compared on the entity, so `a` and `/a` collide as they
-  do in the recording, while the same id string twice shared its `[[command]]`
-  target as well), and an attitude block no
-  rigid body could have — an inertia tensor that is not positive definite or
-  violates `I1 + I2 >= I3` on its principal moments, `mass <= 0`, or an
-  `initial_quaternion` that cannot be normalized. The `integrator` /
-  `atmosphere` spellings a config accepts are now exactly the ones the
-  equivalent CLI flag accepts.
-
-  A key nothing reads is named rather than refused: the run goes ahead, so a
-  config written for a newer `orts` still works here, and `duraton = 100` no
-  longer runs for one orbital period in silence. `orts config validate` carries
-  the paths in its `warnings`, `run` and `serve` report them at warn level, and
-  the server names the ones in a client's `start_simulation` or `add_satellite`. A `type`-tagged
-  block — `[satellites.orbit]`, `[satellites.controller]`, the reaction wheels
-  and the magnetorquers — refuses instead: `serde_ignored` cannot see inside an
-  internally tagged enum, so there is nothing to name there, and a dropped
-  `inclinaton = 51.6` would leave the orbit equatorial. A singular inertia tensor previously panicked in
-  `SpacecraftDynamics::new`; under `orts serve --config` that happened inside
-  the spawned manager task, leaving the server listening with no simulation and
-  no error to the client. ([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
 - `duration` no longer replaces each satellite's orbital period. It is the
@@ -362,6 +305,16 @@ section is subdivided by package.
   config reach a caller that waits on the banner — `cli/tests/ws_e2e.rs`, the
   Playwright specs — as a refused connection rather than as its own error
   message. ([#351](https://github.com/sksat/orts/pull/351))
+- Each controller runs on its own `sample_period`. Two loops moved it: the
+  non-realtime `orts serve` cut the timeline at `stream_interval` and called the
+  controller once per cut, so the README quick start's config — which leaves
+  `output_interval` and `stream_interval` at `dt = 0.01` while `pd-rw-control`
+  asks for 0.1 s — ran a 10 Hz controller at 100 Hz and held each command for a
+  tenth of its intended span (measured: 100 ticks per second of sim time instead
+  of 10); and `orts run` drove every satellite on the fleet's shortest period,
+  so a 1.0 s controller beside a 0.1 s one ticked 10 times a second. Both loops
+  now propagate to whatever boundary they need under the held command and tick
+  only the satellites due there. ([#TBD](https://github.com/sksat/orts/pull/TBD))
 - `orts run --format csv --output <path>` now writes the CSV to `<path>`.
   Previously every `--format csv` run wrote to stdout regardless of `--output`,
   silently ignoring the given path. ([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,11 +207,6 @@ section is subdivided by package.
   empty `back = {}` says the same as the flag). Either way the area, `cd` and
   centre of pressure are shared, and `two_sided = false` beside `back` is
   rejected as a contradiction. Writing panels
-  `area`, `normal`, `cd`, `specular`, `diffuse`, `cp_offset` and `back` ([#395](https://github.com/sksat/orts/pull/395)).
-  A panel is one face, so `back` is what gives a thin plate — a solar array —
-  its far side: the area, `cd` and centre of pressure are shared and the
-  reflectivities are its own, with an empty table (`back = {}`) copying the
-  front's. Writing panels
   makes SRP and drag attitude-dependent, and an off-centre centre of pressure
   turns them into attitude disturbances — which is what the isotropic
   `srp_area_to_mass` / `ballistic_coeff` cannot express. Panels require

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,7 +314,7 @@ section is subdivided by package.
   of 10); and `orts run` drove every satellite on the fleet's shortest period,
   so a 1.0 s controller beside a 0.1 s one ticked 10 times a second. Both loops
   now propagate to whatever boundary they need under the held command and tick
-  only the satellites due there. ([#TBD](https://github.com/sksat/orts/pull/TBD))
+  only the satellites due there. ([#369](https://github.com/sksat/orts/pull/369))
 - `orts run --format csv --output <path>` now writes the CSV to `<path>`.
   Previously every `--format csv` run wrote to stdout regardless of `--output`,
   silently ignoring the given path. ([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,41 +327,6 @@ section is subdivided by package.
   period boundary, and the boundary for a newly added satellite was read from
   the *previous* entry in the fleet (or a hardcoded 5554 s when it was the
   first). ([#368](https://github.com/sksat/orts/pull/368))
-- `orts` now writes its diagnostics to stderr. With no `log` backend installed
-  every `log::` call was discarded, so a displaced stream-io stdio plug, a stream
-  socket error, a halted `serve` simulation, and every line a WASM plugin logged
-  through the WIT `host-env.log` import all went unreported. The diagnostics the
-  rerun crates emit while writing an `.rrd` now appear in the same output.
-  `RUST_LOG` selects the level — default `warn,orts=info`, ours at info and
-  dependencies at warn — and `NO_COLOR`, or a stderr that is not a terminal,
-  drops the styling; `orts --help` documents both. stdout is unchanged: the CSV,
-  the `--json` summary, or the `serve --stream-stdio` protocol and nothing else. ([#390](https://github.com/sksat/orts/pull/390))
-- `orts config validate` and `orts serve --config` refuse a `tle` or `norad`
-  orbit about any body but Earth. SGP4 is Earth's, and `SimParams::from_config`
-  reached that rule through a panic, so such a config validated clean and then
-  took down `orts run --config`. ([#351](https://github.com/sksat/orts/pull/351))
-- `orts config validate` and `orts serve --config` refuse a fleet no
-  simulation mode can run: `[satellites.attitude]` or
-  `[satellites.controller]` on some satellites but not all, or a controller on
-  every satellite with attitude on none. The engine already refused these, but
-  `orts serve` builds it inside the spawned manager, so the config validated
-  clean, the startup banner printed, and the server sat idle with the given
-  config never running. `serve` now exits with the error instead of announcing
-  a listening server. ([#351](https://github.com/sksat/orts/pull/351))
-- The WebSocket `add_satellite` refuses an id whose entity path
-  (`/world/sat/<id>`) already belongs to a satellite in the running fleet. Two
-  satellites on one path meant `[[command]]` reached only the one added last. An
-  omitted `id` takes `sat-<current fleet size>`, which collides the same
-  way. ([#351](https://github.com/sksat/orts/pull/351))
-- `orts serve` answers a message that does not deserialize into `ClientMessage`
-  with a `{"type":"error"}` frame. The error used to be discarded, leaving the
-  client waiting for a response that never came. An unknown key in a
-  `type`-tagged block is what fails. ([#351](https://github.com/sksat/orts/pull/351))
-- `orts serve` prints its `Server listening` / `WebSocket endpoint` banner only
-  after the `--config` file is accepted. Printing it first made a rejected
-  config reach a caller that waits on the banner — `cli/tests/ws_e2e.rs`, the
-  Playwright specs — as a refused connection rather than as its own error
-  message. ([#351](https://github.com/sksat/orts/pull/351))
 - Each controller runs on its own `sample_period`. Two loops moved it: the
   non-realtime `orts serve` cut the timeline at `stream_interval` and called the
   controller once per cut, so the README quick start's config — which leaves

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -273,9 +273,9 @@ pub struct SimArgs {
     /// Async backend execution mode (`orts run` only).
     ///
     /// - `throughput` (default): multi-worker tokio runtime,
-    ///   `orts run` fans the per-satellite `step_controlled` out
+    ///   `orts run` fans the per-satellite control step out
     ///   across CPU cores via rayon. Measurably faster on any
-    ///   multi-core host. Since each satellite's `step_controlled`
+    ///   multi-core host. Since each satellite's control step
     ///   is independent (no shared mutable state between sats),
     ///   the result is byte-for-byte identical to deterministic
     ///   mode — the speedup comes for free.

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -1188,15 +1188,7 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Result<Record
     let mut last_output_t = 0.0;
 
     while t < duration - 1e-12 {
-        // The next moment anything happens: the earliest controller tick due,
-        // or the end of the run. Stepping the whole fleet on one tick — the
-        // shortest `sample_period` in the fleet — ran every slower controller
-        // at that rate instead of its own.
-        let next_t = satellites
-            .iter()
-            .map(|sat| sat.next_tick_t())
-            .fold(f64::INFINITY, f64::min)
-            .min(duration);
+        let next_t = crate::sim::controlled::next_fleet_event_t(&satellites, duration);
         let dt = next_t - t;
 
         // 時刻指定コマンド: この区間の終端 (next_t) までに due なものを

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -1040,9 +1040,7 @@ fn lookup_field_names(component_name: &str, n: usize) -> Vec<String> {
 
 /// 制御付きシミュレーション（プラグインコントローラ + RW + センサ）。
 fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Result<Recording, CmdError> {
-    use crate::sim::controlled::{
-        ControlledBuildContext, build_controlled_satellite, step_controlled,
-    };
+    use crate::sim::controlled::{ControlledBuildContext, build_controlled_satellite};
     let _ = sim; // Plugin backend is now stored in SimParams directly.
 
     let duration = params.duration.unwrap_or_else(|| {
@@ -1102,9 +1100,10 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Result<Record
             plugin_backend,
         };
         for spec in &params.satellites {
-            let sat = build_controlled_satellite(spec, params.epoch, &mut ctx).map_err(|e| {
-                CmdError::failure(format!("building controlled satellite '{}': {e}", spec.id))
-            })?;
+            let sat =
+                build_controlled_satellite(spec, params.epoch, 0.0, &mut ctx).map_err(|e| {
+                    CmdError::failure(format!("building controlled satellite '{}': {e}", spec.id))
+                })?;
             satellites.push(sat);
         }
     }
@@ -1165,7 +1164,8 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Result<Record
         );
     }
 
-    // 全衛星の sample_period の最小値をグローバル tick に使う。
+    // Reject a period no control loop can advance on. The fold also catches
+    // the empty fleet, which yields `INFINITY` and cannot be stepped either.
     //
     // Validate per satellite *before* folding: `f64::min` returns the other
     // argument when one side is NaN, so a NaN period would be silently
@@ -1181,7 +1181,6 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Result<Record
     // `fold` also yields `INFINITY` for an empty fleet, which the loop below
     // cannot step with either.
     crate::config::validate_sample_period(dt_ctrl).map_err(CmdError::failure)?;
-    let dt_ode = params.dt.min(dt_ctrl);
 
     let mut t = 0.0;
     let mut step: u64 = 1;
@@ -1189,15 +1188,36 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Result<Record
     let mut last_output_t = 0.0;
 
     while t < duration - 1e-12 {
-        let dt = dt_ctrl.min(duration - t);
+        // The next moment anything happens: the earliest controller tick due,
+        // or the end of the run. Stepping the whole fleet on one tick — the
+        // shortest `sample_period` in the fleet — ran every slower controller
+        // at that rate instead of its own.
+        let next_t = satellites
+            .iter()
+            .map(|sat| sat.next_tick_t)
+            .fold(f64::INFINITY, f64::min)
+            .min(duration);
+        let dt = next_t - t;
 
-        // 時刻指定コマンド: この制御 tick の終端 (t+dt) までに due なものを
+        // 時刻指定コマンド: この区間の終端 (next_t) までに due なものを
         // 配送する。`src` は controller(host) が確定する。
-        for sc in command_schedule.drain_due(t + dt) {
+        for sc in command_schedule.drain_due(next_t) {
             satellites[sc.sat_index]
                 .controller
                 .deliver(sc.message.clone());
         }
+
+        // Every satellite is propagated to `next_t` under the command it
+        // holds; only the ones whose tick lands there see their controller.
+        // A span shorter than a period — the run's last one, or the gap
+        // between two rates — therefore integrates without a tick.
+        let step_one = |sat: &mut crate::sim::controlled::ControlledSatellite| {
+            crate::sim::controlled::propagate_controlled(sat, t, next_t, params.dt)?;
+            if sat.tick_due_at(next_t) {
+                crate::sim::controlled::tick_controller(sat, next_t, params.epoch.as_ref())?;
+            }
+            Ok::<(), String>(())
+        };
 
         // `try_for_each` rather than `for_each` + exit: a rayon worker calling
         // `std::process::exit` tears the process down from inside the pool,
@@ -1206,11 +1226,11 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Result<Record
             use rayon::prelude::*;
             satellites
                 .par_iter_mut()
-                .try_for_each(|sat| step_controlled(sat, t, dt, dt_ode, params.epoch.as_ref()))
+                .try_for_each(step_one)
                 .map_err(|e| CmdError::failure(format!("simulation error at t={t:.3}: {e}")))?;
         } else {
             for sat in &mut satellites {
-                step_controlled(sat, t, dt, dt_ode, params.epoch.as_ref())
+                step_one(sat)
                     .map_err(|e| CmdError::failure(format!("simulation error at t={t:.3}: {e}")))?;
             }
         }

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -1194,7 +1194,7 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Result<Record
         // at that rate instead of its own.
         let next_t = satellites
             .iter()
-            .map(|sat| sat.next_tick_t)
+            .map(|sat| sat.next_tick_t())
             .fold(f64::INFINITY, f64::min)
             .min(duration);
         let dt = next_t - t;

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -1257,7 +1257,12 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Result<Record
             }
         }
 
-        t += dt;
+        // The event time itself, not `t + dt`. The subtraction that made `dt`
+        // is exact at every magnitude measured (base 0 through 1e15, 0.1 s
+        // period), so the two agree today — but the tick schedule is
+        // `base + n × period` and this keeps the clock on it by construction
+        // rather than by an argument about rounding.
+        t = next_t;
 
         // 可視性は出力間引きと独立に、制御 tick ごとにサンプリングする。
         if let Some(monitors) = visibility.as_mut() {

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -114,23 +114,19 @@ impl SimGroup {
         };
         for sat in sats.iter_mut() {
             crate::config::validate_sample_period(sat.controller.sample_period())?;
-            let mut t = current_t;
-            // Every tick due inside this span, then the rest of the span under
-            // the command the last tick left. `target_t - current_t` is the
-            // stream/output interval, which has no reason to be a multiple of
-            // the controller period: the loop used to call the controller once
-            // per span with `dt = span`, so a span shorter than the period ran
-            // the controller too often and shortened its hold.
-            while sat.tick_due_at(target_t) {
-                let tick_t = sat.next_tick_t();
-                crate::sim::controlled::propagate_controlled(sat, t, tick_t, params.dt)
-                    .map_err(|e| format!("controlled simulation error at t={t:.3}: {e}"))?;
-                crate::sim::controlled::tick_controller(sat, tick_t, params.epoch.as_ref())
-                    .map_err(|e| format!("controlled simulation error at t={tick_t:.3}: {e}"))?;
-                t = tick_t;
-            }
-            crate::sim::controlled::propagate_controlled(sat, t, target_t, params.dt)
-                .map_err(|e| format!("controlled simulation error at t={t:.3}: {e}"))?;
+            // `target_t - current_t` is the stream/output interval, which has
+            // no reason to be a multiple of the controller period: this used
+            // to call the controller once per span with `dt = span`, so a span
+            // shorter than the period ran the controller too often and
+            // shortened its hold.
+            crate::sim::controlled::advance_controlled(
+                sat,
+                current_t,
+                target_t,
+                params.dt,
+                params.epoch.as_ref(),
+            )
+            .map_err(|e| format!("controlled simulation error at t={current_t:.3}: {e}"))?;
         }
         Ok(())
     }

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -122,7 +122,7 @@ impl SimGroup {
             // per span with `dt = span`, so a span shorter than the period ran
             // the controller too often and shortened its hold.
             while sat.tick_due_at(target_t) {
-                let tick_t = sat.next_tick_t;
+                let tick_t = sat.next_tick_t();
                 crate::sim::controlled::propagate_controlled(sat, t, tick_t, params.dt)
                     .map_err(|e| format!("controlled simulation error at t={t:.3}: {e}"))?;
                 crate::sim::controlled::tick_controller(sat, tick_t, params.epoch.as_ref())

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -1333,14 +1333,23 @@ fn invalid_path_segment(s: &str) -> bool {
 /// The single sample period shared by all controllers, or an error when the
 /// fleet mixes periods (the stream-io bridge steps every controller on the
 /// same global tick, so mixed rates would over-step the slower ones).
+///
+/// Exact equality, not a tolerance. The first period becomes the interval the
+/// bridge pumps on, and each controller now ticks on its own
+/// `base + n · period`: with `[0.1, 0.1000000005]` the second controller's
+/// first tick falls just past the 0.1 boundary, so it does not tick in that
+/// interval and instead ticks on the next pump — after the bytes staged for
+/// the later interval were already handed over. A tolerance that once only
+/// smoothed over rounding now decides which interval a controller sees.
 fn uniform_tick(periods: &[f64]) -> Result<f64, String> {
     let Some(&first) = periods.first() else {
         return Err("stream-io bridge requires at least one controller".to_string());
     };
-    if periods.iter().any(|p| (p - first).abs() > 1e-9) {
+    if periods.iter().any(|p| *p != first) {
         return Err(format!(
-            "stream-io bridge requires a uniform controller sample period, got {periods:?}; \
-             mixed-rate fleets are not supported with streams yet"
+            "stream-io bridge requires one controller sample period, got {periods:?}; \
+             the bridge pumps on a single interval, and a period that differs even \
+             slightly ticks in a different interval than the bytes it should read"
         ));
     }
     Ok(first)
@@ -1920,6 +1929,13 @@ streams = ["comlink"]
         // A 1.0 s controller stepped on a 0.1 s global tick would update
         // 10x too often — must be rejected, not silently mis-simulated.
         assert!(uniform_tick(&[0.1, 1.0]).is_err());
+        // And a period that differs only slightly: the bridge pumps on the
+        // first one, so the second controller's ticks fall in a different
+        // interval than the bytes staged for them.
+        assert!(
+            uniform_tick(&[0.1, 0.100_000_000_5]).is_err(),
+            "a near-equal period still reads the wrong interval"
+        );
     }
 
     #[test]

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -113,16 +113,24 @@ impl SimGroup {
             return Ok(());
         };
         for sat in sats.iter_mut() {
-            let dt_ctrl = sat.controller.sample_period();
-            crate::config::validate_sample_period(dt_ctrl)?;
-            let dt_ode = params.dt.min(dt_ctrl);
+            crate::config::validate_sample_period(sat.controller.sample_period())?;
             let mut t = current_t;
-            while t < target_t - 1e-12 {
-                let dt = dt_ctrl.min(target_t - t);
-                crate::sim::controlled::step_controlled(sat, t, dt, dt_ode, params.epoch.as_ref())
+            // Every tick due inside this span, then the rest of the span under
+            // the command the last tick left. `target_t - current_t` is the
+            // stream/output interval, which has no reason to be a multiple of
+            // the controller period: the loop used to call the controller once
+            // per span with `dt = span`, so a span shorter than the period ran
+            // the controller too often and shortened its hold.
+            while sat.tick_due_at(target_t) {
+                let tick_t = sat.next_tick_t;
+                crate::sim::controlled::propagate_controlled(sat, t, tick_t, params.dt)
                     .map_err(|e| format!("controlled simulation error at t={t:.3}: {e}"))?;
-                t += dt;
+                crate::sim::controlled::tick_controller(sat, tick_t, params.epoch.as_ref())
+                    .map_err(|e| format!("controlled simulation error at t={tick_t:.3}: {e}"))?;
+                t = tick_t;
             }
+            crate::sim::controlled::propagate_controlled(sat, t, target_t, params.dt)
+                .map_err(|e| format!("controlled simulation error at t={t:.3}: {e}"))?;
         }
         Ok(())
     }
@@ -434,7 +442,7 @@ impl ServeEngine {
         };
 
         let group = if has_controller {
-            // Plugin-controlled mode: direct integration with step_controlled.
+            // Plugin-controlled mode: direct integration under the controller.
             let mut controlled_sats = Vec::new();
             {
                 #[cfg(feature = "plugin-wasm")]
@@ -452,6 +460,7 @@ impl ServeEngine {
                     let sat = crate::sim::controlled::build_controlled_satellite(
                         spec,
                         params.epoch,
+                        0.0,
                         &mut ctx,
                     )
                     .map_err(|e| format!("controlled satellite '{}': {e}", spec.id))?;
@@ -1159,8 +1168,13 @@ impl ServeEngine {
                 wasm_cache,
                 plugin_backend,
             };
-            crate::sim::controlled::build_controlled_satellite(&spec, initial_epoch, &mut ctx)
-                .map_err(|e| format!("build controlled satellite: {e}"))?
+            crate::sim::controlled::build_controlled_satellite(
+                &spec,
+                initial_epoch,
+                self.current_t,
+                &mut ctx,
+            )
+            .map_err(|e| format!("build controlled satellite: {e}"))?
         };
 
         let initial = new_sat.state.plant.orbit.clone();

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -350,6 +350,14 @@ pub(super) struct ServeEngine {
     /// unbounded growth in long-running sims with many deorbiting satellites.
     terminated_events: VecDeque<String>,
     current_t: f64,
+    /// How many `stream_step` boundaries have been crossed. The next boundary
+    /// is `(steps_done + 1) * stream_step`, not `current_t + stream_step`:
+    /// repeated addition drifts below the exact multiple — measured, six 0.1 s
+    /// steps accumulate to 0.6 while `6 * 0.1` is 0.6000000000000001 — and a
+    /// controller tick scheduled on the exact multiple would then fall outside
+    /// the interval that should have run it, and be taken a whole interval
+    /// late.
+    steps_done: u64,
     has_perturbations: bool,
     /// Each satellite's declared stream names, indexed like `metas`. The
     /// engine iterates these to pump the injected [`StreamIo`]; resolving a
@@ -676,6 +684,7 @@ impl ServeEngine {
             info_json,
             terminated_events: VecDeque::new(),
             current_t: 0.0,
+            steps_done: 0,
             has_perturbations,
             sat_streams,
             stream_step,
@@ -785,7 +794,7 @@ impl ServeEngine {
         let body_radius = self.params.body.properties().radius;
 
         for _ in 0..outputs_per_chunk {
-            let target_t = self.current_t + self.stream_step;
+            let target_t = (self.steps_done + 1) as f64 * self.stream_step;
 
             // Orbit boundary reset (only for unperturbed 2-body, orbit-only mode)
             if !self.has_perturbations {
@@ -900,6 +909,7 @@ impl ServeEngine {
             }
 
             self.current_t = target_t;
+            self.steps_done += 1;
         }
 
         all_outputs.sort_by(|a, b| a.t.partial_cmp(&b.t).unwrap());
@@ -1388,6 +1398,46 @@ orbit = { type = "circular", altitude = 500 }
         assert_eq!(init.engine.current_t(), 0.0);
         // No declared streams → empty layout entry for the one satellite.
         assert_eq!(init.stream_layout, vec![("sat-a".to_string(), vec![])]);
+    }
+
+    /// Output boundaries are exact multiples of the step, not an accumulated
+    /// sum.
+    ///
+    /// `current_t + stream_step` drifts below `n * stream_step`: measured,
+    /// six 0.1 s steps accumulate to 0.6 while `6 * 0.1` is
+    /// 0.6000000000000001. A controller tick is scheduled on the exact
+    /// multiple (`tick_base_t + n * sample_period`), so a boundary that lands
+    /// below it leaves the tick outside the interval that should have run it,
+    /// and it is taken a whole interval late.
+    #[test]
+    fn output_boundaries_are_exact_multiples_of_the_step() {
+        let mut init = engine_from_toml(
+            r#"
+dt = 0.01
+output_interval = 0.1
+stream_interval = 0.1
+
+[[satellites]]
+id = "sat-a"
+orbit = { type = "circular", altitude = 500 }
+"#,
+        )
+        .expect("engine builds");
+        let step = init.engine.effective_step();
+        assert!((step - 0.1).abs() < 1e-12, "the step is the one configured");
+
+        // Past the sixth boundary, where accumulation starts trailing.
+        for n in 1..=12u32 {
+            init.engine
+                .step_chunk(1, &mut NullStreamIo)
+                .expect("a stable orbit propagates");
+            let expected = f64::from(n) * step;
+            assert_eq!(
+                init.engine.current_t(),
+                expected,
+                "boundary {n} must be n * step exactly, not an accumulated sum"
+            );
+        }
     }
 
     #[test]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1527,10 +1527,12 @@ pub fn validate_time_params(
 
 /// Reject a controller tick that cannot advance the control loop.
 ///
-/// Both controlled-run loops step with `dt = sample_period.min(remaining)`, so
-/// a zero period leaves `t += 0` spinning and a negative one walks backwards.
-/// The period comes from the plugin/controller rather than from user config,
-/// so it has to be checked where it is first used.
+/// Both controlled-run loops schedule ticks at `start_t + n · sample_period`,
+/// so a zero period leaves every tick on the start time and a negative one
+/// walks backwards. The period comes from the plugin/controller rather than
+/// from user config, so it has to be checked where it is first used. A period
+/// that is positive but below the sim clock's resolution at the satellite's
+/// start time is caught separately, where that start time is known.
 pub fn validate_sample_period(dt_ctrl: f64) -> Result<(), String> {
     if dt_ctrl.is_finite() && dt_ctrl > 0.0 {
         Ok(())

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -126,8 +126,14 @@ fn validate_tick_advances(start_t: f64, sample_period: f64) -> Result<(), String
     // The ULP grows with the magnitude of the time, so a period accepted here
     // can still collide far enough into a run. That is the case the doc above
     // describes and does not rule out: a 0.1 s period needs t of about 1e15 s.
+    // The resolution at the anchor, and at the first tick: crossing a binade
+    // doubles the ULP, so a period equal to the anchor's can be half of one
+    // just above it. Measured: at `start_t = 8.0f64.next_down()` with
+    // `period = 8.0 - start_t`, ticks 1 and 2 both land on 8.0.
     let ulp = start_t.next_up() - start_t;
-    if sample_period >= ulp {
+    let first = start_t + sample_period;
+    let ulp_at_first = first.next_up() - first;
+    if sample_period >= ulp && sample_period >= ulp_at_first {
         Ok(())
     } else {
         Err(format!(
@@ -477,7 +483,23 @@ pub fn tick_controller(
     // command whose length does not match the actuator, and a schedule advanced
     // past a tick that failed would resume on the wrong phase.
     apply_held_commands(sat)?;
+    // The schedule has to advance, or the caller's `while sat.tick_due_at(to)`
+    // would tick again at this instant and never finish. Construction refuses
+    // a period below the clock's resolution there, but the resolution halves
+    // going up a binade and grows with the time, so the invariant is checked
+    // where it has to hold rather than only where the satellite was built.
+    let taken = sat.next_tick_t();
     sat.ticks_done += 1;
+    let following = sat.next_tick_t();
+    // `partial_cmp` rather than `!(following > taken)`: a NaN either side is
+    // incomparable, and that has to count as "did not advance" too.
+    if following.partial_cmp(&taken) != Some(core::cmp::Ordering::Greater) {
+        return Err(format!(
+            "controller sample period {} cannot advance the schedule past \
+             t={taken}: the next tick lands on the same instant",
+            sat.controller.sample_period()
+        ));
+    }
     Ok(())
 }
 
@@ -834,6 +856,17 @@ mod tests {
         // One ULP exactly is the smallest period that keeps the ticks apart.
         validate_tick_advances(5.0, 5.0f64.next_up() - 5.0)
             .expect("one ULP separates every consecutive pair");
+        // Just below a binade boundary the ULP doubles on the way up, so a
+        // period equal to the anchor's own ULP is half of one above it.
+        let below_eight = 8.0f64.next_down();
+        let one_ulp_there = 8.0 - below_eight;
+        assert_eq!(
+            below_eight + one_ulp_there,
+            below_eight + 2.0 * one_ulp_there,
+            "precondition: ticks 1 and 2 both land on 8.0"
+        );
+        validate_tick_advances(below_eight, one_ulp_there)
+            .expect_err("a period that collides across the binade must be refused");
         // The same period is fine from zero, where it is representable.
         validate_tick_advances(0.0, 1e-16).expect("representable at t=0");
         validate_tick_advances(5.0, 0.1).expect("an ordinary period is fine");

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -100,9 +100,15 @@ impl ControlledSatellite {
 ///
 /// [`crate::config::validate_sample_period`] only asks for a positive finite
 /// period, which `1e-16` satisfies — and `5.0 + 1e-16 == 5.0`, so the schedule
-/// would never leave `start_t` and every loop waiting on it would spin. The
-/// tick time is `base + n · period`, so a period that clears one ULP of the
-/// base clears every later tick too, and this one check covers the whole run.
+/// would never leave `start_t` and every loop waiting on it would spin.
+///
+/// What this guarantees is that the schedule leaves the anchor. A tick time is
+/// `base + n · period`, and an ULP grows with the magnitude of the value, so a
+/// period that clears one ULP at the anchor does not clear one at every later
+/// tick: far enough out, `base + n · period` and `base + (n+1) · period` round
+/// together. That is not a run anyone reaches — a 0.1 s period needs t of about
+/// 1e15 s, some 32 million years, before an ULP catches up with it — but it is
+/// not what this check rules out.
 fn validate_tick_advances(start_t: f64, sample_period: f64) -> Result<(), String> {
     if start_t + sample_period > start_t {
         Ok(())

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -571,7 +571,7 @@ mod tests {
         let body = arika::body::KnownBody::Earth;
         let mu = body.properties().mu;
         let inertia = nalgebra::Matrix3::identity() * 10.0;
-        let dynamics = build_spacecraft_dynamics(
+        let dynamics = orts::setup::build_spacecraft_dynamics(
             &body,
             mu,
             None,
@@ -580,6 +580,10 @@ mod tests {
                 ballistic_coeff: None,
                 srp_area_to_mass: None,
                 srp_cr: None,
+                // This test watches the controller's tick cadence, so the plant
+                // carries no disturbance torque and no panels to make one.
+                disturbances: orts::setup::DisturbanceTorques::default(),
+                shape: None,
             },
             &[],
             inertia,

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -111,8 +111,10 @@ impl ControlledSatellite {
 /// check does not rule it out. What it does rule out is a period that cannot
 /// separate the first two ticks from each other at the start.
 fn validate_tick_advances(start_t: f64, sample_period: f64) -> Result<(), String> {
-    // At least one ULP of the start time, so consecutive `start_t + n · period`
-    // always land on different f64 values.
+    // At least one ULP, so the ticks this schedule generates near the start
+    // land on different f64 values. Later ticks are the runtime guard's
+    // business: the ULP grows with the time, and no check here can bound
+    // that (see the doc above).
     //
     // Sampling the first few ticks instead is not enough. `start_t + period >
     // start_t` accepts a period that separates the first tick from the start
@@ -136,10 +138,13 @@ fn validate_tick_advances(start_t: f64, sample_period: f64) -> Result<(), String
     if sample_period >= ulp && sample_period >= ulp_at_first {
         Ok(())
     } else {
+        // Name the resolution that the period actually fell short of: at a
+        // binade boundary the anchor's is met and the first tick's is not.
+        let needed = ulp.max(ulp_at_first);
         Err(format!(
             "controller sample period {sample_period} is below the sim clock's \
-             resolution at t={start_t} ({ulp}), so consecutive ticks would \
-             land on the same instant"
+             resolution around t={start_t} ({needed}), so consecutive ticks \
+             would land on the same instant"
         ))
     }
 }
@@ -865,8 +870,14 @@ mod tests {
             below_eight + 2.0 * one_ulp_there,
             "precondition: ticks 1 and 2 both land on 8.0"
         );
-        validate_tick_advances(below_eight, one_ulp_there)
+        let err = validate_tick_advances(below_eight, one_ulp_there)
             .expect_err("a period that collides across the binade must be refused");
+        // The message has to name the bound that failed: here the anchor's own
+        // resolution is met and the first tick's is not.
+        assert!(
+            err.contains(&format!("{}", 8.0f64.next_up() - 8.0)),
+            "the message should report the first tick's resolution: {err}"
+        );
         // The same period is fine from zero, where it is representable.
         validate_tick_advances(0.0, 1e-16).expect("representable at t=0");
         validate_tick_advances(5.0, 0.1).expect("an ordinary period is fine");

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -66,35 +66,52 @@ pub struct ControlledSatellite {
     pub thruster_specs: Vec<ThrusterSpec>,
     /// Thruster assembly-level propellant floor [kg]。
     pub thruster_dry_mass: f64,
-    /// Sim time of this satellite's next controller tick [s].
+    /// Sim time this satellite's controller schedule is anchored at [s]: where
+    /// the satellite entered the simulation.
+    tick_base_t: f64,
+    /// Ticks this controller has already run since `tick_base_t`.
     ///
     /// The schedule belongs to the satellite because `sample_period` is fixed
-    /// per controller and a fleet may mix rates. Output samples, stream
-    /// flushes and the end of a run all cut the timeline at their own
-    /// boundaries; carrying the next tick here is what keeps those cuts from
-    /// moving the controller. Advanced by `sample_period` on each tick, never
-    /// snapped to a boundary, so a span with no tick in it leaves the phase
-    /// intact.
-    pub next_tick_t: f64,
+    /// per controller and a fleet may mix rates. Output samples, stream flushes
+    /// and the end of a run all cut the timeline at their own boundaries, and
+    /// keeping the count here is what stops those cuts from moving the
+    /// controller.
+    ///
+    /// A count rather than a running `next_tick_t += sample_period`: the sum
+    /// drifts by a few ULPs per tick, which then has to be absorbed by a
+    /// tolerance on every boundary comparison — and a tolerance wide enough to
+    /// cover the drift also fires ticks that lie just past the boundary.
+    ticks_done: u64,
 }
 
 impl ControlledSatellite {
-    /// Whether a tick is due at or before `t`.
-    ///
-    /// The tolerance absorbs the accumulated error of repeated
-    /// `next_tick_t += sample_period`, which otherwise leaves a tick a few
-    /// ULPs past a boundary that should have contained it.
+    /// Sim time of this satellite's next controller tick [s].
+    pub fn next_tick_t(&self) -> f64 {
+        self.tick_base_t + (self.ticks_done + 1) as f64 * self.controller.sample_period()
+    }
+
+    /// Whether the next tick lands at or before `t`.
     pub fn tick_due_at(&self, t: f64) -> bool {
-        self.next_tick_t <= t + TICK_EPS
+        self.next_tick_t() <= t
     }
 }
 
-/// Slack for comparing a scheduled tick against a span boundary [s].
+/// Reject a sample period too small to move the clock from `start_t`.
 ///
-/// Sim times here are sums of `dt`-sized terms, so a tick meant to land on a
-/// boundary can miss it by a few ULPs of the elapsed time. 1 ns is far below
-/// any control period the plugin contract admits and far above that drift.
-pub const TICK_EPS: f64 = 1e-9;
+/// [`crate::config::validate_sample_period`] only asks for a positive finite
+/// period, which `1e-16` satisfies — and `5.0 + 1e-16 == 5.0`, so the schedule
+/// would never leave `start_t` and every loop waiting on it would spin. The
+/// tick time is `base + n · period`, so a period that clears one ULP of the
+/// base clears every later tick too, and this one check covers the whole run.
+fn validate_tick_advances(start_t: f64, sample_period: f64) -> Result<(), String> {
+    if start_t + sample_period > start_t {
+        Ok(())
+    } else {
+        Err(format!(
+            "controller sample period {sample_period} is below the resolution of              the sim clock at t={start_t}, so its schedule could never advance"
+        ))
+    }
+}
 
 /// Config からプラグイン制御付き衛星を構築する。
 ///
@@ -211,6 +228,8 @@ pub fn build_controlled_satellite(
 
     let actuators = ActuatorBundle::new();
     let sample_period = controller.sample_period();
+    crate::config::validate_sample_period(sample_period)?;
+    validate_tick_advances(start_t, sample_period)?;
 
     Ok(ControlledSatellite {
         dynamics,
@@ -223,11 +242,8 @@ pub fn build_controlled_satellite(
         mtq_max_moment,
         thruster_specs,
         thruster_dry_mass,
-        // The first tick sits one period in, matching the phase of
-        // the old `step_controlled`: a cycle is propagated before the controller
-        // its end. `start_t` is 0 for a fleet built up front and the current
-        // sim time for one added to a running `serve`.
-        next_tick_t: start_t + sample_period,
+        tick_base_t: start_t,
+        ticks_done: 0,
     })
 }
 
@@ -395,11 +411,11 @@ pub fn tick_controller(
             .apply(&cmd)
             .map_err(|e| format!("actuator error at t={t_next:.3}: {e}"))?;
     }
-    sat.next_tick_t += sat.controller.sample_period();
+    sat.ticks_done += 1;
     apply_held_commands(sat)
 }
 
-// builder helpersuilder helpers
+// builder helpers
 
 fn build_controller(
     config: &ControllerConfig,
@@ -583,7 +599,8 @@ mod tests {
             mtq_max_moment: 0.0,
             thruster_specs: Vec::new(),
             thruster_dry_mass: 0.0,
-            next_tick_t: start_t + period,
+            tick_base_t: start_t,
+            ticks_done: 0,
         };
         (sat, ticks)
     }
@@ -593,7 +610,7 @@ mod tests {
     fn advance(sat: &mut ControlledSatellite, from: f64, to: f64, params_dt: f64) {
         let mut t = from;
         while sat.tick_due_at(to) {
-            let tick_t = sat.next_tick_t;
+            let tick_t = sat.next_tick_t();
             propagate_controlled(sat, t, tick_t, params_dt).expect("integrates");
             tick_controller(sat, tick_t, None).expect("ticks");
             t = tick_t;
@@ -657,14 +674,76 @@ mod tests {
 
     /// A satellite added mid-run takes its first tick one period after it
     /// enters, not one period after `t = 0`.
+    ///
+    /// Pins the phase rule, not the wiring: the fixture below anchors the
+    /// schedule the same way `build_controlled_satellite` does, so a caller
+    /// passing the wrong `start_t` would still pass here. Reaching the real
+    /// builder needs a WASM plugin to construct the controller from.
     #[test]
     fn a_satellite_starting_late_phases_its_ticks_from_its_start() {
         let (sat, _) = satellite_with(0.1, 5.0);
         assert!(
-            (sat.next_tick_t - 5.1).abs() < 1e-9,
+            (sat.next_tick_t() - 5.1).abs() < 1e-9,
             "first tick at {}, expected 5.1",
-            sat.next_tick_t
+            sat.next_tick_t()
         );
+    }
+
+    /// A span that stops just short of the next tick does not run it.
+    ///
+    /// The end of a run, or a stream flush that lands a hair before a tick,
+    /// must leave that tick for the next span. Comparing with a tolerance —
+    /// which a drifting `next_tick_t += period` needs — would fire it here and
+    /// integrate past the boundary the caller asked for.
+    #[test]
+    fn a_span_ending_just_before_a_tick_does_not_run_it() {
+        let (mut sat, ticks) = satellite_with(0.1, 0.0);
+
+        advance(&mut sat, 0.0, 0.1 - 1e-10, 0.01);
+        assert!(
+            ticks.lock().unwrap().is_empty(),
+            "a tick 1e-10 s past the span's end was run: {:?}",
+            ticks.lock().unwrap()
+        );
+
+        // And it is still there for the span that does contain it.
+        advance(&mut sat, 0.1 - 1e-10, 0.15, 0.01);
+        let seen = ticks.lock().unwrap().clone();
+        assert_eq!(seen.len(), 1, "the deferred tick should run next: {seen:?}");
+        assert!((seen[0] - 0.1).abs() < 1e-12, "at {}", seen[0]);
+    }
+
+    /// Repeated ticks do not drift off the period.
+    ///
+    /// `tick_base_t + n · period` is one multiply; summing `period` a thousand
+    /// times is not, and the accumulated error is what a boundary tolerance
+    /// would have had to cover.
+    #[test]
+    fn the_thousandth_tick_is_still_on_the_period() {
+        let (mut sat, ticks) = satellite_with(0.1, 0.0);
+        advance(&mut sat, 0.0, 100.0, 1.0);
+
+        let seen = ticks.lock().unwrap().clone();
+        assert_eq!(seen.len(), 1000, "100 s at 10 Hz is 1000 ticks");
+        assert_eq!(
+            seen[999], 100.0,
+            "the last tick should be exactly 100.0, got {}",
+            seen[999]
+        );
+    }
+
+    /// A period the sim clock cannot resolve is refused, not spun on.
+    ///
+    /// `validate_sample_period` accepts any positive finite period, and
+    /// `5.0 + 1e-16 == 5.0`: a schedule anchored there would never advance and
+    /// every loop waiting on the next tick would run forever.
+    #[test]
+    fn a_period_below_the_clock_resolution_is_rejected() {
+        validate_tick_advances(5.0, 1e-16)
+            .expect_err("a period that cannot move the clock must be refused");
+        // The same period is fine from zero, where it is representable.
+        validate_tick_advances(0.0, 1e-16).expect("representable at t=0");
+        validate_tick_advances(5.0, 0.1).expect("an ordinary period is fine");
     }
 
     /// Two controllers at different rates each run at their own.
@@ -681,7 +760,7 @@ mod tests {
         // the run loop does.
         let mut t = 0.0;
         while t < 1.0 - 1e-12 {
-            let next_t = fast.next_tick_t.min(slow.next_tick_t).min(1.0);
+            let next_t = fast.next_tick_t().min(slow.next_tick_t()).min(1.0);
             propagate_controlled(&mut fast, t, next_t, 0.01).expect("integrates");
             if fast.tick_due_at(next_t) {
                 tick_controller(&mut fast, next_t, None).expect("ticks");

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -345,6 +345,43 @@ fn apply_held_commands(sat: &mut ControlledSatellite) -> Result<(), String> {
 ///
 /// `params_dt` is the requested ODE step; it is capped by the span so a step
 /// cannot reach past `t1`.
+/// The next moment anything happens in a fleet: the earliest controller tick
+/// due, or `horizon` if none falls before it.
+///
+/// An empty fleet has no tick, so the horizon is the answer. Taking the
+/// shortest `sample_period` in the fleet instead — one tick rate for everyone
+/// — ran every slower controller at that rate.
+pub fn next_fleet_event_t(sats: &[ControlledSatellite], horizon: f64) -> f64 {
+    sats.iter()
+        .map(|sat| sat.next_tick_t())
+        .fold(f64::INFINITY, f64::min)
+        .min(horizon)
+}
+
+/// Advance one satellite across `[from, to]`.
+///
+/// Propagates to each tick due inside the span, ticks the controller there,
+/// then propagates the rest of the span under the command that tick left. The
+/// span is the caller's — `stream_interval` in `serve`, the gap between fleet
+/// events in `run` — and has no reason to be a multiple of the controller's
+/// period, so a span shorter than the period integrates without a tick.
+pub fn advance_controlled(
+    sat: &mut ControlledSatellite,
+    from: f64,
+    to: f64,
+    params_dt: f64,
+    epoch: Option<&Epoch>,
+) -> Result<(), String> {
+    let mut t = from;
+    while sat.tick_due_at(to) {
+        let tick_t = sat.next_tick_t();
+        propagate_controlled(sat, t, tick_t, params_dt)?;
+        tick_controller(sat, tick_t, epoch)?;
+        t = tick_t;
+    }
+    propagate_controlled(sat, t, to, params_dt)
+}
+
 pub fn propagate_controlled(
     sat: &mut ControlledSatellite,
     t0: f64,
@@ -620,17 +657,10 @@ mod tests {
         (sat, ticks)
     }
 
-    /// Step one satellite the way a caller does: propagate to each due tick,
-    /// tick there, then propagate the remainder of the span.
+    /// Step one satellite the way a caller does — through the same function
+    /// `serve` and `run` call, so an error in that loop fails these tests.
     fn advance(sat: &mut ControlledSatellite, from: f64, to: f64, params_dt: f64) {
-        let mut t = from;
-        while sat.tick_due_at(to) {
-            let tick_t = sat.next_tick_t();
-            propagate_controlled(sat, t, tick_t, params_dt).expect("integrates");
-            tick_controller(sat, tick_t, None).expect("ticks");
-            t = tick_t;
-        }
-        propagate_controlled(sat, t, to, params_dt).expect("integrates");
+        advance_controlled(sat, from, to, params_dt, None).expect("integrates and ticks");
     }
 
     /// A span shorter than the sample period does not tick the controller.
@@ -768,21 +798,20 @@ mod tests {
     /// rejects outright rather than mis-simulate.
     #[test]
     fn a_mixed_rate_fleet_ticks_each_controller_at_its_own_period() {
-        let (mut fast, fast_ticks) = satellite_with(0.1, 0.0);
-        let (mut slow, slow_ticks) = satellite_with(1.0, 0.0);
+        let (fast, fast_ticks) = satellite_with(0.1, 0.0);
+        let (slow, slow_ticks) = satellite_with(1.0, 0.0);
 
-        // Advance to the earliest tick due in the fleet, repeatedly, the way
-        // the run loop does.
+        // The event times come from the same function the run loop calls, so
+        // an error in that choice fails this test.
+        let mut fleet = vec![fast, slow];
         let mut t = 0.0;
         while t < 1.0 - 1e-12 {
-            let next_t = fast.next_tick_t().min(slow.next_tick_t()).min(1.0);
-            propagate_controlled(&mut fast, t, next_t, 0.01).expect("integrates");
-            if fast.tick_due_at(next_t) {
-                tick_controller(&mut fast, next_t, None).expect("ticks");
-            }
-            propagate_controlled(&mut slow, t, next_t, 0.01).expect("integrates");
-            if slow.tick_due_at(next_t) {
-                tick_controller(&mut slow, next_t, None).expect("ticks");
+            let next_t = next_fleet_event_t(&fleet, 1.0);
+            for sat in &mut fleet {
+                propagate_controlled(sat, t, next_t, 0.01).expect("integrates");
+                if sat.tick_due_at(next_t) {
+                    tick_controller(sat, next_t, None).expect("ticks");
+                }
             }
             t = next_t;
         }

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -66,9 +66,41 @@ pub struct ControlledSatellite {
     pub thruster_specs: Vec<ThrusterSpec>,
     /// Thruster assembly-level propellant floor [kg]。
     pub thruster_dry_mass: f64,
+    /// Sim time of this satellite's next controller tick [s].
+    ///
+    /// The schedule belongs to the satellite because `sample_period` is fixed
+    /// per controller and a fleet may mix rates. Output samples, stream
+    /// flushes and the end of a run all cut the timeline at their own
+    /// boundaries; carrying the next tick here is what keeps those cuts from
+    /// moving the controller. Advanced by `sample_period` on each tick, never
+    /// snapped to a boundary, so a span with no tick in it leaves the phase
+    /// intact.
+    pub next_tick_t: f64,
 }
 
+impl ControlledSatellite {
+    /// Whether a tick is due at or before `t`.
+    ///
+    /// The tolerance absorbs the accumulated error of repeated
+    /// `next_tick_t += sample_period`, which otherwise leaves a tick a few
+    /// ULPs past a boundary that should have contained it.
+    pub fn tick_due_at(&self, t: f64) -> bool {
+        self.next_tick_t <= t + TICK_EPS
+    }
+}
+
+/// Slack for comparing a scheduled tick against a span boundary [s].
+///
+/// Sim times here are sums of `dt`-sized terms, so a tick meant to land on a
+/// boundary can miss it by a few ULPs of the elapsed time. 1 ns is far below
+/// any control period the plugin contract admits and far above that drift.
+pub const TICK_EPS: f64 = 1e-9;
+
 /// Config からプラグイン制御付き衛星を構築する。
+///
+/// `start_t` is the sim time this satellite starts at [s]: 0 for a fleet built
+/// before the run, the current sim time for one added to a running `serve`. It
+/// sets the phase of the satellite's controller schedule.
 ///
 /// 複数衛星をループで構築する場合は、[`ControlledBuildContext`] 内の
 /// `wasm_cache` を使い回すことで WASM コンポーネントのコンパイルが
@@ -83,6 +115,7 @@ pub struct ControlledSatellite {
 pub fn build_controlled_satellite(
     spec: &SatelliteSpec,
     initial_epoch: Option<Epoch>,
+    start_t: f64,
     ctx: &mut ControlledBuildContext<'_>,
 ) -> Result<ControlledSatellite, String> {
     let params = ctx.params;
@@ -177,6 +210,7 @@ pub fn build_controlled_satellite(
     let sensors = build_sensor_bundle(spec.sensor_choices.as_deref());
 
     let actuators = ActuatorBundle::new();
+    let sample_period = controller.sample_period();
 
     Ok(ControlledSatellite {
         dynamics,
@@ -189,19 +223,21 @@ pub fn build_controlled_satellite(
         mtq_max_moment,
         thruster_specs,
         thruster_dry_mass,
+        // The first tick sits one period in, matching the phase of
+        // the old `step_controlled`: a cycle is propagated before the controller
+        // its end. `start_t` is 0 for a fleet built up front and the current
+        // sim time for one added to a running `serve`.
+        next_tick_t: start_t + sample_period,
     })
 }
 
-/// 1 制御サイクル分を積分し、コントローラを呼び出す。
-pub fn step_controlled(
-    sat: &mut ControlledSatellite,
-    t: f64,
-    dt_ctrl: f64,
-    dt_ode: f64,
-    epoch: Option<&Epoch>,
-) -> Result<(), String> {
-    let t_next = t + dt_ctrl;
-
+/// Push the commands the actuator bundle currently holds into the dynamics.
+///
+/// Called right after a controller tick, so any span propagated afterwards is
+/// pure integration under a held command. A command the controller did not name
+/// keeps its previous value — the zero-order hold the plugin contract promises —
+/// so this is also what carries a command across a span with no tick in it.
+fn apply_held_commands(sat: &mut ControlledSatellite) -> Result<(), String> {
     // 前 tick のコマンドで RW を設定。
     if sat.has_rw
         && sat.actuators.has_rw_command()
@@ -273,23 +309,48 @@ pub fn step_controlled(
             return Err("thruster_assembly model not registered in dynamics".into());
         }
     }
+    Ok(())
+}
 
-    // 結合伝播（軌道 + 姿勢 + RW）。
-    //
-    // `try_integrate` を使うのは、`integrate` が不正な刻み幅や停滞した時刻を
-    // panic にしてしまうため。この関数は `Result` を返すので、serve は
-    // graceful-halt 経路でクライアントへ Error を送れる。
+/// Integrate `[t0, t1]` under the command the actuators already hold.
+///
+/// No controller call: `t1` is wherever the caller needs the state next — an
+/// output sample, a stream flush, the end of the run — and those boundaries do
+/// not have to be controller ticks. `PluginController::sample_period` is a
+/// *fixed* period, so a controller runs on its own schedule via
+/// [`tick_controller`] and nothing else may move it.
+///
+/// `params_dt` is the requested ODE step; it is capped by the span so a step
+/// cannot reach past `t1`.
+pub fn propagate_controlled(
+    sat: &mut ControlledSatellite,
+    t0: f64,
+    t1: f64,
+    params_dt: f64,
+) -> Result<(), String> {
+    if t1 <= t0 {
+        return Ok(());
+    }
+    let dt_ode = params_dt.min(t1 - t0);
+    // `try_integrate` rather than `integrate`: the latter panics on a bad step
+    // or a stalled clock, and this returns `Result` so serve can send the
+    // client an Error down its graceful-halt path.
     sat.state = Rk4
-        .try_integrate(
-            &sat.dynamics,
-            sat.state.clone(),
-            t,
-            t_next,
-            dt_ode,
-            |_, _| {},
-        )
-        .map_err(|e| format!("integration failed on [{t:.3}, {t_next:.3}]: {e}"))?;
+        .try_integrate(&sat.dynamics, sat.state.clone(), t0, t1, dt_ode, |_, _| {})
+        .map_err(|e| format!("integration failed on [{t0:.3}, {t1:.3}]: {e}"))?;
+    Ok(())
+}
 
+/// Run one controller tick at `t_next`: read the sensors, call the plugin, and
+/// hand the command it returns to the dynamics.
+///
+/// The state must already have been propagated to `t_next` — the sensors are
+/// read from it.
+pub fn tick_controller(
+    sat: &mut ControlledSatellite,
+    t_next: f64,
+    epoch: Option<&Epoch>,
+) -> Result<(), String> {
     // センサ評価 + プラグイン呼び出し。
     let current_epoch = epoch.map(|e| e.add_si_seconds(t_next));
     let sensors = sat
@@ -334,11 +395,11 @@ pub fn step_controlled(
             .apply(&cmd)
             .map_err(|e| format!("actuator error at t={t_next:.3}: {e}"))?;
     }
-
-    Ok(())
+    sat.next_tick_t += sat.controller.sample_period();
+    apply_held_commands(sat)
 }
 
-// builder helpers
+// builder helpersuilder helpers
 
 fn build_controller(
     config: &ControllerConfig,
@@ -429,5 +490,220 @@ fn build_sensor_bundle(choices: Option<&[SensorChoice]>) -> SensorBundle {
         } else {
             vec![]
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orts::plugin::{Command, PluginError, TickInput};
+
+    /// A controller that records the `t` of every tick it is given.
+    ///
+    /// The point of the tests below is *when* the controller runs, so it
+    /// commands nothing and only keeps the schedule it saw.
+    struct TickRecorder {
+        period: f64,
+        ticks: Arc<std::sync::Mutex<Vec<f64>>>,
+    }
+
+    impl PluginController for TickRecorder {
+        fn name(&self) -> &str {
+            "tick-recorder"
+        }
+        fn sample_period(&self) -> f64 {
+            self.period
+        }
+        fn update(&mut self, input: &TickInput<'_>) -> Result<Option<Command>, PluginError> {
+            self.ticks
+                .lock()
+                .expect("no panics in these tests")
+                .push(input.t);
+            Ok(None)
+        }
+    }
+
+    /// Build a controlled satellite at 400 km with the given controller.
+    ///
+    /// Mirrors the dynamics `build_controlled_satellite` assembles, minus the
+    /// actuators and the WASM plugin the real builder needs: what is under test
+    /// is the tick schedule, and no command is ever issued.
+    fn satellite_with(
+        period: f64,
+        start_t: f64,
+    ) -> (ControlledSatellite, Arc<std::sync::Mutex<Vec<f64>>>) {
+        use orts::orbital::OrbitalState;
+        use orts::spacecraft::SpacecraftState;
+
+        let ticks = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let controller = TickRecorder {
+            period,
+            ticks: Arc::clone(&ticks),
+        };
+
+        let body = arika::body::KnownBody::Earth;
+        let mu = body.properties().mu;
+        let inertia = nalgebra::Matrix3::identity() * 10.0;
+        let dynamics = build_spacecraft_dynamics(
+            &body,
+            mu,
+            None,
+            &orts::setup::SatelliteParams {
+                has_drag: false,
+                ballistic_coeff: None,
+                srp_area_to_mass: None,
+                srp_cr: None,
+            },
+            &[],
+            inertia,
+            None,
+        );
+
+        // Circular orbit 400 km up, in the equatorial plane.
+        let r = body.properties().radius + 400.0;
+        let v = (mu / r).sqrt();
+        let plant = SpacecraftState {
+            orbit: OrbitalState::new(Vector3::new(r, 0.0, 0.0), Vector3::new(0.0, v, 0.0)),
+            attitude: orts::attitude::AttitudeState {
+                quaternion: nalgebra::Vector4::new(1.0, 0.0, 0.0, 0.0),
+                angular_velocity: Vector3::zeros(),
+            },
+            mass: 500.0,
+        };
+        let state = dynamics.initial_augmented_state(plant);
+
+        let sat = ControlledSatellite {
+            dynamics,
+            state,
+            controller: Box::new(controller),
+            sensors: SensorBundle::default(),
+            actuators: ActuatorBundle::new(),
+            has_rw: false,
+            has_mtq: false,
+            mtq_max_moment: 0.0,
+            thruster_specs: Vec::new(),
+            thruster_dry_mass: 0.0,
+            next_tick_t: start_t + period,
+        };
+        (sat, ticks)
+    }
+
+    /// Step one satellite the way a caller does: propagate to each due tick,
+    /// tick there, then propagate the remainder of the span.
+    fn advance(sat: &mut ControlledSatellite, from: f64, to: f64, params_dt: f64) {
+        let mut t = from;
+        while sat.tick_due_at(to) {
+            let tick_t = sat.next_tick_t;
+            propagate_controlled(sat, t, tick_t, params_dt).expect("integrates");
+            tick_controller(sat, tick_t, None).expect("ticks");
+            t = tick_t;
+        }
+        propagate_controlled(sat, t, to, params_dt).expect("integrates");
+    }
+
+    /// A span shorter than the sample period does not tick the controller.
+    ///
+    /// This is the serve case: `stream_interval` cuts the timeline every
+    /// 0.01 s while the controller asks for 0.1 s. The old loop called the
+    /// controller once per cut with `dt = 0.01`, so a 10 Hz controller ran at
+    /// 100 Hz and held each command for a tenth of the time it asked for.
+    #[test]
+    fn spans_shorter_than_the_period_do_not_tick_the_controller() {
+        let (mut sat, ticks) = satellite_with(0.1, 0.0);
+
+        // 1 s of sim time, cut into 0.01 s spans.
+        let mut t = 0.0;
+        for _ in 0..100 {
+            advance(&mut sat, t, t + 0.01, 0.01);
+            t += 0.01;
+        }
+
+        let seen = ticks.lock().unwrap().clone();
+        assert_eq!(
+            seen.len(),
+            10,
+            "10 Hz over 1 s is 10 ticks, got {} at {seen:?}",
+            seen.len()
+        );
+        for (i, tick_t) in seen.iter().enumerate() {
+            let expected = 0.1 * (i + 1) as f64;
+            assert!(
+                (tick_t - expected).abs() < 1e-9,
+                "tick {i} at {tick_t}, expected {expected}"
+            );
+        }
+    }
+
+    /// Ticks stay on the controller's own phase across spans that do not
+    /// divide it.
+    ///
+    /// 0.03 s spans never land on a 0.1 s tick, so every tick falls inside a
+    /// span. Truncating the remainder instead of carrying it would drift the
+    /// schedule.
+    #[test]
+    fn a_span_that_does_not_divide_the_period_keeps_the_phase() {
+        let (mut sat, ticks) = satellite_with(0.1, 0.0);
+
+        let mut t = 0.0;
+        for _ in 0..10 {
+            advance(&mut sat, t, t + 0.03, 0.01);
+            t += 0.03;
+        }
+        // 0.3 s of sim time: ticks at 0.1, 0.2, 0.3.
+        let seen = ticks.lock().unwrap().clone();
+        assert_eq!(seen.len(), 3, "expected 3 ticks in 0.3 s, got {seen:?}");
+        assert!((seen[2] - 0.3).abs() < 1e-9, "third tick at {}", seen[2]);
+    }
+
+    /// A satellite added mid-run takes its first tick one period after it
+    /// enters, not one period after `t = 0`.
+    #[test]
+    fn a_satellite_starting_late_phases_its_ticks_from_its_start() {
+        let (sat, _) = satellite_with(0.1, 5.0);
+        assert!(
+            (sat.next_tick_t - 5.1).abs() < 1e-9,
+            "first tick at {}, expected 5.1",
+            sat.next_tick_t
+        );
+    }
+
+    /// Two controllers at different rates each run at their own.
+    ///
+    /// `orts run` used to drive the fleet on the shortest period, so the 1.0 s
+    /// controller here was called every 0.1 s — the very case the streams path
+    /// rejects outright rather than mis-simulate.
+    #[test]
+    fn a_mixed_rate_fleet_ticks_each_controller_at_its_own_period() {
+        let (mut fast, fast_ticks) = satellite_with(0.1, 0.0);
+        let (mut slow, slow_ticks) = satellite_with(1.0, 0.0);
+
+        // Advance to the earliest tick due in the fleet, repeatedly, the way
+        // the run loop does.
+        let mut t = 0.0;
+        while t < 1.0 - 1e-12 {
+            let next_t = fast.next_tick_t.min(slow.next_tick_t).min(1.0);
+            propagate_controlled(&mut fast, t, next_t, 0.01).expect("integrates");
+            if fast.tick_due_at(next_t) {
+                tick_controller(&mut fast, next_t, None).expect("ticks");
+            }
+            propagate_controlled(&mut slow, t, next_t, 0.01).expect("integrates");
+            if slow.tick_due_at(next_t) {
+                tick_controller(&mut slow, next_t, None).expect("ticks");
+            }
+            t = next_t;
+        }
+
+        assert_eq!(
+            fast_ticks.lock().unwrap().len(),
+            10,
+            "the 0.1 s controller should tick 10 times in 1 s"
+        );
+        let slow_seen = slow_ticks.lock().unwrap().clone();
+        assert_eq!(
+            slow_seen.len(),
+            1,
+            "the 1.0 s controller should tick once in 1 s, got {slow_seen:?}"
+        );
+        assert!((slow_seen[0] - 1.0).abs() < 1e-9, "at {}", slow_seen[0]);
     }
 }

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -490,9 +490,10 @@ pub fn tick_controller(
     apply_held_commands(sat)?;
     // The schedule has to advance, or the caller's `while sat.tick_due_at(to)`
     // would tick again at this instant and never finish. Construction refuses
-    // a period below the clock's resolution there, but the resolution halves
-    // going up a binade and grows with the time, so the invariant is checked
-    // where it has to hold rather than only where the satellite was built.
+    // a period below the clock's resolution there, but that resolution doubles
+    // at each binade boundary, so a period wide enough at the anchor can be
+    // too narrow further along. The invariant is checked where it has to hold
+    // rather than only where the satellite was built.
     let taken = sat.next_tick_t();
     sat.ticks_done += 1;
     let following = sat.next_tick_t();

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -108,7 +108,8 @@ fn validate_tick_advances(start_t: f64, sample_period: f64) -> Result<(), String
         Ok(())
     } else {
         Err(format!(
-            "controller sample period {sample_period} is below the resolution of              the sim clock at t={start_t}, so its schedule could never advance"
+            "controller sample period {sample_period} is below the sim clock's \
+             resolution at t={start_t}, so its schedule could never advance"
         ))
     }
 }
@@ -411,8 +412,12 @@ pub fn tick_controller(
             .apply(&cmd)
             .map_err(|e| format!("actuator error at t={t_next:.3}: {e}"))?;
     }
+    // Only once the whole tick has landed: `apply_held_commands` can reject a
+    // command whose length does not match the actuator, and a schedule advanced
+    // past a tick that failed would resume on the wrong phase.
+    apply_held_commands(sat)?;
     sat.ticks_done += 1;
-    apply_held_commands(sat)
+    Ok(())
 }
 
 // builder helpers

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -107,10 +107,19 @@ impl ControlledSatellite {
 /// period that clears one ULP at the anchor does not clear one at every later
 /// tick: far enough out, `base + n · period` and `base + (n+1) · period` round
 /// together. That is not a run anyone reaches — a 0.1 s period needs t of about
-/// 1e15 s, some 32 million years, before an ULP catches up with it — but it is
-/// not what this check rules out.
+/// 1e15 s, some 32 million years, before an ULP catches up with it — and this
+/// check does not rule it out. What it does rule out is a period that cannot
+/// separate the first two ticks from each other at the start.
 fn validate_tick_advances(start_t: f64, sample_period: f64) -> Result<(), String> {
-    if start_t + sample_period > start_t {
+    // The first two tick times the schedule will generate, formed the way
+    // `next_tick_t` forms them. Both have to be distinct: requiring only
+    // `start_t + period > start_t` accepts a period that separates the first
+    // tick from the start but not the ticks from each other — measured, at
+    // `start_t = 5.0` and `period = 5e-16` both of these round to
+    // 5.000000000000001, so the controller would tick twice at one instant.
+    let first = start_t + sample_period;
+    let second = start_t + 2.0 * sample_period;
+    if first > start_t && second > first {
         Ok(())
     } else {
         Err(format!(
@@ -335,16 +344,6 @@ fn apply_held_commands(sat: &mut ControlledSatellite) -> Result<(), String> {
     Ok(())
 }
 
-/// Integrate `[t0, t1]` under the command the actuators already hold.
-///
-/// No controller call: `t1` is wherever the caller needs the state next — an
-/// output sample, a stream flush, the end of the run — and those boundaries do
-/// not have to be controller ticks. `PluginController::sample_period` is a
-/// *fixed* period, so a controller runs on its own schedule via
-/// [`tick_controller`] and nothing else may move it.
-///
-/// `params_dt` is the requested ODE step; it is capped by the span so a step
-/// cannot reach past `t1`.
 /// The next moment anything happens in a fleet: the earliest controller tick
 /// due, or `horizon` if none falls before it.
 ///
@@ -382,6 +381,16 @@ pub fn advance_controlled(
     propagate_controlled(sat, t, to, params_dt)
 }
 
+/// Integrate `[t0, t1]` under the command the actuators already hold.
+///
+/// No controller call: `t1` is wherever the caller needs the state next — an
+/// output sample, a stream flush, the end of the run — and those boundaries do
+/// not have to be controller ticks. `PluginController::sample_period` is a
+/// *fixed* period, so a controller runs on its own schedule via
+/// [`tick_controller`] and nothing else may move it.
+///
+/// `params_dt` is the requested ODE step; it is capped by the span so a step
+/// cannot reach past `t1`.
 pub fn propagate_controlled(
     sat: &mut ControlledSatellite,
     t0: f64,
@@ -786,6 +795,17 @@ mod tests {
     fn a_period_below_the_clock_resolution_is_rejected() {
         validate_tick_advances(5.0, 1e-16)
             .expect_err("a period that cannot move the clock must be refused");
+        // Separates the first tick from the start, but not the ticks from each
+        // other: `5.0 + 1*5e-16` and `5.0 + 2*5e-16` both round to
+        // 5.000000000000001, so accepting it would tick twice at one instant.
+        assert_ne!(5.0 + 5e-16, 5.0, "precondition: the first tick does move");
+        assert_eq!(
+            5.0 + 5e-16,
+            5.0 + 2.0 * 5e-16,
+            "precondition: the first two ticks land on the same f64"
+        );
+        validate_tick_advances(5.0, 5e-16)
+            .expect_err("a period that cannot separate two ticks must be refused");
         // The same period is fine from zero, where it is representable.
         validate_tick_advances(0.0, 1e-16).expect("representable at t=0");
         validate_tick_advances(5.0, 0.1).expect("an ordinary period is fine");

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -111,20 +111,29 @@ impl ControlledSatellite {
 /// check does not rule it out. What it does rule out is a period that cannot
 /// separate the first two ticks from each other at the start.
 fn validate_tick_advances(start_t: f64, sample_period: f64) -> Result<(), String> {
-    // The first two tick times the schedule will generate, formed the way
-    // `next_tick_t` forms them. Both have to be distinct: requiring only
-    // `start_t + period > start_t` accepts a period that separates the first
-    // tick from the start but not the ticks from each other — measured, at
-    // `start_t = 5.0` and `period = 5e-16` both of these round to
-    // 5.000000000000001, so the controller would tick twice at one instant.
-    let first = start_t + sample_period;
-    let second = start_t + 2.0 * sample_period;
-    if first > start_t && second > first {
+    // At least one ULP of the start time, so consecutive `start_t + n · period`
+    // always land on different f64 values.
+    //
+    // Sampling the first few ticks instead is not enough. `start_t + period >
+    // start_t` accepts a period that separates the first tick from the start
+    // but not the ticks from each other (measured: at `start_t = 5.0` and
+    // `period = 5e-16`, ticks 1 and 2 both round to 5.000000000000001).
+    // Checking two ticks is not enough either: `3 · f64::EPSILON` is 0.75 ULP
+    // there, so ticks 1 and 2 do advance while tick 3 rounds back onto tick 2
+    // (5.000000000000002 twice), and the controller would run twice at one
+    // instant.
+    //
+    // The ULP grows with the magnitude of the time, so a period accepted here
+    // can still collide far enough into a run. That is the case the doc above
+    // describes and does not rule out: a 0.1 s period needs t of about 1e15 s.
+    let ulp = start_t.next_up() - start_t;
+    if sample_period >= ulp {
         Ok(())
     } else {
         Err(format!(
             "controller sample period {sample_period} is below the sim clock's \
-             resolution at t={start_t}, so its schedule could never advance"
+             resolution at t={start_t} ({ulp}), so consecutive ticks would \
+             land on the same instant"
         ))
     }
 }
@@ -806,6 +815,25 @@ mod tests {
         );
         validate_tick_advances(5.0, 5e-16)
             .expect_err("a period that cannot separate two ticks must be refused");
+        // 0.75 ULP at 5.0: the first two ticks advance, and the third rounds
+        // back onto the second. Sampling a fixed number of ticks would accept
+        // this; requiring one ULP refuses it.
+        let three_eps = 3.0 * f64::EPSILON;
+        assert_ne!(5.0 + three_eps, 5.0, "precondition: tick 1 moves");
+        assert_ne!(
+            5.0 + 2.0 * three_eps,
+            5.0 + three_eps,
+            "precondition: tick 2 moves"
+        );
+        assert_eq!(
+            5.0 + 3.0 * three_eps,
+            5.0 + 2.0 * three_eps,
+            "precondition: tick 3 lands back on tick 2"
+        );
+        validate_tick_advances(5.0, three_eps).expect_err("a period below one ULP must be refused");
+        // One ULP exactly is the smallest period that keeps the ticks apart.
+        validate_tick_advances(5.0, 5.0f64.next_up() - 5.0)
+            .expect("one ULP separates every consecutive pair");
         // The same period is fine from zero, where it is representable.
         validate_tick_advances(0.0, 1e-16).expect("representable at t=0");
         validate_tick_advances(5.0, 0.1).expect("an ordinary period is fine");

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -35,7 +35,7 @@ pub enum ResolvedPluginBackend {
 /// TODO: revisit this default. The constellation-phasing bench
 /// (N = 1, 8, 64 on a 16-thread CPU, sample_period = 0.1) found that
 /// async is already ~5× faster than sync from N = 8 because async
-/// throughput mode runs per-satellite `step_controlled()` in parallel
+/// throughput mode runs each satellite's control step in parallel
 /// via `rayon` (see cli/src/commands/run.rs parallel_step path),
 /// whereas sync's sim loop iterates satellites sequentially. The
 /// crossover is likely near N ≈ cores, not cores × 32. Before


### PR DESCRIPTION
制御付きシミュレーションには、独立した 3 つの間隔がある。

- `dt` — ODE の積分刻み
- `output_interval` / `stream_interval` — state を記録・配信する間隔
- `sample_period` — 姿勢制御 plugin が「自分を何秒ごとに呼んでほしいか」を宣言する間隔（`PluginController::sample_period`）

この PR の前は、3 番目が他の 2 つに引きずられていた。`orts serve` は配信間隔ごとに、`orts run` は編隊の最短周期で制御器を呼んでいた。宣言した周期で動く前提で書かれた制御則が、違う周期で回る。

以下、制御器を 1 回呼んでコマンドを更新することを tick と呼ぶ。積分刻み `dt` は独立で、区間の長さは最終ステップを短くするだけ（`propagate_controlled` は `dt.min(t1 - t0)` を使う）。

同じ状況を realtime の streams 経路は拒否している（`uniform_tick`）。そのテストのコメントには「1.0 s の controller を 0.1 s の共通 tick で回すと 10 倍の頻度になるので、黙って誤ったシミュレーションをするのではなく拒否する」と書かれている。守られていたのはその 1 経路だけだった。

## `orts serve`: 配信間隔で tick していた

配信の間隔（`stream_interval`）で時間軸を切り、切るたびに 1 回 tick していた。配信レートと制御周期は本来無関係なので、`stream_interval` が `sample_period` より短ければ宣言の何倍もの頻度になる。

```rust
// 変更前
while t < target {
    let to = t + stream_interval;
    for sat in fleet {
        // sensor 読み取り → controller.update → その区間を積分
        step_controlled(sat, t, to);
    }
    t = to;
}
```

README quick start の設定がその条件になる。`dt = 0.01` で `output_interval` と `stream_interval` を書かないので、どちらも 0.01 になる。`pd-rw-control` の既定 `sample_period` は 0.1。

| | tick 回数（シミュレーション時間 1 s） | 1 コマンドの保持時間 |
|---|---|---|
| 変更前 | 100 | 0.01 s |
| 変更後 | 10 | 0.1 s |

## `orts run`: 編隊の最短周期で tick していた

編隊で一番短い `sample_period` を共通の tick 周期にしていた。速い機に合わせて遅い機も呼ばれる。

```rust
// 変更前
let dt_ctrl = fleet.iter().map(|s| s.sample_period()).min();
while t < duration {
    let to = t + dt_ctrl;
    for sat in fleet {
        step_controlled(sat, t, to);   // 全機を同じ周期で tick
    }
    t = to;
}
```

0.1 s と 1.0 s を混ぜた編隊で 1.0 s 側の tick 時刻を実測すると `[0.1, 0.2, ..., 1.0]` の 10 回。宣言どおりなら `[1.0]` の 1 回。

## 直した形

`step_controlled` を 2 つに分ける。`propagate_controlled` は「保持中のコマンドで積分する」だけ、`tick_controller` は「sensor 読み取り → `controller.update` → dynamics へ反映」だけ。`ControlledSatellite` が自分の次の tick 時刻を持つ。

```rust
// 変更後: orts run
while t < duration {
    // 次に tick が来る時刻。どの機の tick も来なければ duration
    let next_t = next_fleet_event_t(fleet, duration);
    for sat in fleet {
        propagate_controlled(sat, t, next_t);   // 保持中のコマンドで積分
        if sat.tick_due_at(next_t) {
            tick_controller(sat, next_t);       // 自分の tick が来た機だけ
        }
    }
    t = next_t;
}

// 変更後: orts serve の 1 区間 [from, to]、1 衛星ぶん
fn advance_controlled(sat, from, to) {
    let mut t = from;
    while sat.tick_due_at(to) {
        let tick_t = sat.next_tick_t();
        propagate_controlled(sat, t, tick_t);
        tick_controller(sat, tick_t);
        t = tick_t;
    }
    propagate_controlled(sat, t, to);   // 残りは保持中のコマンドで
}
```

tick を挟まない区間でもコマンドは保たれる。`ActuatorBundle` が制御器の返した最後の値を持ち、dynamics 側の各 model が積分中の物理量を持つという 2 層構造は元からある。新しいコマンドが model に届く時刻も変わらない（変更前は次区間の冒頭、変更後は tick 直後で、同じ時刻）。

## tick 時刻の持ち方

`next_tick_t += sample_period` をやめた。0.1 s 周期の 1000 tick 目で 99.9999999999986 になる（誤差 1.4e-12）。このずれを境界比較の許容誤差で吸収すると、境界の少し先にある tick まで実行してしまう。次の tick の 1e-10 s 前で終わる区間がその tick を回し、呼び出し側が指定した時刻を越えて積分することになる。

`起点 + n × 周期` で計算すれば、境界比較を厳密なまま保てる。

同じ理由で、`serve` の出力境界も回数から作る。`current_t + stream_interval` の累積は厳密な倍数を下回る。

```
n  累積               n*step
 5 0.5                0.5                  一致
 6 0.6                0.6000000000000001   累積が下回る
 8 0.7999999999999999 0.8                  累積が下回る
```

6 回目以降は、その区間で走るべき tick が境界の外に出て 1 区間遅れる。stream が繋がっていれば、後の区間で受けたバイトが前の tick の時刻に渡ることになる。

## 周期の下限

`5.0 + 1e-16 == 5.0` のように、その時刻の f64 の刻みより小さい周期は `validate_sample_period`（正の有限値のみ要求）を通る。すると次の tick 時刻が起点から動かず、ループが回り続ける。

tick 時刻が `起点 + n × 周期` なので、周期が起点の 1 ULP 以上あることを確認すれば、連続する tick は必ず別の f64 になる。tick を数個だけ見る検査では足りない: `3 × f64::EPSILON` は 5.0 で 0.75 ULP なので、tick 1 と 2 は進むが tick 3 が tick 2 に戻る（どちらも 5.000000000000002）。

## テスト

`cli/src/sim/controlled.rs` に 7 本。tick 時刻を記録する制御器と手組みの `ControlledSatellite` で、実際に呼ばれた時刻を測る。

- 0.01 s 区間を 100 回進めて tick 10 回、時刻 0.1, 0.2, …
- 0.03 s 区間（周期を割り切らない）で位相が保たれる
- 次の tick の 1e-10 s 前で終わる区間は、その tick を次の区間に回す
- 1000 tick 目が正確に 100.0
- 分解能を下回る周期を拒否する（1 ULP 未満の 3 通りを含む）
- `start_t = 5.0` の衛星の初回 tick が 5.1
- 0.1 s と 1.0 s の混在編隊が各自の周期で tick する

`serve` 側には出力境界のテストを 1 本追加した（12 境界が `n × stream_interval` と厳密に一致すること）。

修正を戻すと落ちることを実測した。区間ごとに 1 回呼ぶ形に戻すと tick が 100 回になって 2 本、編隊を共通 tick に戻すと 1.0 s 側が 10 回になって 1 本、`next_tick_t()` を累積和に戻すと 1000 tick 目が 99.9999999999986 になって 1 本、出力境界を累積和に戻すと境界テストが 1 本落ちる。

`cargo test -p orts-cli` 347 件 pass。

## 適用範囲

realtime の streams 経路は `uniform_tick` のまま。stream の受け渡しが共通の区間境界で動くので、混在周期の拒否を続ける。

`output_interval` が `sample_period` より短い場合、出力は tick の境界にだけ出る。この PR が扱うのは tick の周期の方。
