### PR TITLE
fix: cli-plugin-backend-e2e の 31.5 分を削る (build script の毎回再実行を含む)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -596,6 +596,25 @@ jobs:
       - name: Make orts binary executable
         run: chmod +x ./bin/orts
 
+      # One cargo invocation for every suite below, so the test targets
+      # compile and link in parallel. Run as separate invocations they
+      # serialize: each target is its own rustc, largely single-threaded,
+      # so a per-suite `cargo test` leaves most of the runner idle and the
+      # build cost adds up target by target. The per-suite invocations
+      # that follow then find everything built and only run the tests.
+      - name: Build CLI E2E test binaries
+        run: |
+          cargo test --locked -p orts-cli --no-run \
+            --test plugin_backend_e2e \
+            --test serve_dynamic_controlled_add_e2e \
+            --test throughput_mode_speedup_e2e \
+            --test e2e \
+            --test plugin_msg_config_command_e2e \
+            --test serve_stream_bridge_e2e \
+            --test serve_kble_e2e \
+            --test serve_kble_stdio_e2e \
+            --test run_mode_e2e
+
       - name: Run CLI plugin-backend E2E
         env:
           ORTS_BIN: ${{ github.workspace }}/bin/orts

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -52,10 +52,24 @@ fn main() {
                 .unwrap_or_else(|e| panic!("failed to copy texture {name}: {e}"));
         }
     }
-    println!("cargo:rerun-if-changed=../viewer/public/textures/");
-
-    // Rerun if viewer/dist/ changes
-    println!("cargo:rerun-if-changed=../viewer/dist/");
+    // Both watched paths live outside the package, so neither exists in a
+    // crates.io install, and `../viewer/dist/` is absent in the workspace too
+    // until someone builds the viewer. A `rerun-if-changed` path that cargo
+    // cannot stat counts as changed, which re-runs this script — and so
+    // recompiles orts-cli, its bin and every integration test — on every
+    // single cargo invocation. Watch them only when they are there, and
+    // create `../viewer/dist/` inside the workspace so that watching it
+    // survives the viewer being built later.
+    if textures_src.is_dir() {
+        println!("cargo:rerun-if-changed=../viewer/public/textures/");
+    }
+    let viewer_dir = manifest_dir.join("../viewer");
+    if viewer_dir.is_dir() {
+        std::fs::create_dir_all(&source_dist).ok();
+    }
+    if source_dist.is_dir() {
+        println!("cargo:rerun-if-changed=../viewer/dist/");
+    }
 
     run_license_notice();
 }

--- a/cli/tests/run_mode_e2e.rs
+++ b/cli/tests/run_mode_e2e.rs
@@ -520,18 +520,20 @@ path = {:?}
 /// A large unnormalized quaternion runs to completion, with a finite attitude
 /// throughout.
 ///
-/// Integrated raw, it grows until its sum of squares overflows; the post-step
-/// projection then divides by infinity and publishes all zeros, which
-/// `is_finite` accepts — so the run reports success while every attitude row
-/// from that point on is meaningless.
+/// What keeps it finite is the load-time normalization in
+/// `AttitudeConfig::normalized_initial_quaternion`: integrated raw, a
+/// quaternion this large grows until its sum of squares overflows, and every
+/// attitude row from that point on is meaningless while the run still reports
+/// success. Replacing that division by a pass-through fails this test on the
+/// first data row, so that is the behaviour it pins — the `project` guard in
+/// `OdeState` is reached with a finite norm here and is covered by the unit
+/// tests beside it.
 ///
 /// The span is short on purpose. `initial_angular_velocity` of 1e4 rad/s is
 /// what makes this expensive: the adaptive solver sizes its steps to that rate,
 /// so cost scales with the simulated span, and 30 s of it took over six minutes
 /// in CI. Two seconds gives 21 rows, twice what the row-count assertion below
-/// wants, and the failure shows up on the first row — dropping the load-time
-/// normalization (`AttitudeConfig::normalized_initial_quaternion`) fails this
-/// test in 23 ms.
+/// wants, and detection is immediate — 23 ms with the normalization dropped.
 #[test]
 fn a_large_unnormalized_quaternion_still_integrates() {
     let config = r#"

--- a/cli/tests/run_mode_e2e.rs
+++ b/cli/tests/run_mode_e2e.rs
@@ -524,12 +524,20 @@ path = {:?}
 /// projection then divides by infinity and publishes all zeros, which
 /// `is_finite` accepts — so the run reports success while every attitude row
 /// from that point on is meaningless.
+///
+/// The span is short on purpose. `initial_angular_velocity` of 1e4 rad/s is
+/// what makes this expensive: the adaptive solver sizes its steps to that rate,
+/// so cost scales with the simulated span, and 30 s of it took over six minutes
+/// in CI. Two seconds gives 21 rows, twice what the row-count assertion below
+/// wants, and the failure shows up on the first row — dropping the load-time
+/// normalization (`AttitudeConfig::normalized_initial_quaternion`) fails this
+/// test in 23 ms.
 #[test]
 fn a_large_unnormalized_quaternion_still_integrates() {
     let config = r#"
 body = "earth"
 dt = 0.1
-duration = 30.0
+duration = 2.0
 
 [[satellites]]
 id = "sat-1"


### PR DESCRIPTION
`cli-plugin-backend-e2e` は CI で最も遅い job (31.5 分) で、CI 全体の完了時刻を決めていた。原因を計測して 3 つ特定し、それぞれ直して **10.05 分**にした。シミュレーションの挙動とテストの検証内容は変えていない。

| | before | after |
| --- | --- | --- |
| job 全体 | 31.5 分 | **10.05 分** |
| test target のビルド | 993 s | 207 s + 一度きりの 118 s |
| テスト実行 | 629 s | 125 s |

計測元: before = main run [33380991904](https://github.com/sksat/orts/actions/runs/33380991904)、after = run [33398577283](https://github.com/sksat/orts/actions/runs/33398577283)。どちらも ubuntu-latest 4 コア。

## 1. build script が cargo 呼び出しごとに再実行されていた (`cli/build.rs`)

この job だけの問題ではなく、orts-cli をビルドする全 job に効く。

`build.rs` は `../viewer/dist/` を無条件に `rerun-if-changed` で watch していた。cargo が stat できないパスは「変更あり」と扱われ、このパスは viewer をビルドしていない限り存在しない (PR の全 job、`pnpm build` 前のローカル checkout)。結果、build script が毎回再実行され、orts-cli 本体・bin・15 本の integration test target が毎回無効化されていた。

同じ test target を 3 回連続ビルドした実測 (4 コア):

| | 1 回目 | 2 回目 | 3 回目 |
| --- | --- | --- | --- |
| `../viewer/dist/` なし | 79 s | 148 s | 78 s |
| あり | 77 s | 0.3 s | 0.3 s |

各パスは存在する時だけ watch する。workspace では `../viewer/dist/` を作っておき、後から viewer をビルドした時に再 embed される性質を保つ。

## 2. test target のビルドが逐次化していた (`ci.yml`)

test target 1 本あたりの rustc はほぼシングルスレッドなので、per-suite の `cargo test` に分かれていると 4 コアを使い切れない。先行ステップで `--no-run` に全 suite を渡し、cargo に並行してビルドさせる。後続の per-suite 実行はそのまま残り、ビルド済みのものを実行するだけになる (実測 0.5〜0.9 s)。

## 3. 巨大な quaternion を与えるテストの simulated span (`run_mode_e2e.rs`)

`a_large_unnormalized_quaternion_still_integrates` は `initial_angular_velocity = [1e4, 0, 0]` で 30 秒ぶんを積分していた。adaptive solver は刻み幅をこの回転率に合わせるので、コストは simulated span にほぼ比例する (12.8 s / 1 simulated second)。この 1 本で 386 s、同じ suite の残り 11 テストは合計 9.3 s だった。

span を 2 秒にしても検証内容は変わらない。data row は 21 行で `rows > 10` のアサーションに対して余裕があり、検出は 1 行目で起きる。バグを注入して確認した:

- `AttitudeConfig::normalized_initial_quaternion` の除算を pass-through にすると、2 秒版は **23 ms で FAILED**
- `OdeState::project` の `is_finite` guard を壊しても、元の 30 秒版すら pass する

doc comment はこれに合わせ、このテストが実際に検出できる挙動 (load 時の正規化) を書くよう直した。`project` の degenerate norm は unit test `ode_state_project_leaves_degenerate_quaternions_alone` がテストしている。

## 採らなかった案

- **matrix 分割**: before の run では rust-build 完了から job 開始まで 19 分の queue 待ちがあった。runner を追加で要求すると wall clock が悪化しうる。
- **test binary を artifact で配る**: `rust-build` が既に同じ binary を作っているので配れる。原因 1 の修正でビルドが 207 s まで落ちたので、この複雑さを入れる価値は薄い。

## 別途対応

`cli/tests/e2e.rs` の `test_controlled_simulation_via_config` だけが `ORTS_BIN` を見ずに `env!("CARGO_BIN_EXE_orts")` を使っている。この job は download した prebuilt binary を検証する建前なので、この 1 本だけ意味が違う。高速化とは別の問題なので、この PR には入れていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
