### PR TITLE
fix(viewer): derive the orbital values a .rrd does not carry

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -457,7 +457,9 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   高度 0 km として描かれていた。チャートの行はこれらを状態ベクトルから再計算せず
   point から直読するので、DuckDB の derived 列では埋まらなかった。2 つめの recording を
   開くときは導出の基準にする中心天体をリセットするので、decoder のメッセージがどの順で
-  届いても、効くのは新しい recording の定数になる。([#376](https://github.com/sksat/orts/pull/376))
+  届いても、効くのは新しい recording の定数になる。負の天体半径は、無い場合と同じく地球に fallback する。
+  高度は `r - bodyRadius` なので、地表からでなく軌道からの高さとして描かれてしまう。
+  ([#376](https://github.com/sksat/orts/pull/376))
 - multi-satellite チャートが schema 変更に追従するようになった。hook は起動時にしか
   chart Worker へ schema を伝えていなかったので、中心天体を変えた後は新しい schema で
   行を作る一方 Worker は古い schema で読み、derived SQL に前の天体半径と `mu` が

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -457,9 +457,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   高度 0 km として描かれていた。チャートの行はこれらを状態ベクトルから再計算せず
   point から直読するので、DuckDB の derived 列では埋まらなかった。2 つめの recording を
   開くときは導出の基準にする中心天体をリセットするので、decoder のメッセージがどの順で
-  届いても、効くのは新しい recording の定数になる。負の天体半径は、無い場合と同じく地球に fallback する。
-  高度は `r - bodyRadius` なので、地表からでなく軌道からの高さとして描かれてしまう。
-  ([#376](https://github.com/sksat/orts/pull/376))
+  届いても、効くのは新しい recording の定数になる。([#376](https://github.com/sksat/orts/pull/376))
 - multi-satellite チャートが schema 変更に追従するようになった。hook は起動時にしか
   chart Worker へ schema を伝えていなかったので、中心天体を変えた後は新しい schema で
   行を作る一方 Worker は古い schema で読み、derived SQL に前の天体半径と `mu` が

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -457,7 +457,9 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   高度 0 km として描かれていた。チャートの行はこれらを状態ベクトルから再計算せず
   point から直読するので、DuckDB の derived 列では埋まらなかった。2 つめの recording を
   開くときは導出の基準にする中心天体をリセットするので、どちらの定数が効くかが decoder の
-  メッセージ順に依存しなくなった。([#376](https://github.com/sksat/orts/pull/376))
+  メッセージ順に依存しなくなった。負の天体半径は、無い場合と同じく地球に fallback する。
+  高度は `r - bodyRadius` なので、地表からでなく軌道からの高さとして描かれてしまう。
+  ([#376](https://github.com/sksat/orts/pull/376))
 - multi-satellite チャートが schema 変更に追従するようになった。hook は起動時にしか
   chart Worker へ schema を伝えていなかったので、中心天体を変えた後は新しい schema で
   行を作る一方 Worker は古い schema で読み、derived SQL に前の天体半径と `mu` が

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -212,6 +212,12 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 ### `arika` (Rust, crates.io)
 
 #### Added
+- `arika_wasm::orbit_derived_batch` が、状態ベクトルの配列から Kepler 要素と
+  軌道のスカラー量を返すようになった。ブラウザが `.rrd` を読むときも、CLI が CSV に
+  書くのと同じ `KeplerianElements::from_state_vector` で計算される。軌道面を持たない
+  状態 (`r = 0` や `r × v = 0`、後者は `v = 0` を含む) は 0 ではなく `NaN` を返す。
+  0 は円赤道軌道の角度として実在する値なので、値なしの印には使えない。
+  ([#TBD](https://github.com/sksat/orts/pull/TBD))
 - 要素セットのパース ([#87](https://github.com/sksat/orts/pull/87))。共有の
   no-alloc な `elements::Sgp4Elements` (平均要素セット: カタログ番号、UTC epoch、
   6 個の SGP4 平均要素、B\* drag。角度は rad、平均運動は rad/s) を**検証付き型**に。
@@ -445,6 +451,12 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   wire 型を置き換え、`satellite_added` variant を追加。([#95](https://github.com/sksat/orts/pull/95))
 
 #### Fixed
+- `.rrd` ファイルを開いたとき、recording が持たない軌道量を導出するようになった。
+  decoder が復元するのは位置と速度で、Kepler 要素とチャートが描く高度・比エネルギー・
+  角運動量は 0 のハードコードで届いていた。400 km 軌道の recording が半長軸 0 km、
+  高度 0 km として描かれていた。チャートの行はこれらを状態ベクトルから再計算せず
+  point から直読するので、DuckDB の derived 列では埋まらなかった。
+  ([#TBD](https://github.com/sksat/orts/pull/TBD))
 - multi-satellite チャートが schema 変更に追従するようになった。hook は起動時にしか
   chart Worker へ schema を伝えていなかったので、中心天体を変えた後は新しい schema で
   行を作る一方 Worker は古い schema で読み、derived SQL に前の天体半径と `mu` が

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -455,8 +455,9 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   decoder が復元するのは位置と速度で、Kepler 要素とチャートが描く高度・比エネルギー・
   角運動量は 0 のハードコードで届いていた。400 km 軌道の recording が半長軸 0 km、
   高度 0 km として描かれていた。チャートの行はこれらを状態ベクトルから再計算せず
-  point から直読するので、DuckDB の derived 列では埋まらなかった。
-  ([#376](https://github.com/sksat/orts/pull/376))
+  point から直読するので、DuckDB の derived 列では埋まらなかった。2 つめの recording を
+  開くときは導出の基準にする中心天体をリセットするので、どちらの定数が効くかが decoder の
+  メッセージ順に依存しなくなった。([#376](https://github.com/sksat/orts/pull/376))
 - multi-satellite チャートが schema 変更に追従するようになった。hook は起動時にしか
   chart Worker へ schema を伝えていなかったので、中心天体を変えた後は新しい schema で
   行を作る一方 Worker は古い schema で読み、derived SQL に前の天体半径と `mu` が

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -456,8 +456,8 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   角運動量は 0 のハードコードで届いていた。400 km 軌道の recording が半長軸 0 km、
   高度 0 km として描かれていた。チャートの行はこれらを状態ベクトルから再計算せず
   point から直読するので、DuckDB の derived 列では埋まらなかった。2 つめの recording を
-  開くときは導出の基準にする中心天体をリセットするので、どちらの定数が効くかが decoder の
-  メッセージ順に依存しなくなった。負の天体半径は、無い場合と同じく地球に fallback する。
+  開くときは導出の基準にする中心天体をリセットするので、decoder のメッセージがどの順で
+  届いても、効くのは新しい recording の定数になる。負の天体半径は、無い場合と同じく地球に fallback する。
   高度は `r - bodyRadius` なので、地表からでなく軌道からの高さとして描かれてしまう。
   ([#376](https://github.com/sksat/orts/pull/376))
 - multi-satellite チャートが schema 変更に追従するようになった。hook は起動時にしか

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -217,7 +217,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   書くのと同じ `KeplerianElements::from_state_vector` で計算される。軌道面を持たない
   状態 (`r = 0` や `r × v = 0`、後者は `v = 0` を含む) は 0 ではなく `NaN` を返す。
   0 は円赤道軌道の角度として実在する値なので、値なしの印には使えない。
-  ([#TBD](https://github.com/sksat/orts/pull/TBD))
+  ([#376](https://github.com/sksat/orts/pull/376))
 - 要素セットのパース ([#87](https://github.com/sksat/orts/pull/87))。共有の
   no-alloc な `elements::Sgp4Elements` (平均要素セット: カタログ番号、UTC epoch、
   6 個の SGP4 平均要素、B\* drag。角度は rad、平均運動は rad/s) を**検証付き型**に。
@@ -456,7 +456,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   角運動量は 0 のハードコードで届いていた。400 km 軌道の recording が半長軸 0 km、
   高度 0 km として描かれていた。チャートの行はこれらを状態ベクトルから再計算せず
   point から直読するので、DuckDB の derived 列では埋まらなかった。
-  ([#TBD](https://github.com/sksat/orts/pull/TBD))
+  ([#376](https://github.com/sksat/orts/pull/376))
 - multi-satellite チャートが schema 変更に追従するようになった。hook は起動時にしか
   chart Worker へ schema を伝えていなかったので、中心天体を変えた後は新しい schema で
   行を作る一方 Worker は古い schema で読み、derived SQL に前の天体半径と `mu` が

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -511,8 +511,8 @@ section is subdivided by package.
   of 0 km and an altitude of 0 km. The chart row reads those fields straight off
   the point rather than recomputing from the state vector, so the DuckDB derived
   columns did not cover for them. Opening a second recording resets the central
-  body the values are derived against, so that whose constants apply never
-  depends on the order the decoder's messages arrive in. A negative body radius
+  body the values are derived against, so the constants that apply are the new
+  recording's whatever order the decoder's messages arrive in. A negative body radius
   falls back to Earth as an absent one does: altitude is `r - bodyRadius`, so it
   would chart as a height above the orbit rather than above the surface.
   ([#376](https://github.com/sksat/orts/pull/376))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,7 +238,7 @@ section is subdivided by package.
   writes into CSV. A state with no orbital plane (`r = 0`, or `r × v = 0`, which
   includes `v = 0`) comes back as `NaN`s rather than zeros, since zero is a real
   reading for a circular equatorial orbit's angles.
-  ([#TBD](https://github.com/sksat/orts/pull/TBD))
+  ([#376](https://github.com/sksat/orts/pull/376))
 - Element-set parsing ([#87](https://github.com/sksat/orts/pull/87)). A shared
   no-alloc `elements::Sgp4Elements` — a *validated* mean-element set (catalog
   number, UTC epoch, six SGP4 mean elements, B\* drag; angles in radians, mean
@@ -510,7 +510,7 @@ section is subdivided by package.
   hardcoded zeros — so a recording of a 400 km orbit charted a semi-major axis
   of 0 km and an altitude of 0 km. The chart row reads those fields straight off
   the point rather than recomputing from the state vector, so the DuckDB derived
-  columns did not cover for them. ([#TBD](https://github.com/sksat/orts/pull/TBD))
+  columns did not cover for them. ([#376](https://github.com/sksat/orts/pull/376))
 - Multi-satellite charts follow a changed schema: the hook told the chart Worker
   its schema only at startup, so after a central-body change the rows were built
   under the new schema while the Worker read them under the old one, leaving the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -512,9 +512,7 @@ section is subdivided by package.
   the point rather than recomputing from the state vector, so the DuckDB derived
   columns did not cover for them. Opening a second recording resets the central
   body the values are derived against, so the new recording's constants apply
-  however the decoder's messages happen to be ordered. A negative body radius
-  falls back to Earth as an absent one does: altitude is `r - bodyRadius`, so it
-  would chart as a height above the orbit rather than above the surface.
+  however the decoder's messages happen to be ordered.
   ([#376](https://github.com/sksat/orts/pull/376))
 - Multi-satellite charts follow a changed schema: the hook told the chart Worker
   its schema only at startup, so after a central-body change the rows were built

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -512,7 +512,9 @@ section is subdivided by package.
   the point rather than recomputing from the state vector, so the DuckDB derived
   columns did not cover for them. Opening a second recording resets the central
   body the values are derived against, so that whose constants apply never
-  depends on the order the decoder's messages arrive in.
+  depends on the order the decoder's messages arrive in. A negative body radius
+  falls back to Earth as an absent one does: altitude is `r - bodyRadius`, so it
+  would chart as a height above the orbit rather than above the surface.
   ([#376](https://github.com/sksat/orts/pull/376))
 - Multi-satellite charts follow a changed schema: the hook told the chart Worker
   its schema only at startup, so after a central-body change the rows were built

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -512,7 +512,9 @@ section is subdivided by package.
   the point rather than recomputing from the state vector, so the DuckDB derived
   columns did not cover for them. Opening a second recording resets the central
   body the values are derived against, so the new recording's constants apply
-  however the decoder's messages happen to be ordered.
+  however the decoder's messages happen to be ordered. A negative body radius
+  falls back to Earth as an absent one does: altitude is `r - bodyRadius`, so it
+  would chart as a height above the orbit rather than above the surface.
   ([#376](https://github.com/sksat/orts/pull/376))
 - Multi-satellite charts follow a changed schema: the hook told the chart Worker
   its schema only at startup, so after a central-body change the rows were built

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -510,7 +510,10 @@ section is subdivided by package.
   hardcoded zeros — so a recording of a 400 km orbit charted a semi-major axis
   of 0 km and an altitude of 0 km. The chart row reads those fields straight off
   the point rather than recomputing from the state vector, so the DuckDB derived
-  columns did not cover for them. ([#376](https://github.com/sksat/orts/pull/376))
+  columns did not cover for them. Opening a second recording resets the central
+  body the values are derived against, so that whose constants apply never
+  depends on the order the decoder's messages arrive in.
+  ([#376](https://github.com/sksat/orts/pull/376))
 - Multi-satellite charts follow a changed schema: the hook told the chart Worker
   its schema only at startup, so after a central-body change the rows were built
   under the new schema while the Worker read them under the old one, leaving the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,13 @@ section is subdivided by package.
 ### `arika` (Rust, crates.io)
 
 #### Added
+- `arika_wasm::orbit_derived_batch` returns Keplerian elements and the scalar
+  orbit quantities for a batch of state vectors, so a browser reading a `.rrd`
+  computes them with the same `KeplerianElements::from_state_vector` the CLI
+  writes into CSV. A state with no orbital plane (`r = 0`, or `r × v = 0`, which
+  includes `v = 0`) comes back as `NaN`s rather than zeros, since zero is a real
+  reading for a circular equatorial orbit's angles.
+  ([#TBD](https://github.com/sksat/orts/pull/TBD))
 - Element-set parsing ([#87](https://github.com/sksat/orts/pull/87)). A shared
   no-alloc `elements::Sgp4Elements` — a *validated* mean-element set (catalog
   number, UTC epoch, six SGP4 mean elements, B\* drag; angles in radians, mean
@@ -497,6 +504,13 @@ section is subdivided by package.
   replacing the hand-written wire types and adding the `satellite_added` variant. ([#95](https://github.com/sksat/orts/pull/95))
 
 #### Fixed
+- Opening a `.rrd` file derives the orbital values the recording does not carry.
+  The decoder recovers position and velocity, and the Keplerian elements plus
+  the altitude, specific energy and angular momentum the charts plot arrived as
+  hardcoded zeros — so a recording of a 400 km orbit charted a semi-major axis
+  of 0 km and an altitude of 0 km. The chart row reads those fields straight off
+  the point rather than recomputing from the state vector, so the DuckDB derived
+  columns did not cover for them. ([#TBD](https://github.com/sksat/orts/pull/TBD))
 - Multi-satellite charts follow a changed schema: the hook told the chart Worker
   its schema only at startup, so after a central-body change the rows were built
   under the new schema while the Worker read them under the old one, leaving the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -511,8 +511,8 @@ section is subdivided by package.
   of 0 km and an altitude of 0 km. The chart row reads those fields straight off
   the point rather than recomputing from the state vector, so the DuckDB derived
   columns did not cover for them. Opening a second recording resets the central
-  body the values are derived against, so the constants that apply are the new
-  recording's whatever order the decoder's messages arrive in. A negative body radius
+  body the values are derived against, so the new recording's constants apply
+  however the decoder's messages happen to be ordered. A negative body radius
   falls back to Earth as an absent one does: altitude is `r - bodyRadius`, so it
   would chart as a height above the orbit rather than above the surface.
   ([#376](https://github.com/sksat/orts/pull/376))

--- a/arika/wasm/pkg/arika.d.ts
+++ b/arika/wasm/pkg/arika.d.ts
@@ -84,6 +84,39 @@ export function geodetic_to_eci(lat_deg: number, lon_deg: number, altitude_km: n
 export function jd_to_utc_string(epoch_jd: number, t: number): string;
 
 /**
+ * Batch Keplerian elements plus the scalar orbit quantities charts plot.
+ *
+ * `states`: flat `[x,y,z,vx,vy,vz, ...]` (length = N×6; km and km/s)
+ * `mu`: gravitational parameter of the central body [km³/s²]
+ * `body_radius`: central body radius [km], for the altitude term
+ *
+ * Returns, per state, `[a, e, inc, raan, omega, nu, altitude,
+ * specific_energy, angular_momentum, velocity]` — 10 values, angles in
+ * radians. A state whose elements are undefined yields ten `NaN`s; see below.
+ *
+ * The decoder that reads a `.rrd` recovers position and velocity only, so the
+ * browser has to derive the rest. Doing it here keeps one implementation:
+ * `arika::kepler::KeplerianElements::from_state_vector` is what the CLI writes into
+ * CSV and sends over the WebSocket.
+ *
+ * # Errors
+ *
+ * Returns an error (a JS exception) unless `states.len()` is a multiple of 6,
+ * and unless `mu` and `body_radius` are finite with `mu > 0`. A ragged
+ * `states` would otherwise drop a partial state in silence.
+ *
+ * # Undefined elements
+ *
+ * Classical elements need an orbital plane, so a state with `r = 0` or
+ * `r × v = 0` (which includes `v = 0`) has none — `from_state_vector` divides
+ * by those magnitudes. Such a state, and any state with a non-finite
+ * component, yields `NaN` for all ten values rather than zeros: zero is a
+ * legitimate reading for a circular equatorial orbit's angles, so it cannot
+ * double as "no value".
+ */
+export function orbit_derived_batch(states: Float64Array, mu: number, body_radius: number): Float64Array;
+
+/**
  * Approximate sun direction (unit vector) in Gcrs frame.
  *
  * Returns `[x, y, z]` (3 floats).
@@ -115,19 +148,21 @@ export interface InitOutput {
     readonly memory: WebAssembly.Memory;
     readonly body_orientation: (a: number, b: number, c: number, d: number) => [number, number];
     readonly body_quat_to_rsw: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number) => [number, number];
-    readonly earth_rotation_angle: (a: number, b: number) => number;
     readonly eci_to_ecef: (a: number, b: number, c: number, d: number, e: number) => [number, number];
     readonly eci_to_ecef_batch: (a: number, b: number, c: number, d: number, e: number) => [number, number, number, number];
     readonly geodetic_to_ecef: (a: number, b: number, c: number) => [number, number];
     readonly geodetic_to_eci: (a: number, b: number, c: number, d: number) => [number, number];
     readonly jd_to_utc_string: (a: number, b: number) => [number, number];
+    readonly orbit_derived_batch: (a: number, b: number, c: number, d: number) => [number, number, number, number];
     readonly sun_direction_eci: (a: number, b: number) => [number, number];
     readonly sun_direction_from_body: (a: number, b: number, c: number, d: number) => [number, number];
     readonly sun_distance_from_body: (a: number, b: number, c: number, d: number) => number;
+    readonly earth_rotation_angle: (a: number, b: number) => number;
     readonly __wbindgen_externrefs: WebAssembly.Table;
     readonly __wbindgen_malloc: (a: number, b: number) => number;
     readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
     readonly __wbindgen_free: (a: number, b: number, c: number) => void;
+    readonly __externref_table_dealloc: (a: number) => void;
     readonly __wbindgen_start: () => void;
 }
 

--- a/arika/wasm/src/lib.rs
+++ b/arika/wasm/src/lib.rs
@@ -91,6 +91,111 @@ pub fn earth_rotation_angle(epoch_jd: f64, t: f64) -> f64 {
     epoch.gmst()
 }
 
+/// How many values [`orbit_derived_batch`] emits per state.
+pub const ORBIT_DERIVED_STRIDE: usize = 10;
+
+/// Batch Keplerian elements plus the scalar orbit quantities charts plot.
+///
+/// `states`: flat `[x,y,z,vx,vy,vz, ...]` (length = N×6; km and km/s)
+/// `mu`: gravitational parameter of the central body [km³/s²]
+/// `body_radius`: central body radius [km], for the altitude term
+///
+/// Returns, per state, `[a, e, inc, raan, omega, nu, altitude,
+/// specific_energy, angular_momentum, velocity]` — 10 values, angles in
+/// radians. A state whose elements are undefined yields ten `NaN`s; see below.
+///
+/// The decoder that reads a `.rrd` recovers position and velocity only, so the
+/// browser has to derive the rest. Doing it here keeps one implementation:
+/// `arika::kepler::KeplerianElements::from_state_vector` is what the CLI writes into
+/// CSV and sends over the WebSocket.
+///
+/// # Errors
+///
+/// Returns an error (a JS exception) unless `states.len()` is a multiple of 6,
+/// and unless `mu` and `body_radius` are finite with `mu > 0`. A ragged
+/// `states` would otherwise drop a partial state in silence.
+///
+/// # Undefined elements
+///
+/// Classical elements need an orbital plane, so a state with `r = 0` or
+/// `r × v = 0` (which includes `v = 0`) has none — `from_state_vector` divides
+/// by those magnitudes. Such a state, and any state with a non-finite
+/// component, yields `NaN` for all ten values rather than zeros: zero is a
+/// legitimate reading for a circular equatorial orbit's angles, so it cannot
+/// double as "no value".
+#[wasm_bindgen]
+pub fn orbit_derived_batch(states: &[f64], mu: f64, body_radius: f64) -> Result<Vec<f64>, JsValue> {
+    batch_orbit_derived(states, mu, body_radius).map_err(|e| JsValue::from_str(&e))
+}
+
+/// Length-checked core of [`orbit_derived_batch`], split out because `JsValue`
+/// exists only on `wasm32` — this half is unit-testable on the host target.
+fn batch_orbit_derived(states: &[f64], mu: f64, body_radius: f64) -> Result<Vec<f64>, String> {
+    if !mu.is_finite() || mu <= 0.0 {
+        return Err(format!(
+            "orbit_derived_batch: mu must be positive and finite (got {mu})"
+        ));
+    }
+    if !body_radius.is_finite() {
+        return Err(format!(
+            "orbit_derived_batch: body_radius must be finite (got {body_radius})"
+        ));
+    }
+    if !states.len().is_multiple_of(6) {
+        return Err(format!(
+            "orbit_derived_batch: states has {} elements, expected a multiple of 6 \
+             (x, y, z, vx, vy, vz per state)",
+            states.len()
+        ));
+    }
+
+    let mut out = Vec::with_capacity(states.len() / 6 * ORBIT_DERIVED_STRIDE);
+    for s in states.chunks_exact(6) {
+        let pos = Vector3::new(s[0], s[1], s[2]);
+        let vel = Vector3::new(s[3], s[4], s[5]);
+        out.extend_from_slice(&orbit_derived_one(&pos, &vel, mu, body_radius));
+    }
+    Ok(out)
+}
+
+/// One state's ten derived values, or ten `NaN`s where the elements have no
+/// definition.
+fn orbit_derived_one(
+    pos: &Vector3<f64>,
+    vel: &Vector3<f64>,
+    mu: f64,
+    body_radius: f64,
+) -> [f64; ORBIT_DERIVED_STRIDE] {
+    const UNDEFINED: [f64; ORBIT_DERIVED_STRIDE] = [f64::NAN; ORBIT_DERIVED_STRIDE];
+
+    if !pos.iter().chain(vel.iter()).all(|v| v.is_finite()) {
+        return UNDEFINED;
+    }
+    let r = pos.magnitude();
+    let h = pos.cross(vel);
+    // The plane and the radial direction are what every angle is measured
+    // from. A `.rrd` with no velocity columns decodes as `v = 0`, so `h = 0` is
+    // reachable from a real recording rather than only in theory.
+    if r == 0.0 || h.magnitude() == 0.0 {
+        return UNDEFINED;
+    }
+
+    let el = arika::kepler::KeplerianElements::from_state_vector(pos, vel, mu);
+    let v = vel.magnitude();
+    [
+        el.semi_major_axis,
+        el.eccentricity,
+        el.inclination,
+        el.raan,
+        el.argument_of_periapsis,
+        el.true_anomaly,
+        r - body_radius,
+        v * v / 2.0 - mu / r,
+        h.magnitude(),
+        v,
+    ]
+}
+
 /// Approximate sun direction (unit vector) in Gcrs frame.
 ///
 /// Returns `[x, y, z]` (3 floats).
@@ -257,5 +362,132 @@ mod tests {
             );
             assert_eq!(&batch[i * 3..i * 3 + 3], &single[..]);
         }
+    }
+
+    // orbit_derived_batch
+
+    /// The gravitational parameter and radius of the Earth, as the CLI uses them.
+    const MU_EARTH: f64 = 398600.4418;
+    const R_EARTH: f64 = 6378.137;
+
+    /// A circular orbit 400 km up comes back with the radius as its semi-major
+    /// axis and no eccentricity.
+    #[test]
+    fn derived_values_of_a_circular_orbit() {
+        let r = R_EARTH + 400.0;
+        let v = (MU_EARTH / r).sqrt();
+        let out = batch_orbit_derived(&[r, 0.0, 0.0, 0.0, v, 0.0], MU_EARTH, R_EARTH)
+            .expect("a well-formed state");
+
+        assert_eq!(out.len(), ORBIT_DERIVED_STRIDE);
+        assert!((out[0] - r).abs() < 1e-6, "a = {}", out[0]);
+        assert!(out[1] < 1e-12, "e = {}", out[1]);
+        assert!((out[6] - 400.0).abs() < 1e-6, "altitude = {}", out[6]);
+        assert!((out[9] - v).abs() < 1e-12, "velocity = {}", out[9]);
+        // Specific energy of a circular orbit is -mu/(2a).
+        assert!(
+            (out[7] + MU_EARTH / (2.0 * r)).abs() < 1e-9,
+            "energy = {}",
+            out[7]
+        );
+        // |h| = r·v for a circular orbit.
+        assert!((out[8] - r * v).abs() < 1e-6, "|h| = {}", out[8]);
+    }
+
+    /// Each state in a batch is converted on its own, in order.
+    #[test]
+    fn batch_converts_each_state_independently() {
+        let r1 = R_EARTH + 400.0;
+        let v1 = (MU_EARTH / r1).sqrt();
+        let r2 = R_EARTH + 800.0;
+        let v2 = (MU_EARTH / r2).sqrt();
+        let out = batch_orbit_derived(
+            &[r1, 0.0, 0.0, 0.0, v1, 0.0, r2, 0.0, 0.0, 0.0, v2, 0.0],
+            MU_EARTH,
+            R_EARTH,
+        )
+        .expect("two well-formed states");
+
+        assert_eq!(out.len(), 2 * ORBIT_DERIVED_STRIDE);
+        assert!((out[0] - r1).abs() < 1e-6);
+        assert!((out[ORBIT_DERIVED_STRIDE] - r2).abs() < 1e-6);
+    }
+
+    /// The angles match the same call through arika's own API, so the WASM
+    /// facade cannot drift from what the CLI writes.
+    #[test]
+    fn derived_angles_match_the_arika_api() {
+        // A 51.6-degree inclined, slightly eccentric orbit.
+        let pos = Vector3::new(5000.0, 3000.0, 4000.0);
+        let vel = Vector3::new(-3.0, 5.5, 2.0);
+        let out = batch_orbit_derived(
+            &[pos.x, pos.y, pos.z, vel.x, vel.y, vel.z],
+            MU_EARTH,
+            R_EARTH,
+        )
+        .expect("a well-formed state");
+
+        let el = arika::kepler::KeplerianElements::from_state_vector(&pos, &vel, MU_EARTH);
+        assert_eq!(out[0], el.semi_major_axis);
+        assert_eq!(out[1], el.eccentricity);
+        assert_eq!(out[2], el.inclination);
+        assert_eq!(out[3], el.raan);
+        assert_eq!(out[4], el.argument_of_periapsis);
+        assert_eq!(out[5], el.true_anomaly);
+    }
+
+    /// A state with no orbital plane yields `NaN`, not zeros.
+    ///
+    /// Zero is a real reading for a circular equatorial orbit's angles, so it
+    /// cannot also mean "no value". A `.rrd` without velocity columns decodes
+    /// as `v = 0`, which is this case.
+    #[test]
+    fn states_without_an_orbital_plane_are_nan() {
+        let r = R_EARTH + 400.0;
+        for (label, state) in [
+            ("v = 0", [r, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            ("r = 0", [0.0, 0.0, 0.0, 0.0, 7.6, 0.0]),
+            ("r parallel to v", [r, 0.0, 0.0, 7.6, 0.0, 0.0]),
+            ("NaN component", [r, f64::NAN, 0.0, 0.0, 7.6, 0.0]),
+            ("infinite component", [r, f64::INFINITY, 0.0, 0.0, 7.6, 0.0]),
+        ] {
+            let out = batch_orbit_derived(&state, MU_EARTH, R_EARTH).expect("length is fine");
+            assert!(
+                out.iter().all(|v| v.is_nan()),
+                "{label} should be all NaN, got {out:?}"
+            );
+        }
+    }
+
+    /// A ragged `states` is refused rather than silently dropping the tail.
+    #[test]
+    fn batch_requires_six_values_per_state() {
+        let err = batch_orbit_derived(&[1.0, 2.0, 3.0, 4.0, 5.0], MU_EARTH, R_EARTH)
+            .expect_err("5 values is not a whole state");
+        assert!(err.contains("multiple of 6"), "{err}");
+    }
+
+    /// A `mu` that cannot scale an orbit is refused at the boundary.
+    #[test]
+    fn batch_requires_a_usable_mu_and_radius() {
+        let state = [7000.0, 0.0, 0.0, 0.0, 7.5, 0.0];
+        for mu in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            assert!(
+                batch_orbit_derived(&state, mu, R_EARTH).is_err(),
+                "mu = {mu} should be refused"
+            );
+        }
+        assert!(batch_orbit_derived(&state, MU_EARTH, f64::NAN).is_err());
+        // Zero radius is a legitimate request for the radial distance itself.
+        assert!(batch_orbit_derived(&state, MU_EARTH, 0.0).is_ok());
+    }
+
+    /// An empty batch is an empty result.
+    #[test]
+    fn an_empty_batch_returns_nothing() {
+        assert_eq!(
+            batch_orbit_derived(&[], MU_EARTH, R_EARTH).expect("empty is fine"),
+            Vec::<f64>::new()
+        );
     }
 }

--- a/viewer/src/sources/RrdFileAdapter.test.ts
+++ b/viewer/src/sources/RrdFileAdapter.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ORBIT_DERIVED_STRIDE } from "./rrdOrbitDerived.js";
+import type { RrdWorkerMessage } from "./rrdParseLogic.js";
+import type { SourceEvent, SourceId } from "./types.js";
+
+/// Records what the derived batch was asked to compute against.
+const derivedCalls: { mu: number; bodyRadius: number; states: number }[] = [];
+
+vi.mock("../wasm/arikaInit.js", () => ({
+  initArika: () => Promise.resolve(),
+  orbit_derived_batch: (states: Float64Array, mu: number, bodyRadius: number) => {
+    derivedCalls.push({ mu, bodyRadius, states: states.length / 6 });
+    return new Float64Array((states.length / 6) * ORBIT_DERIVED_STRIDE).fill(0);
+  },
+}));
+
+const { RrdFileAdapter } = await import("./RrdFileAdapter.js");
+
+class MockWorker {
+  static instances: MockWorker[] = [];
+  onmessage: ((e: { data: RrdWorkerMessage }) => void) | null = null;
+  onerror: ((e: ErrorEvent) => void) | null = null;
+  terminated = false;
+
+  constructor() {
+    MockWorker.instances.push(this);
+  }
+
+  postMessage(_data: unknown, _transfer?: unknown[]) {}
+
+  terminate() {
+    this.terminated = true;
+  }
+
+  simulateMessage(msg: RrdWorkerMessage) {
+    this.onmessage?.({ data: msg });
+  }
+}
+
+class MockFileReader {
+  static instances: MockFileReader[] = [];
+  result: ArrayBuffer | null = null;
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor() {
+    MockFileReader.instances.push(this);
+  }
+
+  readAsArrayBuffer(_file: File) {
+    this.result = new ArrayBuffer(8);
+    this.onload?.();
+  }
+
+  abort() {}
+}
+
+beforeEach(() => {
+  derivedCalls.length = 0;
+  MockWorker.instances = [];
+  MockFileReader.instances = [];
+  vi.stubGlobal("Worker", function MockWorkerConstructor() {
+    return new MockWorker();
+  });
+  vi.stubGlobal("FileReader", MockFileReader);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/// The worker is started from a promise chain, so it exists a microtask later.
+async function latestWorker(): Promise<MockWorker> {
+  await Promise.resolve();
+  await Promise.resolve();
+  const worker = MockWorker.instances.at(-1);
+  expect(worker).toBeDefined();
+  return worker as MockWorker;
+}
+
+function metadata(mu: number | null, bodyRadius: number | null) {
+  return {
+    type: "metadata" as const,
+    metadata: {
+      epoch_jd: null,
+      epoch_iso: null,
+      mu,
+      body_radius: bodyRadius,
+      altitude: null,
+      period: null,
+      body_name: null,
+      orbit_description: null,
+    },
+  };
+}
+
+function chunk(): RrdWorkerMessage {
+  return {
+    type: "chunk",
+    points: [
+      {
+        t: 0,
+        x: 7000,
+        y: 0,
+        z: 0,
+        vx: 0,
+        vy: 7.5,
+        vz: 0,
+        entityPath: "world/sat/default",
+      },
+    ],
+  } as RrdWorkerMessage;
+}
+
+describe("RrdFileAdapter", () => {
+  it("derives against the central body its own metadata names", async () => {
+    const events: SourceEvent[] = [];
+    const handler = (_id: SourceId, e: SourceEvent) => events.push(e);
+    const adapter = new RrdFileAdapter("rrd-0", new File([new Uint8Array(8)], "a.rrd"), handler);
+
+    adapter.start();
+    const worker = await latestWorker();
+    worker.simulateMessage(metadata(42_000, 1234) as unknown as RrdWorkerMessage);
+    worker.simulateMessage(chunk());
+
+    expect(derivedCalls).toHaveLength(1);
+    expect(derivedCalls[0].mu).toBe(42_000);
+    expect(derivedCalls[0].bodyRadius).toBe(1234);
+  });
+
+  it("does not carry the previous load's central body into the next one", async () => {
+    const events: SourceEvent[] = [];
+    const handler = (_id: SourceId, e: SourceEvent) => events.push(e);
+    const adapter = new RrdFileAdapter("rrd-0", new File([new Uint8Array(8)], "a.rrd"), handler);
+
+    // A first recording that names its own central body.
+    adapter.start();
+    const first = await latestWorker();
+    first.simulateMessage(metadata(42_000, 1234) as unknown as RrdWorkerMessage);
+    first.simulateMessage(chunk());
+    expect(derivedCalls[0].mu).toBe(42_000);
+
+    // A second load whose first chunk arrives before any metadata. The worker
+    // posts metadata first, so this is the ordering `start()` must not depend
+    // on: `start()` resets every other per-load field, and leaving the central
+    // body behind derived the new recording against the old one's.
+    adapter.start();
+    const second = await latestWorker();
+    expect(second).not.toBe(first);
+    second.simulateMessage(chunk());
+
+    expect(derivedCalls).toHaveLength(2);
+    expect(derivedCalls[1].mu).not.toBe(42_000);
+    expect(derivedCalls[1].bodyRadius).not.toBe(1234);
+  });
+});

--- a/viewer/src/sources/RrdFileAdapter.test.ts
+++ b/viewer/src/sources/RrdFileAdapter.test.ts
@@ -6,8 +6,17 @@ import type { SourceEvent, SourceId } from "./types.js";
 /// Records what the derived batch was asked to compute against.
 const derivedCalls: { mu: number; bodyRadius: number; states: number }[] = [];
 
+/// Lets a test hold `initArika()` pending across a restart.
+const pendingInits: (() => void)[] = [];
+let holdInit = false;
+
 vi.mock("../wasm/arikaInit.js", () => ({
-  initArika: () => Promise.resolve(),
+  initArika: () =>
+    holdInit
+      ? new Promise<void>((resolve) => {
+          pendingInits.push(resolve);
+        })
+      : Promise.resolve(),
   orbit_derived_batch: (states: Float64Array, mu: number, bodyRadius: number) => {
     derivedCalls.push({ mu, bodyRadius, states: states.length / 6 });
     return new Float64Array((states.length / 6) * ORBIT_DERIVED_STRIDE).fill(0);
@@ -57,6 +66,8 @@ class MockFileReader {
 
 beforeEach(() => {
   derivedCalls.length = 0;
+  pendingInits.length = 0;
+  holdInit = false;
   MockWorker.instances = [];
   MockFileReader.instances = [];
   vi.stubGlobal("Worker", function MockWorkerConstructor() {
@@ -152,5 +163,34 @@ describe("RrdFileAdapter", () => {
     expect(derivedCalls).toHaveLength(2);
     expect(derivedCalls[1].mu).not.toBe(42_000);
     expect(derivedCalls[1].bodyRadius).not.toBe(1234);
+  });
+
+  it("a load restarted while the WASM was loading does not start a second worker", async () => {
+    holdInit = true;
+    const events: SourceEvent[] = [];
+    const handler = (_id: SourceId, e: SourceEvent) => events.push(e);
+    const adapter = new RrdFileAdapter("rrd-0", new File([new Uint8Array(8)], "a.rrd"), handler);
+
+    // Both loads read the file and then wait on the WASM.
+    adapter.start();
+    adapter.start();
+    expect(pendingInits).toHaveLength(2);
+    expect(MockWorker.instances).toHaveLength(0);
+
+    // The first load's wait finishes after the restart owns the adapter. It
+    // must not put its own buffer behind the current load's worker reference:
+    // `stopped` is false again by then, so it alone let the stale load through.
+    pendingInits[0]();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(MockWorker.instances).toHaveLength(0);
+
+    // The current load still starts, and it is the only worker.
+    pendingInits[1]();
+    const worker = await latestWorker();
+    expect(MockWorker.instances).toHaveLength(1);
+    worker.simulateMessage(metadata(42_000, 1234) as unknown as RrdWorkerMessage);
+    worker.simulateMessage(chunk());
+    expect(derivedCalls).toHaveLength(1);
   });
 });

--- a/viewer/src/sources/RrdFileAdapter.ts
+++ b/viewer/src/sources/RrdFileAdapter.ts
@@ -7,41 +7,17 @@
  */
 
 import type { OrbitPoint } from "../orbit.js";
+import { initArika, orbit_derived_batch } from "../wasm/arikaInit.js";
 import { rrdMetadataToSimInfo } from "./normalizeMetadata.js";
+import {
+  ORBIT_DERIVED_STRIDE,
+  type OrbitDerivedContext,
+  orbitDerivedContext,
+  packStates,
+  toOrbitPoints,
+} from "./rrdOrbitDerived.js";
 import type { RrdPointOut, RrdWorkerMessage } from "./rrdParseLogic.js";
 import type { SourceAdapter, SourceEventHandler, SourceId } from "./types.js";
-
-function rrdPointToOrbitPoint(p: RrdPointOut): OrbitPoint {
-  return {
-    t: p.t,
-    x: p.x,
-    y: p.y,
-    z: p.z,
-    vx: p.vx,
-    vy: p.vy,
-    vz: p.vz,
-    entityPath: p.entityPath ?? undefined,
-    // Keplerian elements — not available from RRD decode (raw state vectors only)
-    a: 0,
-    e: 0,
-    inc: 0,
-    raan: 0,
-    omega: 0,
-    nu: 0,
-    altitude: 0,
-    specific_energy: 0,
-    angular_momentum: 0,
-    velocity_mag: Math.sqrt(p.vx * p.vx + p.vy * p.vy + p.vz * p.vz),
-    // Attitude (optional)
-    qw: p.qw,
-    qx: p.qx,
-    qy: p.qy,
-    qz: p.qz,
-    wx: p.wx,
-    wy: p.wy,
-    wz: p.wz,
-  };
-}
 
 export class RrdFileAdapter implements SourceAdapter {
   readonly sourceId: SourceId;
@@ -52,6 +28,11 @@ export class RrdFileAdapter implements SourceAdapter {
   private file: File;
   private estimatedDt = 10;
   private stopped = false;
+  /// The central body constants the derived values are computed against. The
+  /// Worker sends metadata before the first chunk, so this is set by then.
+  private derivedContext: OrbitDerivedContext | null = null;
+  /// Whether this load has already published its first point for the E2E.
+  private debugPointExposed = false;
 
   constructor(sourceId: SourceId, file: File, onEvent: SourceEventHandler) {
     this.sourceId = sourceId;
@@ -69,13 +50,25 @@ export class RrdFileAdapter implements SourceAdapter {
     this.lastTByEntity.clear();
     this.infoEmitted = false;
     this.stopped = false;
+    this.debugPointExposed = false;
 
     const reader = new FileReader();
     this.reader = reader;
     reader.onload = () => {
       if (this.stopped) return;
       const buffer = reader.result as ArrayBuffer;
-      this.startWorker(buffer);
+      // The derived values need `arika-wasm`. The app starts loading it at
+      // mount, but the file input is usable before that finishes, so wait
+      // here rather than letting the first chunks come out non-finite with no
+      // second chance at them.
+      initArika()
+        .catch((e) => {
+          console.warn("RrdFileAdapter: arika WASM failed to load:", e);
+        })
+        .then(() => {
+          if (this.stopped) return;
+          this.startWorker(buffer);
+        });
     };
     reader.onerror = () => {
       if (this.stopped) return;
@@ -123,12 +116,43 @@ export class RrdFileAdapter implements SourceAdapter {
   /** Last seen timestamp per entity, persisted across chunks for dt estimation. */
   private lastTByEntity = new Map<string, number>();
 
+  /**
+   * Fill in the Keplerian elements and the chart scalars for one chunk.
+   *
+   * The `arika-wasm` instance is awaited before the file is read, so this is a
+   * synchronous call by the time chunks arrive. If initialisation itself failed,
+   * the points still reach the store with the state vectors intact and the
+   * derived fields left non-finite — dropping the chunk would lose the
+   * trajectory as well.
+   */
+  private deriveChunk(points: readonly RrdPointOut[]): OrbitPoint[] {
+    const ctx = this.derivedContext ?? orbitDerivedContext({ mu: null, body_radius: null });
+    let derived: Float64Array;
+    try {
+      derived = orbit_derived_batch(packStates(points), ctx.mu, ctx.bodyRadius);
+    } catch (e) {
+      console.warn("RrdFileAdapter: could not derive orbital values:", e);
+      derived = new Float64Array(points.length * ORBIT_DERIVED_STRIDE).fill(Number.NaN);
+    }
+    const orbitPoints = toOrbitPoints(points, derived);
+    // `IngestBuffer` only drains, so an E2E cannot read a point back out of it.
+    // Expose this load's first one instead: what the derived fields hold there
+    // is what this whole path exists to produce. Per adapter, so opening a
+    // second recording replaces it rather than keeping the first file's point.
+    if (import.meta.env.DEV && orbitPoints.length > 0 && !this.debugPointExposed) {
+      (window as unknown as Record<string, unknown>).__debug_rrd_first_point = orbitPoints[0];
+      this.debugPointExposed = true;
+    }
+    return orbitPoints;
+  }
+
   private handleWorkerMessage(msg: RrdWorkerMessage): void {
     const id = this.sourceId;
 
     switch (msg.type) {
       case "metadata": {
         this.pendingMetadata = msg.metadata;
+        this.derivedContext = orbitDerivedContext(msg.metadata);
         break;
       }
 
@@ -154,7 +178,7 @@ export class RrdFileAdapter implements SourceAdapter {
         }
 
         // Convert and emit points as history-chunk (info emitted later on done)
-        const orbitPoints: OrbitPoint[] = msg.points.map(rrdPointToOrbitPoint);
+        const orbitPoints: OrbitPoint[] = this.deriveChunk(msg.points);
         this.onEvent(id, {
           kind: "history-chunk",
           points: orbitPoints,

--- a/viewer/src/sources/RrdFileAdapter.ts
+++ b/viewer/src/sources/RrdFileAdapter.ts
@@ -51,6 +51,17 @@ export class RrdFileAdapter implements SourceAdapter {
     this.infoEmitted = false;
     this.stopped = false;
     this.debugPointExposed = false;
+    // Every other per-load field is reset here, and this one holds the central
+    // body the derived values are computed against. The worker posts metadata
+    // before any chunk, so a second load overwrites it in practice; keeping it
+    // anyway would make that ordering load-bearing, and a chunk arriving first
+    // would be derived against the previous recording's body.
+    this.derivedContext = null;
+    // Every other per-load field is reset here, and this one holds the central
+    // body the derived values are computed against. The worker posts metadata
+    // before any chunk, so a second load overwrites it in practice; keeping it
+    // anyway would make that ordering load-bearing, and a chunk arriving first
+    // would be derived against the previous recording's body.
 
     const reader = new FileReader();
     this.reader = reader;

--- a/viewer/src/sources/RrdFileAdapter.ts
+++ b/viewer/src/sources/RrdFileAdapter.ts
@@ -28,10 +28,12 @@ export class RrdFileAdapter implements SourceAdapter {
   private file: File;
   private estimatedDt = 10;
   private stopped = false;
-  /// The central body constants the derived values are computed against. The
-  /// Worker sends metadata before the first chunk, so this is set by then.
+  /**
+   * The central body constants the derived values are computed against. The
+   * Worker sends metadata before the first chunk, so this is set by then.
+   */
   private derivedContext: OrbitDerivedContext | null = null;
-  /// Whether this load has already published its first point for the E2E.
+  /** Whether this load has already published its first point for the E2E. */
   private debugPointExposed = false;
 
   constructor(sourceId: SourceId, file: File, onEvent: SourceEventHandler) {
@@ -57,11 +59,6 @@ export class RrdFileAdapter implements SourceAdapter {
     // anyway would make that ordering load-bearing, and a chunk arriving first
     // would be derived against the previous recording's body.
     this.derivedContext = null;
-    // Every other per-load field is reset here, and this one holds the central
-    // body the derived values are computed against. The worker posts metadata
-    // before any chunk, so a second load overwrites it in practice; keeping it
-    // anyway would make that ordering load-bearing, and a chunk arriving first
-    // would be derived against the previous recording's body.
 
     const reader = new FileReader();
     this.reader = reader;

--- a/viewer/src/sources/RrdFileAdapter.ts
+++ b/viewer/src/sources/RrdFileAdapter.ts
@@ -35,6 +35,11 @@ export class RrdFileAdapter implements SourceAdapter {
   private derivedContext: OrbitDerivedContext | null = null;
   /** Whether this load has already published its first point for the E2E. */
   private debugPointExposed = false;
+  /**
+   * Which load is current. `stopped` cannot stand in for this: a restart clears
+   * it, so a callback of the load before would read it as its own go-ahead.
+   */
+  private loadGeneration = 0;
 
   constructor(sourceId: SourceId, file: File, onEvent: SourceEventHandler) {
     this.sourceId = sourceId;
@@ -60,10 +65,13 @@ export class RrdFileAdapter implements SourceAdapter {
     // would be derived against the previous recording's body.
     this.derivedContext = null;
 
+    const generation = ++this.loadGeneration;
+    const isCurrent = () => !this.stopped && this.loadGeneration === generation;
+
     const reader = new FileReader();
     this.reader = reader;
     reader.onload = () => {
-      if (this.stopped) return;
+      if (!isCurrent()) return;
       const buffer = reader.result as ArrayBuffer;
       // The derived values need `arika-wasm`. The app starts loading it at
       // mount, but the file input is usable before that finishes, so wait
@@ -74,12 +82,16 @@ export class RrdFileAdapter implements SourceAdapter {
           console.warn("RrdFileAdapter: arika WASM failed to load:", e);
         })
         .then(() => {
-          if (this.stopped) return;
+          // A restart while this was pending owns the adapter now. Starting a
+          // worker here would put the previous file's buffer behind the current
+          // load's worker reference, leaving both workers reporting into it and
+          // neither of them stoppable.
+          if (!isCurrent()) return;
           this.startWorker(buffer);
         });
     };
     reader.onerror = () => {
-      if (this.stopped) return;
+      if (!isCurrent()) return;
       this.onEvent(this.sourceId, {
         kind: "error",
         message: `Failed to read file: ${this.file.name}`,

--- a/viewer/src/sources/centralBody.ts
+++ b/viewer/src/sources/centralBody.ts
@@ -27,6 +27,11 @@ export interface CentralBody {
  * A `mu` that is absent, zero, negative or non-finite cannot scale an orbit —
  * every element derived from it would come out non-finite — so it falls back to
  * Earth rather than propagating through the charts.
+ *
+ * A negative radius falls back too: altitude is `r - bodyRadius`, so it would
+ * read as a height above the orbit rather than above the surface, which is
+ * plausible enough on a chart to go unnoticed. Zero stands, being a point mass
+ * whose altitude is `r`.
  */
 export function resolveCentralBody(
   mu: number | null | undefined,
@@ -35,6 +40,8 @@ export function resolveCentralBody(
   return {
     mu: mu != null && Number.isFinite(mu) && mu > 0 ? mu : DEFAULT_MU,
     bodyRadius:
-      bodyRadius != null && Number.isFinite(bodyRadius) ? bodyRadius : DEFAULT_BODY_RADIUS,
+      bodyRadius != null && Number.isFinite(bodyRadius) && bodyRadius >= 0
+        ? bodyRadius
+        : DEFAULT_BODY_RADIUS,
   };
 }

--- a/viewer/src/sources/centralBody.ts
+++ b/viewer/src/sources/centralBody.ts
@@ -1,0 +1,40 @@
+/**
+ * The central body constants a source is read against.
+ *
+ * A recording written by `orts` carries `mu` and the body radius. Anything
+ * missing falls back to Earth, which is what the rest of the viewer assumes
+ * when a source declares nothing.
+ *
+ * One module because two readers have to agree: the WASM batch that derives the
+ * orbital values, and the `SimInfo` / DuckDB schema that the charts are built
+ * from. A `mu` that differs between them shows the same recording two ways.
+ */
+
+/** Earth's gravitational parameter [km³/s²]. */
+export const DEFAULT_MU = 398600.4418;
+/** Earth's equatorial radius [km]. */
+export const DEFAULT_BODY_RADIUS = 6378.137;
+
+/** Resolved central body constants. */
+export interface CentralBody {
+  mu: number;
+  bodyRadius: number;
+}
+
+/**
+ * Resolve `mu` and the body radius from what a source declared.
+ *
+ * A `mu` that is absent, zero, negative or non-finite cannot scale an orbit —
+ * every element derived from it would come out non-finite — so it falls back to
+ * Earth rather than propagating through the charts.
+ */
+export function resolveCentralBody(
+  mu: number | null | undefined,
+  bodyRadius: number | null | undefined,
+): CentralBody {
+  return {
+    mu: mu != null && Number.isFinite(mu) && mu > 0 ? mu : DEFAULT_MU,
+    bodyRadius:
+      bodyRadius != null && Number.isFinite(bodyRadius) ? bodyRadius : DEFAULT_BODY_RADIUS,
+  };
+}

--- a/viewer/src/sources/centralBody.ts
+++ b/viewer/src/sources/centralBody.ts
@@ -28,10 +28,14 @@ export interface CentralBody {
  * every element derived from it would come out non-finite — so it falls back to
  * Earth rather than propagating through the charts.
  *
- * A negative radius falls back too: altitude is `r - bodyRadius`, so it would
- * read as a height above the orbit rather than above the surface, which is
- * plausible enough on a chart to go unnoticed. Zero stands, being a point mass
- * whose altitude is `r`.
+ * TODO: the two fields fall back on their own, so a recording naming Mars with
+ * no radius is read as Mars' `mu` over Earth's radius, and altitude
+ * (`r - bodyRadius`) comes out against a body that does not exist. Falling back
+ * at all is the wrong shape here: a default belongs to a body we know, and a
+ * value that is present but unusable belongs in an error. That needs the body
+ * constants `arika`'s `KnownBody::properties` already holds, exposed through
+ * `arika-wasm`, and an error path out of this layer. Kept as it stands on main
+ * until then, since this module only gathers a fallback that was already there.
  */
 export function resolveCentralBody(
   mu: number | null | undefined,
@@ -40,8 +44,6 @@ export function resolveCentralBody(
   return {
     mu: mu != null && Number.isFinite(mu) && mu > 0 ? mu : DEFAULT_MU,
     bodyRadius:
-      bodyRadius != null && Number.isFinite(bodyRadius) && bodyRadius >= 0
-        ? bodyRadius
-        : DEFAULT_BODY_RADIUS,
+      bodyRadius != null && Number.isFinite(bodyRadius) ? bodyRadius : DEFAULT_BODY_RADIUS,
   };
 }

--- a/viewer/src/sources/centralBody.ts
+++ b/viewer/src/sources/centralBody.ts
@@ -28,14 +28,19 @@ export interface CentralBody {
  * every element derived from it would come out non-finite — so it falls back to
  * Earth rather than propagating through the charts.
  *
- * TODO: the two fields fall back on their own, so a recording naming Mars with
- * no radius is read as Mars' `mu` over Earth's radius, and altitude
- * (`r - bodyRadius`) comes out against a body that does not exist. Falling back
- * at all is the wrong shape here: a default belongs to a body we know, and a
- * value that is present but unusable belongs in an error. That needs the body
- * constants `arika`'s `KnownBody::properties` already holds, exposed through
- * `arika-wasm`, and an error path out of this layer. Kept as it stands on main
- * until then, since this module only gathers a fallback that was already there.
+ * A negative radius falls back too: altitude is `r - bodyRadius`, so it would
+ * read as a height above the orbit rather than above the surface, which is
+ * plausible enough on a chart to go unnoticed. Zero stands, being a point mass
+ * whose altitude is `r`.
+ *
+ * TODO: falling back per field is the wrong shape. A recording naming Mars with
+ * no radius is read as Mars' `mu` over Earth's radius, a body that does not
+ * exist. A default belongs to a body we know, and a value that is present but
+ * unusable belongs in an error — which needs the constants `arika`'s
+ * `KnownBody::properties` already holds, exposed through `arika-wasm`, and an
+ * error path out of this layer. It reaches `useSimulationData`'s own
+ * `?? 398600.4418` too, so it is a root of its own rather than part of this
+ * module's.
  */
 export function resolveCentralBody(
   mu: number | null | undefined,
@@ -44,6 +49,8 @@ export function resolveCentralBody(
   return {
     mu: mu != null && Number.isFinite(mu) && mu > 0 ? mu : DEFAULT_MU,
     bodyRadius:
-      bodyRadius != null && Number.isFinite(bodyRadius) ? bodyRadius : DEFAULT_BODY_RADIUS,
+      bodyRadius != null && Number.isFinite(bodyRadius) && bodyRadius >= 0
+        ? bodyRadius
+        : DEFAULT_BODY_RADIUS,
   };
 }

--- a/viewer/src/sources/normalizeMetadata.ts
+++ b/viewer/src/sources/normalizeMetadata.ts
@@ -39,9 +39,10 @@ export function csvMetadataToSimInfo(metadata: CSVMetadata, fileName: string, dt
           },
         ];
 
-  // One resolution for `mu` and the radius, so the two always come from the
-  // same fallback decision. `central_body` is the name the source gave and
-  // is passed through, so it can still read "mars" over Earth's constants.
+  // Resolved once and read twice, rather than resolved per field. Each field
+  // falls back on its own, so a valid `mu` can sit beside Earth's radius, and
+  // `central_body` is the name the source gave and passes through: it can read
+  // "mars" over Earth's constants.
   const centralBody = resolveCentralBody(metadata.mu, metadata.centralBodyRadius);
 
   return {
@@ -96,9 +97,10 @@ export function rrdMetadataToSimInfo(
     });
   }
 
-  // One resolution for `mu` and the radius, so the two always come from the
-  // same fallback decision. `central_body` is the name the source gave and
-  // is passed through, so it can still read "mars" over Earth's constants.
+  // Resolved once and read twice, rather than resolved per field. Each field
+  // falls back on its own, so a valid `mu` can sit beside Earth's radius, and
+  // `central_body` is the name the source gave and passes through: it can read
+  // "mars" over Earth's constants.
   const centralBody = resolveCentralBody(metadata.mu, metadata.body_radius);
 
   return {

--- a/viewer/src/sources/normalizeMetadata.ts
+++ b/viewer/src/sources/normalizeMetadata.ts
@@ -7,13 +7,12 @@
 
 import type { CSVMetadata } from "../orbit.js";
 import type { RrdMetadata } from "../wasm/rrdWasmInit.js";
+import { resolveCentralBody } from "./centralBody.js";
 import type { SimInfo } from "./types.js";
 
 /** WGS84 Earth gravitational parameter [km³/s²]. */
-const DEFAULT_MU = 398600.4418;
 
 /** WGS84 Earth equatorial radius [km]. */
-const DEFAULT_RADIUS = 6378.137;
 
 /**
  * Build a SimInfo from CSV metadata.
@@ -45,12 +44,12 @@ export function csvMetadataToSimInfo(metadata: CSVMetadata, fileName: string, dt
         ];
 
   return {
-    mu: metadata.mu ?? DEFAULT_MU,
+    mu: resolveCentralBody(metadata.mu, metadata.centralBodyRadius).mu,
     dt,
     output_interval: dt,
     stream_interval: dt,
     central_body: metadata.centralBody ?? "earth",
-    central_body_radius: metadata.centralBodyRadius ?? DEFAULT_RADIUS,
+    central_body_radius: resolveCentralBody(metadata.mu, metadata.centralBodyRadius).bodyRadius,
     epoch_jd: metadata.epochJd,
     satellites,
   };
@@ -97,12 +96,12 @@ export function rrdMetadataToSimInfo(
   }
 
   return {
-    mu: metadata.mu ?? DEFAULT_MU,
+    mu: resolveCentralBody(metadata.mu, metadata.body_radius).mu,
     dt,
     output_interval: dt,
     stream_interval: dt,
     central_body: metadata.body_name ?? "earth",
-    central_body_radius: metadata.body_radius ?? DEFAULT_RADIUS,
+    central_body_radius: resolveCentralBody(metadata.mu, metadata.body_radius).bodyRadius,
     epoch_jd: metadata.epoch_jd ?? null,
     satellites,
   };

--- a/viewer/src/sources/normalizeMetadata.ts
+++ b/viewer/src/sources/normalizeMetadata.ts
@@ -39,7 +39,9 @@ export function csvMetadataToSimInfo(metadata: CSVMetadata, fileName: string, dt
           },
         ];
 
-  // One resolution for both fields, so they cannot disagree on the body.
+  // One resolution for `mu` and the radius, so the two always come from the
+  // same fallback decision. `central_body` is the name the source gave and
+  // is passed through, so it can still read "mars" over Earth's constants.
   const centralBody = resolveCentralBody(metadata.mu, metadata.centralBodyRadius);
 
   return {
@@ -94,7 +96,9 @@ export function rrdMetadataToSimInfo(
     });
   }
 
-  // One resolution for both fields, so they cannot disagree on the body.
+  // One resolution for `mu` and the radius, so the two always come from the
+  // same fallback decision. `central_body` is the name the source gave and
+  // is passed through, so it can still read "mars" over Earth's constants.
   const centralBody = resolveCentralBody(metadata.mu, metadata.body_radius);
 
   return {

--- a/viewer/src/sources/normalizeMetadata.ts
+++ b/viewer/src/sources/normalizeMetadata.ts
@@ -43,13 +43,16 @@ export function csvMetadataToSimInfo(metadata: CSVMetadata, fileName: string, dt
           },
         ];
 
+  // One resolution for both fields, so they cannot disagree on the body.
+  const centralBody = resolveCentralBody(metadata.mu, metadata.centralBodyRadius);
+
   return {
-    mu: resolveCentralBody(metadata.mu, metadata.centralBodyRadius).mu,
+    mu: centralBody.mu,
     dt,
     output_interval: dt,
     stream_interval: dt,
     central_body: metadata.centralBody ?? "earth",
-    central_body_radius: resolveCentralBody(metadata.mu, metadata.centralBodyRadius).bodyRadius,
+    central_body_radius: centralBody.bodyRadius,
     epoch_jd: metadata.epochJd,
     satellites,
   };
@@ -95,13 +98,16 @@ export function rrdMetadataToSimInfo(
     });
   }
 
+  // One resolution for both fields, so they cannot disagree on the body.
+  const centralBody = resolveCentralBody(metadata.mu, metadata.body_radius);
+
   return {
-    mu: resolveCentralBody(metadata.mu, metadata.body_radius).mu,
+    mu: centralBody.mu,
     dt,
     output_interval: dt,
     stream_interval: dt,
     central_body: metadata.body_name ?? "earth",
-    central_body_radius: resolveCentralBody(metadata.mu, metadata.body_radius).bodyRadius,
+    central_body_radius: centralBody.bodyRadius,
     epoch_jd: metadata.epoch_jd ?? null,
     satellites,
   };

--- a/viewer/src/sources/normalizeMetadata.ts
+++ b/viewer/src/sources/normalizeMetadata.ts
@@ -10,10 +10,6 @@ import type { RrdMetadata } from "../wasm/rrdWasmInit.js";
 import { resolveCentralBody } from "./centralBody.js";
 import type { SimInfo } from "./types.js";
 
-/** WGS84 Earth gravitational parameter [km³/s²]. */
-
-/** WGS84 Earth equatorial radius [km]. */
-
 /**
  * Build a SimInfo from CSV metadata.
  *

--- a/viewer/src/sources/rrdOrbitDerived.test.ts
+++ b/viewer/src/sources/rrdOrbitDerived.test.ts
@@ -46,16 +46,6 @@ describe("orbitDerivedContext", () => {
       DEFAULT_BODY_RADIUS,
     );
   });
-
-  it("falls back for a negative radius, and keeps a zero one", () => {
-    // Altitude is `r - bodyRadius`: a negative radius reads as a height above
-    // the orbit rather than above the surface, which a chart shows without
-    // complaint. Zero is a point mass, whose altitude is `r`.
-    expect(orbitDerivedContext({ mu: DEFAULT_MU, body_radius: -6378.137 }).bodyRadius).toBe(
-      DEFAULT_BODY_RADIUS,
-    );
-    expect(orbitDerivedContext({ mu: DEFAULT_MU, body_radius: 0 }).bodyRadius).toBe(0);
-  });
 });
 
 describe("packStates", () => {

--- a/viewer/src/sources/rrdOrbitDerived.test.ts
+++ b/viewer/src/sources/rrdOrbitDerived.test.ts
@@ -46,6 +46,16 @@ describe("orbitDerivedContext", () => {
       DEFAULT_BODY_RADIUS,
     );
   });
+
+  it("falls back for a negative radius, and keeps a zero one", () => {
+    // Altitude is `r - bodyRadius`: a negative radius reads as a height above
+    // the orbit rather than above the surface, which a chart shows without
+    // complaint. Zero is a point mass, whose altitude is `r`.
+    expect(orbitDerivedContext({ mu: DEFAULT_MU, body_radius: -6378.137 }).bodyRadius).toBe(
+      DEFAULT_BODY_RADIUS,
+    );
+    expect(orbitDerivedContext({ mu: DEFAULT_MU, body_radius: 0 }).bodyRadius).toBe(0);
+  });
 });
 
 describe("packStates", () => {

--- a/viewer/src/sources/rrdOrbitDerived.test.ts
+++ b/viewer/src/sources/rrdOrbitDerived.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_BODY_RADIUS, DEFAULT_MU } from "./centralBody.js";
+import { orbitPointToChartRow } from "./eventDispatcher.js";
+import {
+  ORBIT_DERIVED_STRIDE,
+  orbitDerivedContext,
+  packStates,
+  toOrbitPoints,
+} from "./rrdOrbitDerived.js";
+import type { RrdPointOut } from "./rrdParseLogic.js";
+
+function point(overrides: Partial<RrdPointOut> = {}): RrdPointOut {
+  return {
+    t: 0,
+    x: 6778.137,
+    y: 0,
+    z: 0,
+    vx: 0,
+    vy: 7.6686,
+    vz: 0,
+    entityPath: "/world/sat/sat-1",
+    ...overrides,
+  };
+}
+
+describe("orbitDerivedContext", () => {
+  it("takes the recording's own central body constants", () => {
+    const ctx = orbitDerivedContext({ mu: 42828.37, body_radius: 3396.2 });
+    expect(ctx.mu).toBe(42828.37);
+    expect(ctx.bodyRadius).toBe(3396.2);
+  });
+
+  it("falls back to Earth when the recording carries neither", () => {
+    const ctx = orbitDerivedContext({ mu: null, body_radius: null });
+    expect(ctx.mu).toBe(DEFAULT_MU);
+    expect(ctx.bodyRadius).toBe(DEFAULT_BODY_RADIUS);
+  });
+
+  it("falls back for a mu no orbit can be scaled by", () => {
+    // A recording could carry a corrupt or placeholder value; dividing by it
+    // would make every element non-finite.
+    for (const mu of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(orbitDerivedContext({ mu, body_radius: 6378.137 }).mu).toBe(DEFAULT_MU);
+    }
+    expect(orbitDerivedContext({ mu: DEFAULT_MU, body_radius: Number.NaN }).bodyRadius).toBe(
+      DEFAULT_BODY_RADIUS,
+    );
+  });
+});
+
+describe("packStates", () => {
+  it("lays out six values per point in order", () => {
+    const packed = packStates([
+      point({ x: 1, y: 2, z: 3, vx: 4, vy: 5, vz: 6 }),
+      point({ x: 7, y: 8, z: 9, vx: 10, vy: 11, vz: 12 }),
+    ]);
+    expect(Array.from(packed)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+  });
+
+  it("packs nothing for no points", () => {
+    expect(packStates([]).length).toBe(0);
+  });
+});
+
+describe("toOrbitPoints", () => {
+  /** One state's worth of derived values, distinct so a misplaced index shows. */
+  const derived = [6778.137, 0.001, 0.9, 1.1, 1.2, 1.3, 400, -29.4, 51981, 7.6686];
+
+  it("puts each derived value in its own field", () => {
+    const [p] = toOrbitPoints([point()], derived);
+    expect(p.a).toBe(6778.137);
+    expect(p.e).toBe(0.001);
+    expect(p.inc).toBe(0.9);
+    expect(p.raan).toBe(1.1);
+    expect(p.omega).toBe(1.2);
+    expect(p.nu).toBe(1.3);
+    expect(p.altitude).toBe(400);
+    expect(p.specific_energy).toBe(-29.4);
+    expect(p.angular_momentum).toBe(51981);
+    expect(p.velocity_mag).toBe(7.6686);
+  });
+
+  it("keeps the state vector and attitude the decoder recovered", () => {
+    const [p] = toOrbitPoints([point({ t: 10, qw: 1, qx: 0, wx: 0.01 })], derived);
+    expect(p.t).toBe(10);
+    expect(p.x).toBe(6778.137);
+    expect(p.vy).toBe(7.6686);
+    expect(p.entityPath).toBe("/world/sat/sat-1");
+    expect(p.qw).toBe(1);
+    expect(p.wx).toBe(0.01);
+  });
+
+  it("reads the nth point from the nth block", () => {
+    const second = derived.map((v) => v * 2);
+    const points = toOrbitPoints([point(), point({ t: 10 })], [...derived, ...second]);
+    expect(points[1].a).toBe(6778.137 * 2);
+    expect(points[1].t).toBe(10);
+  });
+
+  it("rejects a batch whose length does not match the points", () => {
+    // A silent mismatch would shift every satellite's elements by one block.
+    expect(() => toOrbitPoints([point(), point()], derived)).toThrow(/expected 20/);
+  });
+
+  /**
+   * The chart row reads these four straight off `OrbitPoint`, so what arrives
+   * here is what a state with no orbital plane reports. It stays non-finite
+   * rather than becoming zero, because zero is a real reading — a circular
+   * equatorial orbit sitting at the body's surface — and would be plotted as
+   * one.
+   */
+  it("carries a state with no orbital plane through as non-finite", () => {
+    const undefinedState = new Array(ORBIT_DERIVED_STRIDE).fill(Number.NaN);
+    const [p] = toOrbitPoints([point({ vy: 0 })], undefinedState);
+    expect(p.a).toBeNaN();
+    expect(p.altitude).toBeNaN();
+
+    const row = orbitPointToChartRow(p);
+    expect(row.altitude).toBeNaN();
+    expect(row.energy).toBeNaN();
+    expect(row.angular_momentum).toBeNaN();
+  });
+
+  /**
+   * The whole point of the change: these four used to be hardcoded zeros in the
+   * adapter, and the chart row reads them directly rather than recomputing from
+   * the state vector.
+   */
+  it("gives the chart row the derived values rather than zeros", () => {
+    const [p] = toOrbitPoints([point()], derived);
+    const row = orbitPointToChartRow(p);
+    expect(row.altitude).toBe(400);
+    expect(row.energy).toBe(-29.4);
+    expect(row.angular_momentum).toBe(51981);
+    expect(row.a).toBe(6778.137);
+    // Angles reach the chart in degrees.
+    expect(row.inc_deg).toBeCloseTo((0.9 * 180) / Math.PI, 9);
+  });
+});

--- a/viewer/src/sources/rrdOrbitDerived.ts
+++ b/viewer/src/sources/rrdOrbitDerived.ts
@@ -1,0 +1,95 @@
+/**
+ * Derive the orbital quantities a `.rrd` recording does not carry.
+ *
+ * The decoder recovers position and velocity; the Keplerian elements and the
+ * scalar quantities the charts plot have to be computed from those. The
+ * WebSocket source gets them from the server, so this is the file source's
+ * half of the same job.
+ *
+ * The arithmetic lives in `arika-wasm` (`orbit_derived_batch`), which calls the
+ * same `KeplerianElements::from_state_vector` the CLI writes into CSV.
+ */
+
+import type { OrbitPoint } from "../orbit.js";
+import { type CentralBody, resolveCentralBody } from "./centralBody.js";
+import type { RrdPointOut } from "./rrdParseLogic.js";
+
+/** Values `orbit_derived_batch` returns per state. */
+export const ORBIT_DERIVED_STRIDE = 10;
+
+/** The central body constants a batch is converted against. */
+export type OrbitDerivedContext = CentralBody;
+
+/** Read `mu` and the body radius out of a recording's metadata. */
+export function orbitDerivedContext(metadata: {
+  mu: number | null;
+  body_radius: number | null;
+}): OrbitDerivedContext {
+  return resolveCentralBody(metadata.mu, metadata.body_radius);
+}
+
+/** Flatten points into the `[x,y,z,vx,vy,vz, ...]` layout the batch takes. */
+export function packStates(points: readonly RrdPointOut[]): Float64Array {
+  const out = new Float64Array(points.length * 6);
+  for (let i = 0; i < points.length; i++) {
+    const p = points[i];
+    const o = i * 6;
+    out[o] = p.x;
+    out[o + 1] = p.y;
+    out[o + 2] = p.z;
+    out[o + 3] = p.vx;
+    out[o + 4] = p.vy;
+    out[o + 5] = p.vz;
+  }
+  return out;
+}
+
+/**
+ * Build `OrbitPoint`s from decoded states and the batch's output.
+ *
+ * `derived` is the flat result of `orbit_derived_batch` over the same points in
+ * the same order. A state with no orbital plane comes back as `NaN`s and is
+ * carried through as such, because zero is a real reading — a circular
+ * equatorial orbit at the body's surface — and cannot double as "no value".
+ */
+export function toOrbitPoints(
+  points: readonly RrdPointOut[],
+  derived: Float64Array | readonly number[],
+): OrbitPoint[] {
+  if (derived.length !== points.length * ORBIT_DERIVED_STRIDE) {
+    throw new Error(
+      `orbit-derived batch returned ${derived.length} values for ${points.length} points ` +
+        `(expected ${points.length * ORBIT_DERIVED_STRIDE})`,
+    );
+  }
+  return points.map((p, i) => {
+    const o = i * ORBIT_DERIVED_STRIDE;
+    return {
+      t: p.t,
+      x: p.x,
+      y: p.y,
+      z: p.z,
+      vx: p.vx,
+      vy: p.vy,
+      vz: p.vz,
+      entityPath: p.entityPath ?? undefined,
+      a: derived[o],
+      e: derived[o + 1],
+      inc: derived[o + 2],
+      raan: derived[o + 3],
+      omega: derived[o + 4],
+      nu: derived[o + 5],
+      altitude: derived[o + 6],
+      specific_energy: derived[o + 7],
+      angular_momentum: derived[o + 8],
+      velocity_mag: derived[o + 9],
+      qw: p.qw,
+      qx: p.qx,
+      qy: p.qy,
+      qz: p.qz,
+      wx: p.wx,
+      wy: p.wy,
+      wz: p.wz,
+    };
+  });
+}

--- a/viewer/src/wasm/arikaInit.ts
+++ b/viewer/src/wasm/arikaInit.ts
@@ -12,6 +12,7 @@ type SunDirectionFromBody = (body: string, epoch_jd: number, t: number) => Float
 type SunDistanceFromBody = (body: string, epoch_jd: number, t: number) => number;
 type JdToUtcString = (epoch_jd: number, t: number) => string;
 type BodyOrientation = (body: string, epoch_jd: number, t: number) => Float64Array;
+type OrbitDerivedBatch = (states: Float64Array, mu: number, body_radius: number) => Float64Array;
 
 let initialized = false;
 let initPromise: Promise<void> | undefined;
@@ -23,6 +24,7 @@ let wasmSunDirFromBody: SunDirectionFromBody | undefined;
 let wasmSunDistFromBody: SunDistanceFromBody | undefined;
 let wasmJdToUtc: JdToUtcString | undefined;
 let wasmBodyOrientation: BodyOrientation | undefined;
+let wasmOrbitDerived: OrbitDerivedBatch | undefined;
 
 /** Options for {@link initArika}. */
 export interface InitArikaOptions {
@@ -57,6 +59,7 @@ export function initArika(options?: InitArikaOptions): Promise<void> {
     wasmSunDistFromBody = mod.sun_distance_from_body;
     wasmJdToUtc = mod.jd_to_utc_string;
     wasmBodyOrientation = mod.body_orientation;
+    wasmOrbitDerived = mod.orbit_derived_batch;
     initialized = true;
   });
   initPromise = p;
@@ -75,6 +78,22 @@ export function eci_to_ecef_batch(
   epoch_jd: number,
 ): Float32Array {
   return wasmBatch!(positions, times, epoch_jd);
+}
+
+/**
+ * Keplerian elements and chart scalars for a batch of state vectors, via WASM.
+ *
+ * `states` is `[x,y,z,vx,vy,vz, ...]`; the result is 10 values per state,
+ * `[a, e, inc, raan, omega, nu, altitude, specific_energy, angular_momentum,
+ * velocity]`, with angles in radians. A state with no orbital plane comes back
+ * as ten `NaN`s.
+ */
+export function orbit_derived_batch(
+  states: Float64Array,
+  mu: number,
+  body_radius: number,
+): Float64Array {
+  return wasmOrbitDerived!(states, mu, body_radius);
 }
 
 /** Single-point ECI→ECEF transform via WASM. Returns [ex, ey, ez]. */

--- a/viewer/tests/rrd-file-load.spec.ts
+++ b/viewer/tests/rrd-file-load.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * E2E: opening a `.rrd` file fills in the orbital values the recording does
+ * not carry.
+ *
+ * The decoder recovers position and velocity only. The Keplerian elements and
+ * the chart scalars used to arrive as hardcoded zeros, so a recording of a
+ * 400 km orbit charted a semi-major axis of 0 km and an altitude of 0 km. This
+ * exercises the wiring the unit tests cannot: the adapter really calls
+ * `arika-wasm` and the values really reach the ingest buffer.
+ */
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+
+/** The recording committed for `rrd-wasm`'s own decoder tests. */
+const FIXTURE = fileURLToPath(
+  new URL("../../rrd-wasm/tests/fixtures/test_orbit.rrd", import.meta.url),
+);
+
+test("opening an .rrd derives its Keplerian elements and chart scalars", async ({ page }) => {
+  const logs: string[] = [];
+  page.on("console", (m) => logs.push(`[${m.type()}] ${m.text()}`));
+  page.on("pageerror", (e) => logs.push(`[pageerror] ${e.message}`));
+
+  await page.goto("/?noAutoConnect=1");
+
+  const fileInput = page.locator('input[type="file"]');
+  await fileInput.setInputFiles(FIXTURE);
+
+  // Wait on the decoded point rather than the DOM: the info bar depends on
+  // playback state, while this is the value under test.
+  await page
+    .waitForFunction(
+      () => (window as unknown as Record<string, unknown>).__debug_rrd_first_point != null,
+      { timeout: 20000 },
+    )
+    .catch(() => {
+      throw new Error(`no point was decoded from the .rrd. console:\n${logs.join("\n")}`);
+    });
+
+  const sample = await page.evaluate(() => {
+    const p = (window as unknown as Record<string, unknown>).__debug_rrd_first_point as
+      | Record<string, number>
+      | undefined;
+    if (!p) return { ok: false as const, error: "no decoded point was exposed" };
+    return {
+      ok: true as const,
+      a: p.a,
+      e: p.e,
+      altitude: p.altitude,
+      specific_energy: p.specific_energy,
+      angular_momentum: p.angular_momentum,
+      velocity_mag: p.velocity_mag,
+      r: Math.hypot(p.x, p.y, p.z),
+    };
+  });
+
+  expect(sample.ok, `${sample.ok ? "" : sample.error}`).toBe(true);
+  if (!sample.ok) return; // narrows the type; unreachable
+
+  // The fixture is one satellite on a circular orbit 400 km up. Pinning the
+  // measured values, not just "non-zero": a wrong field order or a unit slip
+  // would still clear a range check.
+  expect(sample.a, "semi-major axis (was hardcoded 0)").toBeCloseTo(6778.137, 3);
+  expect(sample.e, "a circular orbit's eccentricity").toBeCloseTo(0, 6);
+  expect(sample.altitude, "altitude (was hardcoded 0)").toBeCloseTo(400, 3);
+  expect(sample.altitude).toBeCloseTo(sample.r - 6378.137, 6);
+  expect(sample.specific_energy, "bound orbit, so negative (was 0)").toBeCloseTo(-29.4034, 3);
+  expect(sample.angular_momentum, "|r x v| (was 0)").toBeCloseTo(51978.5379, 2);
+  expect(sample.velocity_mag).toBeCloseTo(7.668558, 5);
+});


### PR DESCRIPTION
viewer で `.rrd` を直接開くと、軌道要素とチャートのスカラー量が 0 のハードコードで届いていた。

```typescript
// viewer/src/sources/RrdFileAdapter.ts（変更前）
    a: 0, e: 0, inc: 0, raan: 0, omega: 0, nu: 0,
    altitude: 0, specific_energy: 0, angular_momentum: 0,
```

decoder が recording から復元するのは位置と速度だけなので、残りは browser 側で導出する必要がある。WebSocket 経路は server が計算した値を受け取るので、これは file 経路だけの欠落。

## 0 がチャートまで届く理由

`viewer/src/sources/eventDispatcher.ts` の `orbitPointToChartRow` が、これらを `OrbitPoint` から直読する。

```typescript
altitude: p.altitude ?? 0,
energy: p.specific_energy ?? 0,
angular_momentum: p.angular_momentum ?? 0,
```

DuckDB の derived SQL は高度・エネルギー・角運動量を状態ベクトルから正しく計算するが、file load 後は `goLive()` されるので単一衛星の通常表示ではこの live 経路が使われる。結果、400 km 軌道の recording を開くと半長軸 0 km、高度 0 km として描かれていた。

## 変更内容

`arika/wasm` に batch export を足す。

```rust
pub fn orbit_derived_batch(states: &[f64], mu: f64, body_radius: f64)
    -> Result<Vec<f64>, JsValue>
```

state あたり 10 値 `[a, e, inc, raan, omega, nu, altitude, specific_energy, angular_momentum, velocity]` を返す。中身は `arika::kepler::KeplerianElements::from_state_vector` で、CLI が CSV に書き WebSocket で送るのと同じ実装になる。既存の `eci_to_ecef_batch` と同じ形で、長さ検証付きの core を host からテストできるよう分離した。

viewer 側は `src/sources/rrdOrbitDerived.ts`（`orbitDerivedContext` / `packStates` / `toOrbitPoints`）を純関数として切り出し、`RrdFileAdapter` が recording の metadata から `mu` と body radius を取って chunk ごとに batch を呼ぶ。

### 軌道面を持たない状態

`r = 0` と `r × v = 0`（`v = 0` を含む）では古典要素が定義できず、`from_state_vector` はその大きさで除算する。この場合と非有限成分を含む場合は 10 個の `NaN` を返す。

0 を返さないのは、0 が円赤道軌道の角度として実在する値だから。高度 0 は天体表面を意味してしまう。velocity 列を持たない recording は `v = 0` として decode されるので、この経路は実在する。

### WASM の初期化待ち

`initArika()` は app の mount で開始するが、完了前でも file input は操作できる。`RrdFileAdapter` は decode 前にこれを待つ。待たないと、初期化前に届いた chunk が `NaN` のまま残り、後から計算し直す機会がない。

### 中心天体定数の解決

`src/sources/centralBody.ts` に `resolveCentralBody` を置き、`rrdOrbitDerived` と `normalizeMetadata` の両方がこれを使う。要素を導出する `mu` と、`SimInfo` や DuckDB schema が報告する `mu` が同じ値になる。`mu` が 0・負・非有限のときは Earth に倒す（その値で割ると全要素が非有限になる）。

## 実測

committed fixture（`rrd-wasm/tests/fixtures/test_orbit.rrd`、400 km 円軌道）を viewer で開いた結果:

| 項目 | 変更前 | 変更後 |
|---|---|---|
| a | 0 | 6778.137 km |
| e | 0 | 0 |
| altitude | 0 | 400 km |
| specific_energy | 0 | −29.4034 km²/s² |
| angular_momentum | 0 | 51978.5379 km²/s |
| velocity | 7.668558 km/s | 7.668558 km/s |

velocity は変更前も adapter が計算していた。

## テスト

**arika/wasm 6 本**: 円軌道の各値（比エネルギーが `−mu/2a`、`|h|` が `r·v`）、batch が各 state を独立に変換すること、角度が arika の API と厳密一致すること、軌道面を持たない 5 パターンが `NaN`、6 の倍数でない `states` の拒否、`mu` と radius の検証、空 batch。

**viewer vitest 11 本**: 定数の解決、`packStates` の並び、`toOrbitPoints` の field 対応と index、長さ不一致の拒否、`NaN` が chart row まで `NaN` で届くこと、chart row が 0 ではなく導出値を得ること。

**Playwright 1 本**: fixture を file input に渡し、上表の実測値を `toBeCloseTo` で固定する。範囲チェックだけでは field の順序違いや単位のずれを通してしまうため。adapter を旧 0 埋めに戻すと `a = 0` で落ちることを実測した。

`pnpm exec tsc --noEmit` 0 件、`pnpm lint` exit 0、`pnpm exec vitest run src/sources/` 70 pass、`cargo test -p arika-wasm` 9 pass、`cargo clippy --locked --workspace -- -D warnings` 0 件。

## 関連

- `arika/wasm/pkg/arika.d.ts` は tracked な生成物なので diff に入る。CI が pin している wasm-pack 0.13.1 で生成した（ABI 宣言の並び替えと `__externref_table_dealloc` の追加は export 1 本の追加に伴うもので、wasm-pack の版差ではない）
- DuckDB 経路では `NaN` が insert 時に `NULL` になり、Arrow の `toArray()` が validity を落とすため 0 として読み戻される可能性がある。live 経路とは別の扱いになっており、uneri 側の往復として別途扱う
- 複数衛星の recording の高度と周期のメタデータは先頭衛星の値だけが書かれている
