### PR TITLE
refactor(orts-cli): rename OrbitSpec::Omm to ElementSet

### DIFF
--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -757,12 +757,12 @@ fn sim_metadata(params: &SimParams) -> orts::record::recording::SimMetadata {
                 altitude, r0
             )
         }
-        OrbitSpec::Omm { omm } => {
+        OrbitSpec::ElementSet { elements } => {
             format!(
                 "Initial orbit: from TLE/OMM (a = {:.1} km, e = {:.6}, i = {:.2}°)",
-                omm.semi_major_axis(params.mu),
-                omm.fields().eccentricity,
-                omm.fields().inclination.to_degrees()
+                elements.semi_major_axis(params.mu),
+                elements.fields().eccentricity,
+                elements.fields().inclination.to_degrees()
             )
         }
     });

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -1017,7 +1017,10 @@ impl ServeEngine {
             eprintln!("Warning: {w}");
         }
         // SGP4/TEME is Earth-centered; reject a TLE/OMM orbit on a non-Earth sim.
-        crate::sim::params::validate_omm_body(self.params.body, std::slice::from_ref(&spec))?;
+        crate::sim::params::validate_element_set_body(
+            self.params.body,
+            std::slice::from_ref(&spec),
+        )?;
         let third_bodies = default_third_bodies(&self.params.body);
         let system = build_orbital_system(
             &self.params.body,
@@ -1130,7 +1133,10 @@ impl ServeEngine {
         let sat_index = self.metas.len();
         let spec = satellite.to_satellite_spec(sat_index, self.params.body, self.params.mu);
         // SGP4/TEME is Earth-centered; reject a TLE/OMM orbit on a non-Earth sim.
-        crate::sim::params::validate_omm_body(self.params.body, std::slice::from_ref(&spec))?;
+        crate::sim::params::validate_element_set_body(
+            self.params.body,
+            std::slice::from_ref(&spec),
+        )?;
         // Re-use the startup validation so we cannot crash
         // build_controlled_satellite → build_spacecraft_dynamics on
         // a singular inertia tensor or non-positive mass.

--- a/cli/src/commands/serve/manager.rs
+++ b/cli/src/commands/serve/manager.rs
@@ -232,7 +232,7 @@ fn validate_sim_config(config: &SimConfig) -> Result<(), String> {
     // SGP4/TEME is Earth-centered: reject a non-Earth TLE/OMM config here so a
     // WebSocket `StartSimulation` returns an error to the client instead of
     // reaching the panic in `SimParams::from_config`.
-    crate::sim::params::validate_omm_body(body, &specs)?;
+    crate::sim::params::validate_element_set_body(body, &specs)?;
     // Reject fleets that no single mode can honor (mixed attitude / mixed
     // controller) with the same rule `ServeEngine::build` and `orts run` use,
     // so a WebSocket `StartSimulation` fails here instead of at engine build.

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1668,7 +1668,7 @@ impl SimConfig {
                 sat.orbit,
                 OrbitConfig::Tle { .. } | OrbitConfig::Norad { .. }
             ) {
-                crate::sim::params::ensure_body_carries_omm(body)
+                crate::sim::params::ensure_body_carries_an_element_set(body)
                     .map_err(|e| format!("satellites[{i}]: {e}"))?;
             }
         }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1289,14 +1289,14 @@ impl SatelliteConfig {
                 let tle = parsed.elements;
                 let period = tle.period();
                 let tle_name = parsed.object_name.clone();
-                (OrbitSpec::Omm { omm: tle }, period, tle_name)
+                (OrbitSpec::ElementSet { elements: tle }, period, tle_name)
             }
             OrbitConfig::Norad { norad_id } => {
                 let parsed = fetch_tle_by_norad_id(*norad_id);
                 let tle = parsed.elements;
                 let period = tle.period();
                 let tle_name = parsed.object_name.clone();
-                (OrbitSpec::Omm { omm: tle }, period, tle_name)
+                (OrbitSpec::ElementSet { elements: tle }, period, tle_name)
             }
         };
 
@@ -2023,7 +2023,7 @@ mod tests {
         let spec = sat_cfg.to_satellite_spec(0, body, mu);
 
         assert_eq!(spec.id, "iss");
-        assert!(matches!(spec.orbit, OrbitSpec::Omm { .. }));
+        assert!(matches!(spec.orbit, OrbitSpec::ElementSet { .. }));
         assert!(spec.period > 0.0);
     }
 

--- a/cli/src/satellite.rs
+++ b/cli/src/satellite.rs
@@ -24,7 +24,7 @@ pub enum OrbitSpec {
     },
     /// From a parsed element set — TLE or OMM input, both decode into the
     /// canonical [`Sgp4Elements`] record (propagated with SGP4).
-    Omm { omm: Sgp4Elements },
+    ElementSet { elements: Sgp4Elements },
 }
 
 /// Per-satellite specification.
@@ -94,7 +94,7 @@ impl SatelliteSpec {
     /// malformed element set), so a caller on a fallible boundary — a dynamic
     /// `add_satellite` over WebSocket — can reject it instead of crashing the
     /// server. SGP4/TEME is Earth-centered; callers must ensure the central
-    /// body is Earth (see `validate_omm_body`).
+    /// body is Earth (see `validate_element_set_body`).
     pub fn initial_state(
         &self,
         mu: f64,
@@ -118,9 +118,9 @@ impl SatelliteSpec {
                 let (pos, vel) = elements.to_state_vector(mu);
                 Ok(OrbitalState::new(pos, vel))
             }
-            OrbitSpec::Omm { omm, .. } => {
+            OrbitSpec::ElementSet { elements, .. } => {
                 let epoch = epoch.ok_or("a TLE/OMM orbit requires a simulation epoch")?;
-                let propagator = Sgp4Propagator::from_elements(omm)
+                let propagator = Sgp4Propagator::from_elements(elements)
                     .map_err(|e| format!("SGP4 initialization failed: {e}"))?;
                 let (r_teme, v_teme) = propagator
                     .propagate(epoch)
@@ -138,9 +138,9 @@ impl SatelliteSpec {
     pub fn altitude(&self, body: &KnownBody) -> f64 {
         match &self.orbit {
             OrbitSpec::Circular { altitude, .. } => *altitude,
-            OrbitSpec::Omm { omm } => {
-                let a = omm.semi_major_axis(body.properties().mu);
-                let perigee_r = a * (1.0 - omm.fields().eccentricity);
+            OrbitSpec::ElementSet { elements } => {
+                let a = elements.semi_major_axis(body.properties().mu);
+                let perigee_r = a * (1.0 - elements.fields().eccentricity);
                 perigee_r - body.properties().radius
             }
         }
@@ -307,18 +307,18 @@ pub fn parse_sat_spec(s: &str, body: KnownBody) -> SatelliteSpec {
     // Determine orbit
     let (orbit, period, derived_name) = if let Some(norad) = norad_id {
         let parsed = fetch_tle_by_norad_id(norad);
-        let omm = parsed.elements;
-        let period = omm.period();
+        let elements = parsed.elements;
+        let period = elements.period();
         let obj_name = parsed.object_name.clone();
-        (OrbitSpec::Omm { omm }, period, obj_name)
+        (OrbitSpec::ElementSet { elements }, period, obj_name)
     } else if let (Some(l1), Some(l2)) = (tle_line1, tle_line2) {
         let text = format!("{l1}\n{l2}");
         let parsed = arika::tle::parse(&text)
             .unwrap_or_else(|e| panic!("Failed to parse TLE in --sat: {e}"));
-        let omm = parsed.elements;
-        let period = omm.period();
+        let elements = parsed.elements;
+        let period = elements.period();
         let obj_name = parsed.object_name.clone();
-        (OrbitSpec::Omm { omm }, period, obj_name)
+        (OrbitSpec::ElementSet { elements }, period, obj_name)
     } else {
         let alt = altitude.unwrap_or(400.0);
         let r0 = body.properties().radius + alt;
@@ -422,7 +422,7 @@ mod tests {
             KnownBody::Earth,
         );
         assert_eq!(spec.id, "iss");
-        assert!(matches!(spec.orbit, OrbitSpec::Omm { .. }));
+        assert!(matches!(spec.orbit, OrbitSpec::ElementSet { .. }));
     }
 
     #[test]

--- a/cli/src/sim/core.rs
+++ b/cli/src/sim/core.rs
@@ -198,8 +198,7 @@ pub fn force_channel(model_name: &str) -> &str {
 
 /// Convert a SatelliteSpec to SatelliteParams for OrbitalSystem construction.
 pub fn sat_params(spec: &SatelliteSpec) -> SatelliteParams {
-    let has_bstar_drag =
-        matches!(&spec.orbit, OrbitSpec::Omm { omm, .. } if omm.fields().bstar.abs() > 1e-15);
+    let has_bstar_drag = matches!(&spec.orbit, OrbitSpec::ElementSet { elements, .. } if elements.fields().bstar.abs() > 1e-15);
     SatelliteParams {
         has_drag: has_bstar_drag || spec.ballistic_coeff.is_some(),
         ballistic_coeff: spec.ballistic_coeff,

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -132,7 +132,7 @@ pub(crate) fn validate_element_set_body(
     Ok(())
 }
 
-/// The half of [`validate_omm_body`] that a config settles on its own.
+/// The half of [`validate_element_set_body`] that a config settles on its own.
 ///
 /// Shared with [`crate::config::SimConfig::validate`], which knows a satellite
 /// declares `tle` or `norad` without building the spec — building it would fetch

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -127,7 +127,7 @@ pub(crate) fn validate_element_set_body(
         .iter()
         .any(|s| matches!(s.orbit, OrbitSpec::ElementSet { .. }))
     {
-        return ensure_body_carries_omm(body);
+        return ensure_body_carries_an_element_set(body);
     }
     Ok(())
 }
@@ -139,7 +139,7 @@ pub(crate) fn validate_element_set_body(
 /// a `norad_id` over the network. Reaching this only through `SimParams` meant
 /// `orts config validate` called a non-Earth TLE config valid and `orts run
 /// --config` then panicked on it.
-pub(crate) fn ensure_body_carries_omm(body: KnownBody) -> Result<(), String> {
+pub(crate) fn ensure_body_carries_an_element_set(body: KnownBody) -> Result<(), String> {
     if body == KnownBody::Earth {
         return Ok(());
     }

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -109,7 +109,7 @@ fn default_auto_threshold() -> usize {
 /// them.
 fn element_set_epoch(satellites: &[SatelliteSpec]) -> Option<Epoch> {
     satellites.iter().find_map(|s| match &s.orbit {
-        OrbitSpec::Omm { omm, .. } => Some(omm.fields().epoch),
+        OrbitSpec::ElementSet { elements, .. } => Some(elements.fields().epoch),
         OrbitSpec::Circular { .. } => None,
     })
 }
@@ -119,13 +119,13 @@ fn element_set_epoch(satellites: &[SatelliteSpec]) -> Option<Epoch> {
 /// combination of a non-Earth central body with any TLE/OMM orbit up front, so
 /// we never integrate an Earth-relative SGP4 state under a foreign body's μ,
 /// radius and perturbation set (which would silently produce nonsense).
-pub(crate) fn validate_omm_body(
+pub(crate) fn validate_element_set_body(
     body: KnownBody,
     satellites: &[SatelliteSpec],
 ) -> Result<(), String> {
     if satellites
         .iter()
-        .any(|s| matches!(s.orbit, OrbitSpec::Omm { .. }))
+        .any(|s| matches!(s.orbit, OrbitSpec::ElementSet { .. }))
     {
         return ensure_body_carries_omm(body);
     }
@@ -265,16 +265,16 @@ impl SimParams {
                 .collect()
         } else {
             // No --sat flags: use legacy single-satellite args
-            let omm_opt = Self::parse_orbit_from_args(args);
+            let element_set_opt = Self::parse_orbit_from_args(args);
 
-            if let Some(parsed) = omm_opt {
-                let omm = parsed.elements;
-                let period = omm.period();
+            if let Some(parsed) = element_set_opt {
+                let elements = parsed.elements;
+                let period = elements.period();
                 let sat_name = parsed.object_name.clone();
                 vec![SatelliteSpec {
                     id: "default".to_string(),
                     name: sat_name,
-                    orbit: OrbitSpec::Omm { omm },
+                    orbit: OrbitSpec::ElementSet { elements },
                     period,
                     ballistic_coeff: None,
                     srp_area_to_mass: None,
@@ -328,7 +328,7 @@ impl SimParams {
             .or_else(|| element_set_epoch(&satellites))
             .or_else(|| Some(Epoch::now()));
 
-        validate_omm_body(body, &satellites).unwrap_or_else(|e| panic!("{e}"));
+        validate_element_set_body(body, &satellites).unwrap_or_else(|e| panic!("{e}"));
 
         Self {
             body,
@@ -403,7 +403,7 @@ impl SimParams {
             .or_else(|| element_set_epoch(&satellites))
             .or_else(|| Some(Epoch::now()));
 
-        validate_omm_body(body, &satellites).unwrap_or_else(|e| panic!("{e}"));
+        validate_element_set_body(body, &satellites).unwrap_or_else(|e| panic!("{e}"));
 
         Self {
             body,
@@ -521,7 +521,7 @@ impl SimParams {
         sats.push(SatelliteSpec {
             id: "iss".to_string(),
             name: sat_name,
-            orbit: OrbitSpec::Omm { omm: iss_tle },
+            orbit: OrbitSpec::ElementSet { elements: iss_tle },
             period,
             ballistic_coeff: None,
             srp_area_to_mass: None,
@@ -849,7 +849,7 @@ mod tests {
         // Should have one satellite in TLE mode
         assert_eq!(params.satellites.len(), 1);
         let sat = &params.satellites[0];
-        assert!(matches!(sat.orbit, OrbitSpec::Omm { .. }));
+        assert!(matches!(sat.orbit, OrbitSpec::ElementSet { .. }));
 
         // Altitude should be ~400 km
         let alt = sat.altitude(&params.body);
@@ -904,7 +904,7 @@ mod tests {
 
         assert_eq!(params.satellites.len(), 1);
         let sat = &params.satellites[0];
-        assert!(matches!(sat.orbit, OrbitSpec::Omm { .. }));
+        assert!(matches!(sat.orbit, OrbitSpec::ElementSet { .. }));
         let alt = sat.altitude(&params.body);
         assert!(
             (alt - 400.0).abs() < 30.0,
@@ -962,7 +962,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_omm_body_rejects_non_earth() {
+    fn validate_element_set_body_rejects_non_earth() {
         let args = SimArgs {
             body: "earth".to_string(),
             dt: 10.0,
@@ -993,12 +993,15 @@ mod tests {
             plugin_backend_async_mode: PluginAsyncModeChoice::Deterministic,
         };
         let params = SimParams::from_sim_args(&args, false);
-        assert!(matches!(params.satellites[0].orbit, OrbitSpec::Omm { .. }));
+        assert!(matches!(
+            params.satellites[0].orbit,
+            OrbitSpec::ElementSet { .. }
+        ));
 
         // The same TLE-backed satellite is valid on Earth (SGP4/TEME is
         // Earth-centered) but must be rejected about any other body.
-        assert!(validate_omm_body(KnownBody::Earth, &params.satellites).is_ok());
-        let err = validate_omm_body(KnownBody::Mars, &params.satellites)
+        assert!(validate_element_set_body(KnownBody::Earth, &params.satellites).is_ok());
+        let err = validate_element_set_body(KnownBody::Mars, &params.satellites)
             .expect_err("a TLE/OMM orbit about Mars must be rejected");
         assert!(err.contains("Earth-centered"), "unexpected error: {err}");
     }

--- a/cli/src/tle.rs
+++ b/cli/src/tle.rs
@@ -2,8 +2,8 @@ use arika::elements::ParsedElementSet;
 
 /// Try fetching a TLE by NORAD catalog number. Tries CelesTrak first, falls back to SatNOGS.
 pub fn try_fetch_tle_by_norad_id(norad_id: u32) -> Option<ParsedElementSet> {
-    if let Some(omm) = fetch_tle_celestrak(norad_id) {
-        return Some(omm);
+    if let Some(parsed) = fetch_tle_celestrak(norad_id) {
+        return Some(parsed);
     }
     eprintln!("CelesTrak failed, trying SatNOGS...");
     fetch_tle_satnogs(norad_id)
@@ -37,7 +37,7 @@ fn fetch_tle_celestrak(norad_id: u32) -> Option<ParsedElementSet> {
         return None;
     }
     match arika::tle::parse(&body) {
-        Ok(omm) => Some(omm),
+        Ok(parsed) => Some(parsed),
         Err(e) => {
             eprintln!("Failed to parse CelesTrak TLE: {e}");
             None
@@ -75,7 +75,7 @@ fn fetch_tle_satnogs(norad_id: u32) -> Option<ParsedElementSet> {
     let tle2 = entry["tle2"].as_str()?;
     let tle_text = format!("{tle0}\n{tle1}\n{tle2}");
     match arika::tle::parse(&tle_text) {
-        Ok(omm) => Some(omm),
+        Ok(parsed) => Some(parsed),
         Err(e) => {
             eprintln!("Failed to parse SatNOGS TLE: {e}");
             None
@@ -90,14 +90,14 @@ mod tests {
     #[test]
     #[ignore] // Requires network access
     fn fetch_iss_tle_from_celestrak() {
-        let omm = fetch_tle_celestrak(25544);
-        assert!(omm.is_some());
+        let parsed = fetch_tle_celestrak(25544);
+        assert!(parsed.is_some());
     }
 
     #[test]
     #[ignore] // Requires network access
     fn fetch_iss_tle_satnogs_fallback() {
-        let omm = fetch_tle_satnogs(25544);
-        assert!(omm.is_some());
+        let parsed = fetch_tle_satnogs(25544);
+        assert!(parsed.is_some());
     }
 }


### PR DESCRIPTION
`OrbitSpec::Omm` が実態と合っていない。この variant は parse 済みの element set 全般を持ち、`--tle` / `--tle-line1/2` / `--norad-id` / `--omm` の 4 つの入力がすべてこの variant に収まる。受理する入力の 1 つの名前を付けているので、何を含むのか読み手が誤解する。field 名 `omm: Sgp4Elements` も同じ。

Copilot が #230 のレビューで指摘した点で、SGP4/TEME 取り込み（#230 / #235 / #240 / #241 / #243 / #245）の最後の follow-up。

## 変更

挙動は変えない rename。

| 変更前 | 変更後 |
|---|---|
| `OrbitSpec::Omm { omm: Sgp4Elements }` | `OrbitSpec::ElementSet { elements: Sgp4Elements }` |
| `validate_omm_body` | `validate_element_set_body` |
| `ensure_body_carries_omm` | `ensure_body_carries_an_element_set` |
| `omm_opt` | `element_set_opt` |
| `cli/src/tle.rs` の `omm` (TLE fetch が返す `ParsedElementSet`) | `parsed` |

周囲で既に使われている用語（`Sgp4Elements`、`ParsedElementSet`、`element_set_epoch`）に揃える。

本当に CCSDS OMM を指しているものは名前を変えない。`--omm` flag、`SimArgs::omm`、OMM 形式の help text と docs。エラー文の "TLE/OMM orbits are Earth-centered" も、user が書く 2 つの入力形式を指しているのでそのまま。

## 範囲

`OrbitSpec` は `orts-cli` binary の内部（この package は lib target を持たない）なので、changelog には載せない。

`orts-cli` 309 件 pass、`cargo clippy -p orts-cli -- -D warnings` 0 件。repo 全体を grep して旧名が 0 件であることを確認した。

