### PR TITLE
perf(orts): send .rrd columns instead of one log call per value

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -73,6 +73,19 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   とタグ付けされた effector 荷重を変換なしで host frame `F` に貼り替えており、
   `F != SimpleEci` (例: `Gcrs`) で座標を黙って誤ラベルしていた。出荷済み
   effector が torque のみのため潜在的だったが、並進 effector では誤りとなる。([#148](https://github.com/sksat/orts/pull/148), [#103](https://github.com/sksat/orts/issues/103))
+- 負の `sim_time` が .rrd に届くようになった。`save_as_rrd` は timeline を
+  `set_duration_secs` で設定していたが、これは符号なしの `std::time::Duration`
+  を経由するので負値を拒否し、直前の行の timestamp をそのまま残していた。
+  `-30, -20, -10, 0, 10` は `0, 0, 0, 0, 10` として書かれていた。([#379](https://github.com/sksat/orts/pull/379))
+
+#### Performance
+- `save_as_rrd` が .rrd を値ごとの `rec.log()` でなく
+  `RecordingStream::send_columns` で列単位に書くようになった。呼び出し回数は
+  行数でなく field 数に比例する: 2500 行 13 field の segment で 32,500 回が 13 回。
+  行単位のループは `HistoryBuffer::flush` 224ms のうち呼び出しスレッドの 165ms を
+  占めており、writer スレッドの Arrow IPC + LZ4 は 55ms、665KB のファイル書き込みは
+  0.2ms だった。batcher を迂回して chunk の境界が呼び出し側の責任になるため、
+  8192 行で分割する。([#379](https://github.com/sksat/orts/pull/379))
 
 #### Removed
 - **BREAKING**: `orts::tle` module を削除。TLE パースは `arika::tle`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,21 @@ section is subdivided by package.
   (the only shipped effector is torque-only) but wrong for a translational
   effector. ([#148](https://github.com/sksat/orts/pull/148), [#103](https://github.com/sksat/orts/issues/103))
 
+- A negative `sim_time` reaches the .rrd. `save_as_rrd` set the timeline through
+  `set_duration_secs`, which converts via the unsigned `std::time::Duration`:
+  the value was rejected and the previous row's timestamp stayed in place, so
+  `-30, -20, -10, 0, 10` was written as `0, 0, 0, 0, 10`. ([#379](https://github.com/sksat/orts/pull/379))
+
+#### Performance
+- `save_as_rrd` writes .rrd columns through `RecordingStream::send_columns`
+  instead of one `rec.log()` call per value, so the call count scales with the
+  number of fields rather than the number of rows — 32,500 calls became 13 for a
+  2500-row, 13-field segment. The row-oriented loop was 165ms of
+  `HistoryBuffer::flush`'s 224ms on the calling thread, against 55ms of Arrow
+  IPC + LZ4 on the writer thread and 0.2ms for the 665KB file write. Chunks are
+  split at 8192 rows, since bypassing the batcher puts chunk boundaries in the
+  caller's hands. ([#379](https://github.com/sksat/orts/pull/379))
+
 #### Removed
 - **BREAKING**: the `orts::tle` module is removed; TLE parsing moved to
   `arika::tle` (decoding into the shared `arika::elements::Sgp4Elements`).

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -201,7 +201,8 @@ pub fn save_as_rrd(
                 let indexes = index.time_columns(rows.clone());
                 let points: Vec<[f32; 3]> = rows
                     .map(|i| {
-                        let row = &pos_col.data[i * scalars_per_row..];
+                        let start = i * scalars_per_row;
+                        let row = &pos_col.data[start..start + 3];
                         [row[0] as f32, row[1] as f32, row[2] as f32]
                     })
                     .collect();
@@ -3247,6 +3248,59 @@ mod tests {
             under_entity.is_empty(),
             "expected no chunks under the entity, got {under_entity:?}"
         );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Two timeline arrays that cover different logical rows cannot both index the
+    /// data, so the shorter axis is dropped rather than truncated. Logging rows 0-4
+    /// with `step` alone and rows 5-9 with both leaves `sim_time` 5 long and `step`
+    /// 10 long, and index 0 of each names a *different* row: `sim_time[0]` is row
+    /// 5's time while `step[0]` is row 0's step. Truncating `step` to the exported
+    /// range would therefore pair row 0-4 steps with row 5-9 times.
+    #[test]
+    fn a_step_axis_that_covers_other_rows_is_dropped() {
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/divergent");
+
+        for i in 0..10u64 {
+            let tp = if i < 5 {
+                TimePoint::new().with_step(i)
+            } else {
+                TimePoint::new()
+                    .with_sim_time(i as f64 * 100.0)
+                    .with_step(i)
+            };
+            let os = OrbitalState::new(
+                Vector3::new(i as f64, 0.0, 0.0),
+                Vector3::new(0.0, 7.5, 0.0),
+            );
+            rec.log_orbital_state(&sat, &tp, &os);
+        }
+
+        // The premise: the axes really do diverge in this shape.
+        let store = rec.entity(&sat).expect("entity");
+        assert_eq!(store.timelines[&TimelineName::SimTime].len(), 5);
+        assert_eq!(store.timelines[&TimelineName::Step].len(), 10);
+
+        let path = std::env::temp_dir().join("test_orts_divergent_axes.rrd");
+        let path_str = path.to_str().unwrap();
+        save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
+
+        for chunk in decode_chunks(path_str) {
+            if !chunk
+                .entity_path()
+                .to_string()
+                .starts_with("/world/sat/divergent")
+            {
+                continue;
+            }
+            assert!(
+                chunk.timelines().keys().all(|name| name.as_str() != "step"),
+                "{} kept a step axis covering other rows",
+                chunk.entity_path()
+            );
+        }
 
         let _ = std::fs::remove_file(&path);
     }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -1,10 +1,115 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::ops::Range;
+
+use re_chunk::TimeColumn;
 
 use crate::record::component::Component;
 use crate::record::components::Position3D;
 use crate::record::entity_path::EntityPath;
-use crate::record::recording::{Recording, SimMetadata};
+use crate::record::recording::{EntityStore, Recording, SimMetadata};
 use crate::record::timeline::{TimeIndex, TimelineName};
+
+/// Rows per columnar chunk.
+///
+/// `send_columns` bypasses the batcher, so the chunk boundaries are ours to pick.
+/// The batcher's own bound on sorted data is `flush_num_bytes`, 2 MiB by default;
+/// a row here costs a scalar, a list offset, a row id and the two index values, so
+/// 8192 rows stay well inside that while keeping a long `orts run` from emitting
+/// one multi-million-row chunk that a reader has to materialize whole before it can
+/// show anything.
+const CHUNK_ROWS: usize = 8192;
+
+/// The index columns for one entity, as plain values.
+///
+/// Only `sim_time` (a duration) and `step` (a sequence) are written, which is what
+/// the export has always written; `WallClock` and `Custom` timelines have no
+/// read-back contract yet.
+struct EntityIndex {
+    sim_time_secs: Option<Vec<f64>>,
+    steps: Option<Vec<i64>>,
+    /// Logical rows this index covers.
+    n_rows: usize,
+}
+
+impl EntityIndex {
+    fn from_store(store: &EntityStore) -> Self {
+        // The logical row count comes from the timelines, preferring `sim_time`.
+        let mut n_rows = store
+            .timelines
+            .get(&TimelineName::SimTime)
+            .or_else(|| store.timelines.get(&TimelineName::Step))
+            .map(|tl| tl.len())
+            .unwrap_or(0);
+
+        // A `TimeColumn` carries no "no time on this row", so an axis holding the
+        // wrong `TimeIndex` variant is dropped whole rather than written
+        // misaligned. `sim_time` needs no length check: `n_rows` is its own length
+        // whenever it exists.
+        let sim_time_secs = store.timelines.get(&TimelineName::SimTime).and_then(|tl| {
+            tl.iter()
+                .map(|index| match index {
+                    TimeIndex::Seconds(t) => Some(*t),
+                    TimeIndex::Sequence(_) => None,
+                })
+                .collect::<Option<Vec<_>>>()
+        });
+
+        // `step` can be shorter than `n_rows` — rows logged with a `TimePoint` that
+        // omits it push nothing — and a short index cannot align with the data.
+        let steps = store
+            .timelines
+            .get(&TimelineName::Step)
+            .and_then(|tl| {
+                tl.iter()
+                    .map(|index| match index {
+                        TimeIndex::Sequence(s) => i64::try_from(*s).ok(),
+                        TimeIndex::Seconds(_) => None,
+                    })
+                    .collect::<Option<Vec<_>>>()
+            })
+            .filter(|steps| steps.len() == n_rows);
+
+        // `send_columns` reads an empty index list as *static* data, and static data
+        // unconditionally shadows every temporal value at the same path in the
+        // viewer. An entity whose rows have no usable axis left is better dropped
+        // than turned static, so zero the row count and export nothing temporal.
+        if sim_time_secs.is_none() && steps.is_none() {
+            n_rows = 0;
+        }
+
+        Self {
+            sim_time_secs,
+            steps,
+            n_rows,
+        }
+    }
+
+    /// The `TimeColumn`s covering `rows`. `send_columns` requires every index
+    /// column to be as long as the component columns it accompanies.
+    fn time_columns(&self, rows: Range<usize>) -> Vec<TimeColumn> {
+        let mut columns = Vec::with_capacity(2);
+        if let Some(secs) = &self.sim_time_secs {
+            columns.push(TimeColumn::new_duration_secs(
+                "sim_time",
+                secs[rows.clone()].iter().copied(),
+            ));
+        }
+        if let Some(steps) = &self.steps {
+            columns.push(TimeColumn::new_sequence(
+                "step",
+                steps[rows].iter().copied(),
+            ));
+        }
+        columns
+    }
+}
+
+/// Split `n` rows into consecutive ranges of at most [`CHUNK_ROWS`].
+fn chunk_ranges(n: usize) -> impl Iterator<Item = Range<usize>> {
+    (0..n)
+        .step_by(CHUNK_ROWS)
+        .map(move |start| start..(start + CHUNK_ROWS).min(n))
+}
 
 /// Save a Recording to a .rrd file using the Rerun SDK.
 ///
@@ -38,54 +143,73 @@ pub fn save_as_rrd(
             }
         }
 
-        // Log temporal data (generic: iterate all component columns)
-        let sim_times = store.timelines.get(&TimelineName::SimTime);
-        let steps = store.timelines.get(&TimelineName::Step);
+        // Log temporal data (generic: iterate all component columns). Each field is
+        // sent as whole columns, so the call count scales with the number of fields
+        // rather than with the number of rows.
+        let index = EntityIndex::from_store(store);
 
-        // Determine number of logical time rows from timelines (no stride hack needed)
-        let n_rows = sim_times.or(steps).map(|tl| tl.len()).unwrap_or(0);
+        for (comp_name, column) in &store.columns {
+            let fields = recording.lookup_component_fields(comp_name);
+            let scalars_per_row = column.scalars_per_row;
+            // `lookup_component_fields` names one synthetic field for an
+            // unregistered component, and a registered one may name fewer fields
+            // than the column is wide. Export exactly the fields that are named and
+            // that the column actually holds.
+            let n_fields = fields.len().min(scalars_per_row);
+            if n_fields == 0 {
+                continue;
+            }
+            let paths: Vec<String> = fields[..n_fields]
+                .iter()
+                .map(|field| format!("{rr_path}/{field}"))
+                .collect();
 
-        if n_rows > 0 {
-            for i in 0..n_rows {
-                // Set timeline for this row (1:1 mapping, no stride)
-                if let Some(sim_times) = sim_times
-                    && let Some(TimeIndex::Seconds(t)) = sim_times.get(i)
-                {
-                    rec.set_duration_secs("sim_time", *t);
-                }
-                if let Some(steps) = steps
-                    && let Some(TimeIndex::Sequence(s)) = steps.get(i)
-                {
-                    rec.set_time_sequence("step", *s as i64);
-                }
+            // A column with fewer rows than the entity has logical rows keeps the
+            // leading alignment it had under the row-oriented export (see #375).
+            // The `min` is also what holds the index columns to the data length.
+            let n_rows = column.num_rows().min(index.n_rows);
 
-                // Export all component columns as f64 Scalars
-                for (comp_name, column) in &store.columns {
-                    if let Some(row) = column.get_row(i) {
-                        let fields = recording.lookup_component_fields(comp_name);
-                        for (k, field) in fields.iter().enumerate() {
-                            if let Some(&val) = row.get(k) {
-                                rec.log(
-                                    format!("{rr_path}/{field}"),
-                                    &re_sdk_types::archetypes::Scalars::new([val]),
-                                )?;
-                            }
-                        }
-                    }
-                }
-
-                // Orthogonal: if Position3D exists, also log Points3D for
-                // Rerun 3D Viewer visualization. This intentionally duplicates the
-                // position data already logged as f64 Scalars above — Points3D uses
-                // f32 internally and is only consumed by the 3D spatial view.
-                if let Some(pos_col) = store.columns.get(&Position3D::component_name())
-                    && let Some(pos) = pos_col.get_row(i)
-                {
-                    rec.log(
-                        rr_path.clone(),
-                        &re_sdk_types::archetypes::Points3D::new([[pos[0], pos[1], pos[2]]]),
+            for rows in chunk_ranges(n_rows) {
+                // Built once per chunk and cloned per field: a `TimeColumn` clone is
+                // a refcount bump on the Arrow buffer, whereas rebuilding one
+                // re-scales every timestamp.
+                let indexes = index.time_columns(rows.clone());
+                for (k, path) in paths.iter().enumerate() {
+                    let values: Vec<f64> = rows
+                        .clone()
+                        .map(|i| column.data[i * scalars_per_row + k])
+                        .collect();
+                    rec.send_columns(
+                        path.as_str(),
+                        indexes.iter().cloned(),
+                        re_sdk_types::archetypes::Scalars::new(values).columns_of_unit_batches()?,
                     )?;
                 }
+            }
+        }
+
+        // Orthogonal: if Position3D exists, also log Points3D for Rerun 3D Viewer
+        // visualization. This intentionally duplicates the position data already
+        // logged as f64 Scalars above — Points3D uses f32 internally and is only
+        // consumed by the 3D spatial view.
+        if let Some(pos_col) = store.columns.get(&Position3D::component_name())
+            && pos_col.scalars_per_row >= 3
+        {
+            let scalars_per_row = pos_col.scalars_per_row;
+            let n_rows = pos_col.num_rows().min(index.n_rows);
+            for rows in chunk_ranges(n_rows) {
+                let indexes = index.time_columns(rows.clone());
+                let points: Vec<[f32; 3]> = rows
+                    .map(|i| {
+                        let row = &pos_col.data[i * scalars_per_row..];
+                        [row[0] as f32, row[1] as f32, row[2] as f32]
+                    })
+                    .collect();
+                rec.send_columns(
+                    rr_path.as_str(),
+                    indexes,
+                    re_sdk_types::archetypes::Points3D::new(points).columns_of_unit_batches()?,
+                )?;
             }
         }
     }
@@ -2711,5 +2835,479 @@ mod tests {
                 "a velocity with no values reports zero, as a position-only row does"
             );
         }
+    }
+
+    /// Decode every Arrow chunk in an .rrd file, in file order.
+    fn decode_chunks(path: &str) -> Vec<re_chunk::Chunk> {
+        use re_log_encoding::DecoderApp;
+        use re_log_types::LogMsg;
+
+        let file = std::fs::File::open(path).expect("open .rrd");
+        let reader = std::io::BufReader::new(file);
+        let mut chunks = Vec::new();
+        for msg in DecoderApp::decode_lazy(reader) {
+            if let LogMsg::ArrowMsg(_, arrow_msg) = msg.expect("decode log message") {
+                chunks.push(re_chunk::Chunk::from_arrow_msg(&arrow_msg).expect("decode chunk"));
+            }
+        }
+        chunks
+    }
+
+    /// Every field of every row carries a distinct value, so a row that shifts by
+    /// one position shows up as a value mismatch. `roundtrip_save_and_load_rrd`
+    /// writes the same state five times over and cannot see such a shift.
+    #[test]
+    fn each_value_lands_on_its_own_time() {
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/dense");
+
+        const N: usize = 7;
+        for i in 0..N {
+            let t = i as f64 * 10.0;
+            let b = i as f64;
+            let os = OrbitalState::new(
+                Vector3::new(7000.0 + b, 100.0 + b, 200.0 + b),
+                Vector3::new(1.0 + b, 2.0 + b, 3.0 + b),
+            );
+            let tp = TimePoint::new().with_sim_time(t).with_step(i as u64);
+            rec.log_orbital_state(&sat, &tp, &os);
+        }
+
+        let path = std::env::temp_dir().join("test_orts_dense_rows.rrd");
+        let path_str = path.to_str().unwrap();
+        save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
+
+        let rows = load_from_rrd(path_str).expect("failed to load .rrd");
+        assert_eq!(rows.len(), N, "expected {N} rows");
+
+        for (i, row) in rows.iter().enumerate() {
+            let b = i as f64;
+            // `t` gets a looser bar than the values: the timeline stores whole
+            // nanoseconds, so 1e-9 s is its quantum and a rounding difference there
+            // would read like a row misalignment. A shift of one row moves `t` by
+            // the 10 s step, far above this.
+            assert!(
+                (row.t - i as f64 * 10.0).abs() < 1e-6,
+                "t[{i}] = {}, expected {}",
+                row.t,
+                i as f64 * 10.0
+            );
+            for (name, got, want) in [
+                ("x", row.x, 7000.0 + b),
+                ("y", row.y, 100.0 + b),
+                ("z", row.z, 200.0 + b),
+                ("vx", row.vx, 1.0 + b),
+                ("vy", row.vy, 2.0 + b),
+                ("vz", row.vz, 3.0 + b),
+            ] {
+                assert!(
+                    (got - want).abs() < 1e-9,
+                    "{name}[{i}] = {got}, expected {want}"
+                );
+            }
+        }
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The columnar writer carries its index columns explicitly, so the .rrd holds
+    /// exactly the timelines the `Recording` had. `rec.log()` also injects
+    /// `log_time` and `log_tick`, which nothing in this repository reads.
+    #[test]
+    fn export_writes_only_the_recording_timelines() {
+        use std::collections::BTreeSet;
+
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/timelines");
+
+        for i in 0..4u64 {
+            let tp = TimePoint::new().with_sim_time(i as f64).with_step(i);
+            let os = OrbitalState::new(Vector3::new(7000.0, 0.0, 0.0), Vector3::new(0.0, 7.5, 0.0));
+            rec.log_orbital_state(&sat, &tp, &os);
+        }
+
+        let path = std::env::temp_dir().join("test_orts_timelines.rrd");
+        let path_str = path.to_str().unwrap();
+        save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
+
+        let names: BTreeSet<String> = decode_chunks(path_str)
+            .iter()
+            .flat_map(|chunk| {
+                chunk
+                    .timelines()
+                    .keys()
+                    .map(|name| name.as_str().to_string())
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        assert_eq!(
+            names,
+            BTreeSet::from(["sim_time".to_string(), "step".to_string()]),
+            "unexpected timelines in the .rrd"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Scalar values per entity path, in file order — the same way every reader in
+    /// the repository collects them. Paths keep the leading slash Rerun gives them.
+    fn scalars_by_path(path: &str) -> BTreeMap<String, Vec<f64>> {
+        let mut out: BTreeMap<String, Vec<f64>> = BTreeMap::new();
+        for chunk in decode_chunks(path) {
+            for comp_id in chunk.components_identifiers() {
+                if !comp_id.as_str().contains("Scalar") && !comp_id.as_str().contains("scalars") {
+                    continue;
+                }
+                for row_idx in 0..chunk.num_rows() {
+                    if let Some(Ok(batch)) =
+                        chunk.component_batch::<re_sdk_types::components::Scalar>(comp_id, row_idx)
+                    {
+                        out.entry(chunk.entity_path().to_string())
+                            .or_default()
+                            .extend(batch.iter().map(|s| s.0.0));
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// A recording of `n` rows on one satellite, `x` counting up from zero so a
+    /// row can be identified by its value.
+    fn counted_recording(entity: &str, n: usize) -> Recording {
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse(entity);
+        for i in 0..n {
+            let tp = TimePoint::new().with_sim_time(i as f64).with_step(i as u64);
+            let os = OrbitalState::new(
+                Vector3::new(i as f64, 0.0, 0.0),
+                Vector3::new(0.0, 7.5, 0.0),
+            );
+            rec.log_orbital_state(&sat, &tp, &os);
+        }
+        rec
+    }
+
+    /// `send_columns` writes whatever it is handed as a single chunk, so the row
+    /// count per chunk is this module's responsibility. Every row must appear
+    /// exactly once and no chunk may exceed the cap.
+    #[test]
+    fn chunk_rows_are_bounded() {
+        let n = CHUNK_ROWS + 1;
+        let rec = counted_recording("/world/sat/bounded", n);
+
+        let path = std::env::temp_dir().join("test_orts_chunk_bounds.rrd");
+        let path_str = path.to_str().unwrap();
+        save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
+
+        let chunks = decode_chunks(path_str);
+        let mut rows_per_path: BTreeMap<String, usize> = BTreeMap::new();
+        for chunk in &chunks {
+            assert!(
+                chunk.num_rows() <= CHUNK_ROWS,
+                "{} holds {} rows, cap is {CHUNK_ROWS}",
+                chunk.entity_path(),
+                chunk.num_rows()
+            );
+            *rows_per_path
+                .entry(chunk.entity_path().to_string())
+                .or_default() += chunk.num_rows();
+        }
+
+        for field in ["x", "y", "z", "vx", "vy", "vz"] {
+            assert_eq!(
+                rows_per_path.get(&format!("/world/sat/bounded/{field}")),
+                Some(&n),
+                "{field} row total"
+            );
+        }
+
+        // The split must not reorder or drop rows either.
+        let xs = &scalars_by_path(path_str)["/world/sat/bounded/x"];
+        assert_eq!(xs.len(), n);
+        for (i, x) in xs.iter().enumerate() {
+            assert!((x - i as f64).abs() < 1e-9, "x[{i}] = {x}");
+        }
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Every scalar row holds exactly one value. The readers count a row per
+    /// value, so a wide batch would silently change how many rows they see.
+    #[test]
+    fn scalar_rows_stay_unit_batches() {
+        let rec = counted_recording("/world/sat/unit", 5);
+
+        let path = std::env::temp_dir().join("test_orts_unit_batches.rrd");
+        let path_str = path.to_str().unwrap();
+        save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
+
+        let mut checked = 0;
+        for chunk in decode_chunks(path_str) {
+            for comp_id in chunk.components_identifiers() {
+                if !comp_id.as_str().contains("Scalar") && !comp_id.as_str().contains("scalars") {
+                    continue;
+                }
+                for row_idx in 0..chunk.num_rows() {
+                    if let Some(Ok(batch)) =
+                        chunk.component_batch::<re_sdk_types::components::Scalar>(comp_id, row_idx)
+                    {
+                        assert_eq!(
+                            batch.len(),
+                            1,
+                            "{} row {row_idx} holds {} scalars",
+                            chunk.entity_path(),
+                            batch.len()
+                        );
+                        checked += 1;
+                    }
+                }
+            }
+        }
+        assert!(checked > 0, "no scalar rows were inspected");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// No reader in the repository reconstructs the `step` timeline, so the only
+    /// way to pin it is to read the decoded chunk directly.
+    #[test]
+    fn step_timeline_survives_the_columnar_export() {
+        let n = 6;
+        let rec = counted_recording("/world/sat/steps", n);
+
+        let path = std::env::temp_dir().join("test_orts_step_timeline.rrd");
+        let path_str = path.to_str().unwrap();
+        save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
+
+        let expected: Vec<i64> = (0..n as i64).collect();
+        let mut seen = 0;
+        for chunk in decode_chunks(path_str) {
+            if chunk.entity_path().to_string() != "/world/sat/steps/x" {
+                continue;
+            }
+            let (_, steps) = chunk
+                .timelines()
+                .iter()
+                .find(|(name, _)| name.as_str() == "step")
+                .expect("step timeline missing");
+            assert_eq!(steps.times_raw(), expected.as_slice());
+            seen += 1;
+        }
+        assert_eq!(seen, 1, "expected one chunk for /world/sat/steps/x");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The `Points3D` convenience archetype must cover the same rows as the
+    /// position column it mirrors.
+    #[test]
+    fn points3d_rows_match_position_rows() {
+        let n = 9;
+        let rec = counted_recording("/world/sat/points", n);
+
+        let path = std::env::temp_dir().join("test_orts_points3d_rows.rrd");
+        let path_str = path.to_str().unwrap();
+        save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
+
+        // Only Points3D is logged at the entity itself; the scalars live one level
+        // down, under the field names.
+        let points_rows: usize = decode_chunks(path_str)
+            .iter()
+            .filter(|chunk| chunk.entity_path().to_string() == "/world/sat/points")
+            .map(|chunk| chunk.num_rows())
+            .sum();
+        let position_rows = scalars_by_path(path_str)["/world/sat/points/x"].len();
+        assert_eq!(position_rows, n, "the fixture should have written {n} rows");
+        assert_eq!(
+            points_rows, position_rows,
+            "Points3D must cover the same rows as the position column it mirrors"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A negative `sim_time` reaches the file. The row-oriented export could not
+    /// write one: `set_duration_secs` goes through `std::time::Duration`, which is
+    /// unsigned, so it rejected the value and left the previous row's timestamp in
+    /// place. `TimeColumn::new_duration_secs` takes it.
+    #[test]
+    fn negative_sim_time_reaches_the_file() {
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/countdown");
+
+        let times = [-30.0, -20.0, -10.0, 0.0, 10.0];
+        for (i, &t) in times.iter().enumerate() {
+            let tp = TimePoint::new().with_sim_time(t).with_step(i as u64);
+            let os = OrbitalState::new(
+                Vector3::new(i as f64, 0.0, 0.0),
+                Vector3::new(0.0, 7.5, 0.0),
+            );
+            rec.log_orbital_state(&sat, &tp, &os);
+        }
+
+        let path = std::env::temp_dir().join("test_orts_negative_time.rrd");
+        let path_str = path.to_str().unwrap();
+        save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
+
+        let rows = load_from_rrd(path_str).expect("failed to load .rrd");
+        assert_eq!(rows.len(), times.len());
+        for (row, &want) in rows.iter().zip(times.iter()) {
+            assert!(
+                (row.t - want).abs() < 1e-6,
+                "t = {}, expected {want}",
+                row.t
+            );
+        }
+        // Each row keeps its own x, so the negative times are not all collapsed
+        // onto one index.
+        for (i, row) in rows.iter().enumerate() {
+            assert!((row.x - i as f64).abs() < 1e-9, "x[{i}] = {}", row.x);
+        }
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A component whose logging starts late has fewer rows than the entity has
+    /// logical rows. Every logged value must still reach the file — this pins the
+    /// count and the order, not the timestamps, which are wrong for a different
+    /// reason (see #375).
+    #[test]
+    fn sparse_column_writes_every_value() {
+        use crate::record::components::MtqCommand3D;
+
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/sparse");
+
+        const N: u64 = 10;
+        const FIRST_MTQ_STEP: u64 = 5;
+        for i in 0..N {
+            let tp = TimePoint::new().with_sim_time(i as f64).with_step(i);
+            let os = OrbitalState::new(Vector3::new(7000.0, 0.0, 0.0), Vector3::new(0.0, 7.5, 0.0));
+            rec.log_orbital_state(&sat, &tp, &os);
+            if i >= FIRST_MTQ_STEP {
+                rec.log_temporal(&sat, &tp, &MtqCommand3D(Vector3::new(i as f64, 0.0, 0.0)));
+            }
+        }
+
+        let path = std::env::temp_dir().join("test_orts_sparse_column.rrd");
+        let path_str = path.to_str().unwrap();
+        save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
+
+        let scalars = scalars_by_path(path_str);
+        let expected: Vec<f64> = (FIRST_MTQ_STEP..N).map(|i| i as f64).collect();
+        assert_eq!(
+            scalars.get("/world/sat/sparse/mtq_mx"),
+            Some(&expected),
+            "every logged mtq_mx value must reach the file, in order"
+        );
+        assert_eq!(
+            scalars["/world/sat/sparse/x"].len(),
+            N as usize,
+            "the dense column is unaffected"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// An entity whose only timeline carries the wrong `TimeIndex` variant has no
+    /// usable index left. `send_columns` reads an empty index list as *static* data,
+    /// and static data unconditionally shadows every temporal value at the same path
+    /// in the viewer, so such an entity must write nothing rather than write statics.
+    #[test]
+    fn an_entity_with_no_usable_index_writes_nothing() {
+        use crate::record::recording::ComponentColumn;
+
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/unindexed");
+        {
+            let store = rec.entity_mut(&sat);
+            let mut column = ComponentColumn::new(3);
+            column.push(&[1.0, 2.0, 3.0]);
+            store.columns.insert(Position3D::component_name(), column);
+            // A sequence on the sim-time axis, and no step axis at all.
+            store
+                .timelines
+                .insert(TimelineName::SimTime, vec![TimeIndex::Sequence(0)]);
+            store.num_rows = 1;
+        }
+        rec.register_component_fields(Position3D::component_name(), vec!["x", "y", "z"]);
+
+        let path = std::env::temp_dir().join("test_orts_unindexed.rrd");
+        let path_str = path.to_str().unwrap();
+        save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
+
+        let under_entity: Vec<String> = decode_chunks(path_str)
+            .iter()
+            .map(|chunk| chunk.entity_path().to_string())
+            .filter(|entity| entity.starts_with("/world/sat/unindexed"))
+            .collect();
+        assert!(
+            under_entity.is_empty(),
+            "expected no chunks under the entity, got {under_entity:?}"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// `rrd-wasm` (and with it the viewer's file source) reads .rrd without any
+    /// schema: it looks up leaf field names, the `sim_time` timeline, and the
+    /// `meta/sim/*` statics, and it recognises components by a substring of their
+    /// identifier. Pin that contract here rather than depending on `rrd-wasm`.
+    #[test]
+    fn rrd_wasm_read_contract_holds() {
+        let mut rec = counted_recording("/world/sat/contract", 4);
+        rec.metadata = SimMetadata {
+            mu: Some(398600.4418),
+            body_name: Some("Earth".to_string()),
+            ..Default::default()
+        };
+
+        let path = std::env::temp_dir().join("test_orts_wasm_contract.rrd");
+        let path_str = path.to_str().unwrap();
+        save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
+
+        let chunks = decode_chunks(path_str);
+
+        // Leaf field names, with a `sim_time` index on each.
+        for field in ["x", "y", "z", "vx", "vy", "vz"] {
+            let wanted = format!("/world/sat/contract/{field}");
+            let chunk = chunks
+                .iter()
+                .find(|chunk| chunk.entity_path().to_string() == wanted)
+                .unwrap_or_else(|| panic!("{wanted} missing"));
+            assert!(
+                chunk
+                    .timelines()
+                    .iter()
+                    .any(|(name, _)| name.as_str() == "sim_time"),
+                "{wanted} has no sim_time index"
+            );
+            assert!(
+                chunk
+                    .components_identifiers()
+                    .any(|id| id.as_str().contains("Scalar") || id.as_str().contains("scalars")),
+                "{wanted} carries no component the readers recognise as a scalar"
+            );
+        }
+
+        // `meta/sim/*` statics: a scalar and a text one, both timeless.
+        for (wanted, needle) in [("/meta/sim/mu", "Scalar"), ("/meta/sim/body_name", "Text")] {
+            let chunk = chunks
+                .iter()
+                .find(|chunk| chunk.entity_path().to_string() == wanted)
+                .unwrap_or_else(|| panic!("{wanted} missing"));
+            assert!(chunk.is_static(), "{wanted} is not static");
+            assert!(
+                chunk.components_identifiers().any(|id| {
+                    let id = id.as_str();
+                    id.contains(needle) || id.contains(&needle.to_lowercase())
+                }),
+                "{wanted} carries no component containing {needle:?}"
+            );
+        }
+
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -33,18 +33,9 @@ struct EntityIndex {
 
 impl EntityIndex {
     fn from_store(store: &EntityStore) -> Self {
-        // The logical row count comes from the timelines, preferring `sim_time`.
-        let mut n_rows = store
-            .timelines
-            .get(&TimelineName::SimTime)
-            .or_else(|| store.timelines.get(&TimelineName::Step))
-            .map(|tl| tl.len())
-            .unwrap_or(0);
-
-        // A `TimeColumn` carries no "no time on this row", so an axis holding the
-        // wrong `TimeIndex` variant is dropped whole rather than written
-        // misaligned. `sim_time` needs no length check: `n_rows` is its own length
-        // whenever it exists.
+        // Read both axes before choosing a row count. A `TimeColumn` carries no "no
+        // time on this row", so an axis holding the wrong `TimeIndex` variant cannot
+        // be written at all, and the row count has to come from one that can.
         let sim_time_secs = store.timelines.get(&TimelineName::SimTime).and_then(|tl| {
             tl.iter()
                 .map(|index| match index {
@@ -54,28 +45,40 @@ impl EntityIndex {
                 .collect::<Option<Vec<_>>>()
         });
 
-        // `step` can be shorter than `n_rows` — rows logged with a `TimePoint` that
-        // omits it push nothing — and a short index cannot align with the data.
-        let steps = store
-            .timelines
-            .get(&TimelineName::Step)
-            .and_then(|tl| {
-                tl.iter()
-                    .map(|index| match index {
-                        TimeIndex::Sequence(s) => i64::try_from(*s).ok(),
-                        TimeIndex::Seconds(_) => None,
-                    })
-                    .collect::<Option<Vec<_>>>()
-            })
-            .filter(|steps| steps.len() == n_rows);
+        let mut steps = store.timelines.get(&TimelineName::Step).and_then(|tl| {
+            tl.iter()
+                .map(|index| match index {
+                    TimeIndex::Sequence(s) => i64::try_from(*s).ok(),
+                    TimeIndex::Seconds(_) => None,
+                })
+                .collect::<Option<Vec<_>>>()
+        });
+
+        // Prefer `sim_time`, as the row-oriented export did, and fall back to `step`
+        // when `sim_time` cannot be written. Deriving the count from a usable axis is
+        // also what keeps the invariant below: a non-zero `n_rows` always has at
+        // least one index column to go with it.
+        let n_rows = sim_time_secs
+            .as_ref()
+            .map(Vec::len)
+            .or_else(|| steps.as_ref().map(Vec::len))
+            .unwrap_or(0);
+
+        // Two axes can cover different logical rows: `log_temporal` pushes only to
+        // the axes a `TimePoint` names, so each is packed over its own rows and the
+        // same index can mean different rows in each. A `step` axis that does not
+        // cover exactly the exported rows is dropped rather than truncated.
+        if steps.as_ref().is_some_and(|steps| steps.len() != n_rows) {
+            steps = None;
+        }
 
         // `send_columns` reads an empty index list as *static* data, and static data
         // unconditionally shadows every temporal value at the same path in the
-        // viewer. An entity whose rows have no usable axis left is better dropped
-        // than turned static, so zero the row count and export nothing temporal.
-        if sim_time_secs.is_none() && steps.is_none() {
-            n_rows = 0;
-        }
+        // viewer. `n_rows` came from a usable axis, so this cannot fire.
+        debug_assert!(
+            n_rows == 0 || sim_time_secs.is_some() || steps.is_some(),
+            "rows to export with no index column"
+        );
 
         Self {
             sim_time_secs,
@@ -3248,6 +3251,67 @@ mod tests {
             under_entity.is_empty(),
             "expected no chunks under the entity, got {under_entity:?}"
         );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// An unusable `sim_time` axis must not take a usable `step` axis down with it.
+    /// The row count is taken from whichever axis can actually be written, so these
+    /// rows are exported on `step` alone — which is what the row-oriented export did,
+    /// since its `set_duration_secs` call was skipped on the variant mismatch while
+    /// `set_time_sequence` still ran.
+    #[test]
+    fn a_usable_step_axis_carries_the_export_on_its_own() {
+        use crate::record::recording::ComponentColumn;
+
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/steponly");
+        const N: usize = 3;
+        {
+            let store = rec.entity_mut(&sat);
+            let mut column = ComponentColumn::new(3);
+            for i in 0..N {
+                column.push(&[i as f64, 0.0, 0.0]);
+            }
+            store.columns.insert(Position3D::component_name(), column);
+            // `sim_time` holds the wrong variant, and is a different length from
+            // `step` as well, so neither its values nor its length can be used.
+            store
+                .timelines
+                .insert(TimelineName::SimTime, vec![TimeIndex::Sequence(0)]);
+            store.timelines.insert(
+                TimelineName::Step,
+                (0..N as u64).map(TimeIndex::Sequence).collect(),
+            );
+            store.num_rows = N;
+        }
+        rec.register_component_fields(Position3D::component_name(), vec!["x", "y", "z"]);
+
+        let path = std::env::temp_dir().join("test_orts_step_only.rrd");
+        let path_str = path.to_str().unwrap();
+        save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
+
+        let xs = scalars_by_path(path_str);
+        let xs = xs
+            .get("/world/sat/steponly/x")
+            .expect("the rows should have been exported on the step axis");
+        assert_eq!(xs.len(), N, "every row should reach the file");
+        for (i, x) in xs.iter().enumerate() {
+            assert!((x - i as f64).abs() < 1e-9, "x[{i}] = {x}");
+        }
+
+        // Temporal, not static — and indexed by `step` only.
+        let chunk = decode_chunks(path_str)
+            .into_iter()
+            .find(|chunk| chunk.entity_path().to_string() == "/world/sat/steponly/x")
+            .expect("chunk missing");
+        assert!(!chunk.is_static(), "the rows were written as static data");
+        let names: Vec<String> = chunk
+            .timelines()
+            .keys()
+            .map(|name| name.as_str().to_string())
+            .collect();
+        assert_eq!(names, vec!["step".to_string()]);
 
         let _ = std::fs::remove_file(&path);
     }


### PR DESCRIPTION
`save_as_rrd` は f64 1 つにつき `rec.log()` を 1 回呼んでいた。呼ぶたびに entity path を
`format!` で組み立て、要素 1 個の `Scalars` archetype を Arrow に変換する。姿勢付き衛星
1 機で 13 field あるので、2500 行なら 35,000 回になる。probe で測ると
`HistoryBuffer::flush` の 224ms のうち 165ms（73%）がこのループで、ファイル書き込みは
0.2ms しかなかった（#370）。

## 変更

`RecordingStream::send_columns` に置き換えた。`EntityStore` はもともと列でデータを持って
いるので、それを行に崩してから 1 値ずつ渡す手間がなくなり、呼び出し回数は行数ではなく
field 数で決まる。

`send_columns` は batcher を通らないので、chunk をどこで切るかを自分で決める必要がある。
1 chunk あたり 8192 行を上限にした。batcher は `flush_num_bytes`（既定 2 MiB）で切って
おり、1 行は scalar と list offset、row id、index 2 本なので、8192 行ならこれをかなり
下回る。

static データと `meta/*` は今までどおり `log_static` で書く。

## 実測

行指向（run [33376152354](https://github.com/sksat/orts/actions/runs/33376152354)）と
列指向（run [33378894983](https://github.com/sksat/orts/actions/runs/33378894983)）を
`flush-bench` で比較した。同じ workflow・同じ runner 種別で、warm-up 2 回のあとの
8 rep の median。

| OS | enqueue | flush 全体 |
|---|---|---|
| Linux | 486 → 14ms (35x) | 542 → 73ms (7.4x) |
| macOS | 226 → 10ms (23x) | 305 → 66ms (4.6x) |
| Windows | 157 → 15ms (10x) | 238 → 95ms (2.5x) |

ばらつきも小さくなり、Linux の enqueue は 357-682ms（p90 603ms）から
14-17ms（p90 16ms）に収まった。

`orts run` のように 1 回で全行を書く場合も測った（`save_as_rrd` 単体、warm-up 2 回の
あとの 7 rep の median。共有マシンなので絶対値は参考値）。

| 内容 | rows | 変更前 | 変更後 | | 出力サイズ |
|---|---|---|---|---|---|
| 軌道のみ 1 周期 (dt=10) | 555 | 62ms | 17ms | 3.6x | 171 → 106 KB |
| 軌道のみ 1 日 (dt=10) | 8,640 | 565ms | 104ms | 5.4x | 2.4 → 1.4 MB |
| 軌道のみ 1 日 (dt=1) | 86,400 | 4.98s | 0.79s | 6.3x | 24.3 → 14.4 MB |
| 姿勢つき 1 日 (dt=1) | 86,400 | 9.66s | 1.44s | 6.7x | 48.2 → 28.0 MB |

サイズが縮むのは差分 1 の帰結で、`log_time` / `log_tick` の index 列 2 本
（1 行あたり i64 × 2 = 16 バイト）が chunk ごとに消えるため。86,400 行・14 path なら
16B × 86,400 × 14 = 19.4 MB で、実測差 20.1 MB とほぼ一致する。

## .rrd の変化

どの値がどの時刻の行に載るかは変わらない。変わるのは次の 3 点。

1. 暗黙の `log_time` / `log_tick` timeline が付かなくなる（`send_columns` は明示した
   index 列だけを載せる）。`sim_time` と `step` は従来どおり載るので、Viewer の軸は
   そちらで足りる。出力が 4 割小さくなるのはこの 2 本が消えるためで、repo 内で参照して
   いる箇所はない
2. 負の `sim_time` が書けるようになる。`set_duration_secs` は符号なしの
   `std::time::Duration` を通すため負値を受け付けず、直前の行の timestamp が
   そのまま残っていた（`-30,-20,-10,0,10` が `0,0,0,0,10` になっていた）
3. timeline を持たない entity が、直前の entity の timestamp を引き継がなくなる

index 列が 1 本も作れなかった entity は、temporal データを書かずに飛ばす。`send_columns`
は index 列が空だと static として扱い、static は同じ path の temporal をすべて隠して
しまうため。

## テスト

既存の 20 本はそのまま残し、12 本足した。主なものは次の 3 つ。

- 全 field・全 row に別々の値を入れ、行が 1 つずれたら値の不一致として現れるようにした
  等価性テスト。既存の round-trip は同じ状態を 5 回書いていたので、ずれを検出できなかった
- timeline 名が `{sim_time, step}` だけになることの確認。行指向のままだと
  `log_time` / `log_tick` が付くので落ちる
- `rrd-wasm` が schema なしで .rrd を読むときに前提にしていること（1 行 1 scalar、
  `sim_time` index、`meta/sim/*` が static）を orts 側から固定するテスト

`-p orts --lib record::rerun_export` 40 本、`-p rrd-wasm` 23 本、`-p orts-cli` の
flush・attitude・CSV 変換のテストもすべて pass。

## 関連

- #370
- #375 — 途中から logging を始めた component が誤った時刻で書かれる writer 側の問題。
  この PR では現状の対応をそのまま残し、修正は別の根として切り出した
- #366 — reader が行を時刻 index で join するようにした変更。この PR はその前提
  （1 行 1 scalar、`sim_time` / `step` が載っていること）を保っている
