### PR TITLE
fix(orts)!: give flat-panel SRP its reflection term, so the torque points the right way

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -30,6 +30,18 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - WIT v0 plugin interface に msg-io / stream-io チャネルを追加。([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
+- `SurfacePanel` が lumped な `cr` の代わりに `optics: PanelOptics { specular,
+  diffuse }` を持つようになった。吸収率は `1 - specular - diffuse` として導出する。
+  単一係数は face-on の SRP 力の大きさを決めるだけで、斜入射での向きが決まらない
+  ── 下の平板 SRP 修正が必要とするのはその向きである。`PanelOptics` の field は
+  private で、`new` の検証を struct literal で迂回できない: specular が 1 を超えると
+  吸収率が負になり、力の太陽方向成分が太陽側を向く。`SpacecraftShape::Sphere` は
+  `cr` を維持する。等方面では lumped 係数がモデルの定義そのもので、specular / diffuse
+  の項が依存する入射角が存在しない。`SurfacePanel::at_com` は optics を必須引数に取り、
+  `SpacecraftShape::cube` は `cr` の代わりに optics を取る。SRP 力が黙って変わるのでは
+  なくコンパイルエラーとして出るようにするため: `Cr = 1.5` は単一の `(ρ_s, ρ_d)`
+  に対応せず、力の向きがこの分解に依存するようになったので、どの既定値も face-on 以外
+  で旧振る舞いを再現しない。面が本当に不明なら `PanelOptics::absorber()` を渡す。([#377](https://github.com/sksat/orts/pull/377))
 - `StateEffector` を frame-generic 化 — `StateEffector<S, F: frame::Eci =
   SimpleEci>` で `ExternalLoads<F>` を返す (`Model<S, F>` と同様)。effector は
   host の慣性 frame で荷重を生成するようになった。既定の `F` により既存の
@@ -59,6 +71,15 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   別の瞬間。この PR が直すブラウザ側の
   decoder と同じ欠陥で、3 つは独立に
   decode するため 3 つとも抱えていた。([#366](https://github.com/sksat/orts/pull/366))
+- `PanelSrp` が平板ごとの反射力を出すようになった。per-panel の力は
+  `-P·Cr·A·cosθ·ŝ` で常に反太陽方向だった。平板では鏡面反射と拡散再放射が panel
+  normal 方向の力を作るが、その項が無く、力が
+  `F = -P·A·cosθ·[(α + ρ_d)·ŝ + 2·(ρ_s·cosθ + ρ_d/3)·n̂]` に従うのは黒体の場合だけ
+  だった。SRP トルクは大きさだけでなく向きも誤っていた: 圧力中心が ŝ–n̂ 平面の外に
+  あるとき `r × ŝ` と `r × n̂` は別方向を向くので、`Cr` をどう選んでも正しい答えには
+  ならない。太陽電池パドル相当 (ρ_s ≈ 0.2, ρ_d ≈ 0.1) では 45° 入射で欠けていた項が
+  力の ~30% を占める。model の導入時から存在し、0.2.0 も該当する。
+  ([#377](https://github.com/sksat/orts/pull/377))
 - `AttitudeState::q_dot` が、和を計算した後でなく積を作る前に角速度を半分にする
   ようになった。結果が有限な入力で overflow しなくなる: `q = [0, 1/√2, 1/√2, 0]`、
   `ω = [1.4e308, 1.4e308, 0]` の `q̇.w` は約 -9.9e307 だが、途中の和が -1.98e308 に

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,22 @@ section is subdivided by package.
 - WIT v0 plugin interface extended with the msg-io and stream-io channels. ([#58](https://github.com/sksat/orts/pull/58), [#84](https://github.com/sksat/orts/pull/84))
 
 #### Changed
+- `SurfacePanel` carries `optics: PanelOptics { specular, diffuse }` in place of
+  a lumped `cr`, with the absorbed fraction derived as `1 - specular - diffuse`.
+  A single coefficient fixes the SRP force magnitude face-on but leaves its
+  direction undetermined at oblique incidence, which is what the flat-panel fix
+  below needs. `PanelOptics`' fields are private so `new`'s validation cannot be
+  bypassed by a struct literal: a specular above 1 makes the absorbed fraction
+  negative and points the Sun-line component of the force toward the Sun.
+  `SpacecraftShape::Sphere` keeps `cr` — for an isotropic surface a lumped
+  coefficient is the whole model, and there is no incidence angle for the
+  specular and diffuse terms to depend on. `SurfacePanel::at_com` takes the
+  optics as a required argument and `SpacecraftShape::cube` takes them in place
+  of `cr`, so the change surfaces as a compile error rather than as a silently
+  different SRP force: `Cr = 1.5` maps to no single `(ρ_s, ρ_d)` pair, and
+  since the force direction now depends on that split, no default reproduces the
+  old behaviour anywhere but face-on. Pass `PanelOptics::absorber()` when the
+  surface is genuinely unknown. ([#377](https://github.com/sksat/orts/pull/377))
 - `StateEffector` is now frame-generic — `StateEffector<S, F: frame::Eci =
   SimpleEci>` returning `ExternalLoads<F>`, like `Model<S, F>` — so effectors
   produce loads already in the host inertial frame. The defaulted `F` keeps
@@ -66,6 +82,16 @@ section is subdivided by package.
   1, and two rows of one `sim_time` at different `frame`s are two moments. Same
   defect as the browser-side decoder in this PR: the three decode independently,
   and all three carried it. ([#366](https://github.com/sksat/orts/pull/366))
+- `PanelSrp` gives each flat panel its reflection force. The per-panel force was
+  `-P·Cr·A·cosθ·ŝ`, always anti-Sun; a flat plate's specular reflection and
+  diffuse re-emission push along the panel normal, and that term was absent, so
+  the force followed `F = -P·A·cosθ·[(α + ρ_d)·ŝ + 2·(ρ_s·cosθ + ρ_d/3)·n̂]` only
+  for a black panel. The SRP torque was wrong in direction, not just magnitude:
+  where the centre of pressure lies off the ŝ–n̂ plane, `r × ŝ` and `r × n̂` point
+  different ways, so no choice of `Cr` recovers the right answer. For a solar
+  array (ρ_s ≈ 0.2, ρ_d ≈ 0.1) the missing term carries ~30% of the force at 45°
+  incidence. Present since the model was introduced, 0.2.0 included.
+  ([#377](https://github.com/sksat/orts/pull/377))
 - `AttitudeState::q_dot` halves the angular velocity before forming the
   products rather than the sum afterwards, so it no longer overflows where its
   result is finite: `q = [0, 1/√2, 1/√2, 0]` with `ω = [1.4e308, 1.4e308, 0]`

--- a/orts/Cargo.toml
+++ b/orts/Cargo.toml
@@ -19,6 +19,9 @@ include = [
     "wit/**/*.wit",
     "Cargo.toml",
     "/README.md",
+    # A unit test in src/ includes this Orekit reference fixture, so the
+    # packaged crate has to carry it or `cargo test` there fails to compile.
+    "tests/fixtures/orekit_panel_srp_reference.json",
 ]
 
 [dependencies]

--- a/orts/proptest-regressions/spacecraft/panel_srp.txt
+++ b/orts/proptest-regressions/spacecraft/panel_srp.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 8fc3db99798f92208915b009be1d043eeb7ccc75a2846181952d322bb57d837d # shrinks to angle = 0.01

--- a/orts/src/perturbations/srp.rs
+++ b/orts/src/perturbations/srp.rs
@@ -35,9 +35,10 @@ pub const DEFAULT_AREA_TO_MASS: f64 = 0.02;
 ///
 /// a = -P × Cr × (A/m) × (AU/r_sun)² × ŝ
 ///
-/// where P is [`SOLAR_RADIATION_PRESSURE`] — already a pressure, so no further
-/// division by c — and ŝ is the unit vector from the satellite toward the Sun,
-/// giving acceleration directed away from the Sun.
+/// P is [`SOLAR_RADIATION_PRESSURE`], which is the solar irradiance already
+/// divided by the speed of light, so it is a pressure in N/m² and the formula
+/// applies no further `/c`. ŝ is the unit vector from the satellite toward the
+/// Sun, giving acceleration directed away from the Sun.
 ///
 /// Produces no torque, and takes no attitude: with no orientation there is no
 /// lever arm to cross the force against. That is exactly the model's premise,

--- a/orts/src/perturbations/srp.rs
+++ b/orts/src/perturbations/srp.rs
@@ -37,6 +37,11 @@ pub const DEFAULT_AREA_TO_MASS: f64 = 0.02;
 ///
 /// where ŝ is the unit vector from the satellite toward the Sun,
 /// giving acceleration directed away from the Sun.
+///
+/// Produces no torque, and takes no attitude: an isotropic surface has its
+/// centre of pressure at the centre of mass, so the SRP torque is zero by
+/// definition. Attitude-dependent SRP, including the torque an off-centre
+/// centre of pressure produces, is [`crate::spacecraft::PanelSrp`].
 pub struct SolarRadiationPressure {
     /// Radiation pressure coefficient (1.0 = absorber, 2.0 = reflector)
     pub cr: f64,

--- a/orts/src/perturbations/srp.rs
+++ b/orts/src/perturbations/srp.rs
@@ -33,15 +33,18 @@ pub const DEFAULT_AREA_TO_MASS: f64 = 0.02;
 ///
 /// Computes acceleration from solar photon pressure on a satellite:
 ///
-/// a = -(P/c) × Cr × (A/m) × (AU/r_sun)² × ŝ
+/// a = -P × Cr × (A/m) × (AU/r_sun)² × ŝ
 ///
-/// where ŝ is the unit vector from the satellite toward the Sun,
+/// where P is [`SOLAR_RADIATION_PRESSURE`] — already a pressure, so no further
+/// division by c — and ŝ is the unit vector from the satellite toward the Sun,
 /// giving acceleration directed away from the Sun.
 ///
-/// Produces no torque, and takes no attitude: an isotropic surface has its
-/// centre of pressure at the centre of mass, so the SRP torque is zero by
-/// definition. Attitude-dependent SRP, including the torque an off-centre
-/// centre of pressure produces, is [`crate::spacecraft::PanelSrp`].
+/// Produces no torque, and takes no attitude: with no orientation there is no
+/// lever arm to cross the force against. That is exactly the model's premise,
+/// an isotropic surface presenting the same cross-section in every direction,
+/// with its centre of pressure taken at the centre of mass. Attitude-dependent
+/// SRP, including the torque an off-centre centre of pressure produces, is
+/// [`crate::spacecraft::PanelSrp`].
 pub struct SolarRadiationPressure {
     /// Radiation pressure coefficient (1.0 = absorber, 2.0 = reflector)
     pub cr: f64,

--- a/orts/src/spacecraft/mod.rs
+++ b/orts/src/spacecraft/mod.rs
@@ -11,7 +11,7 @@ pub use mtq::{Mtq, MtqAssembly, MtqAssemblyCore, MtqCommand};
 pub use panel_srp::PanelSrp;
 pub use reaction_wheel::{ReactionWheelAssembly, RwCommand};
 pub use state::SpacecraftState;
-pub use surface::{PanelDrag, SpacecraftShape, SurfacePanel};
+pub use surface::{PanelDrag, PanelOptics, SpacecraftShape, SurfacePanel};
 pub use thruster::{
     BurnWindow, ConstantThrottle, G0, ScheduledBurn, ThrustProfile, Thruster, ThrusterAssembly,
     ThrusterAssemblyCore, ThrusterSpec,

--- a/orts/src/spacecraft/panel_srp.rs
+++ b/orts/src/spacecraft/panel_srp.rs
@@ -393,7 +393,12 @@ mod tests {
         // A black panel re-emits nothing, so the entire force is absorbed
         // photon momentum: along −ŝ, scaled by the projected area A·cosθ.
         let area = 4.0;
-        let panel = SurfacePanel::at_com(area, Vector3::new(1.0, 0.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            area,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let s_body = sun_tilted_in_xy(OBLIQUE_ANGLE);
 
         let f = panel_force(&panel, &s_body, TEST_PRESSURE);
@@ -412,8 +417,12 @@ mod tests {
         // force is purely along −n̂ and follows cos²θ. This is the term an
         // anti-Sun-only force law drops entirely.
         let area = 4.0;
-        let panel = SurfacePanel::at_com(area, Vector3::new(1.0, 0.0, 0.0), 2.2)
-            .with_optics(PanelOptics::new(1.0, 0.0));
+        let panel = SurfacePanel::at_com(
+            area,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::new(1.0, 0.0),
+        );
         let s_body = sun_tilted_in_xy(OBLIQUE_ANGLE);
 
         let f = panel_force(&panel, &s_body, TEST_PRESSURE);
@@ -433,7 +442,7 @@ mod tests {
         // contributes 1, its isotropic re-emission a further 2/3.
         let area = 4.0;
         let normal = Vector3::new(1.0, 0.0, 0.0);
-        let panel = SurfacePanel::at_com(area, normal, 2.2).with_optics(PanelOptics::new(0.0, 1.0));
+        let panel = SurfacePanel::at_com(area, normal, 2.2, PanelOptics::new(0.0, 1.0));
 
         let f = panel_force(&panel, &normal, TEST_PRESSURE);
         let expected = -(1.0 + 2.0 / 3.0) * TEST_PRESSURE * area * normal;
@@ -453,8 +462,12 @@ mod tests {
         // force of the right magnitude pointing the wrong way.
         let (specular, diffuse) = (0.2, 0.1);
         let area = 4.0;
-        let panel = SurfacePanel::at_com(area, Vector3::new(1.0, 0.0, 0.0), 2.2)
-            .with_optics(PanelOptics::new(specular, diffuse));
+        let panel = SurfacePanel::at_com(
+            area,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::new(specular, diffuse),
+        );
         let s_body = sun_tilted_in_xy(OBLIQUE_ANGLE);
         let normal = panel.normal;
 
@@ -492,8 +505,12 @@ mod tests {
 
     #[test]
     fn edge_on_and_backside_are_zero() {
-        let panel = SurfacePanel::at_com(4.0, Vector3::new(1.0, 0.0, 0.0), 2.2)
-            .with_optics(PanelOptics::new(0.4, 0.3));
+        let panel = SurfacePanel::at_com(
+            4.0,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::new(0.4, 0.3),
+        );
 
         for (label, s_body) in [
             ("edge-on", Vector3::new(0.0, 1.0, 0.0)),
@@ -510,8 +527,12 @@ mod tests {
         // force by the same amount: the law may not favour any body axis.
         use nalgebra::{Unit, UnitQuaternion};
 
-        let panel = SurfacePanel::at_com(4.0, Vector3::new(1.0, 0.0, 0.0), 2.2)
-            .with_optics(PanelOptics::new(0.2, 0.1));
+        let panel = SurfacePanel::at_com(
+            4.0,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::new(0.2, 0.1),
+        );
         let s_body = sun_tilted_in_xy(OBLIQUE_ANGLE);
         let f = panel_force(&panel, &s_body, TEST_PRESSURE);
 
@@ -540,7 +561,12 @@ mod tests {
         // Panel normal = +X in body frame, identity attitude → +X in inertial.
         // Default optics absorb everything, so F = -P * A * cos(θ) * ŝ with
         // cos(θ) ≈ 1 — no reflection term, hence no Cr factor.
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
         let epoch = test_epoch();
         let state = iss_state(); // at +X, identity attitude
@@ -576,7 +602,12 @@ mod tests {
     #[test]
     fn single_panel_backface_zero() {
         // Panel normal = -X (facing away from Sun), should get zero force.
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(-1.0, 0.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(-1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
         let epoch = test_epoch();
         let state = iss_state(); // at +X, Sun roughly at +X
@@ -595,8 +626,18 @@ mod tests {
         let epoch = test_epoch();
         let state = iss_state();
 
-        let p1 = SurfacePanel::at_com(5.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
-        let p2 = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
+        let p1 = SurfacePanel::at_com(
+            5.0,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
+        let p2 = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
 
         let l1 = PanelSrp::new(SpacecraftShape::panels(vec![p1])).eval(0.0, &state, Some(&epoch));
         let l2 = PanelSrp::new(SpacecraftShape::panels(vec![p2])).eval(0.0, &state, Some(&epoch));
@@ -617,9 +658,8 @@ mod tests {
         let state = iss_state();
         let normal = sat_to_sun_unit(&epoch);
 
-        let absorber = SurfacePanel::at_com(10.0, normal, 2.2);
-        let mirror =
-            SurfacePanel::at_com(10.0, normal, 2.2).with_optics(PanelOptics::new(1.0, 0.0));
+        let absorber = SurfacePanel::at_com(10.0, normal, 2.2, PanelOptics::absorber());
+        let mirror = SurfacePanel::at_com(10.0, normal, 2.2, PanelOptics::new(1.0, 0.0));
 
         let l1 =
             PanelSrp::new(SpacecraftShape::panels(vec![absorber])).eval(0.0, &state, Some(&epoch));
@@ -641,7 +681,7 @@ mod tests {
         let epoch = test_epoch();
         let sun_dir = sun::sun_direction_eci(&epoch.to_tdb()).into_inner();
 
-        let panel = SurfacePanel::at_com(10.0, sun_dir, 2.2);
+        let panel = SurfacePanel::at_com(10.0, sun_dir, 2.2, PanelOptics::absorber());
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
 
         // Identity attitude: panel faces Sun → non-zero SRP
@@ -673,7 +713,12 @@ mod tests {
         // Earth in shadow → shadow function should zero out the force.
         // We rotate the body 180° about Z so that body +X points toward +X in inertial
         // (the Sun direction), ensuring the panel *would* receive SRP if sunlit.
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(-1.0, 0.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(-1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let srp = PanelSrp::for_earth(SpacecraftShape::panels(vec![panel]));
         let epoch = test_epoch();
 
@@ -699,6 +744,7 @@ mod tests {
             10.0,
             Vector3::new(-1.0, 0.0, 0.0),
             2.2,
+            PanelOptics::absorber(),
         )]));
         let loads_no_shadow = srp_no_shadow.eval(0.0, &state, Some(&epoch));
         assert!(
@@ -711,7 +757,12 @@ mod tests {
     fn no_shadow_body_always_sunlit() {
         // Place satellite behind Earth at -X with a Sun-facing panel.
         // With shadow_body_radius=None, the force should still be non-zero.
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(-1.0, 0.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(-1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel])); // no shadow
 
         let epoch = test_epoch();
@@ -736,6 +787,7 @@ mod tests {
                 10.0,
                 Vector3::new(-1.0, 0.0, 0.0),
                 2.2,
+                PanelOptics::absorber(),
             )]));
         let loads_shadow = srp_with_shadow.eval(0.0, &state, Some(&epoch));
         assert_eq!(
@@ -812,7 +864,12 @@ mod tests {
         // ephemeris rotation reaching the panel formula — not the attitude
         // accessors, which are covered by SimpleEci behaviour-preservation and
         // compile-time typing.
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
         let epoch = test_epoch();
         let sat = vector![7000.0, 1000.0, 500.0];
@@ -863,7 +920,12 @@ mod tests {
 
     #[test]
     fn panels_cp_at_com_zero_torque() {
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
         let epoch = test_epoch();
         let loads = srp.eval(0.0, &iss_state(), Some(&epoch));
@@ -1040,7 +1102,12 @@ mod tests {
         use crate::spacecraft::SpacecraftDynamics;
         use utsuroi::{DynamicalSystem, Integrator, Rk4};
 
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let dynamics = SpacecraftDynamics::new(MU_EARTH, PointMass, nalgebra::Matrix3::identity())
             .with_model(PanelSrp::new(SpacecraftShape::panels(vec![panel])))
             .with_epoch(test_epoch());
@@ -1062,8 +1129,18 @@ mod tests {
         use utsuroi::DynamicalSystem;
 
         let panels = vec![
-            SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2),
-            SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2),
+            SurfacePanel::at_com(
+                10.0,
+                Vector3::new(1.0, 0.0, 0.0),
+                2.2,
+                PanelOptics::absorber(),
+            ),
+            SurfacePanel::at_com(
+                10.0,
+                Vector3::new(0.0, -1.0, 0.0),
+                2.2,
+                PanelOptics::absorber(),
+            ),
         ];
         let shape = SpacecraftShape::panels(panels);
 
@@ -1084,8 +1161,12 @@ mod tests {
         // GEO satellite: A=30m², m=2000kg, solar-array optics (ρ_s=0.2, ρ_d=0.1)
         // → face-on Cr = 1 + ρ_s + 2ρ_d/3 ≈ 1.27
         // |a| = P_sr * Cr * A/m / 1000 ≈ 4.54e-6 * 1.27 * 0.015 / 1000 ≈ 8.6e-11 km/s²
-        let panel = SurfacePanel::at_com(30.0, Vector3::new(1.0, 0.0, 0.0), 2.2)
-            .with_optics(PanelOptics::new(0.2, 0.1));
+        let panel = SurfacePanel::at_com(
+            30.0,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::new(0.2, 0.1),
+        );
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
         let epoch = test_epoch();
 
@@ -1132,7 +1213,12 @@ mod tests {
         use utsuroi::{Integrator, Rk4};
 
         // Asymmetric single panel: SRP depends on orientation
-        let panel = SurfacePanel::at_com(20.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            20.0,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
 
         let inertia = Matrix3::from_diagonal(&Vector3::new(100.0, 200.0, 300.0));
@@ -1209,7 +1295,12 @@ mod tests {
     #[test]
     fn panel_force_scales_inversely_with_mass() {
         let epoch = test_epoch();
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
 
         let mut s1 = iss_state();
         s1.mass = 500.0;
@@ -1238,9 +1329,19 @@ mod tests {
         let state = iss_state();
 
         // Panel facing Sun (+X normal)
-        let sunlit = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
+        let sunlit = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         // Panel facing away (-X normal) — backface, should not contribute
-        let dark = SurfacePanel::at_com(10.0, Vector3::new(-1.0, 0.0, 0.0), 2.2);
+        let dark = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(-1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
 
         let l_single = PanelSrp::new(SpacecraftShape::panels(vec![sunlit.clone()])).eval(
             0.0,
@@ -1313,7 +1414,7 @@ mod tests {
                 let epoch = test_epoch();
 
                 // Face-on panel (normal = +X, Sun ≈ +X)
-                let p_face_on = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
+                let p_face_on = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2, PanelOptics::absorber());
                 let l_face_on = PanelSrp::new(SpacecraftShape::panels(vec![p_face_on]))
                     .eval(0.0, &iss_state(), Some(&epoch));
 
@@ -1322,7 +1423,7 @@ mod tests {
                 state.attitude.quaternion =
                     quat_from_axis_angle(Vector3::new(0.0, 0.0, 1.0), angle);
 
-                let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
+                let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2, PanelOptics::absorber());
                 let l_tilted = PanelSrp::new(SpacecraftShape::panels(vec![panel]))
                     .eval(0.0, &state, Some(&epoch));
 
@@ -1362,8 +1463,7 @@ mod tests {
             #[test]
             fn specular_force_follows_cos_squared(angle in angle_facing_sun()) {
                 let area = 4.0;
-                let panel = SurfacePanel::at_com(area, Vector3::new(1.0, 0.0, 0.0), 2.2)
-                    .with_optics(PanelOptics::new(1.0, 0.0));
+                let panel = SurfacePanel::at_com(area, Vector3::new(1.0, 0.0, 0.0), 2.2, PanelOptics::new(1.0, 0.0));
                 let s_body = sun_tilted_in_xy(angle);
 
                 let f = panel_force(&panel, &s_body, TEST_PRESSURE);

--- a/orts/src/spacecraft/panel_srp.rs
+++ b/orts/src/spacecraft/panel_srp.rs
@@ -1105,6 +1105,22 @@ mod tests {
             a_mag > 1e-12 && a_mag < 1e-8,
             "GEO SRP should be ~1e-10 km/s², got {a_mag:.3e}"
         );
+
+        // The decade bound above would pass for Cr = 1 or Cr = 2 alike, so hold
+        // the result to the coefficient this panel's optics actually imply. The
+        // panel faces +X and the Sun is near +X at the equinox, so cosθ is close
+        // to 1 but not equal to it — hence the 5% band rather than an equality.
+        let cr_face_on = 1.0 + 0.2 + 2.0 * 0.1 / 3.0;
+        let sun = sun::sun_position_eci(&epoch.to_tdb()).into_inner();
+        let r_sun = (sun - state.orbit.position()).magnitude();
+        let expected = SOLAR_RADIATION_PRESSURE * (sun::AU_KM / r_sun).powi(2) * cr_face_on * 30.0
+            / (2000.0 * 1000.0);
+        let rel_err = (a_mag - expected).abs() / expected;
+        assert!(
+            rel_err < 0.05,
+            "GEO SRP should follow Cr = {cr_face_on:.4}: expected ~{expected:.3e}, \
+             got {a_mag:.3e}, rel_err={rel_err:.3}"
+        );
     }
 
     // Tumbling (time-varying attitude)
@@ -1335,6 +1351,30 @@ mod tests {
                         );
                     }
                 }
+            }
+
+            /// A mirror's force is `-2·P·A·cos²θ·n̂` at every incidence.
+            ///
+            /// `cos_theta_scaling` above uses a black panel, whose reflection
+            /// term is identically zero, so it constrains only the `cosθ`
+            /// projected-area factor. Without this the `cos²θ` specular
+            /// dependence is pinned at a single angle.
+            #[test]
+            fn specular_force_follows_cos_squared(angle in angle_facing_sun()) {
+                let area = 4.0;
+                let panel = SurfacePanel::at_com(area, Vector3::new(1.0, 0.0, 0.0), 2.2)
+                    .with_optics(PanelOptics::new(1.0, 0.0));
+                let s_body = sun_tilted_in_xy(angle);
+
+                let f = panel_force(&panel, &s_body, TEST_PRESSURE);
+                let cos = angle.cos();
+                let expected = -2.0 * TEST_PRESSURE * area * cos * cos * panel.normal;
+
+                let err = (f - expected).magnitude() / expected.magnitude();
+                prop_assert!(
+                    err < 1e-13,
+                    "mirror at angle={angle:.4}: expected {expected:?}, got {f:?}, rel_err={err:.3e}"
+                );
             }
         }
     }

--- a/orts/src/spacecraft/panel_srp.rs
+++ b/orts/src/spacecraft/panel_srp.rs
@@ -16,18 +16,15 @@ use super::{ExternalLoads, SpacecraftShape, SurfacePanel};
 /// `s_body` is the unit vector from the spacecraft toward the Sun in the body
 /// frame; `pressure` [N/m²] is the solar radiation pressure already scaled for
 /// heliocentric distance and illumination fraction. Returns zero for a panel
-/// facing away from the Sun. `panel.normal` must be unit length.
+/// facing away from the Sun.
+///
+/// `panel.normal` must be unit length; every constructor of a model holding
+/// panels enforces that, so this runs without re-checking it per stage.
 ///
 /// Split out as a pure function so the force law can be checked against
 /// closed-form values and for rotational equivariance without the Sun
 /// ephemeris, which an inertial rotation of the state does not carry along.
 fn panel_force(panel: &SurfacePanel, s_body: &Vector3<f64>, pressure: f64) -> Vector3<f64> {
-    debug_assert!(
-        (panel.normal.magnitude() - 1.0).abs() < 1e-9,
-        "Panel normal must be unit length, got |n|={}",
-        panel.normal.magnitude()
-    );
-
     let cos_theta = panel.normal.dot(s_body);
     if cos_theta <= 0.0 {
         return Vector3::zeros();
@@ -73,12 +70,11 @@ pub struct PanelSrp {
 
 impl PanelSrp {
     /// Create a panel-based (attitude-dependent) SRP model from surface panels.
+    ///
+    /// # Panics
+    /// Panics unless every panel normal is unit length.
     pub fn panels(panels: Vec<super::SurfacePanel>) -> Self {
-        Self {
-            shape: SpacecraftShape::Panels(panels),
-            shadow_body_radius: None,
-            shadow_model: ShadowModel::Cylindrical,
-        }
+        Self::new(SpacecraftShape::panels(panels))
     }
 
     /// Create an SRP model for Earth orbit with cylindrical Earth shadow.
@@ -88,7 +84,11 @@ impl PanelSrp {
     /// area and [`PanelOptics`].
     ///
     /// [`PanelOptics`]: super::PanelOptics
+    ///
+    /// # Panics
+    /// Panics unless every panel normal is unit length.
     pub fn for_earth(shape: SpacecraftShape) -> Self {
+        shape.assert_normals_are_unit();
         Self {
             shape,
             shadow_body_radius: Some(R_EARTH),
@@ -97,7 +97,11 @@ impl PanelSrp {
     }
 
     /// Create an SRP model without shadow.
+    ///
+    /// # Panics
+    /// Panics unless every panel normal is unit length.
     pub fn new(shape: SpacecraftShape) -> Self {
+        shape.assert_normals_are_unit();
         Self {
             shape,
             shadow_body_radius: None,
@@ -281,6 +285,21 @@ mod tests {
         let loads = srp.eval(0.0, &iss_state(), None);
         assert_eq!(loads.acceleration_inertial.into_inner(), Vector3::zeros());
         assert_eq!(loads.torque_body.into_inner(), Vector3::zeros());
+    }
+
+    #[test]
+    #[should_panic(expected = "normal must be unit length")]
+    fn for_earth_rejects_a_non_unit_normal() {
+        // `SpacecraftShape::Panels` is a public variant, so a shape can reach
+        // the model without passing through `SpacecraftShape::panels`.
+        let shape = SpacecraftShape::Panels(vec![SurfacePanel {
+            area: 10.0,
+            normal: Vector3::new(0.0, 2.0, 0.0),
+            cd: 2.2,
+            optics: PanelOptics::absorber(),
+            cp_offset: Vector3::zeros(),
+        }]);
+        PanelSrp::for_earth(shape);
     }
 
     #[test]

--- a/orts/src/spacecraft/panel_srp.rs
+++ b/orts/src/spacecraft/panel_srp.rs
@@ -9,22 +9,50 @@ use arika::earth::transform::EphemerisFrameBridge;
 
 use crate::model::{HasAttitude, HasFrame, HasMass, HasOrbit, Model};
 
-use super::{ExternalLoads, SpacecraftShape};
+use super::{ExternalLoads, PanelOptics, SpacecraftShape, SurfacePanel};
+
+/// Radiation-pressure force on one flat panel [N, body frame].
+///
+/// `s_body` is the unit vector from the spacecraft toward the Sun in the body
+/// frame; `pressure` [N/m²] is the solar radiation pressure already scaled for
+/// heliocentric distance and illumination fraction. Returns zero for a panel
+/// facing away from the Sun.
+///
+/// ```text
+/// F = -P·A·cosθ · [ (α + ρ_d)·ŝ  +  2·(ρ_s·cosθ + ρ_d/3)·n̂ ]
+/// ```
+///
+/// with `cosθ = n̂·ŝ`, absorbed fraction `α`, specular `ρ_s`, diffuse `ρ_d`, and
+/// `α + ρ_s + ρ_d = 1`. Absorption and diffuse *incidence* push along the Sun
+/// line; specular reflection and diffuse *re-emission* push along the panel
+/// normal. Face-on this collapses to `Cr = 1 + ρ_s + 2ρ_d/3`, recovering the
+/// textbook 1 for a black panel, 2 for a mirror and 5/3 for a Lambertian one.
+///
+/// Split out as a pure function so the force law can be checked against
+/// closed-form values and for rotational equivariance without the Sun
+/// ephemeris, which an inertial rotation of the state does not carry along.
+fn panel_force(panel: &SurfacePanel, s_body: &Vector3<f64>, pressure: f64) -> Vector3<f64> {
+    let cos_theta = panel.normal.dot(s_body);
+    if cos_theta <= 0.0 {
+        return Vector3::zeros();
+    }
+
+    let optics = panel.optics;
+    let along_sun = optics.absorptivity() + optics.diffuse;
+    let along_normal = 2.0 * (optics.specular * cos_theta + optics.diffuse / 3.0);
+
+    -pressure * panel.area * cos_theta * (along_sun * s_body + along_normal * panel.normal)
+}
 
 /// Attitude-dependent solar radiation pressure model using flat surface panels.
 ///
-/// Implements [`LoadModel`] to produce both translational acceleration and
+/// Implements [`Model`] to produce both translational acceleration and
 /// SRP torque from per-panel radiation forces.  For the [`SpacecraftShape::Sphere`]
 /// variant, the `cr` and `area` are read from the shape itself.
 ///
-/// Per-panel force (simplified per panel):
-///
-/// ```text
-/// F_panel = -P_sr × Cr × A × cos(θ) × (AU/r_sun)² × ŝ   [N]
-/// ```
-///
-/// where `θ` is the angle between the panel normal and the Sun direction,
-/// and `ŝ` is the unit vector from the satellite toward the Sun.
+/// Per-panel force: see [`panel_force`]. The torque is `Σ r_cp × F_panel`, so a
+/// panel whose centre of pressure sits off the centre of mass produces an
+/// attitude disturbance.
 pub struct PanelSrp {
     shape: SpacecraftShape,
     /// Central body radius for shadow model [km].
@@ -47,7 +75,8 @@ impl PanelSrp {
     /// Create an SRP model for Earth orbit with cylindrical Earth shadow.
     ///
     /// For the [`SpacecraftShape::Sphere`] variant, `cr` and `area` come from
-    /// the shape. For [`SpacecraftShape::Panels`], each panel carries its own `cr`.
+    /// the shape. For [`SpacecraftShape::Panels`], each panel carries its own
+    /// area and [`PanelOptics`].
     pub fn for_earth(shape: SpacecraftShape) -> Self {
         Self {
             shape,
@@ -143,15 +172,7 @@ impl PanelSrp {
                 let mut total_torque_body = Vector3::zeros(); // [N·m]
 
                 for panel in panels {
-                    // cos(θ) = n̂ · ŝ  (panel must face the Sun)
-                    let cos_theta = panel.normal.dot(&s_body);
-                    if cos_theta <= 0.0 {
-                        continue;
-                    }
-
-                    // F = -base_pressure * Cr * A * cos(θ) * ŝ_body  [N]
-                    // Force is away from Sun (opposite ŝ)
-                    let force = -base_pressure * panel.cr * panel.area * cos_theta * s_body;
+                    let force = panel_force(panel, &s_body, base_pressure); // [N]
 
                     total_force_body += force;
                     total_torque_body += panel.cp_offset.cross(&force);
@@ -217,6 +238,16 @@ mod tests {
             attitude: AttitudeState::identity(),
             mass: 1000.0,
         }
+    }
+
+    /// Unit vector from the [`iss_state`] satellite toward the Sun, in the
+    /// inertial frame — and, at identity attitude, in the body frame too.
+    /// Aligning a panel normal with it makes cosθ exactly 1, so a face-on
+    /// oracle is exact instead of "≈ 1". The geocentric Sun direction is not a
+    /// substitute: the satellite sits 6771 km off the geocentre.
+    fn sat_to_sun_unit(epoch: &Epoch) -> Vector3<f64> {
+        let sun = sun::sun_position_eci(&epoch.to_tdb()).into_inner();
+        (sun - iss_state().orbit.position()).normalize()
     }
 
     fn quat_from_axis_angle(axis: Vector3<f64>, angle: f64) -> Vector4<f64> {
@@ -327,24 +358,187 @@ mod tests {
         );
     }
 
+    // Per-panel force law, against closed-form values.
+    //
+    // These drive `panel_force` directly. Going through `eval` would tie every
+    // oracle to the Sun ephemeris, and would make the equivariance check
+    // impossible: rotating the state does not carry the Sun along with it.
+
+    /// Solar radiation pressure at 1 AU [N/m²]. Any positive value works — the
+    /// oracles are linear in it — so use the real one rather than a round number.
+    const TEST_PRESSURE: f64 = SOLAR_RADIATION_PRESSURE;
+    /// Incidence well away from both face-on and edge-on, where a `cosθ` law
+    /// and a `cos²θ` law are clearly distinguishable.
+    const OBLIQUE_ANGLE: f64 = 0.6; // rad ≈ 34°
+
+    /// Sun direction tilted `angle` from `+X` within the XY plane, so `+X` as a
+    /// panel normal sees `cosθ = cos(angle)`.
+    fn sun_tilted_in_xy(angle: f64) -> Vector3<f64> {
+        Vector3::new(angle.cos(), angle.sin(), 0.0)
+    }
+
+    #[test]
+    fn absorber_oblique_matches_pure_anti_sun() {
+        // A black panel re-emits nothing, so the entire force is absorbed
+        // photon momentum: along −ŝ, scaled by the projected area A·cosθ.
+        let area = 4.0;
+        let panel = SurfacePanel::at_com(area, Vector3::new(1.0, 0.0, 0.0), 2.2);
+        let s_body = sun_tilted_in_xy(OBLIQUE_ANGLE);
+
+        let f = panel_force(&panel, &s_body, TEST_PRESSURE);
+        let expected = -TEST_PRESSURE * area * OBLIQUE_ANGLE.cos() * s_body;
+
+        let err = (f - expected).magnitude() / expected.magnitude();
+        assert!(
+            err < 1e-14,
+            "black panel: expected {expected:?}, got {f:?}, rel_err={err:.3e}"
+        );
+    }
+
+    #[test]
+    fn specular_oblique_is_normal_directed() {
+        // A mirror reflects the incident momentum about the normal, so the net
+        // force is purely along −n̂ and follows cos²θ. This is the term an
+        // anti-Sun-only force law drops entirely.
+        let area = 4.0;
+        let panel = SurfacePanel::at_com(area, Vector3::new(1.0, 0.0, 0.0), 2.2)
+            .with_optics(PanelOptics::new(1.0, 0.0));
+        let s_body = sun_tilted_in_xy(OBLIQUE_ANGLE);
+
+        let f = panel_force(&panel, &s_body, TEST_PRESSURE);
+        let cos = OBLIQUE_ANGLE.cos();
+        let expected = -2.0 * TEST_PRESSURE * area * cos * cos * panel.normal;
+
+        let err = (f - expected).magnitude() / expected.magnitude();
+        assert!(
+            err < 1e-14,
+            "mirror: expected {expected:?}, got {f:?}, rel_err={err:.3e}"
+        );
+    }
+
+    #[test]
+    fn diffuse_face_on_matches_lambertian() {
+        // Face-on, a Lambertian panel gives Cr = 1 + 2/3: the incident momentum
+        // contributes 1, its isotropic re-emission a further 2/3.
+        let area = 4.0;
+        let normal = Vector3::new(1.0, 0.0, 0.0);
+        let panel = SurfacePanel::at_com(area, normal, 2.2).with_optics(PanelOptics::new(0.0, 1.0));
+
+        let f = panel_force(&panel, &normal, TEST_PRESSURE);
+        let expected = -(1.0 + 2.0 / 3.0) * TEST_PRESSURE * area * normal;
+
+        let err = (f - expected).magnitude() / expected.magnitude();
+        assert!(
+            err < 1e-14,
+            "Lambertian: expected {expected:?}, got {f:?}, rel_err={err:.3e}"
+        );
+    }
+
+    #[test]
+    fn mixed_optics_component_oracle() {
+        // A solar-array-like surface at oblique incidence, checked one component
+        // at a time. Projecting onto a direction perpendicular to n̂ isolates the
+        // Sun-line coefficient and vice versa, so this cannot be satisfied by a
+        // force of the right magnitude pointing the wrong way.
+        let (specular, diffuse) = (0.2, 0.1);
+        let area = 4.0;
+        let panel = SurfacePanel::at_com(area, Vector3::new(1.0, 0.0, 0.0), 2.2)
+            .with_optics(PanelOptics::new(specular, diffuse));
+        let s_body = sun_tilted_in_xy(OBLIQUE_ANGLE);
+        let normal = panel.normal;
+
+        let f = panel_force(&panel, &s_body, TEST_PRESSURE);
+
+        let (cos, sin) = (OBLIQUE_ANGLE.cos(), OBLIQUE_ANGLE.sin());
+        let scale = -TEST_PRESSURE * area * cos;
+
+        // Perpendicular within the ŝ–n̂ plane to one of the two directions.
+        let perp_to_normal = (s_body - normal * cos).normalize();
+        let perp_to_sun = (normal - s_body * cos).normalize();
+        // ŝ·perp_to_normal = n̂·perp_to_sun = sinθ, so each projection is the
+        // corresponding coefficient times sinθ.
+        let sun_coeff = f.dot(&perp_to_normal) / sin;
+        let normal_coeff = f.dot(&perp_to_sun) / sin;
+
+        let expected_sun = scale * (1.0 - specular); // α + ρ_d = 1 − ρ_s
+        let expected_normal = scale * 2.0 * (specular * cos + diffuse / 3.0);
+        assert!(
+            (sun_coeff - expected_sun).abs() < expected_sun.abs() * 1e-12,
+            "Sun-line coefficient: expected {expected_sun:.6e}, got {sun_coeff:.6e}"
+        );
+        assert!(
+            (normal_coeff - expected_normal).abs() < expected_normal.abs() * 1e-12,
+            "normal coefficient: expected {expected_normal:.6e}, got {normal_coeff:.6e}"
+        );
+
+        // Nothing out of the ŝ–n̂ plane.
+        let out_of_plane = f.dot(&s_body.cross(&normal).normalize());
+        assert!(
+            out_of_plane.abs() < f.magnitude() * 1e-14,
+            "force should lie in the ŝ–n̂ plane, out-of-plane={out_of_plane:.3e}"
+        );
+    }
+
+    #[test]
+    fn edge_on_and_backside_are_zero() {
+        let panel = SurfacePanel::at_com(4.0, Vector3::new(1.0, 0.0, 0.0), 2.2)
+            .with_optics(PanelOptics::new(0.4, 0.3));
+
+        for (label, s_body) in [
+            ("edge-on", Vector3::new(0.0, 1.0, 0.0)),
+            ("backside", Vector3::new(-1.0, 0.0, 0.0)),
+        ] {
+            let f = panel_force(&panel, &s_body, TEST_PRESSURE);
+            assert_eq!(f, Vector3::zeros(), "{label} panel should feel no force");
+        }
+    }
+
+    #[test]
+    fn panel_force_equivariance_under_body_rotation() {
+        // Rotating the panel and the Sun direction together must rotate the
+        // force by the same amount: the law may not favour any body axis.
+        use nalgebra::{Unit, UnitQuaternion};
+
+        let panel = SurfacePanel::at_com(4.0, Vector3::new(1.0, 0.0, 0.0), 2.2)
+            .with_optics(PanelOptics::new(0.2, 0.1));
+        let s_body = sun_tilted_in_xy(OBLIQUE_ANGLE);
+        let f = panel_force(&panel, &s_body, TEST_PRESSURE);
+
+        // An axis off every coordinate axis, so a per-axis mistake cannot hide.
+        let rot =
+            UnitQuaternion::from_axis_angle(&Unit::new_normalize(Vector3::new(1.0, 2.0, 3.0)), 0.7);
+        let rotated = SurfacePanel {
+            normal: rot * panel.normal,
+            ..panel.clone()
+        };
+        let f_rotated = panel_force(&rotated, &(rot * s_body), TEST_PRESSURE);
+
+        let err = (f_rotated - rot * f).magnitude() / f.magnitude();
+        assert!(
+            err < 1e-14,
+            "force should be equivariant, rel_err={err:.3e}"
+        );
+    }
+
     // Ideal single panel + single Sun direction
 
     #[test]
     fn single_panel_face_on_analytical() {
-        // A single panel facing exactly toward the Sun at identity attitude.
+        // A single black panel facing the Sun at identity attitude.
         // At March equinox, Sun is roughly +X, satellite at +X.
         // Panel normal = +X in body frame, identity attitude → +X in inertial.
-        // cos(θ) ≈ 1, F = -P * Cr * A * ŝ
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2).with_cr(1.5);
+        // Default optics absorb everything, so F = -P * A * cos(θ) * ŝ with
+        // cos(θ) ≈ 1 — no reflection term, hence no Cr factor.
+        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
         let epoch = test_epoch();
         let state = iss_state(); // at +X, identity attitude
 
         let loads = srp.eval(0.0, &state, Some(&epoch));
 
-        // Expected magnitude: P_sr * (AU/r_sun)^2 * Cr * A * cos(θ) / (mass * 1000)
+        // Expected magnitude: P_sr * (AU/r_sun)^2 * A * cos(θ) / (mass * 1000)
         // cos(θ) ≈ 1 (panel faces Sun), r_sun ≈ AU
-        let expected_a = SOLAR_RADIATION_PRESSURE * 1.5 * 10.0 / (1000.0 * 1000.0);
+        let expected_a = SOLAR_RADIATION_PRESSURE * 10.0 / (1000.0 * 1000.0);
         let actual_a = loads.acceleration_inertial.magnitude();
 
         let rel_err = (actual_a - expected_a).abs() / expected_a;
@@ -371,7 +565,7 @@ mod tests {
     #[test]
     fn single_panel_backface_zero() {
         // Panel normal = -X (facing away from Sun), should get zero force.
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(-1.0, 0.0, 0.0), 2.2).with_cr(1.5);
+        let panel = SurfacePanel::at_com(10.0, Vector3::new(-1.0, 0.0, 0.0), 2.2);
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
         let epoch = test_epoch();
         let state = iss_state(); // at +X, Sun roughly at +X
@@ -390,8 +584,8 @@ mod tests {
         let epoch = test_epoch();
         let state = iss_state();
 
-        let p1 = SurfacePanel::at_com(5.0, Vector3::new(1.0, 0.0, 0.0), 2.2).with_cr(1.5);
-        let p2 = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2).with_cr(1.5);
+        let p1 = SurfacePanel::at_com(5.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
+        let p2 = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
 
         let l1 = PanelSrp::new(SpacecraftShape::panels(vec![p1])).eval(0.0, &state, Some(&epoch));
         let l2 = PanelSrp::new(SpacecraftShape::panels(vec![p2])).eval(0.0, &state, Some(&epoch));
@@ -404,20 +598,27 @@ mod tests {
     }
 
     #[test]
-    fn panel_force_scales_with_cr() {
+    fn panel_force_scales_with_reflectivity() {
+        // Face-on, a mirror (Cr = 2) pushes exactly twice as hard as a black
+        // panel (Cr = 1). Aligning the normal with the satellite-to-Sun vector
+        // makes cosθ exactly 1, so the factor is 2 and not 2cosθ.
         let epoch = test_epoch();
         let state = iss_state();
+        let normal = sat_to_sun_unit(&epoch);
 
-        let p1 = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2).with_cr(1.0);
-        let p2 = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2).with_cr(2.0);
+        let absorber = SurfacePanel::at_com(10.0, normal, 2.2);
+        let mirror =
+            SurfacePanel::at_com(10.0, normal, 2.2).with_optics(PanelOptics::new(1.0, 0.0));
 
-        let l1 = PanelSrp::new(SpacecraftShape::panels(vec![p1])).eval(0.0, &state, Some(&epoch));
-        let l2 = PanelSrp::new(SpacecraftShape::panels(vec![p2])).eval(0.0, &state, Some(&epoch));
+        let l1 =
+            PanelSrp::new(SpacecraftShape::panels(vec![absorber])).eval(0.0, &state, Some(&epoch));
+        let l2 =
+            PanelSrp::new(SpacecraftShape::panels(vec![mirror])).eval(0.0, &state, Some(&epoch));
 
         let ratio = l2.acceleration_inertial.magnitude() / l1.acceleration_inertial.magnitude();
         assert!(
             (ratio - 2.0).abs() < 1e-10,
-            "2x Cr should give 2x force, ratio={ratio}"
+            "A mirror should push 2x a black panel face-on, ratio={ratio}"
         );
     }
 
@@ -429,7 +630,7 @@ mod tests {
         let epoch = test_epoch();
         let sun_dir = sun::sun_direction_eci(&epoch.to_tdb()).into_inner();
 
-        let panel = SurfacePanel::at_com(10.0, sun_dir, 2.2).with_cr(1.5);
+        let panel = SurfacePanel::at_com(10.0, sun_dir, 2.2);
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
 
         // Identity attitude: panel faces Sun → non-zero SRP
@@ -461,7 +662,7 @@ mod tests {
         // Earth in shadow → shadow function should zero out the force.
         // We rotate the body 180° about Z so that body +X points toward +X in inertial
         // (the Sun direction), ensuring the panel *would* receive SRP if sunlit.
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(-1.0, 0.0, 0.0), 2.2).with_cr(1.5);
+        let panel = SurfacePanel::at_com(10.0, Vector3::new(-1.0, 0.0, 0.0), 2.2);
         let srp = PanelSrp::for_earth(SpacecraftShape::panels(vec![panel]));
         let epoch = test_epoch();
 
@@ -483,9 +684,11 @@ mod tests {
         );
 
         // Verify it *would* be non-zero without shadow (confirms we're testing shadow, not backface)
-        let srp_no_shadow = PanelSrp::new(SpacecraftShape::panels(vec![
-            SurfacePanel::at_com(10.0, Vector3::new(-1.0, 0.0, 0.0), 2.2).with_cr(1.5),
-        ]));
+        let srp_no_shadow = PanelSrp::new(SpacecraftShape::panels(vec![SurfacePanel::at_com(
+            10.0,
+            Vector3::new(-1.0, 0.0, 0.0),
+            2.2,
+        )]));
         let loads_no_shadow = srp_no_shadow.eval(0.0, &state, Some(&epoch));
         assert!(
             loads_no_shadow.acceleration_inertial.magnitude() > 0.0,
@@ -497,7 +700,7 @@ mod tests {
     fn no_shadow_body_always_sunlit() {
         // Place satellite behind Earth at -X with a Sun-facing panel.
         // With shadow_body_radius=None, the force should still be non-zero.
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(-1.0, 0.0, 0.0), 2.2).with_cr(1.5);
+        let panel = SurfacePanel::at_com(10.0, Vector3::new(-1.0, 0.0, 0.0), 2.2);
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel])); // no shadow
 
         let epoch = test_epoch();
@@ -517,9 +720,12 @@ mod tests {
         );
 
         // And verify that with shadow it would be zero
-        let srp_with_shadow = PanelSrp::for_earth(SpacecraftShape::panels(vec![
-            SurfacePanel::at_com(10.0, Vector3::new(-1.0, 0.0, 0.0), 2.2).with_cr(1.5),
-        ]));
+        let srp_with_shadow =
+            PanelSrp::for_earth(SpacecraftShape::panels(vec![SurfacePanel::at_com(
+                10.0,
+                Vector3::new(-1.0, 0.0, 0.0),
+                2.2,
+            )]));
         let loads_shadow = srp_with_shadow.eval(0.0, &state, Some(&epoch));
         assert_eq!(
             loads_shadow.acceleration_inertial.into_inner(),
@@ -595,7 +801,7 @@ mod tests {
         // ephemeris rotation reaching the panel formula — not the attitude
         // accessors, which are covered by SimpleEci behaviour-preservation and
         // compile-time typing.
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2).with_cr(1.5);
+        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
         let epoch = test_epoch();
         let sat = vector![7000.0, 1000.0, 500.0];
@@ -631,7 +837,7 @@ mod tests {
             area: 10.0,
             normal: Vector3::new(1.0, 0.0, 0.0),
             cd: 2.2,
-            cr: 1.5,
+            optics: PanelOptics::absorber(),
             cp_offset: Vector3::new(0.0, 1.0, 0.0), // 1 m offset in +y
         };
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
@@ -646,7 +852,7 @@ mod tests {
 
     #[test]
     fn panels_cp_at_com_zero_torque() {
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2).with_cr(1.5);
+        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
         let epoch = test_epoch();
         let loads = srp.eval(0.0, &iss_state(), Some(&epoch));
@@ -667,7 +873,7 @@ mod tests {
             area: 10.0,
             normal: Vector3::new(1.0, 0.0, 0.0),
             cd: 2.2,
-            cr: 1.5,
+            optics: PanelOptics::absorber(),
             cp_offset: Vector3::new(0.0, 1.0, 0.0),
         };
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
@@ -695,6 +901,126 @@ mod tests {
         );
     }
 
+    /// Solar radiation pressure at the [`iss_state`] satellite for `epoch`,
+    /// scaled for heliocentric distance. Rebuilt here so torque oracles do not
+    /// borrow the model's own intermediate value.
+    fn pressure_at_iss(epoch: &Epoch) -> f64 {
+        let sun = sun::sun_position_eci(&epoch.to_tdb()).into_inner();
+        let r_sun = (sun - iss_state().orbit.position()).magnitude();
+        SOLAR_RADIATION_PRESSURE * (sun::AU_KM / r_sun).powi(2)
+    }
+
+    #[test]
+    fn torque_exact_cross_product_out_of_plane() {
+        // The centre of pressure sits off the ŝ–n̂ plane, where r × ŝ and r × n̂
+        // point in genuinely different directions. A force law that pushes only
+        // along −ŝ therefore gets the torque *direction* wrong, not merely its
+        // magnitude — so this pins the torque against a full closed-form force
+        // and then shows it is measurably off the anti-Sun-only answer.
+        let epoch = test_epoch();
+        let s_body = sat_to_sun_unit(&epoch); // identity attitude → body == inertial
+        let area = 8.0;
+        let optics = PanelOptics::new(0.3, 0.2);
+        // Normal 45° between +X and +Z, so cosθ ≈ 0.7 against the near-+X Sun,
+        // and an offset along +Y, perpendicular to that plane.
+        let normal = Vector3::new(1.0, 0.0, 1.0).normalize();
+        let cp_offset = Vector3::new(0.0, 1.0, 0.0);
+        let panel = SurfacePanel {
+            area,
+            normal,
+            cd: 2.2,
+            optics,
+            cp_offset,
+        };
+
+        let loads = PanelSrp::new(SpacecraftShape::panels(vec![panel])).eval(
+            0.0,
+            &iss_state(),
+            Some(&epoch),
+        );
+        let tau = loads.torque_body.into_inner();
+
+        let pressure = pressure_at_iss(&epoch);
+        let cos = normal.dot(&s_body);
+        assert!(cos > 0.6, "panel should be well illuminated, cosθ={cos:.3}");
+        let force = -pressure
+            * area
+            * cos
+            * ((optics.absorptivity() + optics.diffuse) * s_body
+                + 2.0 * (optics.specular * cos + optics.diffuse / 3.0) * normal);
+        let expected = cp_offset.cross(&force);
+
+        let err = (tau - expected).magnitude() / expected.magnitude();
+        assert!(
+            err < 1e-12,
+            "τ should equal r × F: expected {expected:?}, got {tau:?}, rel_err={err:.3e}"
+        );
+
+        // The superseded anti-Sun-only law, at the lumped Cr this panel replaced.
+        let anti_sun_only = -pressure * area * cos * 1.5 * s_body;
+        let tau_anti_sun_only = cp_offset.cross(&anti_sun_only);
+        let alignment = tau.normalize().dot(&tau_anti_sun_only.normalize());
+        assert!(
+            alignment < 0.99,
+            "an anti-Sun-only force gives a different torque direction; \
+             alignment={alignment:.6} means the normal term is missing"
+        );
+    }
+
+    #[test]
+    fn torque_exact_under_non_identity_attitude() {
+        // Under a real attitude the Sun direction must be rotated into the body
+        // frame before the cross product, and the torque must stay in the body
+        // frame. Computing either in the inertial frame breaks this.
+        let epoch = test_epoch();
+        let angle = 0.9;
+        let mut state = iss_state();
+        state.attitude.quaternion = quat_from_axis_angle(Vector3::new(0.0, 0.0, 1.0), angle);
+
+        let area = 6.0;
+        let optics = PanelOptics::new(0.25, 0.15);
+        let normal = Vector3::new(1.0, 0.0, 0.0);
+        let cp_offset = Vector3::new(0.0, 0.0, 1.2);
+        let panel = SurfacePanel {
+            area,
+            normal,
+            cd: 2.2,
+            optics,
+            cp_offset,
+        };
+
+        let loads =
+            PanelSrp::new(SpacecraftShape::panels(vec![panel])).eval(0.0, &state, Some(&epoch));
+        let tau = loads.torque_body.into_inner();
+
+        // Rotate the Sun direction into the body frame by hand: a rotation of
+        // the body by +angle about Z takes an inertial vector to the body frame
+        // by −angle.
+        let s_inertial = sat_to_sun_unit(&epoch);
+        let s_body = Vector3::new(
+            angle.cos() * s_inertial.x + angle.sin() * s_inertial.y,
+            -angle.sin() * s_inertial.x + angle.cos() * s_inertial.y,
+            s_inertial.z,
+        );
+
+        let pressure = pressure_at_iss(&epoch);
+        let cos = normal.dot(&s_body);
+        assert!(cos > 0.5, "panel should be well illuminated, cosθ={cos:.3}");
+        let force = -pressure
+            * area
+            * cos
+            * ((optics.absorptivity() + optics.diffuse) * s_body
+                + 2.0 * (optics.specular * cos + optics.diffuse / 3.0) * normal);
+        let expected = cp_offset.cross(&force);
+
+        let err = (tau - expected).magnitude() / expected.magnitude();
+        assert!(
+            err < 1e-12,
+            "τ should equal r × F in the body frame: expected {expected:?}, \
+             got {tau:?}, rel_err={err:.3e}"
+        );
+    }
+
     // Integration with SpacecraftDynamics
 
     #[test]
@@ -703,7 +1029,7 @@ mod tests {
         use crate::spacecraft::SpacecraftDynamics;
         use utsuroi::{DynamicalSystem, Integrator, Rk4};
 
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2).with_cr(1.5);
+        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
         let dynamics = SpacecraftDynamics::new(MU_EARTH, PointMass, nalgebra::Matrix3::identity())
             .with_model(PanelSrp::new(SpacecraftShape::panels(vec![panel])))
             .with_epoch(test_epoch());
@@ -725,8 +1051,8 @@ mod tests {
         use utsuroi::DynamicalSystem;
 
         let panels = vec![
-            SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2).with_cr(1.5),
-            SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2).with_cr(1.5),
+            SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2),
+            SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2),
         ];
         let shape = SpacecraftShape::panels(panels);
 
@@ -744,9 +1070,11 @@ mod tests {
 
     #[test]
     fn srp_order_of_magnitude_geo() {
-        // GEO satellite: A=30m², m=2000kg, Cr=1.5
-        // |a| = P_sr * Cr * A/m / 1000 ≈ 4.54e-6 * 1.5 * 0.015 / 1000 ≈ 1.02e-10 km/s²
-        let panel = SurfacePanel::at_com(30.0, Vector3::new(1.0, 0.0, 0.0), 2.2).with_cr(1.5);
+        // GEO satellite: A=30m², m=2000kg, solar-array optics (ρ_s=0.2, ρ_d=0.1)
+        // → face-on Cr = 1 + ρ_s + 2ρ_d/3 ≈ 1.27
+        // |a| = P_sr * Cr * A/m / 1000 ≈ 4.54e-6 * 1.27 * 0.015 / 1000 ≈ 8.6e-11 km/s²
+        let panel = SurfacePanel::at_com(30.0, Vector3::new(1.0, 0.0, 0.0), 2.2)
+            .with_optics(PanelOptics::new(0.2, 0.1));
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
         let epoch = test_epoch();
 
@@ -777,7 +1105,7 @@ mod tests {
         use utsuroi::{Integrator, Rk4};
 
         // Asymmetric single panel: SRP depends on orientation
-        let panel = SurfacePanel::at_com(20.0, Vector3::new(1.0, 0.0, 0.0), 2.2).with_cr(1.5);
+        let panel = SurfacePanel::at_com(20.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
         let srp = PanelSrp::new(SpacecraftShape::panels(vec![panel]));
 
         let inertia = Matrix3::from_diagonal(&Vector3::new(100.0, 200.0, 300.0));
@@ -854,7 +1182,7 @@ mod tests {
     #[test]
     fn panel_force_scales_inversely_with_mass() {
         let epoch = test_epoch();
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2).with_cr(1.5);
+        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
 
         let mut s1 = iss_state();
         s1.mass = 500.0;
@@ -883,9 +1211,9 @@ mod tests {
         let state = iss_state();
 
         // Panel facing Sun (+X normal)
-        let sunlit = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2).with_cr(1.5);
+        let sunlit = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
         // Panel facing away (-X normal) — backface, should not contribute
-        let dark = SurfacePanel::at_com(10.0, Vector3::new(-1.0, 0.0, 0.0), 2.2).with_cr(1.5);
+        let dark = SurfacePanel::at_com(10.0, Vector3::new(-1.0, 0.0, 0.0), 2.2);
 
         let l_single = PanelSrp::new(SpacecraftShape::panels(vec![sunlit.clone()])).eval(
             0.0,
@@ -922,7 +1250,7 @@ mod tests {
         // For identity attitude and Sun ≈ +X, the +X face is fully illuminated,
         // while ±Y and ±Z faces get glancing illumination from the Sun's small
         // off-axis components. The -X, and the other back faces get zero.
-        let cube = SpacecraftShape::cube(0.5, 2.2, 1.5); // 1m cube, half_size=0.5
+        let cube = SpacecraftShape::cube(0.5, 2.2, PanelOptics::absorber()); // 1m cube, half_size=0.5
         let srp = PanelSrp::new(cube);
         let epoch = test_epoch();
         let state = iss_state();
@@ -958,8 +1286,7 @@ mod tests {
                 let epoch = test_epoch();
 
                 // Face-on panel (normal = +X, Sun ≈ +X)
-                let p_face_on = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2)
-                    .with_cr(1.5);
+                let p_face_on = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
                 let l_face_on = PanelSrp::new(SpacecraftShape::panels(vec![p_face_on]))
                     .eval(0.0, &iss_state(), Some(&epoch));
 
@@ -968,8 +1295,7 @@ mod tests {
                 state.attitude.quaternion =
                     quat_from_axis_angle(Vector3::new(0.0, 0.0, 1.0), angle);
 
-                let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2)
-                    .with_cr(1.5);
+                let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
                 let l_tilted = PanelSrp::new(SpacecraftShape::panels(vec![panel]))
                     .eval(0.0, &state, Some(&epoch));
 

--- a/orts/src/spacecraft/panel_srp.rs
+++ b/orts/src/spacecraft/panel_srp.rs
@@ -571,6 +571,64 @@ mod tests {
         );
     }
 
+    /// Orekit cross-validation of the per-panel force.
+    ///
+    /// The closed-form tests above are independent of the implementation but
+    /// not of the formula: a shared error in the flat-plate law, or a
+    /// misreading of what the coefficients mean, would satisfy them. Orekit's
+    /// paneled radiation model is a separate implementation of the same
+    /// physics, so agreeing with it pins the formula and the convention.
+    ///
+    /// Fixture from `tools/generate_orekit_panel_srp_fixtures.py`, which drives
+    /// Orekit's `RadiationSensitive::radiationPressureAcceleration` on a
+    /// one-panel spacecraft. That needs no propagator and no attitude provider,
+    /// which is why a force oracle is available where a torque one is not:
+    /// Orekit's paneled model returns an acceleration only. The torque this
+    /// model builds from the force is pinned by the exact cross-product tests.
+    #[test]
+    fn orekit_panel_force_reference() {
+        #[derive(serde::Deserialize)]
+        struct Case {
+            name: String,
+            specular: f64,
+            diffuse: f64,
+            incidence_deg: f64,
+            force_body_n: [f64; 3],
+        }
+        #[derive(serde::Deserialize)]
+        struct Fixture {
+            pressure_n_m2: f64,
+            area_m2: f64,
+            panel_normal_body: [f64; 3],
+            cases: Vec<Case>,
+        }
+
+        let raw = include_str!("../../tests/fixtures/orekit_panel_srp_reference.json");
+        let fx: Fixture = serde_json::from_str(raw).expect("fixture parses");
+        assert!(fx.cases.len() >= 12, "expected the full case set");
+
+        let normal = Vector3::from_row_slice(&fx.panel_normal_body);
+        for case in &fx.cases {
+            let optics = PanelOptics::new(case.specular, case.diffuse);
+            let panel = SurfacePanel::at_com(fx.area_m2, normal, 2.2, optics);
+            let th = case.incidence_deg.to_radians();
+            let s_body = Vector3::new(th.sin(), 0.0, th.cos());
+
+            let ours = panel_force(&panel, &s_body, fx.pressure_n_m2);
+            let theirs = Vector3::from_row_slice(&case.force_body_n);
+
+            let err = (ours - theirs).magnitude() / theirs.magnitude();
+            assert!(
+                err < 1e-12,
+                "{}: orekit {:?}, ours {:?}, rel_err={:.3e}",
+                case.name,
+                theirs,
+                ours,
+                err
+            );
+        }
+    }
+
     // Ideal single panel + single Sun direction
 
     #[test]

--- a/orts/src/spacecraft/panel_srp.rs
+++ b/orts/src/spacecraft/panel_srp.rs
@@ -9,14 +9,44 @@ use arika::earth::transform::EphemerisFrameBridge;
 
 use crate::model::{HasAttitude, HasFrame, HasMass, HasOrbit, Model};
 
-use super::{ExternalLoads, PanelOptics, SpacecraftShape, SurfacePanel};
+use super::{ExternalLoads, SpacecraftShape, SurfacePanel};
 
 /// Radiation-pressure force on one flat panel [N, body frame].
 ///
 /// `s_body` is the unit vector from the spacecraft toward the Sun in the body
 /// frame; `pressure` [N/m²] is the solar radiation pressure already scaled for
 /// heliocentric distance and illumination fraction. Returns zero for a panel
-/// facing away from the Sun.
+/// facing away from the Sun. `panel.normal` must be unit length.
+///
+/// Split out as a pure function so the force law can be checked against
+/// closed-form values and for rotational equivariance without the Sun
+/// ephemeris, which an inertial rotation of the state does not carry along.
+fn panel_force(panel: &SurfacePanel, s_body: &Vector3<f64>, pressure: f64) -> Vector3<f64> {
+    debug_assert!(
+        (panel.normal.magnitude() - 1.0).abs() < 1e-9,
+        "Panel normal must be unit length, got |n|={}",
+        panel.normal.magnitude()
+    );
+
+    let cos_theta = panel.normal.dot(s_body);
+    if cos_theta <= 0.0 {
+        return Vector3::zeros();
+    }
+
+    let optics = panel.optics;
+    let along_sun = optics.absorptivity() + optics.diffuse();
+    let along_normal = 2.0 * (optics.specular() * cos_theta + optics.diffuse() / 3.0);
+
+    -pressure * panel.area * cos_theta * (along_sun * s_body + along_normal * panel.normal)
+}
+
+/// Attitude-dependent solar radiation pressure model using flat surface panels.
+///
+/// Implements [`Model`] to produce both translational acceleration and
+/// SRP torque from per-panel radiation forces.  For the [`SpacecraftShape::Sphere`]
+/// variant, the `cr` and `area` are read from the shape itself.
+///
+/// Per-panel force, from the panel's [`PanelOptics`]:
 ///
 /// ```text
 /// F = -P·A·cosθ · [ (α + ρ_d)·ŝ  +  2·(ρ_s·cosθ + ρ_d/3)·n̂ ]
@@ -28,31 +58,10 @@ use super::{ExternalLoads, PanelOptics, SpacecraftShape, SurfacePanel};
 /// normal. Face-on this collapses to `Cr = 1 + ρ_s + 2ρ_d/3`, recovering the
 /// textbook 1 for a black panel, 2 for a mirror and 5/3 for a Lambertian one.
 ///
-/// Split out as a pure function so the force law can be checked against
-/// closed-form values and for rotational equivariance without the Sun
-/// ephemeris, which an inertial rotation of the state does not carry along.
-fn panel_force(panel: &SurfacePanel, s_body: &Vector3<f64>, pressure: f64) -> Vector3<f64> {
-    let cos_theta = panel.normal.dot(s_body);
-    if cos_theta <= 0.0 {
-        return Vector3::zeros();
-    }
-
-    let optics = panel.optics;
-    let along_sun = optics.absorptivity() + optics.diffuse;
-    let along_normal = 2.0 * (optics.specular * cos_theta + optics.diffuse / 3.0);
-
-    -pressure * panel.area * cos_theta * (along_sun * s_body + along_normal * panel.normal)
-}
-
-/// Attitude-dependent solar radiation pressure model using flat surface panels.
+/// The torque is `Σ r_cp × F_panel`, so a panel whose centre of pressure sits
+/// off the centre of mass produces an attitude disturbance.
 ///
-/// Implements [`Model`] to produce both translational acceleration and
-/// SRP torque from per-panel radiation forces.  For the [`SpacecraftShape::Sphere`]
-/// variant, the `cr` and `area` are read from the shape itself.
-///
-/// Per-panel force: see [`panel_force`]. The torque is `Σ r_cp × F_panel`, so a
-/// panel whose centre of pressure sits off the centre of mass produces an
-/// attitude disturbance.
+/// [`PanelOptics`]: super::PanelOptics
 pub struct PanelSrp {
     shape: SpacecraftShape,
     /// Central body radius for shadow model [km].
@@ -77,6 +86,8 @@ impl PanelSrp {
     /// For the [`SpacecraftShape::Sphere`] variant, `cr` and `area` come from
     /// the shape. For [`SpacecraftShape::Panels`], each panel carries its own
     /// area and [`PanelOptics`].
+    ///
+    /// [`PanelOptics`]: super::PanelOptics
     pub fn for_earth(shape: SpacecraftShape) -> Self {
         Self {
             shape,
@@ -222,7 +233,7 @@ mod tests {
     use crate::SpacecraftState;
     use crate::attitude::AttitudeState;
     use crate::perturbations::SolarRadiationPressure;
-    use crate::spacecraft::SurfacePanel;
+    use crate::spacecraft::{PanelOptics, SurfacePanel};
     use arika::earth::MU as MU_EARTH;
     use nalgebra::{Vector4, vector};
 
@@ -946,8 +957,8 @@ mod tests {
         let force = -pressure
             * area
             * cos
-            * ((optics.absorptivity() + optics.diffuse) * s_body
-                + 2.0 * (optics.specular * cos + optics.diffuse / 3.0) * normal);
+            * ((optics.absorptivity() + optics.diffuse()) * s_body
+                + 2.0 * (optics.specular() * cos + optics.diffuse() / 3.0) * normal);
         let expected = cp_offset.cross(&force);
 
         let err = (tau - expected).magnitude() / expected.magnitude();
@@ -1009,8 +1020,8 @@ mod tests {
         let force = -pressure
             * area
             * cos
-            * ((optics.absorptivity() + optics.diffuse) * s_body
-                + 2.0 * (optics.specular * cos + optics.diffuse / 3.0) * normal);
+            * ((optics.absorptivity() + optics.diffuse()) * s_body
+                + 2.0 * (optics.specular() * cos + optics.diffuse() / 3.0) * normal);
         let expected = cp_offset.cross(&force);
 
         let err = (tau - expected).magnitude() / expected.magnitude();

--- a/orts/src/spacecraft/surface.rs
+++ b/orts/src/spacecraft/surface.rs
@@ -110,20 +110,25 @@ impl SurfacePanel {
     /// Create a panel whose centre of pressure coincides with the CoM.
     ///
     /// The `normal` vector is normalised internally; it need not be unit length.
-    /// Optics default to [`PanelOptics::absorber`] — a lumped `Cr` has no unique
-    /// specular/diffuse split, so the default is a stated physical surface
-    /// rather than an inferred one. Set it with [`Self::with_optics`].
+    ///
+    /// `optics` is a required argument rather than a default. The lumped `Cr`
+    /// this replaced has no unique specular/diffuse split, so any default would
+    /// be an invented surface; and since the force direction now depends on the
+    /// split, no default reproduces the old behaviour at oblique incidence.
+    /// Making it explicit turns what would be a silent change in every existing
+    /// caller's SRP force into a compile error. [`PanelOptics::absorber`] is the
+    /// value to pass when the surface is genuinely unknown.
     ///
     /// # Panics
     /// Panics if `normal` is zero-length.
-    pub fn at_com(area: f64, normal: Vector3<f64>, cd: f64) -> Self {
+    pub fn at_com(area: f64, normal: Vector3<f64>, cd: f64, optics: PanelOptics) -> Self {
         let n = normal.normalize();
         assert!(n.magnitude() > 0.5, "Panel normal must be non-zero");
         Self {
             area,
             normal: n,
             cd,
-            optics: PanelOptics::absorber(),
+            optics,
             cp_offset: Vector3::zeros(),
         }
     }
@@ -446,13 +451,23 @@ mod tests {
 
     #[test]
     fn at_com_zero_cp_offset() {
-        let p = SurfacePanel::at_com(2.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
+        let p = SurfacePanel::at_com(
+            2.0,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         assert_eq!(p.cp_offset, Vector3::zeros());
     }
 
     #[test]
     fn at_com_normalises_normal() {
-        let p = SurfacePanel::at_com(1.0, Vector3::new(3.0, 4.0, 0.0), 2.0);
+        let p = SurfacePanel::at_com(
+            1.0,
+            Vector3::new(3.0, 4.0, 0.0),
+            2.0,
+            PanelOptics::absorber(),
+        );
         let expected = Vector3::new(0.6, 0.8, 0.0);
         assert!(
             (p.normal - expected).magnitude() < 1e-15,
@@ -464,30 +479,47 @@ mod tests {
     #[test]
     fn at_com_already_unit() {
         let n = Vector3::new(0.0, 0.0, 1.0);
-        let p = SurfacePanel::at_com(5.0, n, 2.2);
+        let p = SurfacePanel::at_com(5.0, n, 2.2, PanelOptics::absorber());
         assert!((p.normal - n).magnitude() < 1e-15);
     }
 
     #[test]
     #[should_panic]
     fn at_com_zero_normal_panics() {
-        SurfacePanel::at_com(1.0, Vector3::zeros(), 2.0);
+        SurfacePanel::at_com(1.0, Vector3::zeros(), 2.0, PanelOptics::absorber());
     }
 
     #[test]
     fn at_com_preserves_area_and_cd() {
-        let p = SurfacePanel::at_com(3.5, Vector3::new(0.0, 1.0, 0.0), 2.1);
+        let p = SurfacePanel::at_com(
+            3.5,
+            Vector3::new(0.0, 1.0, 0.0),
+            2.1,
+            PanelOptics::absorber(),
+        );
         assert!((p.area - 3.5).abs() < 1e-15);
         assert!((p.cd - 2.1).abs() < 1e-15);
     }
 
     #[test]
-    fn at_com_defaults_to_a_black_panel() {
-        // The default has to be a stated surface, since a lumped Cr has no
-        // unique specular/diffuse split to infer one from.
-        let p = SurfacePanel::at_com(3.5, Vector3::new(0.0, 1.0, 0.0), 2.1);
-        assert_eq!(p.optics, PanelOptics::absorber());
-        assert!((p.optics.absorptivity() - 1.0).abs() < 1e-15);
+    fn at_com_carries_the_optics_it_is_given() {
+        let optics = PanelOptics::new(0.3, 0.2);
+        let p = SurfacePanel::at_com(3.5, Vector3::new(0.0, 1.0, 0.0), 2.1, optics);
+        assert_eq!(p.optics, optics);
+    }
+
+    #[test]
+    fn with_optics_replaces_the_panel_optics() {
+        // The builder is how a face of a `cube` gets its own surface.
+        let replacement = PanelOptics::new(0.6, 0.1);
+        let p = SurfacePanel::at_com(
+            3.5,
+            Vector3::new(0.0, 1.0, 0.0),
+            2.1,
+            PanelOptics::absorber(),
+        )
+        .with_optics(replacement);
+        assert_eq!(p.optics, replacement);
     }
 
     // PanelOptics
@@ -555,8 +587,18 @@ mod tests {
     #[test]
     fn panels_stores_panels() {
         let panels = vec![
-            SurfacePanel::at_com(1.0, Vector3::new(1.0, 0.0, 0.0), 2.0),
-            SurfacePanel::at_com(2.0, Vector3::new(0.0, 1.0, 0.0), 2.2),
+            SurfacePanel::at_com(
+                1.0,
+                Vector3::new(1.0, 0.0, 0.0),
+                2.0,
+                PanelOptics::absorber(),
+            ),
+            SurfacePanel::at_com(
+                2.0,
+                Vector3::new(0.0, 1.0, 0.0),
+                2.2,
+                PanelOptics::absorber(),
+            ),
         ];
         let shape = SpacecraftShape::panels(panels.clone());
         match shape {
@@ -1041,7 +1083,12 @@ mod tests {
     #[test]
     fn panels_facing_flow_nonzero_drag() {
         // Single panel facing -y (into the +y flow)
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(0.0, -1.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
         let loads = drag.eval(0.0, &iss_state(), None);
         assert!(
@@ -1053,7 +1100,12 @@ mod tests {
     #[test]
     fn panels_backface_zero_drag() {
         // Single panel facing +y (away from the +y flow) — backface
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(0.0, 1.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(0.0, 1.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
         let loads = drag.eval(0.0, &iss_state(), None);
         assert_eq!(
@@ -1065,7 +1117,12 @@ mod tests {
 
     #[test]
     fn panels_drag_opposes_velocity() {
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(0.0, -1.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
         let loads = drag.eval(0.0, &iss_state(), None);
         // Drag should oppose velocity (predominantly -y)
@@ -1078,7 +1135,12 @@ mod tests {
     #[test]
     fn panels_different_attitude_different_drag() {
         // This is the core coupling test: rotating the spacecraft changes the drag
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(0.0, -1.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
 
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
 
@@ -1105,7 +1167,12 @@ mod tests {
     #[test]
     fn panels_rotated_to_backface_zero() {
         // Panel faces -y in body frame. Rotate 180° about z → panel faces +y → backface
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(0.0, -1.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
 
         let mut state = iss_state();
@@ -1122,7 +1189,12 @@ mod tests {
 
     #[test]
     fn panels_above_atmosphere_zero() {
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(0.0, -1.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
 
         let state = SpacecraftState {
@@ -1141,7 +1213,12 @@ mod tests {
 
     #[test]
     fn panels_at_com_zero_torque() {
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(0.0, -1.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
         let loads = drag.eval(0.0, &iss_state(), None);
         assert_eq!(
@@ -1235,7 +1312,12 @@ mod tests {
         let cd = 2.2;
 
         // Panel facing -y (into the +y flow at identity attitude)
-        let panel = SurfacePanel::at_com(area, Vector3::new(0.0, -1.0, 0.0), cd);
+        let panel = SurfacePanel::at_com(
+            area,
+            Vector3::new(0.0, -1.0, 0.0),
+            cd,
+            PanelOptics::absorber(),
+        );
         let panel_drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
         let sphere_drag = PanelDrag::for_earth(SpacecraftShape::sphere(area, cd, 1.5));
 
@@ -1286,7 +1368,12 @@ mod tests {
     #[test]
     fn cos_theta_scaling_45_degrees() {
         // Rotate 45° about x: cos θ = cos(45°) = √2/2
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(0.0, -1.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
 
         let s0 = iss_state(); // identity attitude
@@ -1308,7 +1395,12 @@ mod tests {
     #[test]
     fn cos_theta_scaling_60_degrees() {
         // Rotate 60° about x: cos θ = cos(60°) = 0.5
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(0.0, -1.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
 
         let s0 = iss_state();
@@ -1329,7 +1421,12 @@ mod tests {
     #[test]
     fn cos_theta_scaling_90_degrees_zero() {
         // Rotate 90° about x: cos θ = 0 → zero drag
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(0.0, -1.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
 
         let mut s90 = iss_state();
@@ -1344,7 +1441,12 @@ mod tests {
     fn force_direction_always_anti_velocity() {
         // Pure drag invariant: a_inertial ∥ -v_rel for any attitude with nonzero drag.
         // Proof: F_body ∝ -v̂_body → a_inertial = R_ib*(-K·v̂_body) = -K·v̂_inertial
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(0.0, -1.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
 
         let angles = [0.0, 0.3, 0.7, 1.0, -0.5];
@@ -1390,7 +1492,12 @@ mod tests {
     #[test]
     fn energy_dissipation_always_negative() {
         // F · v_rel ≤ 0 for drag at any attitude (energy is always removed)
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(0.0, -1.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
 
         for i in 0..20 {
@@ -1415,8 +1522,18 @@ mod tests {
     fn two_sided_panel_no_dead_zone() {
         // Two panels with opposite normals (±y): at least one faces the flow at any attitude
         let panels = vec![
-            SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2),
-            SurfacePanel::at_com(10.0, Vector3::new(0.0, 1.0, 0.0), 2.2),
+            SurfacePanel::at_com(
+                10.0,
+                Vector3::new(0.0, -1.0, 0.0),
+                2.2,
+                PanelOptics::absorber(),
+            ),
+            SurfacePanel::at_com(
+                10.0,
+                Vector3::new(0.0, 1.0, 0.0),
+                2.2,
+                PanelOptics::absorber(),
+            ),
         ];
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(panels));
 
@@ -1597,7 +1714,12 @@ mod tests {
                 optics: PanelOptics::absorber(),
                 cp_offset: Vector3::new(1.0, 0.0, 0.0),
             },
-            SurfacePanel::at_com(5.0, Vector3::new(1.0, 0.0, 0.0), 2.0),
+            SurfacePanel::at_com(
+                5.0,
+                Vector3::new(1.0, 0.0, 0.0),
+                2.0,
+                PanelOptics::absorber(),
+            ),
         ];
         let drag = mock_drag(SpacecraftShape::panels(panels), 1e-12);
 
@@ -1709,7 +1831,12 @@ mod tests {
         //     cos θ = n_b · (-v̂_body) = (1,0,0)·(-1,0,0) = -1 → backface → ZERO
         //   → Wrong (R_ib): v_body = R_ib * (0,v,0) = (-v,0,0)
         //     cos θ = (1,0,0)·(1,0,0) = +1 → FULL drag
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = mock_drag(SpacecraftShape::panels(vec![panel]), 1e-12);
 
         let mut state = iss_state();
@@ -1731,7 +1858,12 @@ mod tests {
         //   R_ib maps body_x → inertial -y.
         //   Correct R_bi: v_body = R_bi * (0,v,0) = (-v,0,0)
         //     cos θ = (1,0,0)·(1,0,0) = +1 → full drag
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = mock_drag(SpacecraftShape::panels(vec![panel]), 1e-12);
 
         let mut state = iss_state();
@@ -1746,7 +1878,12 @@ mod tests {
 
         // Verify magnitude matches the identity case for a -y normal panel
         // (which faces the +y flow at identity). Both should give same exposure.
-        let panel_y = SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2);
+        let panel_y = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(0.0, -1.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag_y = mock_drag(SpacecraftShape::panels(vec![panel_y]), 1e-12);
         let ref_loads = drag_y.eval(0.0, &iss_state(), None);
 
@@ -1772,7 +1909,12 @@ mod tests {
                 optics: PanelOptics::absorber(),
                 cp_offset: Vector3::new(1.0, 0.0, 0.0),
             },
-            SurfacePanel::at_com(5.0, Vector3::new(1.0, 0.0, 0.0), 2.0),
+            SurfacePanel::at_com(
+                5.0,
+                Vector3::new(1.0, 0.0, 0.0),
+                2.0,
+                PanelOptics::absorber(),
+            ),
         ];
         let drag = mock_drag(SpacecraftShape::panels(panels), 1e-12);
 
@@ -1830,7 +1972,12 @@ mod tests {
     fn velocity_squared_scaling() {
         // a ∝ |v|² (at constant density, same direction)
         // Use mock to eliminate altitude-dependent density changes
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(0.0, -1.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = mock_drag(SpacecraftShape::panels(vec![panel]), 1e-12);
 
         let s1 = iss_state();
@@ -1859,7 +2006,12 @@ mod tests {
         let mass = 500.0; // kg
         let rho = 1e-12; // kg/m³
 
-        let panel = SurfacePanel::at_com(area, Vector3::new(0.0, -1.0, 0.0), cd);
+        let panel = SurfacePanel::at_com(
+            area,
+            Vector3::new(0.0, -1.0, 0.0),
+            cd,
+            PanelOptics::absorber(),
+        );
         let drag = mock_drag(SpacecraftShape::panels(vec![panel]), rho);
 
         let state = iss_state();
@@ -1889,7 +2041,12 @@ mod tests {
         use nalgebra::Matrix3;
         use utsuroi::{Integrator, OdeState, Rk4};
 
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(0.0, -1.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
 
         let inertia = Matrix3::from_diagonal(&Vector3::new(100.0, 200.0, 300.0));
@@ -1911,7 +2068,12 @@ mod tests {
         use nalgebra::Matrix3;
         use utsuroi::{Integrator, Rk4};
 
-        let panel = SurfacePanel::at_com(10.0, Vector3::new(0.0, -1.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            10.0,
+            Vector3::new(0.0, -1.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
 
         let inertia = Matrix3::from_diagonal(&Vector3::new(100.0, 200.0, 300.0));
@@ -1940,7 +2102,12 @@ mod tests {
         use utsuroi::{Integrator, Rk4};
 
         // Asymmetric panel: only one face, so drag depends on orientation
-        let panel = SurfacePanel::at_com(20.0, Vector3::new(1.0, 0.0, 0.0), 2.2);
+        let panel = SurfacePanel::at_com(
+            20.0,
+            Vector3::new(1.0, 0.0, 0.0),
+            2.2,
+            PanelOptics::absorber(),
+        );
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
 
         let inertia = Matrix3::from_diagonal(&Vector3::new(100.0, 200.0, 300.0));

--- a/orts/src/spacecraft/surface.rs
+++ b/orts/src/spacecraft/surface.rs
@@ -303,6 +303,9 @@ impl PanelDrag<frame::SimpleEci> {
     /// Create a panel drag model for Earth orbit in the default `SimpleEci` frame.
     ///
     /// Uses piecewise exponential atmosphere and WGS-84 geodetic altitude by default.
+    ///
+    /// # Panics
+    /// Panics unless every panel normal is unit length.
     pub fn for_earth(shape: SpacecraftShape) -> Self {
         Self::for_earth_in_frame(shape, ())
     }
@@ -311,7 +314,11 @@ impl PanelDrag<frame::SimpleEci> {
 impl<F: EarthFixedTransform> PanelDrag<F> {
     /// Create a panel drag model for Earth orbit in an arbitrary inertial frame
     /// `F`, with that frame's EOP storage (`()` for `SimpleEci`).
+    ///
+    /// # Panics
+    /// Panics unless every panel normal is unit length.
     pub fn for_earth_in_frame(shape: SpacecraftShape, eop: F::EopStorage) -> Self {
+        shape.assert_normals_are_unit();
         Self {
             shape,
             atmosphere: Box::new(Exponential),
@@ -574,6 +581,23 @@ mod tests {
             optics: PanelOptics::absorber(),
             cp_offset: Vector3::zeros(),
         }]);
+    }
+
+    /// `SpacecraftShape::Panels` is a public variant, so a shape can reach the
+    /// drag model without passing through `SpacecraftShape::panels`. The drag
+    /// projection relies on the unit normal too, so its constructor has to
+    /// check as well.
+    #[test]
+    #[should_panic(expected = "normal must be unit length")]
+    fn panel_drag_rejects_a_non_unit_normal() {
+        let shape = SpacecraftShape::Panels(vec![SurfacePanel {
+            area: 10.0,
+            normal: Vector3::new(0.0, 0.0, 3.0),
+            cd: 2.2,
+            optics: PanelOptics::absorber(),
+            cp_offset: Vector3::zeros(),
+        }]);
+        PanelDrag::for_earth(shape);
     }
 
     #[test]

--- a/orts/src/spacecraft/surface.rs
+++ b/orts/src/spacecraft/surface.rs
@@ -180,8 +180,40 @@ impl SpacecraftShape {
     }
 
     /// Create a panel model from an arbitrary set of panels.
+    ///
+    /// # Panics
+    /// Panics unless every panel normal is unit length — see
+    /// [`Self::assert_normals_are_unit`].
     pub fn panels(panels: Vec<SurfacePanel>) -> Self {
-        Self::Panels(panels)
+        let shape = Self::Panels(panels);
+        shape.assert_normals_are_unit();
+        shape
+    }
+
+    /// Check the unit-normal invariant the panel force models rely on.
+    ///
+    /// Both force models project onto the panel normal, and panel SRP is cubic
+    /// in its length through the specular term, so a non-unit normal inflates
+    /// the force silently. The check belongs at model construction rather than
+    /// inside the force law: a model owns its shape and cannot be mutated
+    /// afterwards, so once past here the invariant holds for the model's life —
+    /// and the force law runs at every integrator stage, where a square root
+    /// per panel would be pure overhead.
+    ///
+    /// # Panics
+    /// Panics if any panel normal is not unit length. `Sphere` never panics.
+    pub(crate) fn assert_normals_are_unit(&self) {
+        let Self::Panels(panels) = self else {
+            return;
+        };
+        for (i, panel) in panels.iter().enumerate() {
+            let len = panel.normal.magnitude();
+            assert!(
+                (len - 1.0).abs() < 1e-9,
+                "Panel {i} normal must be unit length, got |n|={len}. \
+                 `SurfacePanel::at_com` normalises; a struct literal does not."
+            );
+        }
     }
 
     /// Create a cube with the given half-size, drag coefficient, and optical
@@ -523,6 +555,35 @@ mod tests {
     }
 
     // PanelOptics
+
+    #[test]
+    #[should_panic(expected = "normal must be unit length")]
+    fn panels_rejects_a_non_unit_normal() {
+        // A struct literal skips `at_com`'s normalisation, and the SRP force is
+        // cubic in |n| through its specular term, so the shape constructor is
+        // where that has to be caught.
+        SpacecraftShape::panels(vec![SurfacePanel {
+            area: 10.0,
+            normal: Vector3::new(1.0, 0.0, 1.0),
+            cd: 2.2,
+            optics: PanelOptics::absorber(),
+            cp_offset: Vector3::zeros(),
+        }]);
+    }
+
+    #[test]
+    fn panels_accepts_normals_at_com_produced() {
+        let shape = SpacecraftShape::panels(vec![SurfacePanel::at_com(
+            10.0,
+            Vector3::new(1.0, 0.0, 1.0),
+            2.2,
+            PanelOptics::absorber(),
+        )]);
+        let SpacecraftShape::Panels(panels) = shape else {
+            panic!("expected a panel shape");
+        };
+        assert!((panels[0].normal.magnitude() - 1.0).abs() < 1e-15);
+    }
 
     #[test]
     fn panel_optics_absorptivity_is_the_remainder() {

--- a/orts/src/spacecraft/surface.rs
+++ b/orts/src/spacecraft/surface.rs
@@ -72,9 +72,14 @@ impl PanelOptics {
         self.diffuse
     }
 
-    /// Absorbed fraction α = 1 − ρ_s − ρ_d.
+    /// Absorbed fraction α = 1 − (ρ_s + ρ_d).
+    ///
+    /// Never negative: [`Self::new`] has already checked that the sum is at
+    /// most 1, and subtracting that one sum keeps the guarantee. Subtracting
+    /// the two terms one after the other would not — `1.0 - 0.9 - 0.1` is
+    /// -2.8e-17, because the second subtraction rounds again.
     pub fn absorptivity(self) -> f64 {
-        1.0 - self.specular - self.diffuse
+        1.0 - (self.specular + self.diffuse)
     }
 }
 
@@ -590,6 +595,24 @@ mod tests {
         let o = PanelOptics::new(0.25, 0.15);
         assert!((o.absorptivity() - 0.6).abs() < 1e-15);
         assert!((o.absorptivity() + o.specular() + o.diffuse() - 1.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn absorptivity_is_never_negative() {
+        // Subtracting the two reflectivities one at a time rounds twice, and
+        // for 2077 of these 10001 pairs the result lands just below zero
+        // (`1.0 - 0.9 - 0.1` is -2.8e-17). Subtracting their sum inherits
+        // `new`'s check that the sum is at most 1, so it cannot.
+        for i in 0..=10_000u32 {
+            let specular = f64::from(i) / 10_000.0;
+            let diffuse = f64::from(10_000 - i) / 10_000.0;
+            let optics = PanelOptics::new(specular, diffuse);
+            assert!(
+                optics.absorptivity() >= 0.0,
+                "α should not go negative: specular={specular}, diffuse={diffuse}, α={:e}",
+                optics.absorptivity()
+            );
+        }
     }
 
     #[test]

--- a/orts/src/spacecraft/surface.rs
+++ b/orts/src/spacecraft/surface.rs
@@ -14,8 +14,12 @@ use super::ExternalLoads;
 /// How a flat panel reflects sunlight, for radiation pressure.
 ///
 /// Absorption, specular reflection and diffuse reflection sum to 1, so two of
-/// them determine the third. Absorption is derived rather than stored, which
-/// keeps the three from drifting out of agreement.
+/// them determine the third. Absorption is derived rather than stored, and the
+/// two stored fractions are private, so the constraint holds for every value
+/// that exists — unlike the sibling fields of [`SurfacePanel`], which are
+/// independent scalars a struct literal can set freely. A `specular` above 1
+/// would make the absorbed fraction negative and point the Sun-line component
+/// of the force *toward* the Sun.
 ///
 /// A single lumped `Cr` cannot stand in for these: it fixes the force magnitude
 /// face-on but leaves the direction undetermined at oblique incidence, where
@@ -23,16 +27,17 @@ use super::ExternalLoads;
 /// along the Sun line.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PanelOptics {
-    /// Specular reflectivity ρ_s: the fraction reflected mirror-like.
-    pub specular: f64,
-    /// Diffuse reflectivity ρ_d: the fraction re-emitted Lambertian.
-    pub diffuse: f64,
+    specular: f64,
+    diffuse: f64,
 }
 
 impl PanelOptics {
+    /// Reflection properties from the specular and diffuse fractions; the rest
+    /// of the incident light is absorbed.
+    ///
     /// # Panics
     /// Panics unless both coefficients are finite, non-negative and sum to at
-    /// most 1; the remainder is the absorbed fraction.
+    /// most 1.
     pub fn new(specular: f64, diffuse: f64) -> Self {
         assert!(
             specular.is_finite() && diffuse.is_finite(),
@@ -57,6 +62,16 @@ impl PanelOptics {
         }
     }
 
+    /// Specular reflectivity ρ_s: the fraction reflected mirror-like.
+    pub fn specular(self) -> f64 {
+        self.specular
+    }
+
+    /// Diffuse reflectivity ρ_d: the fraction re-emitted Lambertian.
+    pub fn diffuse(self) -> f64 {
+        self.diffuse
+    }
+
     /// Absorbed fraction α = 1 − ρ_s − ρ_d.
     pub fn absorptivity(self) -> f64 {
         1.0 - self.specular - self.diffuse
@@ -73,11 +88,15 @@ impl PanelOptics {
 /// For thin surfaces like solar panels where both sides are exposed to the
 /// flow, model each side as a separate panel with opposite normals; the two
 /// sides may then carry different optical properties.
+///
+/// Both force models assume `normal` is unit length. [`Self::at_com`] and
+/// [`SpacecraftShape::cube`] guarantee that; a struct literal does not, and the
+/// SRP force is cubic in `|normal|` through its specular term.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SurfacePanel {
     /// Panel area [m²].
     pub area: f64,
-    /// Outward-pointing unit normal in the body frame.
+    /// Outward-pointing unit normal in the body frame. Must be unit length.
     pub normal: Vector3<f64>,
     /// Drag coefficient (typically 2.0–2.2 for LEO free-molecular flow).
     pub cd: f64,
@@ -130,7 +149,13 @@ pub enum SpacecraftShape {
         area: f64,
         /// Drag coefficient (typically 2.0–2.2)
         cd: f64,
-        /// Radiation pressure coefficient (1.0 absorber, 2.0 reflector)
+        /// Radiation pressure coefficient (1.0 absorber, 2.0 reflector).
+        ///
+        /// A lumped coefficient is the whole model here, not the shorthand it
+        /// would be for a flat panel: an isotropic surface presents the same
+        /// cross-section whatever the Sun direction, so there is no incidence
+        /// angle for the specular and diffuse terms of [`PanelOptics`] to
+        /// depend on.
         cr: f64,
     },
     /// Flat-panel model: attitude-dependent.
@@ -471,7 +496,7 @@ mod tests {
     fn panel_optics_absorptivity_is_the_remainder() {
         let o = PanelOptics::new(0.25, 0.15);
         assert!((o.absorptivity() - 0.6).abs() < 1e-15);
-        assert!((o.absorptivity() + o.specular + o.diffuse - 1.0).abs() < 1e-15);
+        assert!((o.absorptivity() + o.specular() + o.diffuse() - 1.0).abs() < 1e-15);
     }
 
     #[test]

--- a/orts/src/spacecraft/surface.rs
+++ b/orts/src/spacecraft/surface.rs
@@ -11,15 +11,68 @@ use tobari::{AtmosphereInput, AtmosphereModel, Exponential};
 
 use super::ExternalLoads;
 
+/// How a flat panel reflects sunlight, for radiation pressure.
+///
+/// Absorption, specular reflection and diffuse reflection sum to 1, so two of
+/// them determine the third. Absorption is derived rather than stored, which
+/// keeps the three from drifting out of agreement.
+///
+/// A single lumped `Cr` cannot stand in for these: it fixes the force magnitude
+/// face-on but leaves the direction undetermined at oblique incidence, where
+/// specular and diffuse reflection push along the panel normal rather than
+/// along the Sun line.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PanelOptics {
+    /// Specular reflectivity ρ_s: the fraction reflected mirror-like.
+    pub specular: f64,
+    /// Diffuse reflectivity ρ_d: the fraction re-emitted Lambertian.
+    pub diffuse: f64,
+}
+
+impl PanelOptics {
+    /// # Panics
+    /// Panics unless both coefficients are finite, non-negative and sum to at
+    /// most 1; the remainder is the absorbed fraction.
+    pub fn new(specular: f64, diffuse: f64) -> Self {
+        assert!(
+            specular.is_finite() && diffuse.is_finite(),
+            "Panel reflectivities must be finite, got specular={specular}, diffuse={diffuse}"
+        );
+        assert!(
+            specular >= 0.0 && diffuse >= 0.0,
+            "Panel reflectivities must be non-negative, got specular={specular}, diffuse={diffuse}"
+        );
+        assert!(
+            specular + diffuse <= 1.0,
+            "Panel reflectivities must sum to at most 1, got specular={specular} + diffuse={diffuse}"
+        );
+        Self { specular, diffuse }
+    }
+
+    /// A black panel: everything absorbed, nothing reflected (Cr = 1 face-on).
+    pub fn absorber() -> Self {
+        Self {
+            specular: 0.0,
+            diffuse: 0.0,
+        }
+    }
+
+    /// Absorbed fraction α = 1 − ρ_s − ρ_d.
+    pub fn absorptivity(self) -> f64 {
+        1.0 - self.specular - self.diffuse
+    }
+}
+
 /// A flat surface panel on a spacecraft body.
 ///
 /// Represents one face of the spacecraft's outer surface for computing
-/// aerodynamic (and eventually SRP) forces.  Each panel has an outward-pointing
-/// normal in the body frame, a drag coefficient, and a centre-of-pressure
-/// offset from the centre of mass.
+/// aerodynamic and SRP forces.  Each panel has an outward-pointing normal in
+/// the body frame, a drag coefficient, optical properties, and a
+/// centre-of-pressure offset from the centre of mass.
 ///
 /// For thin surfaces like solar panels where both sides are exposed to the
-/// flow, model each side as a separate panel with opposite normals.
+/// flow, model each side as a separate panel with opposite normals; the two
+/// sides may then carry different optical properties.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SurfacePanel {
     /// Panel area [m²].
@@ -28,9 +81,8 @@ pub struct SurfacePanel {
     pub normal: Vector3<f64>,
     /// Drag coefficient (typically 2.0–2.2 for LEO free-molecular flow).
     pub cd: f64,
-    /// Radiation pressure coefficient (1.0 = absorber, 2.0 = reflector).
-    /// Used by SRP panel models; defaults to 1.5.
-    pub cr: f64,
+    /// Reflection properties, used by SRP panel models.
+    pub optics: PanelOptics,
     /// Centre-of-pressure offset from the spacecraft CoM [m, body frame].
     pub cp_offset: Vector3<f64>,
 }
@@ -39,6 +91,9 @@ impl SurfacePanel {
     /// Create a panel whose centre of pressure coincides with the CoM.
     ///
     /// The `normal` vector is normalised internally; it need not be unit length.
+    /// Optics default to [`PanelOptics::absorber`] — a lumped `Cr` has no unique
+    /// specular/diffuse split, so the default is a stated physical surface
+    /// rather than an inferred one. Set it with [`Self::with_optics`].
     ///
     /// # Panics
     /// Panics if `normal` is zero-length.
@@ -49,14 +104,14 @@ impl SurfacePanel {
             area,
             normal: n,
             cd,
-            cr: 1.5,
+            optics: PanelOptics::absorber(),
             cp_offset: Vector3::zeros(),
         }
     }
 
-    /// Override the radiation pressure coefficient (builder pattern).
-    pub fn with_cr(mut self, cr: f64) -> Self {
-        self.cr = cr;
+    /// Override the reflection properties (builder pattern).
+    pub fn with_optics(mut self, optics: PanelOptics) -> Self {
+        self.optics = optics;
         self
     }
 }
@@ -99,55 +154,55 @@ impl SpacecraftShape {
         Self::Panels(panels)
     }
 
-    /// Create a cube with the given half-size, drag coefficient, and radiation
-    /// pressure coefficient.
+    /// Create a cube with the given half-size, drag coefficient, and optical
+    /// properties, shared by all six faces.
     ///
     /// Generates 6 panels (±x, ±y, ±z), each with area `(2 * half_size)²` m²
     /// and centre of pressure at the face centre (`half_size` m from CoM along
     /// the face normal).
-    pub fn cube(half_size: f64, cd: f64, cr: f64) -> Self {
+    pub fn cube(half_size: f64, cd: f64, optics: PanelOptics) -> Self {
         let face_area = (2.0 * half_size) * (2.0 * half_size);
         let panels = vec![
             SurfacePanel {
                 area: face_area,
                 normal: Vector3::new(1.0, 0.0, 0.0),
                 cd,
-                cr,
+                optics,
                 cp_offset: Vector3::new(half_size, 0.0, 0.0),
             },
             SurfacePanel {
                 area: face_area,
                 normal: Vector3::new(-1.0, 0.0, 0.0),
                 cd,
-                cr,
+                optics,
                 cp_offset: Vector3::new(-half_size, 0.0, 0.0),
             },
             SurfacePanel {
                 area: face_area,
                 normal: Vector3::new(0.0, 1.0, 0.0),
                 cd,
-                cr,
+                optics,
                 cp_offset: Vector3::new(0.0, half_size, 0.0),
             },
             SurfacePanel {
                 area: face_area,
                 normal: Vector3::new(0.0, -1.0, 0.0),
                 cd,
-                cr,
+                optics,
                 cp_offset: Vector3::new(0.0, -half_size, 0.0),
             },
             SurfacePanel {
                 area: face_area,
                 normal: Vector3::new(0.0, 0.0, 1.0),
                 cd,
-                cr,
+                optics,
                 cp_offset: Vector3::new(0.0, 0.0, half_size),
             },
             SurfacePanel {
                 area: face_area,
                 normal: Vector3::new(0.0, 0.0, -1.0),
                 cd,
-                cr,
+                optics,
                 cp_offset: Vector3::new(0.0, 0.0, -half_size),
             },
         ];
@@ -157,7 +212,7 @@ impl SpacecraftShape {
 
 /// Attitude-dependent drag model using flat surface panels.
 ///
-/// Implements [`LoadModel`] to produce both translational acceleration and
+/// Implements [`Model`] to produce both translational acceleration and
 /// aerodynamic torque from per-panel drag forces.  For the [`SpacecraftShape::Sphere`]
 /// variant, behaves identically to the scalar `AtmosphericDrag`.
 ///
@@ -401,6 +456,42 @@ mod tests {
         assert!((p.cd - 2.1).abs() < 1e-15);
     }
 
+    #[test]
+    fn at_com_defaults_to_a_black_panel() {
+        // The default has to be a stated surface, since a lumped Cr has no
+        // unique specular/diffuse split to infer one from.
+        let p = SurfacePanel::at_com(3.5, Vector3::new(0.0, 1.0, 0.0), 2.1);
+        assert_eq!(p.optics, PanelOptics::absorber());
+        assert!((p.optics.absorptivity() - 1.0).abs() < 1e-15);
+    }
+
+    // PanelOptics
+
+    #[test]
+    fn panel_optics_absorptivity_is_the_remainder() {
+        let o = PanelOptics::new(0.25, 0.15);
+        assert!((o.absorptivity() - 0.6).abs() < 1e-15);
+        assert!((o.absorptivity() + o.specular + o.diffuse - 1.0).abs() < 1e-15);
+    }
+
+    #[test]
+    #[should_panic(expected = "non-negative")]
+    fn panel_optics_rejects_negative_reflectivity() {
+        PanelOptics::new(-0.1, 0.2);
+    }
+
+    #[test]
+    #[should_panic(expected = "sum to at most 1")]
+    fn panel_optics_rejects_sum_above_one() {
+        PanelOptics::new(0.7, 0.5);
+    }
+
+    #[test]
+    #[should_panic(expected = "finite")]
+    fn panel_optics_rejects_non_finite() {
+        PanelOptics::new(f64::NAN, 0.2);
+    }
+
     // SpacecraftShape::sphere
 
     #[test]
@@ -457,7 +548,7 @@ mod tests {
 
     #[test]
     fn cube_has_six_panels() {
-        let shape = SpacecraftShape::cube(0.5, 2.2, 1.5);
+        let shape = SpacecraftShape::cube(0.5, 2.2, PanelOptics::absorber());
         match &shape {
             SpacecraftShape::Panels(panels) => {
                 assert_eq!(panels.len(), 6, "Cube should have 6 faces");
@@ -470,7 +561,7 @@ mod tests {
     fn cube_face_area() {
         let half = 0.5;
         let expected_area = (2.0 * half) * (2.0 * half); // 1.0 m²
-        let shape = SpacecraftShape::cube(half, 2.2, 1.5);
+        let shape = SpacecraftShape::cube(half, 2.2, PanelOptics::absorber());
         if let SpacecraftShape::Panels(panels) = &shape {
             for (i, p) in panels.iter().enumerate() {
                 assert!(
@@ -484,7 +575,7 @@ mod tests {
 
     #[test]
     fn cube_normals_are_unit() {
-        let shape = SpacecraftShape::cube(1.0, 2.0, 1.5);
+        let shape = SpacecraftShape::cube(1.0, 2.0, PanelOptics::absorber());
         if let SpacecraftShape::Panels(panels) = &shape {
             for (i, p) in panels.iter().enumerate() {
                 assert!(
@@ -498,7 +589,7 @@ mod tests {
 
     #[test]
     fn cube_normals_are_axis_aligned() {
-        let shape = SpacecraftShape::cube(1.0, 2.0, 1.5);
+        let shape = SpacecraftShape::cube(1.0, 2.0, PanelOptics::absorber());
         if let SpacecraftShape::Panels(panels) = &shape {
             let normals: Vec<_> = panels.iter().map(|p| p.normal).collect();
             let expected = [
@@ -521,7 +612,7 @@ mod tests {
     #[test]
     fn cube_cp_at_face_centre() {
         let half = 0.75;
-        let shape = SpacecraftShape::cube(half, 2.0, 1.5);
+        let shape = SpacecraftShape::cube(half, 2.0, PanelOptics::absorber());
         if let SpacecraftShape::Panels(panels) = &shape {
             for (i, p) in panels.iter().enumerate() {
                 // CP should be at half_size along the normal direction
@@ -538,7 +629,7 @@ mod tests {
     #[test]
     fn cube_all_same_cd() {
         let cd = 2.2;
-        let shape = SpacecraftShape::cube(0.5, cd, 1.5);
+        let shape = SpacecraftShape::cube(0.5, cd, PanelOptics::absorber());
         if let SpacecraftShape::Panels(panels) = &shape {
             for (i, p) in panels.iter().enumerate() {
                 assert!(
@@ -552,7 +643,7 @@ mod tests {
 
     #[test]
     fn cube_opposite_normals_cancel() {
-        let shape = SpacecraftShape::cube(1.0, 2.0, 1.5);
+        let shape = SpacecraftShape::cube(1.0, 2.0, PanelOptics::absorber());
         if let SpacecraftShape::Panels(panels) = &shape {
             let normal_sum: Vector3<f64> = panels.iter().map(|p| p.normal).sum();
             assert!(
@@ -637,7 +728,7 @@ mod tests {
     /// Characterization: pinned `SimpleEci` panel-drag loads for a cube.
     #[test]
     fn panels_simple_eci_loads_snapshot() {
-        let drag = PanelDrag::for_earth(SpacecraftShape::cube(0.5, 2.2, 1.5));
+        let drag = PanelDrag::for_earth(SpacecraftShape::cube(0.5, 2.2, PanelOptics::absorber()));
         let loads = drag.eval(0.0, &snapshot_state(), Some(&snapshot_epoch()));
         let expected_a = Vector3::new(
             -1.112965959433058e-10,
@@ -694,28 +785,28 @@ mod tests {
                 area: 2.0,
                 normal: Vector3::x(),
                 cd: 2.2,
-                cr: 1.5,
+                optics: PanelOptics::absorber(),
                 cp_offset: Vector3::new(0.0, 1.5, 0.0),
             },
             SurfacePanel {
                 area: 2.0,
                 normal: -Vector3::x(),
                 cd: 2.2,
-                cr: 1.5,
+                optics: PanelOptics::absorber(),
                 cp_offset: Vector3::new(0.0, 0.4, 0.0),
             },
             SurfacePanel {
                 area: 0.5,
                 normal: Vector3::y(),
                 cd: 2.2,
-                cr: 1.5,
+                optics: PanelOptics::absorber(),
                 cp_offset: Vector3::new(0.0, 0.0, -0.8),
             },
             SurfacePanel {
                 area: 0.5,
                 normal: -Vector3::y(),
                 cd: 2.2,
-                cr: 1.5,
+                optics: PanelOptics::absorber(),
                 cp_offset: Vector3::new(0.9, 0.0, 0.0),
             },
         ])
@@ -1041,7 +1132,7 @@ mod tests {
             area: 10.0,
             normal: Vector3::new(0.0, -1.0, 0.0),
             cd: 2.2,
-            cr: 1.5,
+            optics: PanelOptics::absorber(),
             cp_offset: Vector3::new(1.0, 0.0, 0.0), // 1 m offset in +x
         };
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
@@ -1065,7 +1156,7 @@ mod tests {
             area: 10.0,
             normal: Vector3::new(0.0, -1.0, 0.0),
             cd: 2.2,
-            cr: 1.5,
+            optics: PanelOptics::absorber(),
             cp_offset: Vector3::new(offset, 0.0, 0.0),
         };
 
@@ -1149,7 +1240,7 @@ mod tests {
         // But the other 4 faces (±x, ±z) have cos(θ)=0 for exact +y flow
         // So only -y face contributes, with CP at (0, -half, 0)
         // Force is in -ŷ body: τ = (0,-h,0) × (0,F,0) = 0 (parallel!)
-        let drag = PanelDrag::for_earth(SpacecraftShape::cube(0.5, 2.2, 1.5));
+        let drag = PanelDrag::for_earth(SpacecraftShape::cube(0.5, 2.2, PanelOptics::absorber()));
         let loads = drag.eval(0.0, &iss_state(), None);
         assert!(
             loads.torque_body.magnitude() < 1e-20,
@@ -1357,7 +1448,7 @@ mod tests {
         // At 45° about z: v̂_body = (sin45, cos45, 0) → A_proj = A * (sin45 + cos45) = A * √2
         let half = 0.5;
         let cd = 2.2;
-        let drag = PanelDrag::for_earth(SpacecraftShape::cube(half, cd, 1.5));
+        let drag = PanelDrag::for_earth(SpacecraftShape::cube(half, cd, PanelOptics::absorber()));
 
         let a0 = drag
             .eval(0.0, &iss_state(), None)
@@ -1390,7 +1481,7 @@ mod tests {
             area: 10.0,
             normal: Vector3::new(0.0, -1.0, 0.0),
             cd: 2.2,
-            cr: 1.5,
+            optics: PanelOptics::absorber(),
             cp_offset: Vector3::new(1.0, 0.0, 0.0),
         };
         let drag = PanelDrag::for_earth(SpacecraftShape::panels(vec![panel]));
@@ -1478,7 +1569,7 @@ mod tests {
                 area: 10.0,
                 normal: Vector3::new(0.0, -1.0, 0.0),
                 cd: 2.2,
-                cr: 1.5,
+                optics: PanelOptics::absorber(),
                 cp_offset: Vector3::new(1.0, 0.0, 0.0),
             },
             SurfacePanel::at_com(5.0, Vector3::new(1.0, 0.0, 0.0), 2.0),
@@ -1527,14 +1618,14 @@ mod tests {
                 area: 10.0,
                 normal: Vector3::new(0.0, -1.0, 0.0),
                 cd: 2.2,
-                cr: 1.5,
+                optics: PanelOptics::absorber(),
                 cp_offset: Vector3::new(1.0, 0.0, 0.0),
             },
             SurfacePanel {
                 area: 8.0,
                 normal: Vector3::new(1.0, 0.0, 0.0),
                 cd: 2.0,
-                cr: 1.5,
+                optics: PanelOptics::absorber(),
                 cp_offset: Vector3::new(0.0, 0.0, 0.5),
             },
         ];
@@ -1653,7 +1744,7 @@ mod tests {
                 area: 10.0,
                 normal: Vector3::new(0.0, -1.0, 0.0),
                 cd: 2.2,
-                cr: 1.5,
+                optics: PanelOptics::absorber(),
                 cp_offset: Vector3::new(1.0, 0.0, 0.0),
             },
             SurfacePanel::at_com(5.0, Vector3::new(1.0, 0.0, 0.0), 2.0),
@@ -1686,7 +1777,7 @@ mod tests {
             area: 10.0,
             normal: Vector3::new(0.0, -1.0, 0.0),
             cd: 2.2,
-            cr: 1.5,
+            optics: PanelOptics::absorber(),
             cp_offset: Vector3::new(1.0, 0.0, 0.0),
         }];
 

--- a/orts/tests/fixtures/orekit_panel_srp_reference.json
+++ b/orts/tests/fixtures/orekit_panel_srp_reference.json
@@ -1,0 +1,150 @@
+{
+  "description": "Orekit reference forces for a single flat panel under solar radiation pressure. Panel normal is +Z in the body frame, the Sun is at (sin(incidence), 0, cos(incidence)), and the attitude is identity.",
+  "generator": "tools/generate_orekit_panel_srp_fixtures.py",
+  "orekit_convention": {
+    "absorption": "alpha",
+    "reflection": "rho_s (specular)",
+    "diffuse": "1 - alpha - rho_s"
+  },
+  "pressure_n_m2": 4.5396e-06,
+  "area_m2": 4.0,
+  "panel_normal_body": [
+    0.0,
+    0.0,
+    1.0
+  ],
+  "cases": [
+    {
+      "name": "black_face_on",
+      "specular": 0.0,
+      "diffuse": 0.0,
+      "incidence_deg": 0.0,
+      "force_body_n": [
+        0.0,
+        0.0,
+        -1.81584e-05
+      ]
+    },
+    {
+      "name": "black_30deg",
+      "specular": 0.0,
+      "diffuse": 0.0,
+      "incidence_deg": 30.0,
+      "force_body_n": [
+        -7.862817846039673e-06,
+        0.0,
+        -1.3618800000000002e-05
+      ]
+    },
+    {
+      "name": "black_60deg",
+      "specular": 0.0,
+      "diffuse": 0.0,
+      "incidence_deg": 60.0,
+      "force_body_n": [
+        -7.862817846039676e-06,
+        0.0,
+        -4.539600000000001e-06
+      ]
+    },
+    {
+      "name": "mirror_face_on",
+      "specular": 1.0,
+      "diffuse": 0.0,
+      "incidence_deg": 0.0,
+      "force_body_n": [
+        0.0,
+        0.0,
+        -3.63168e-05
+      ]
+    },
+    {
+      "name": "mirror_30deg",
+      "specular": 1.0,
+      "diffuse": 0.0,
+      "incidence_deg": 30.0,
+      "force_body_n": [
+        0.0,
+        0.0,
+        -2.7237600000000005e-05
+      ]
+    },
+    {
+      "name": "mirror_60deg",
+      "specular": 1.0,
+      "diffuse": 0.0,
+      "incidence_deg": 60.0,
+      "force_body_n": [
+        0.0,
+        0.0,
+        -9.079200000000003e-06
+      ]
+    },
+    {
+      "name": "lambertian_face_on",
+      "specular": 0.0,
+      "diffuse": 1.0,
+      "incidence_deg": 0.0,
+      "force_body_n": [
+        0.0,
+        0.0,
+        -3.0264e-05
+      ]
+    },
+    {
+      "name": "lambertian_45deg",
+      "specular": 0.0,
+      "diffuse": 1.0,
+      "incidence_deg": 45.0,
+      "force_body_n": [
+        -9.0792e-06,
+        0.0,
+        -1.7639151850331868e-05
+      ]
+    },
+    {
+      "name": "solar_array_15deg",
+      "specular": 0.2,
+      "diffuse": 0.1,
+      "incidence_deg": 15.0,
+      "force_body_n": [
+        -3.6316800000000006e-06,
+        0.0,
+        -2.1499732583520104e-05
+      ]
+    },
+    {
+      "name": "solar_array_45deg",
+      "specular": 0.2,
+      "diffuse": 0.1,
+      "incidence_deg": 45.0,
+      "force_body_n": [
+        -7.263360000000001e-06,
+        0.0,
+        -1.1751035185033187e-05
+      ]
+    },
+    {
+      "name": "solar_array_75deg",
+      "specular": 0.2,
+      "diffuse": 0.1,
+      "incidence_deg": 75.0,
+      "force_body_n": [
+        -3.6316799999999998e-06,
+        0.0,
+        -1.7729745679916966e-06
+      ]
+    },
+    {
+      "name": "specular_ish_45deg",
+      "specular": 0.6,
+      "diffuse": 0.1,
+      "incidence_deg": 45.0,
+      "force_body_n": [
+        -3.6316800000000006e-06,
+        0.0,
+        -1.5382715185033187e-05
+      ]
+    }
+  ]
+}

--- a/tools/generate_orekit_panel_srp_fixtures.py
+++ b/tools/generate_orekit_panel_srp_fixtures.py
@@ -45,8 +45,11 @@ from orekit_jpype.pyhelpers import (  # noqa: E402
     setup_orekit_curdir,
 )
 
-# Resolve the default output before chdir'ing away from the repo.
+# Both of these must be captured before the chdir below. Orekit wants its data
+# directory as the working directory, so afterwards a relative path from the
+# command line would resolve inside that cache instead of where it was typed.
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+ORIG_CWD = pathlib.Path.cwd()
 DEFAULT_OUT = REPO_ROOT / "orts" / "tests" / "fixtures" / "orekit_panel_srp_reference.json"
 
 # Orekit needs its data directory; keep the download out of the repo tree.
@@ -160,8 +163,15 @@ def main() -> int:
         "cases": cases,
     }
 
-    out = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_OUT
-    out.parent.mkdir(parents=True, exist_ok=True)
+    if len(sys.argv) > 1:
+        out = pathlib.Path(sys.argv[1])
+        if not out.is_absolute():
+            out = ORIG_CWD / out
+    else:
+        out = DEFAULT_OUT
+    if not out.parent.is_dir():
+        print(f"no such directory: {out.parent}", file=sys.stderr)
+        return 1
     out.write_text(json.dumps(fixture, indent=2) + "\n")
     print(f"wrote {len(cases)} cases to {out}")
     return 0

--- a/tools/generate_orekit_panel_srp_fixtures.py
+++ b/tools/generate_orekit_panel_srp_fixtures.py
@@ -1,0 +1,166 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["orekit-jpype", "jdk4py"]
+# ///
+"""Generate Orekit reference forces for the flat-panel SRP law.
+
+Cross-validates `orts`'s per-panel SRP force against Orekit's paneled
+radiation model. Unlike the propagation fixtures next door, this needs no
+propagator and no attitude provider: `RadiationSensitive` exposes
+`radiationPressureAcceleration(state, flux, parameters)`, so one panel can be
+evaluated directly for a chosen incidence angle.
+
+The comparison is on the force, because Orekit's paneled model returns only an
+acceleration. The torque our model builds from it, `sum(r_cp x F_panel)`, is
+pinned separately by exact cross-product tests.
+
+Convention mapping, established by driving the three limits (a black panel, a
+mirror, and a Lambertian one) and confirmed by this fixture:
+
+    Orekit `absorption` = alpha,  Orekit `reflection` = rho_s,
+    rho_d = 1 - alpha - rho_s
+
+Geometry of every case: panel normal is +Z in the body frame, the Sun sits at
+(sin(theta), 0, cos(theta)), and the attitude is identity so body and inertial
+axes coincide. Orekit's `flux` points from the Sun toward the spacecraft with
+magnitude equal to the radiation pressure.
+
+Run with:  uv run tools/generate_orekit_panel_srp_fixtures.py
+"""
+
+import json
+import math
+import os
+import pathlib
+import sys
+
+import orekit_jpype as orekit
+
+orekit.initVM()
+from orekit_jpype.pyhelpers import (  # noqa: E402
+    download_orekit_data_curdir,
+    setup_orekit_curdir,
+)
+
+# Orekit needs its data directory; keep the download out of the repo tree.
+CACHE = pathlib.Path(os.environ.get("XDG_CACHE_HOME", pathlib.Path.home() / ".cache"))
+WORK = CACHE / "orts-orekit-data"
+WORK.mkdir(parents=True, exist_ok=True)
+os.chdir(WORK)
+if not (WORK / "orekit-data.zip").exists():
+    download_orekit_data_curdir()
+setup_orekit_curdir()
+
+from java.util import ArrayList  # noqa: E402
+from org.hipparchus.geometry.euclidean.threed import Rotation, Vector3D  # noqa: E402
+from org.orekit.attitudes import Attitude  # noqa: E402
+from org.orekit.forces import BoxAndSolarArraySpacecraft, FixedPanel  # noqa: E402
+from org.orekit.frames import FramesFactory  # noqa: E402
+from org.orekit.orbits import CartesianOrbit  # noqa: E402
+from org.orekit.propagation import SpacecraftState  # noqa: E402
+from org.orekit.time import AbsoluteDate, TimeScalesFactory  # noqa: E402
+from org.orekit.utils import AngularCoordinates, Constants, PVCoordinates  # noqa: E402
+
+# Matches orts::perturbations::SOLAR_RADIATION_PRESSURE.
+PRESSURE = 4.5396e-6  # N/m^2 at 1 AU
+AREA = 4.0  # m^2
+MASS = 1000.0  # kg
+CD = 2.2  # unused by the radiation path, but FixedPanel requires it
+
+FRAME = FramesFactory.getEME2000()
+DATE = AbsoluteDate(2024, 3, 20, 12, 0, 0.0, TimeScalesFactory.getUTC())
+ORBIT = CartesianOrbit(
+    PVCoordinates(Vector3D(7.0e6, 0.0, 0.0), Vector3D(0.0, 7500.0, 0.0)),
+    FRAME,
+    DATE,
+    Constants.EIGEN5C_EARTH_MU,
+)
+# Identity attitude: the panel normal below is both a body and an inertial vector.
+STATE = SpacecraftState(
+    ORBIT,
+    Attitude(DATE, FRAME, AngularCoordinates(Rotation.IDENTITY, Vector3D.ZERO)),
+    MASS,
+)
+NORMAL = Vector3D(0.0, 0.0, 1.0)
+
+
+def orekit_force(rho_s: float, rho_d: float, theta_deg: float) -> list[float]:
+    """Force on one panel [N, body frame], from Orekit."""
+    alpha = 1.0 - rho_s - rho_d
+    th = math.radians(theta_deg)
+    s_hat = Vector3D(math.sin(th), 0.0, math.cos(th))  # spacecraft -> Sun
+    flux = Vector3D(-PRESSURE, s_hat)  # Sun -> spacecraft, |flux| = pressure
+
+    panels = ArrayList()
+    # normal, area, doubleSided, drag, liftRatio, absorption, reflection
+    panels.add(FixedPanel(NORMAL, AREA, False, CD, 0.0, alpha, rho_s))
+    craft = BoxAndSolarArraySpacecraft(panels)
+
+    drivers = craft.getRadiationParametersDrivers()
+    params = [drivers.get(i).getValue() for i in range(drivers.size())]
+    a = craft.radiationPressureAcceleration(STATE, flux, params)
+    return [a.getX() * MASS, a.getY() * MASS, a.getZ() * MASS]
+
+
+# The three limits pin the convention; the mixed cases and the angle sweep pin
+# the cos(theta) and cos^2(theta) structure the old law got wrong.
+CASES = [
+    ("black_face_on", 0.0, 0.0, 0.0),
+    ("black_30deg", 0.0, 0.0, 30.0),
+    ("black_60deg", 0.0, 0.0, 60.0),
+    ("mirror_face_on", 1.0, 0.0, 0.0),
+    ("mirror_30deg", 1.0, 0.0, 30.0),
+    ("mirror_60deg", 1.0, 0.0, 60.0),
+    ("lambertian_face_on", 0.0, 1.0, 0.0),
+    ("lambertian_45deg", 0.0, 1.0, 45.0),
+    ("solar_array_15deg", 0.2, 0.1, 15.0),
+    ("solar_array_45deg", 0.2, 0.1, 45.0),
+    ("solar_array_75deg", 0.2, 0.1, 75.0),
+    ("specular_ish_45deg", 0.6, 0.1, 45.0),
+]
+
+
+def main() -> int:
+    cases = []
+    for name, rho_s, rho_d, theta in CASES:
+        cases.append(
+            {
+                "name": name,
+                "specular": rho_s,
+                "diffuse": rho_d,
+                "incidence_deg": theta,
+                "force_body_n": orekit_force(rho_s, rho_d, theta),
+            }
+        )
+
+    from org.orekit.utils import Constants as _C  # noqa: F401  (import proves the VM is up)
+
+    fixture = {
+        "description": (
+            "Orekit reference forces for a single flat panel under solar radiation "
+            "pressure. Panel normal is +Z in the body frame, the Sun is at "
+            "(sin(incidence), 0, cos(incidence)), and the attitude is identity."
+        ),
+        "generator": "tools/generate_orekit_panel_srp_fixtures.py",
+        "orekit_convention": {
+            "absorption": "alpha",
+            "reflection": "rho_s (specular)",
+            "diffuse": "1 - alpha - rho_s",
+        },
+        "pressure_n_m2": PRESSURE,
+        "area_m2": AREA,
+        "panel_normal_body": [0.0, 0.0, 1.0],
+        "cases": cases,
+    }
+
+    out = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else None
+    if out is None:
+        print("usage: generate_orekit_panel_srp_fixtures.py <output.json>", file=sys.stderr)
+        return 2
+    out.write_text(json.dumps(fixture, indent=2) + "\n")
+    print(f"wrote {len(cases)} cases to {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/generate_orekit_panel_srp_fixtures.py
+++ b/tools/generate_orekit_panel_srp_fixtures.py
@@ -26,6 +26,9 @@ axes coincide. Orekit's `flux` points from the Sun toward the spacecraft with
 magnitude equal to the radiation pressure.
 
 Run with:  uv run tools/generate_orekit_panel_srp_fixtures.py
+
+which rewrites orts/tests/fixtures/orekit_panel_srp_reference.json. Pass a path
+to write somewhere else.
 """
 
 import json
@@ -41,6 +44,10 @@ from orekit_jpype.pyhelpers import (  # noqa: E402
     download_orekit_data_curdir,
     setup_orekit_curdir,
 )
+
+# Resolve the default output before chdir'ing away from the repo.
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+DEFAULT_OUT = REPO_ROOT / "orts" / "tests" / "fixtures" / "orekit_panel_srp_reference.json"
 
 # Orekit needs its data directory; keep the download out of the repo tree.
 CACHE = pathlib.Path(os.environ.get("XDG_CACHE_HOME", pathlib.Path.home() / ".cache"))
@@ -153,10 +160,8 @@ def main() -> int:
         "cases": cases,
     }
 
-    out = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else None
-    if out is None:
-        print("usage: generate_orekit_panel_srp_fixtures.py <output.json>", file=sys.stderr)
-        return 2
+    out = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_OUT
+    out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(fixture, indent=2) + "\n")
     print(f"wrote {len(cases)} cases to {out}")
     return 0


### PR DESCRIPTION
平板パネルの太陽光圧が、姿勢外乱トルクの**向き**を誤って計算していた。バグ修正。

## 何が誤っていたか

per-panel の力を、太陽の反対方向 $-\hat{s}$ に固定して計算していた。

```rust
let force = -base_pressure * panel.cr * panel.area * cos_theta * s_body;
```

投影面積 $A\cos\theta$ は正しい。向きが常に $-\hat{s}$ で、パネル法線方向の成分が無かった。

$C_r$ は放射圧係数で、面の反射のしかたを一つの無次元量にまとめたものである。完全吸収で 1、完全反射で 2、既定は 1.5。圧力中心とは関係がない。

誤っていたのは $C_r$ の値ではなく使い方である。面の光学特性を一つのスカラーにまとめ、それを常に $-\hat{s}$ 方向に掛けていた。斜入射で力がどちらを向くかは、鏡面反射と拡散反射の分解が無いと決まらない。

この形では、 $C_r$ は力の大きさをスケールするだけで、向きには効かない。向きは式の形で $-\hat{s}$ に固定されている。

## 面を押す向きは光子の行き先で決まる

![光子の行き先で押す向きが変わる](https://gist.githubusercontent.com/sksat/e8f81dad71b9baa23e34718e2e6cbb1b/raw/69ae88928eb80f4cb464c970397e955e71fd408b/1-photon-fates.svg)

反太陽方向に押すのは吸収された分だけである。鏡面反射では面に平行な運動量が変わらず法線成分だけが反転するので、押す向きは法線方向 $-\hat{n}$ になる。拡散再放射は吸収してから法線まわりに放射するので、両方に効く。

実際の面は三つが混ざるため、力はその合成になる。抜けていたのは法線方向の成分である。

![実際の力は 2 成分の合成](https://gist.githubusercontent.com/sksat/e8f81dad71b9baa23e34718e2e6cbb1b/raw/597ba8af6aab89b6b395d522b7820a6e4ac6905a/2-force-composition.svg)

太陽電池パドル相当の面、つまり $\rho_s = 0.2$ , $\rho_d = 0.1$ の面に 45° で日射が当たる場合、抜けていた成分は力の 32.5% を占める。旧式の力は、正しい力に対して大きさが 1.39 倍、向きが 13.3° ずれる。

## トルクにどう効くか

トルクは $\tau = r \times F$ で、 $r$ は重心から圧力中心へのずれである。 $\tau$ の向きは衛星が回る軸を表すので、向きが誤るとは、衛星が別の軸まわりに回るということである。

力の向きの誤りがトルクの向きに届くかは、圧力中心がどこにあるかで決まる。

![圧力中心の位置で誤りの現れ方が変わる](https://gist.githubusercontent.com/sksat/e8f81dad71b9baa23e34718e2e6cbb1b/raw/28532e3bdeab56953beeca5f4e0aa726b44b4779/3-torque-direction.svg)

圧力中心が $\hat{s}$ と $\hat{n}$ の張る平面の外にあると、 $r \times \hat{s}$ と $r \times \hat{n}$ は別方向を向く。回る軸が変わる。

平面内なら二つは平面に垂直で平行になり、回る軸は正しく、トルクの大きさだけが誤る。この場合でも誤りの割合は一定ではない。旧式は $\cos\theta$ に比例するが、抜けていた成分は $\rho_s \cos^2\theta$ を含むので、入射角によって比が変わる。

`panel_srp.rs` が入ったコミット 9ed886a8 からこの形で、`v0.2.0` も同じ。最近の frame refactor による regression ではない。

## 修正

per-panel の力を平板の式に差し替えた。

$$F = -P A \cos\theta \left[ (\alpha + \rho_d)\,\hat{s} \;+\; 2\left(\rho_s \cos\theta + \tfrac{1}{3}\rho_d\right) \hat{n} \right], \qquad \alpha + \rho_s + \rho_d = 1$$

$\alpha$ は吸収率、 $\rho_s$ は鏡面反射率、 $\rho_d$ は拡散反射率。正面入射、すなわち $\theta = 0$ では $C_r = 1 + \rho_s + \tfrac{2}{3}\rho_d$ に縮退し、黒体で 1、完全鏡面で 2、完全拡散で 5/3 という教科書の値になる。

## API: `cr` から `PanelOptics` へ

単一の $C_r$ ではこの式を書けない。正面入射での力の大きさは決まるが、斜入射での向きが決まらないからである。

`SurfacePanel.cr: f64` を `optics: PanelOptics { specular, diffuse }` に置き換えた。吸収率は $1 - (\rho_s + \rho_d)$ として導出する。

`PanelOptics` のフィールドは private にした。 $\rho_s > 1$ だと吸収率が負になり、力の太陽方向成分が太陽側を向いてしまうので、`new` の検証を struct literal で迂回できないようにするためである。

`SurfacePanel::at_com` は `optics` を必須引数にした。 $C_r = 1.5$ に対応する $(\rho_s, \rho_d)$ は一意に決まらず、しかも向きがこの分解に依存するので、どの既定値を選んでも正面入射以外では旧振る舞いを再現しない。既定値を置けば連続性があるように見えて実は無い状態になるため、コンパイルエラーにして呼び出し側に面を明示させる。面が不明なら `PanelOptics::absorber()` を渡す。

`SpacecraftShape::Sphere` は `cr` を維持した。等方面には入射角という概念が無いので、鏡面と拡散の項が依存する相手がいない。

## 検証

per-panel の力を pure 関数 `panel_force` に切り出し、閉形式と比較できるようにした。`eval` 経由では oracle がすべて太陽エフェメリスに紐づき、equivariance も検証できない。state を慣性回転しても太陽方向は回らないからである。

固定したのは次の性質である。

- 三つの極限、すなわち完全吸収と完全鏡面と完全拡散が、閉形式に厳密一致
- 斜入射で、 $\hat{s}$ 成分と $\hat{n}$ 成分をそれぞれ直交方向へ射影して別々に検証。大きさが合って向きが違う力では通らない
- 回転に対する equivariance
- $\cos^2\theta$ 則を角度横断で。既存の property test は黒体なので鏡面項が恒等ゼロだった
- $\tau = r \times F$ を厳密比較。圧力中心を平面外に置いた場合と、非 identity 姿勢の場合

ただしこれらは実装からは独立でも、式からは独立ではない。閉形式もテストも同じ理解から書いたので、平板の法則の読み違いや係数の意味の取り違えは通ってしまう。そこで Orekit の paneled radiation model と突き合わせた。

`tools/generate_orekit_panel_srp_fixtures.py` が `RadiationSensitive::radiationPressureAcceleration(state, flux, parameters)` を 1 枚のパネルに対して直接呼ぶ。propagator も attitude provider も要らない。12 ケースが 1e-12 相対で一致する。3 極限を複数の入射角、太陽電池パドル相当の面を 15/45/75°、鏡面寄りの面を 45°。

極限は規約も確定させる。ここは式レベルのレビューでは詰められない部分で、Orekit の `absorption` が $\alpha$ 、`reflection` が $\rho_s$ 、 $\rho_d = 1 - \alpha - \rho_s$ だと分かる。

oracle が力の側だけなのは、Orekit の paneled model が加速度しか返さないからである。そこから組むトルクは厳密な外積テストで押さえているので、 $F$ を Orekit に対して、 $\tau = r \times F$ を厳密に、という形で端まで繋がっている。

判別力は mutation で実測した。力の法則を旧式に戻すと 8 テスト、鏡面項から $\cos\theta$ を落とすと 5 テスト、Lambertian の $2/3$ を $1$ にすると Orekit fixture を含む 5 テストが落ちる。

## ゲート

`cargo test -p orts` 全 suite（751 lib + 統合、30 日 GCRF oracle 込み）、`cargo test --workspace --exclude orts`、`cargo clippy --locked --workspace -- -D warnings`、同 `-p orts --no-default-features --features plugin-wasm`、`cargo check -p orts --all-features --all-targets` がすべて exit 0。`cargo fmt --all` clean。

CI の clippy は `--all-targets` を付けない。初版はそのために `--lib` だけで落ちる unused import を含んでいた。`cargo test` と `--all-targets` の両方が、test module の `use super::*` でそれを隠していた。

codex レビュー 3 巡で指摘なし。Copilot は 3 巡目で 2 件を挙げ、どちらも実質的だったので反映した。`PanelDrag` が単位法線の検証を迂回していた点と、reference implementation との突合が無かった点である。後者は「paneled fixture には propagator と attitude provider が必要」という私の思い込みで見送っていたもので、指摘を受けて調べたら誤りだった。
