### PR TITLE
fix(orts): propagate artemis1 in Gcrs, the frame its states come in

### DIFF
--- a/orts/examples/artemis1/main.rs
+++ b/orts/examples/artemis1/main.rs
@@ -258,7 +258,7 @@ use std::sync::Arc;
 #[cfg(feature = "fetch-horizons")]
 use arika::epoch::Epoch;
 #[cfg(feature = "fetch-horizons")]
-use arika::frame::Vec3;
+use arika::frame::{Gcrs, Vec3};
 #[cfg(feature = "fetch-horizons")]
 use arika::horizons::HorizonsTable;
 #[cfg(feature = "fetch-horizons")]
@@ -1110,7 +1110,7 @@ fn verify_coast(
     let fallbacks_before = moon_concrete.fallback_count();
 
     let system = build_artemis_system(start_epoch, moon_ephem, sun_table);
-    let initial_state = OrbitalState::new(start_pos, start_vel);
+    let initial_state = OrbitalState::<Gcrs>::new_in_frame(start_pos, start_vel);
 
     let mut min_moon_distance = f64::MAX;
     let mut max_earth_distance: f64 = 0.0;
@@ -1241,7 +1241,7 @@ fn verify_burn(
     // state: the difference is exactly what the burn contributed above and
     // beyond the gravitational drift the integrator already captures.
     let system = build_artemis_system(pre_epoch, moon_ephem, sun_table);
-    let initial_state = OrbitalState::new(pre_pos, pre_vel);
+    let initial_state = OrbitalState::<Gcrs>::new_in_frame(pre_pos, pre_vel);
     let pure_coast_state = Dop853.integrate(
         &system,
         initial_state.clone(),
@@ -1474,7 +1474,7 @@ fn verify_burn_continuous(
     let fallbacks_before = moon_concrete.fallback_count();
 
     // Method B: same pure-coast Δv extraction as verify_burn
-    let initial_state = OrbitalState::new(pre_pos, pre_vel);
+    let initial_state = OrbitalState::<Gcrs>::new_in_frame(pre_pos, pre_vel);
     let pure_coast_system = build_artemis_system(pre_epoch, moon_ephem, sun_table);
     let pure_coast_state = Dop853.integrate(
         &pure_coast_system,
@@ -1625,7 +1625,7 @@ fn compute_corrected_dv(
     let system = build_artemis_system(pre_epoch, moon_ephem, sun_table);
     let pure_coast_state = Dop853.integrate(
         &system,
-        OrbitalState::new(pre_pos, pre_vel),
+        OrbitalState::<Gcrs>::new_in_frame(pre_pos, pre_vel),
         0.0,
         window_seconds,
         DT_SECONDS,
@@ -1726,7 +1726,7 @@ fn verify_burn_chain(
 
     // Walk the chain: coast to each burn's mid, apply corrected Δv, rebuild
     // system with the new reference epoch for the next segment.
-    let mut state = OrbitalState::new(chain_pre_pos, chain_pre_vel);
+    let mut state = OrbitalState::<Gcrs>::new_in_frame(chain_pre_pos, chain_pre_vel);
     let mut current_epoch = chain_pre_epoch;
     for (burn, dv_kms) in burns.iter().zip(&corrected_dvs) {
         let mid_epoch = Epoch::from_iso8601(burn.mid_epoch_iso).expect("valid burn mid epoch");
@@ -1937,7 +1937,7 @@ fn verify_burn_chain_continuous(
     //      segment → no mid-step discontinuities)
     //   3. current_epoch = burn.end, loop to next burn
     // After the last burn, coast to chain_post_epoch.
-    let mut state = OrbitalState::new(chain_pre_pos, chain_pre_vel);
+    let mut state = OrbitalState::<Gcrs>::new_in_frame(chain_pre_pos, chain_pre_vel);
     let mut current_epoch = chain_pre_epoch;
     for ((burn, (start, end, dv_kms)), _burn_idx) in burns.iter().zip(&burn_windows).zip(0..) {
         // Leg 1: coast to burn start.
@@ -2116,7 +2116,7 @@ impl<'a> ChainRecording<'a> {
     fn maybe_log(
         &mut self,
         local_t: f64,
-        state: &OrbitalState,
+        state: &OrbitalState<Gcrs>,
         leg_start_epoch: Epoch,
         moon_ephem: &dyn MoonEphemeris,
     ) {
@@ -2139,7 +2139,7 @@ impl<'a> ChainRecording<'a> {
     fn force_log(
         &mut self,
         local_t: f64,
-        state: &OrbitalState,
+        state: &OrbitalState<Gcrs>,
         leg_start_epoch: Epoch,
         moon_ephem: &dyn MoonEphemeris,
     ) {
@@ -2273,7 +2273,7 @@ fn record_chain_trajectory(
     let (chain_pre_pos, chain_pre_vel) =
         fetch_orion_sample(&chain_pre_epoch).expect("fetch Orion at chain pre");
 
-    let mut state = OrbitalState::new(chain_pre_pos, chain_pre_vel);
+    let mut state = OrbitalState::<Gcrs>::new_in_frame(chain_pre_pos, chain_pre_vel);
     let mut current_epoch = chain_pre_epoch;
 
     // Anchor the phase start with an unconditional log so the RRD's
@@ -2373,7 +2373,7 @@ fn record_coast_phase(
 
     let (start_pos, start_vel) =
         fetch_orion_sample(&start_epoch).expect("fetch Orion at coast phase start");
-    let state = OrbitalState::new(start_pos, start_vel);
+    let state = OrbitalState::<Gcrs>::new_in_frame(start_pos, start_vel);
 
     let system = build_artemis_system(start_epoch, moon_ephem, sun_table);
 
@@ -2723,7 +2723,7 @@ fn build_artemis_system(
     epoch: Epoch,
     moon_ephem: &Arc<dyn MoonEphemeris>,
     sun_table: &Arc<HorizonsTable>,
-) -> OrbitalSystem {
+) -> OrbitalSystem<Gcrs> {
     use arika::body::KnownBody;
     use arika::earth::{J2 as J2_EARTH, J3 as J3_EARTH, J4 as J4_EARTH, MU as MU_EARTH};
     use arika::sun::MU as MU_SUN;
@@ -2757,7 +2757,7 @@ fn build_artemis_system(
     });
 
     OrbitalSystem::new(MU_EARTH, Box::new(PointMass))
-        .with_model(ZonalGravity::new(
+        .with_model(ZonalGravity::<Gcrs>::new(
             MU_EARTH,
             props.radius,
             J2_EARTH,


### PR DESCRIPTION
artemis1 example は Horizons から `REF_SYSTEM=ICRF` で状態を取得し、それを `OrbitalSystem<SimpleEci>` で積分していた。取得したフレームと積分するフレームが違い、`ZonalGravity` がその差を読む。

- `SimpleEci::earth_pole()` は定義上 `+Z` 固定
- `Gcrs::earth_pole()` は IAU 2006 の CIP (歳差 + 章動)

状態は ICRF/GCRS の慣性軸で表されているのに、J2 はその軸から 484 秒角 (2024 epoch の歳差量) ずれた極まわりに加わっていた。

closes #371

## 変更

`build_artemis_system` の返り型を `OrbitalSystem<Gcrs>` にし、コンパイラが指した箇所を追った。

| 箇所 | 変更 |
|---|---|
| `build_artemis_system` | `OrbitalSystem` → `OrbitalSystem<Gcrs>` |
| `OrbitalState::new` 8 箇所 | `OrbitalState::<Gcrs>::new_in_frame` — Horizons の数値が型システムに入る境界 |
| `ChainRecording::{maybe_log, force_log}` | `&OrbitalState` → `&OrbitalState<Gcrs>` |
| `ZonalGravity::new` | `ZonalGravity::<Gcrs>::new` と明示。推論に任せず、どの極を使うかを呼び出し側で読めるようにした |

`ZonalGravity<Gcrs>` は EOP を要さない (`earth_pole` は観測 dX/dY なしの IAU 2006 model)。epoch は既に `.with_epoch(epoch)` で渡っている。

## 数値影響

同一マシン・同一 Horizons キャッシュで、変更前後の example を実行して比較した。

| フェーズ | `SimpleEci` | `Gcrs` |
|---|---|---|
| Outbound coast | 33.761 km | **33.762 km** |
| DRO | 125.629 km | 125.629 km |
| Return coast | 111.454 km | 111.454 km |
| DRI burn | 2.964 km | 2.964 km |
| DRDI burn | 15.182 km | 15.182 km |
| DRI → DRDI chain | 1192.790 km | 1192.790 km |

Outbound の 1 m のみ。このミッションは TLI 後から始まり地球近傍を通らないので J2 の寄与自体が小さく、その軸を動かしても効かない。パーキング軌道フェーズを含むプロファイルでは効く。

フレームの食い違いは数値の大小とは別に実在していた — `ZonalGravity` が state のフレームに属さない極を読んでいた。

## README の記録値について

example を実行したところ、README の記録値が出力とずれていた。この PR の変更とは独立に古くなっているもので、原因は未特定。

| README | 実測 |
|---|---|
| chain 1036.98 km | 1192.790 km |
| Return coast 105.89 km | 111.454 km |
| Outbound 33.76 km | 33.761 km (一致) |

committed PNG は chain 誤差が 1037 km だった時点で生成されているので、本文だけ直すと図と矛盾する。半端に更新せず現状のままにした。

## 検証

`ZonalGravity::<SimpleEci>::new` に戻すと `expected OrbitalSystem<Gcrs>` でコンパイルエラーになる。フレームの食い違いが型で塞がれている。

`cargo check -p orts --example artemis1` が `fetch-horizons` の有無どちらでも warning 0。`cargo fmt --all` clean。

codex (gpt-5.6-sol) レビューで指摘なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
