### PR TITLE
fix(viewer): resolve a source's central body from the body it names, or refuse it

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -451,6 +451,21 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   wire 型を置き換え、`satellite_added` variant を追加。([#95](https://github.com/sksat/orts/pull/95))
 
 #### Fixed
+- source の中心天体定数を、source が名乗った天体から解決するか、解決できなければ
+  source を拒否するようになった。従来は `mu` と半径がそれぞれ独立に地球へ fallback して
+  いたので、Mars を名乗ってどちらも持たない recording が「Mars の `mu` + 地球の半径」
+  として読まれていた。存在しない天体で、高度 (`r - radius`) が約 3000 km ずれるのに
+  チャート上にその手掛かりが無い。既定値は viewer が定数を持つ天体に属するものとし、
+  `DEFAULT_BODY_CATALOG` (arika が伝播する 10 天体) に置いた。そこに無い天体でも、
+  source が両方の定数を持っていれば通す。何も発明していないため。source が持っている値が
+  値になりえない場合 (`mu` が 0 以下、半径が 0 以下、いずれも非有限) は、既定値で
+  差し替えるのでなくエラーにする。天体名を持たない source は従来どおり地球として読む
+  (この field より古い recording がそれに当たる)。解決は metadata が届いた時点で 1 度だけ
+  行い、その値を派生値と、チャートを組み立てる `SimInfo` の両方で使う。ファイル経路は
+  読み込みの最後に field ごとに解決していたので、その時点で既に point がチャートへ
+  届いていた。live の WebSocket source も同じ経路で解決するので、ファイルなら拒否される
+  天体で読まれることはない。独自の天体で simulation する consumer は、その定数を adapter
+  に渡す ([#383](https://github.com/sksat/orts/pull/383))
 - `.rrd` ファイルを開いたとき、recording が持たない軌道量を導出するようになった。
   decoder が復元するのは位置と速度で、Kepler 要素とチャートが描く高度・比エネルギー・
   角運動量は 0 のハードコードで届いていた。400 km 軌道の recording が半長軸 0 km、

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -504,6 +504,24 @@ section is subdivided by package.
   replacing the hand-written wire types and adding the `satellite_added` variant. ([#95](https://github.com/sksat/orts/pull/95))
 
 #### Fixed
+- A source's central body constants are resolved from the body it names, or the
+  source is refused. `mu` and the radius used to fall back to Earth's on their
+  own, so a recording around Mars carrying neither was read as Mars' `mu` over
+  Earth's radius — a body that does not exist, whose altitude (`r - radius`) is
+  out by some 3000 km with nothing on the chart to say so. A default now belongs
+  to a body the viewer has constants for, in `DEFAULT_BODY_CATALOG` (the ten
+  `arika` propagates around); a body outside it is fine as long as the source
+  carries both constants, since nothing is being invented then. A value the
+  source does carry that cannot be one — a `mu` of zero or less, a radius of
+  zero or less, either non-finite — is an error rather than a reason to
+  substitute a default. A source naming no body at all is still read as Earth,
+  which is what recordings predating the field are. Resolved once, when the
+  metadata arrives, and shared by the derived values and the `SimInfo` the
+  charts are built from: the file path used to resolve it per field at the end
+  of the load, after its points had already reached the charts. The live
+  WebSocket source resolves the same way, so it cannot be read against a body a
+  file would be refused for. A consumer simulating around its own body passes
+  its constants to the adapters ([#383](https://github.com/sksat/orts/pull/383))
 - Opening a `.rrd` file derives the orbital values the recording does not carry.
   The decoder recovers position and velocity, and the Keplerian elements plus
   the altitude, specific energy and angular momentum the charts plot arrived as

--- a/viewer/src/hooks/useSimulationData.ts
+++ b/viewer/src/hooks/useSimulationData.ts
@@ -64,11 +64,15 @@ export function useSimulationData(options: UseSimulationDataOptions): Simulation
     queryRange,
   } = options;
 
-  // Orbit schema (shared by single & multi-satellite Workers)
+  // Orbit schema (shared by single & multi-satellite Workers). A `SimInfo` has
+  // been resolved against a body already, so its `mu` and radius are taken as
+  // they are. The schema's own Earth defaults stand in only while no source has
+  // reported one, where there is no body yet to be wrong about.
   const mu = simInfo?.mu;
   const bodyRadius = simInfo?.central_body_radius;
   const orbitSchema = useMemo(
-    () => createOrbitSchema(mu ?? 398600.4418, bodyRadius ?? 6378.137),
+    () =>
+      mu == null || bodyRadius == null ? createOrbitSchema() : createOrbitSchema(mu, bodyRadius),
     [mu, bodyRadius],
   );
 

--- a/viewer/src/hooks/useWebSocket.test.ts
+++ b/viewer/src/hooks/useWebSocket.test.ts
@@ -223,4 +223,53 @@ describe("dispatchServerMessage", () => {
     };
     expect(() => dispatchServerMessage(msg, { ...baseCallbacks })).not.toThrow();
   });
+
+  it("resolves the server's central body from the body it names", () => {
+    // A server predating `central_body_radius` leaves it out; the body it names
+    // says which radius that is, so the info is usable as it stands.
+    const onInfo = vi.fn();
+    const onError = vi.fn();
+    const msg = {
+      type: "info",
+      mu: 42828.375214,
+      dt: 1,
+      output_interval: 1,
+      central_body: "Mars",
+      satellites: [],
+    } as unknown as ServerMessage;
+
+    const outcome = dispatchServerMessage(msg, { onState: vi.fn(), onInfo, onError });
+
+    expect(outcome).toBe("continue");
+    expect(onError).not.toHaveBeenCalled();
+    expect(onInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mu: 42828.375214,
+        central_body: "mars",
+        central_body_radius: 3396.2,
+      }),
+    );
+  });
+
+  it("rejects the source when the server's info cannot be measured", () => {
+    // Reporting the error and carrying on would let the states that follow
+    // reach the charts with no `SimInfo` to measure them against, which is what
+    // refusing the info exists to prevent. The caller closes on "reject".
+    const onInfo = vi.fn();
+    const onError = vi.fn();
+    const msg = {
+      type: "info",
+      mu: 3531600,
+      dt: 1,
+      output_interval: 1,
+      central_body: "kerbin",
+      satellites: [],
+    } as unknown as ServerMessage;
+
+    const outcome = dispatchServerMessage(msg, { onState: vi.fn(), onInfo, onError });
+
+    expect(outcome).toBe("reject");
+    expect(onInfo).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(expect.stringContaining("kerbin"));
+  });
 });

--- a/viewer/src/hooks/useWebSocket.ts
+++ b/viewer/src/hooks/useWebSocket.ts
@@ -200,7 +200,8 @@ export function dispatchServerMessage(
       );
       return "reject";
     }
-    // The `??` fallbacks tolerate older servers that predate these fields.
+    // The `??` below cover `satellites`, `stream_interval` and `epoch_jd` for a
+    // server that predates them; the central body came from the resolve above.
     const satellites: SatelliteInfo[] = (msg.satellites ?? []).map(normalizeSatelliteInfo);
     callbacks.onInfo?.({
       mu: resolved.body.mu,

--- a/viewer/src/hooks/useWebSocket.ts
+++ b/viewer/src/hooks/useWebSocket.ts
@@ -6,6 +6,7 @@ import type { HistoryState } from "../protocol/generated/HistoryState.js";
 import type { SatelliteInfo as WireSatelliteInfo } from "../protocol/generated/SatelliteInfo.js";
 import type { WsMessage } from "../protocol/generated/WsMessage.js";
 import type { MarkerShape } from "../satelliteShapes.js";
+import { describeCentralBodyError, resolveCentralBody } from "../sources/centralBody.js";
 
 /** Per-satellite info from the server, normalized for app use. */
 export interface SatelliteInfo {
@@ -174,15 +175,29 @@ export function dispatchServerMessage(msg: ServerMessage, callbacks: DispatchCal
       ...parseAttitude(msg.attitude),
     });
   } else if (msg.type === "info") {
+    // A server that predates `central_body_radius` leaves it out, and the body
+    // it names says which radius that is. Resolved the way a file's is, so a
+    // live source cannot be read against a body a file would be refused for.
+    const resolved = resolveCentralBody({
+      bodyId: msg.central_body,
+      mu: msg.mu,
+      bodyRadius: msg.central_body_radius,
+    });
+    if (!resolved.ok) {
+      callbacks.onError?.(
+        `the server's simulation info: ${describeCentralBodyError(resolved.error)}`,
+      );
+      return;
+    }
     // The `??` fallbacks tolerate older servers that predate these fields.
     const satellites: SatelliteInfo[] = (msg.satellites ?? []).map(normalizeSatelliteInfo);
     callbacks.onInfo?.({
-      mu: msg.mu,
+      mu: resolved.body.mu,
       dt: msg.dt,
       output_interval: msg.output_interval,
       stream_interval: msg.stream_interval ?? msg.output_interval,
-      central_body: msg.central_body ?? "earth",
-      central_body_radius: msg.central_body_radius ?? 6378.137,
+      central_body: resolved.body.bodyId,
+      central_body_radius: resolved.body.bodyRadius,
       epoch_jd: msg.epoch_jd ?? null,
       satellites,
     });

--- a/viewer/src/hooks/useWebSocket.ts
+++ b/viewer/src/hooks/useWebSocket.ts
@@ -146,11 +146,22 @@ function parseHistoryPoints(states: HistoryState[]): OrbitPoint[] {
   }));
 }
 
+/** Whether a source is still usable after the message just dispatched. */
+export type DispatchOutcome = "continue" | "reject";
+
 /**
  * Dispatch a parsed server message to the appropriate callback.
  * Extracted as a pure function for testability.
+ *
+ * `"reject"` where the message says the source cannot be read at all. The
+ * caller owns the socket, so closing it is its part: leaving it open would let
+ * the states that follow reach the charts with no `SimInfo` to measure them
+ * against, which is what refusing the info exists to prevent.
  */
-export function dispatchServerMessage(msg: ServerMessage, callbacks: DispatchCallbacks): void {
+export function dispatchServerMessage(
+  msg: ServerMessage,
+  callbacks: DispatchCallbacks,
+): DispatchOutcome {
   if (msg.type === "state") {
     callbacks.onState({
       entityPath: msg.entity_path,
@@ -187,7 +198,7 @@ export function dispatchServerMessage(msg: ServerMessage, callbacks: DispatchCal
       callbacks.onError?.(
         `the server's simulation info: ${describeCentralBodyError(resolved.error)}`,
       );
-      return;
+      return "reject";
     }
     // The `??` fallbacks tolerate older servers that predate these fields.
     const satellites: SatelliteInfo[] = (msg.satellites ?? []).map(normalizeSatelliteInfo);
@@ -220,6 +231,7 @@ export function dispatchServerMessage(msg: ServerMessage, callbacks: DispatchCal
   } else if (msg.type === "satellite_added") {
     callbacks.onSatelliteAdded?.(normalizeSatelliteInfo(msg.satellite), msg.t);
   }
+  return "continue";
 }
 
 export interface UseWebSocketReturn {
@@ -316,7 +328,11 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
     ws.addEventListener("message", (event: MessageEvent) => {
       try {
         const msg = JSON.parse(event.data as string) as ServerMessage;
-        dispatchServerMessage(msg, callbacksRef.current);
+        if (dispatchServerMessage(msg, callbacksRef.current) === "reject") {
+          // The error is already reported. Closing stops the states that would
+          // otherwise follow it, and the close handler resets the rest.
+          ws.close();
+        }
       } catch {
         // Silently ignore malformed messages
       }

--- a/viewer/src/sources/CSVFileAdapter.ts
+++ b/viewer/src/sources/CSVFileAdapter.ts
@@ -10,6 +10,8 @@
 
 import type { CSVMetadata } from "../orbit.js";
 import type { CSVWorkerMessage } from "./csvParseLogic.js";
+import type { BodyCatalog } from "./bodyCatalog.js";
+import { type CentralBody, describeCentralBodyError, resolveCentralBody } from "./centralBody.js";
 import { csvMetadataToSimInfo } from "./normalizeMetadata.js";
 import type { SourceAdapter, SourceEventHandler, SourceId } from "./types.js";
 
@@ -22,11 +24,26 @@ export class CSVFileAdapter implements SourceAdapter {
   private file: File;
   private stopped = false;
 
-  constructor(sourceId: SourceId, file: File, onEvent: SourceEventHandler) {
+  /**
+   * `bodyCatalog` extends the bodies whose constants a recording may leave
+   * out, for a consumer simulating around one this viewer does not ship.
+   */
+  constructor(
+    sourceId: SourceId,
+    file: File,
+    onEvent: SourceEventHandler,
+    bodyCatalog?: BodyCatalog,
+  ) {
     this.sourceId = sourceId;
     this.onEvent = onEvent;
     this.file = file;
+    this.bodyCatalog = bodyCatalog;
   }
+
+  private bodyCatalog: BodyCatalog | undefined;
+  /** The body this file's orbits are measured against, resolved from its
+   * metadata as soon as that arrives. */
+  private centralBody: CentralBody | null = null;
 
   start(): void {
     // Make restart safe: kill any in-flight read/worker first, then reset
@@ -35,6 +52,7 @@ export class CSVFileAdapter implements SourceAdapter {
     this.estimatedDt = null;
     this.lastTByEntity.clear();
     this.pendingMetadata = null;
+    this.centralBody = null;
     this.infoEmitted = false;
     this.stopped = false;
 
@@ -99,6 +117,26 @@ export class CSVFileAdapter implements SourceAdapter {
 
     switch (msg.type) {
       case "metadata": {
+        // Resolved here, once, rather than when the file completes: the
+        // history chunks below reach the charts first, so finding out then
+        // that they cannot be measured would be after the fact.
+        const resolved = resolveCentralBody(
+          {
+            bodyId: msg.metadata.centralBody,
+            mu: msg.metadata.mu,
+            bodyRadius: msg.metadata.centralBodyRadius,
+          },
+          this.bodyCatalog,
+        );
+        if (!resolved.ok) {
+          this.onEvent(id, {
+            kind: "error",
+            message: `${this.file.name}: ${describeCentralBodyError(resolved.error)}`,
+          });
+          this.stop();
+          return;
+        }
+        this.centralBody = resolved.body;
         // Held until "complete", where info is emitted with the final dt
         this.pendingMetadata = msg.metadata;
         break;
@@ -136,11 +174,12 @@ export class CSVFileAdapter implements SourceAdapter {
 
       case "complete":
         // Emit info with the final dt estimate before signalling completion
-        if (!this.infoEmitted && this.pendingMetadata) {
+        if (!this.infoEmitted && this.pendingMetadata && this.centralBody) {
           const info = csvMetadataToSimInfo(
             this.pendingMetadata,
             this.file.name,
             this.estimatedDt ?? CSVFileAdapter.DEFAULT_DT,
+            this.centralBody,
           );
           this.onEvent(id, { kind: "info", info });
           this.infoEmitted = true;

--- a/viewer/src/sources/RrdFileAdapter.test.ts
+++ b/viewer/src/sources/RrdFileAdapter.test.ts
@@ -152,17 +152,22 @@ describe("RrdFileAdapter", () => {
     expect(derivedCalls[0].mu).toBe(42_000);
 
     // A second load whose first chunk arrives before any metadata. The worker
-    // posts metadata first, so this is the ordering `start()` must not depend
-    // on: `start()` resets every other per-load field, and leaving the central
-    // body behind derived the new recording against the old one's.
+    // posts metadata first, so nothing says which body these points are around:
+    // they are reported as an error rather than measured against the recording
+    // before, which is what carrying the resolved body over would have done.
     adapter.start();
     const second = await latestWorker();
     expect(second).not.toBe(first);
+    events.length = 0;
     second.simulateMessage(chunk());
 
-    expect(derivedCalls).toHaveLength(2);
-    expect(derivedCalls[1].mu).not.toBe(42_000);
-    expect(derivedCalls[1].bodyRadius).not.toBe(1234);
+    expect(derivedCalls).toHaveLength(1);
+    expect(events).toEqual([
+      {
+        kind: "error",
+        message: expect.stringContaining("before it said which body"),
+      },
+    ]);
   });
 
   it("a load restarted while the WASM was loading does not start a second worker", async () => {
@@ -192,5 +197,90 @@ describe("RrdFileAdapter", () => {
     worker.simulateMessage(metadata(42_000, 1234) as unknown as RrdWorkerMessage);
     worker.simulateMessage(chunk());
     expect(derivedCalls).toHaveLength(1);
+  });
+
+  it("measures against the body the recording names, not the one it omits", async () => {
+    const events: SourceEvent[] = [];
+    const handler = (_id: SourceId, e: SourceEvent) => events.push(e);
+    const adapter = new RrdFileAdapter("rrd-0", new File([new Uint8Array(8)], "a.rrd"), handler);
+
+    // Mars, with neither constant of its own. Taking Earth's radius here would
+    // put altitude out by about 3000 km with nothing on the chart to say so.
+    adapter.start();
+    const worker = await latestWorker();
+    worker.simulateMessage({
+      type: "metadata",
+      metadata: {
+        epoch_jd: null,
+        epoch_iso: null,
+        mu: null,
+        body_radius: null,
+        altitude: null,
+        period: null,
+        body_name: "mars",
+        orbit_description: null,
+      },
+    } as unknown as RrdWorkerMessage);
+    worker.simulateMessage(chunk());
+
+    expect(derivedCalls).toHaveLength(1);
+    expect(derivedCalls[0].mu).toBeCloseTo(42828.375214, 6);
+    expect(derivedCalls[0].bodyRadius).toBeCloseTo(3396.2, 6);
+  });
+
+  it("reports a recording it cannot measure instead of reading it as Earth", async () => {
+    const events: SourceEvent[] = [];
+    const handler = (_id: SourceId, e: SourceEvent) => events.push(e);
+    const adapter = new RrdFileAdapter("rrd-0", new File([new Uint8Array(8)], "a.rrd"), handler);
+
+    adapter.start();
+    const worker = await latestWorker();
+    worker.simulateMessage({
+      type: "metadata",
+      metadata: {
+        epoch_jd: null,
+        epoch_iso: null,
+        mu: null,
+        body_radius: null,
+        altitude: null,
+        period: null,
+        body_name: "kerbin",
+        orbit_description: null,
+      },
+    } as unknown as RrdWorkerMessage);
+
+    expect(events).toEqual([{ kind: "error", message: expect.stringContaining("kerbin") }]);
+    // Nothing of the recording reaches the charts, and the worker is done.
+    worker.simulateMessage(chunk());
+    expect(derivedCalls).toHaveLength(0);
+    expect(worker.terminated).toBe(true);
+  });
+
+  it("takes a body of the consumer's own from the catalog it is given", async () => {
+    const events: SourceEvent[] = [];
+    const handler = (_id: SourceId, e: SourceEvent) => events.push(e);
+    const adapter = new RrdFileAdapter("rrd-0", new File([new Uint8Array(8)], "a.rrd"), handler, {
+      kerbin: { mu: 3531600, radiusKm: 600 },
+    });
+
+    adapter.start();
+    const worker = await latestWorker();
+    worker.simulateMessage({
+      type: "metadata",
+      metadata: {
+        epoch_jd: null,
+        epoch_iso: null,
+        mu: null,
+        body_radius: null,
+        altitude: null,
+        period: null,
+        body_name: "kerbin",
+        orbit_description: null,
+      },
+    } as unknown as RrdWorkerMessage);
+    worker.simulateMessage(chunk());
+
+    expect(events.filter((e) => e.kind === "error")).toEqual([]);
+    expect(derivedCalls).toEqual([{ mu: 3531600, bodyRadius: 600, states: 1 }]);
   });
 });

--- a/viewer/src/sources/RrdFileAdapter.ts
+++ b/viewer/src/sources/RrdFileAdapter.ts
@@ -8,14 +8,10 @@
 
 import type { OrbitPoint } from "../orbit.js";
 import { initArika, orbit_derived_batch } from "../wasm/arikaInit.js";
+import type { BodyCatalog } from "./bodyCatalog.js";
+import { type CentralBody, describeCentralBodyError, resolveCentralBody } from "./centralBody.js";
 import { rrdMetadataToSimInfo } from "./normalizeMetadata.js";
-import {
-  ORBIT_DERIVED_STRIDE,
-  type OrbitDerivedContext,
-  orbitDerivedContext,
-  packStates,
-  toOrbitPoints,
-} from "./rrdOrbitDerived.js";
+import { ORBIT_DERIVED_STRIDE, packStates, toOrbitPoints } from "./rrdOrbitDerived.js";
 import type { RrdPointOut, RrdWorkerMessage } from "./rrdParseLogic.js";
 import type { SourceAdapter, SourceEventHandler, SourceId } from "./types.js";
 
@@ -29,10 +25,12 @@ export class RrdFileAdapter implements SourceAdapter {
   private estimatedDt = 10;
   private stopped = false;
   /**
-   * The central body constants the derived values are computed against. The
-   * Worker sends metadata before the first chunk, so this is set by then.
+   * The body the derived values are measured against, resolved once from the
+   * recording's metadata. The Worker sends metadata before the first chunk, so
+   * this is set by then; a chunk arriving without it is a protocol violation
+   * rather than a reason to reach for Earth.
    */
-  private derivedContext: OrbitDerivedContext | null = null;
+  private centralBody: CentralBody | null = null;
   /** Whether this load has already published its first point for the E2E. */
   private debugPointExposed = false;
   /**
@@ -41,11 +39,23 @@ export class RrdFileAdapter implements SourceAdapter {
    */
   private loadGeneration = 0;
 
-  constructor(sourceId: SourceId, file: File, onEvent: SourceEventHandler) {
+  /**
+   * `bodyCatalog` extends the bodies whose constants a recording may leave out,
+   * for a consumer simulating around one this viewer does not ship.
+   */
+  constructor(
+    sourceId: SourceId,
+    file: File,
+    onEvent: SourceEventHandler,
+    bodyCatalog?: BodyCatalog,
+  ) {
     this.sourceId = sourceId;
     this.onEvent = onEvent;
     this.file = file;
+    this.bodyCatalog = bodyCatalog;
   }
+
+  private bodyCatalog: BodyCatalog | undefined;
 
   start(): void {
     // Make restart safe: kill any in-flight read/worker first, then reset
@@ -63,7 +73,7 @@ export class RrdFileAdapter implements SourceAdapter {
     // before any chunk, so a second load overwrites it in practice; keeping it
     // anyway would make that ordering load-bearing, and a chunk arriving first
     // would be derived against the previous recording's body.
-    this.derivedContext = null;
+    this.centralBody = null;
 
     const generation = ++this.loadGeneration;
     const isCurrent = () => !this.stopped && this.loadGeneration === generation;
@@ -144,12 +154,26 @@ export class RrdFileAdapter implements SourceAdapter {
    * the points still reach the store with the state vectors intact and the
    * derived fields left non-finite — dropping the chunk would lose the
    * trajectory as well.
+   *
+   * `null` where the chunk cannot be read at all, the adapter having reported
+   * why and stopped.
    */
-  private deriveChunk(points: readonly RrdPointOut[]): OrbitPoint[] {
-    const ctx = this.derivedContext ?? orbitDerivedContext({ mu: null, body_radius: null });
+  private deriveChunk(points: readonly RrdPointOut[]): OrbitPoint[] | null {
+    const body = this.centralBody;
+    if (body == null) {
+      // The Worker posts metadata first, so reaching here means the recording
+      // is being read against a body nobody named. Deriving anyway would put a
+      // number on the chart that stands for nothing.
+      this.onEvent(this.sourceId, {
+        kind: "error",
+        message: `${this.file.name}: the recording's points arrived before it said which body they are around`,
+      });
+      this.stop();
+      return null;
+    }
     let derived: Float64Array;
     try {
-      derived = orbit_derived_batch(packStates(points), ctx.mu, ctx.bodyRadius);
+      derived = orbit_derived_batch(packStates(points), body.mu, body.bodyRadius);
     } catch (e) {
       console.warn("RrdFileAdapter: could not derive orbital values:", e);
       derived = new Float64Array(points.length * ORBIT_DERIVED_STRIDE).fill(Number.NaN);
@@ -171,8 +195,28 @@ export class RrdFileAdapter implements SourceAdapter {
 
     switch (msg.type) {
       case "metadata": {
+        // Resolved here, once, and shared by the derived values and the
+        // `SimInfo` the charts are built from. Waiting until the recording is
+        // complete would put its points on screen before finding out they
+        // cannot be measured.
+        const resolved = resolveCentralBody(
+          {
+            bodyId: msg.metadata.body_name,
+            mu: msg.metadata.mu,
+            bodyRadius: msg.metadata.body_radius,
+          },
+          this.bodyCatalog,
+        );
+        if (!resolved.ok) {
+          this.onEvent(id, {
+            kind: "error",
+            message: `${this.file.name}: ${describeCentralBodyError(resolved.error)}`,
+          });
+          this.stop();
+          return;
+        }
         this.pendingMetadata = msg.metadata;
-        this.derivedContext = orbitDerivedContext(msg.metadata);
+        this.centralBody = resolved.body;
         break;
       }
 
@@ -198,7 +242,8 @@ export class RrdFileAdapter implements SourceAdapter {
         }
 
         // Convert and emit points as history-chunk (info emitted later on done)
-        const orbitPoints: OrbitPoint[] = this.deriveChunk(msg.points);
+        const orbitPoints = this.deriveChunk(msg.points);
+        if (orbitPoints == null) return;
         this.onEvent(id, {
           kind: "history-chunk",
           points: orbitPoints,
@@ -207,12 +252,13 @@ export class RrdFileAdapter implements SourceAdapter {
 
         // When done: emit info (with all entity paths known) then complete
         if (msg.done) {
-          if (!this.infoEmitted && this.pendingMetadata) {
+          if (!this.infoEmitted && this.pendingMetadata && this.centralBody) {
             const info = rrdMetadataToSimInfo(
               this.pendingMetadata,
               this.file.name,
               this.estimatedDt,
               [...this.pendingEntityPaths],
+              this.centralBody,
             );
             this.onEvent(id, { kind: "info", info });
             this.infoEmitted = true;

--- a/viewer/src/sources/bodyCatalog.ts
+++ b/viewer/src/sources/bodyCatalog.ts
@@ -1,0 +1,56 @@
+/**
+ * The physical constants of the bodies a source may name.
+ *
+ * A recording says which body it is around, and may or may not carry that
+ * body's `mu` and radius. A default belongs to a body we know: this catalog is
+ * what "know" means, so a name in it can have a missing field filled in, and a
+ * name outside it cannot.
+ *
+ * Apart from {@link BodyDefinitions}, which says how a body is *drawn*
+ * (textures, colours) and covers only the bodies the scene renders. These are
+ * the numbers the orbit is measured against, and they cover every body `arika`
+ * propagates around. A consumer can extend either.
+ *
+ * The values are `arika`'s, from `KnownBody::properties` in `arika/src/body.rs`.
+ * TODO: generate this from there, the way the WS protocol types are generated
+ * from their Rust definitions, so the two cannot drift.
+ */
+
+/** A body's physical constants. Both are optional: a catalog entry may know
+ * only one of them, and a field it does not know cannot be filled in. */
+export interface BodyConstants {
+  /** Standard gravitational parameter μ = GM \[km³/s²\]. */
+  mu?: number;
+  /** Mean equatorial radius \[km\]. */
+  radiusKm?: number;
+}
+
+/** A map of body id → its physical constants. */
+export type BodyCatalog = Record<string, BodyConstants>;
+
+/**
+ * The bodies `arika` knows, keyed as `orts` writes them: lowercase.
+ *
+ * Earth is also what a source that names no body at all is read as, so its
+ * entry carries the values the viewer has always assumed.
+ */
+export const DEFAULT_BODY_CATALOG: BodyCatalog = {
+  sun: { mu: 132712440018.0, radiusKm: 695700.0 },
+  mercury: { mu: 22031.868551, radiusKm: 2439.7 },
+  venus: { mu: 324858.592, radiusKm: 6051.8 },
+  earth: { mu: 398600.4418, radiusKm: 6378.137 },
+  moon: { mu: 4902.800066, radiusKm: 1737.4 },
+  mars: { mu: 42828.375214, radiusKm: 3396.2 },
+  jupiter: { mu: 126686534.9218, radiusKm: 71492.0 },
+  saturn: { mu: 37931206.159, radiusKm: 60268.0 },
+  uranus: { mu: 5793951.256, radiusKm: 25559.0 },
+  neptune: { mu: 6835099.9754, radiusKm: 24764.0 },
+};
+
+/** The body a source that names none is read as. */
+export const IMPLICIT_BODY_ID = "earth";
+
+/** Merge consumer-supplied constants over the defaults, per body id. */
+export function resolveBodyCatalog(custom?: BodyCatalog): BodyCatalog {
+  return custom ? { ...DEFAULT_BODY_CATALOG, ...custom } : DEFAULT_BODY_CATALOG;
+}

--- a/viewer/src/sources/bodyCatalog.ts
+++ b/viewer/src/sources/bodyCatalog.ts
@@ -50,6 +50,18 @@ export const DEFAULT_BODY_CATALOG: BodyCatalog = {
 /** The body a source that names none is read as. */
 export const IMPLICIT_BODY_ID = "earth";
 
+/**
+ * The id a source's body name keys on.
+ *
+ * `orts run` writes `arika`'s display name — "Earth", "Mars" — into a
+ * recording, and the ids here and the ones the scene renders by are lowercase.
+ * The Rust side lowercases the same field on its way in
+ * (`cli/src/commands/replay.rs`).
+ */
+export function bodyIdOf(name: string): string {
+  return name.trim().toLowerCase();
+}
+
 /** Merge consumer-supplied constants over the defaults, per body id. */
 export function resolveBodyCatalog(custom?: BodyCatalog): BodyCatalog {
   return custom ? { ...DEFAULT_BODY_CATALOG, ...custom } : DEFAULT_BODY_CATALOG;

--- a/viewer/src/sources/bodyCatalog.ts
+++ b/viewer/src/sources/bodyCatalog.ts
@@ -62,7 +62,19 @@ export function bodyIdOf(name: string): string {
   return name.trim().toLowerCase();
 }
 
-/** Merge consumer-supplied constants over the defaults, per body id. */
+/**
+ * Merge consumer-supplied constants over the defaults, field by field.
+ *
+ * Per field rather than per body, so correcting one constant of a body we ship
+ * keeps the other: replacing the entry would leave `{ earth: { mu } }` with no
+ * radius, and a recording that omits its radius would then be refused for a
+ * body the viewer knows.
+ */
 export function resolveBodyCatalog(custom?: BodyCatalog): BodyCatalog {
-  return custom ? { ...DEFAULT_BODY_CATALOG, ...custom } : DEFAULT_BODY_CATALOG;
+  if (!custom) return DEFAULT_BODY_CATALOG;
+  const merged: BodyCatalog = { ...DEFAULT_BODY_CATALOG };
+  for (const [id, constants] of Object.entries(custom)) {
+    merged[id] = { ...merged[id], ...constants };
+  }
+  return merged;
 }

--- a/viewer/src/sources/bodyCatalog.ts
+++ b/viewer/src/sources/bodyCatalog.ts
@@ -69,11 +69,16 @@ export function bodyIdOf(name: string): string {
  * keeps the other: replacing the entry would leave `{ earth: { mu } }` with no
  * radius, and a recording that omits its radius would then be refused for a
  * body the viewer knows.
+ *
+ * A consumer's keys go through {@link bodyIdOf} as a source's name does, so
+ * `{ Kerbin: … }` answers a recording that says "kerbin". Keying one side raw
+ * and the other normalized would refuse a body the consumer had supplied.
  */
 export function resolveBodyCatalog(custom?: BodyCatalog): BodyCatalog {
   if (!custom) return DEFAULT_BODY_CATALOG;
   const merged: BodyCatalog = { ...DEFAULT_BODY_CATALOG };
-  for (const [id, constants] of Object.entries(custom)) {
+  for (const [name, constants] of Object.entries(custom)) {
+    const id = bodyIdOf(name);
     merged[id] = { ...merged[id], ...constants };
   }
   return merged;

--- a/viewer/src/sources/centralBody.test.ts
+++ b/viewer/src/sources/centralBody.test.ts
@@ -103,6 +103,15 @@ describe("resolveCentralBody", () => {
     }
   });
 
+  it("keeps the constant a partial override leaves alone", () => {
+    // Correcting Earth's `mu` should not cost Earth its radius: replacing the
+    // whole entry left a recording that omits its radius refused for a body the
+    // viewer ships.
+    const catalog: BodyCatalog = { earth: { mu: 398600.44 } };
+    const body = resolved({ bodyId: "earth", mu: null, bodyRadius: null }, catalog);
+    expect(body).toEqual({ bodyId: "earth", mu: 398600.44, bodyRadius: EARTH.radiusKm });
+  });
+
   it("holds a catalog's own constants to the same constraint", () => {
     // A catalog is the consumer's to write. A `mu` of -1 in one is as unusable
     // as a `mu` of -1 in a file, and it would otherwise reach every element

--- a/viewer/src/sources/centralBody.test.ts
+++ b/viewer/src/sources/centralBody.test.ts
@@ -87,6 +87,7 @@ describe("resolveCentralBody", () => {
         bodyId: "earth",
         field: "mu",
         value: mu,
+        origin: "source",
       });
     }
   });
@@ -100,6 +101,24 @@ describe("resolveCentralBody", () => {
       if (result.ok) continue;
       expect(result.error).toMatchObject({ kind: "unusable-value", field: "radius" });
     }
+  });
+
+  it("holds a catalog's own constants to the same constraint", () => {
+    // A catalog is the consumer's to write. A `mu` of -1 in one is as unusable
+    // as a `mu` of -1 in a file, and it would otherwise reach every element
+    // derived from it without passing the check the file's value passes.
+    const catalog: BodyCatalog = { kerbin: { mu: -1, radiusKm: 600 } };
+    const result = resolveCentralBody({ bodyId: "kerbin" }, catalog);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toEqual({
+      kind: "unusable-value",
+      bodyId: "kerbin",
+      field: "mu",
+      value: -1,
+      origin: "catalog",
+    });
+    expect(describeCentralBodyError(result.error)).toContain("catalog's");
   });
 
   it("reports the first field that cannot be resolved", () => {

--- a/viewer/src/sources/centralBody.test.ts
+++ b/viewer/src/sources/centralBody.test.ts
@@ -112,6 +112,14 @@ describe("resolveCentralBody", () => {
     expect(body).toEqual({ bodyId: "earth", mu: 398600.44, bodyRadius: EARTH.radiusKm });
   });
 
+  it("keys a consumer's catalog the way it keys a source's name", () => {
+    // Normalizing one side and not the other refused a body the consumer had
+    // supplied, for the case they happened to write it in.
+    const catalog: BodyCatalog = { Kerbin: { mu: 3531600, radiusKm: 600 } };
+    const body = resolved({ bodyId: "kerbin", mu: null, bodyRadius: null }, catalog);
+    expect(body).toEqual({ bodyId: "kerbin", mu: 3531600, bodyRadius: 600 });
+  });
+
   it("holds a catalog's own constants to the same constraint", () => {
     // A catalog is the consumer's to write. A `mu` of -1 in one is as unusable
     // as a `mu` of -1 in a file, and it would otherwise reach every element

--- a/viewer/src/sources/centralBody.test.ts
+++ b/viewer/src/sources/centralBody.test.ts
@@ -31,6 +31,15 @@ describe("resolveCentralBody", () => {
     expect(body.bodyRadius).not.toBe(EARTH.radiusKm);
   });
 
+  it("keys a body on its name whatever case the source wrote it in", () => {
+    // `orts run` writes `arika`'s display name into a recording, so this is
+    // what the default path produces: a case-sensitive lookup read "Earth" as a
+    // body with no constants, and refused a recording that left one out.
+    const body = resolved({ bodyId: "Earth", mu: null, bodyRadius: null });
+    expect(body).toEqual({ bodyId: "earth", mu: EARTH.mu, bodyRadius: EARTH.radiusKm });
+    expect(resolved({ bodyId: " MARS ", mu: null, bodyRadius: null }).bodyId).toBe("mars");
+  });
+
   it("reads a source that names no body as Earth", () => {
     // Recordings predate the field, and their orbits are Earth's.
     const body = resolved({ mu: null, bodyRadius: null });

--- a/viewer/src/sources/centralBody.test.ts
+++ b/viewer/src/sources/centralBody.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import type { BodyCatalog } from "./bodyCatalog.js";
+import { DEFAULT_BODY_CATALOG } from "./bodyCatalog.js";
+import { describeCentralBodyError, resolveCentralBody } from "./centralBody.js";
+
+const EARTH = DEFAULT_BODY_CATALOG.earth;
+const MARS = DEFAULT_BODY_CATALOG.mars;
+
+/** The resolved body, or a failure reported as the test's own message. */
+function resolved(...args: Parameters<typeof resolveCentralBody>) {
+  const result = resolveCentralBody(...args);
+  if (!result.ok) {
+    throw new Error(`expected a resolved body, got ${describeCentralBodyError(result.error)}`);
+  }
+  return result.body;
+}
+
+describe("resolveCentralBody", () => {
+  it("takes what the source declared", () => {
+    const body = resolved({ bodyId: "mars", mu: 42828.37, bodyRadius: 3396.2 });
+    expect(body).toEqual({ bodyId: "mars", mu: 42828.37, bodyRadius: 3396.2 });
+  });
+
+  it("fills a missing value from the body the source names", () => {
+    // The point of naming the body: a recording need not repeat constants that
+    // belong to it. What it must not get is another body's.
+    const body = resolved({ bodyId: "mars", mu: null, bodyRadius: null });
+    expect(body.mu).toBe(MARS.mu);
+    expect(body.bodyRadius).toBe(MARS.radiusKm);
+    expect(body.mu).not.toBe(EARTH.mu);
+    expect(body.bodyRadius).not.toBe(EARTH.radiusKm);
+  });
+
+  it("reads a source that names no body as Earth", () => {
+    // Recordings predate the field, and their orbits are Earth's.
+    const body = resolved({ mu: null, bodyRadius: null });
+    expect(body).toEqual({ bodyId: "earth", mu: EARTH.mu, bodyRadius: EARTH.radiusKm });
+  });
+
+  it("keeps a body it has no constants for, as long as the source has them", () => {
+    // Nothing is invented here, so there is nothing to refuse.
+    const body = resolved({ bodyId: "kerbin", mu: 3531600, bodyRadius: 600 });
+    expect(body).toEqual({ bodyId: "kerbin", mu: 3531600, bodyRadius: 600 });
+  });
+
+  it("fails on a body it has no constants for when a value is missing", () => {
+    const result = resolveCentralBody({ bodyId: "kerbin", mu: 3531600, bodyRadius: null });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toEqual({ kind: "unknown-body", bodyId: "kerbin", missing: "radius" });
+    expect(describeCentralBodyError(result.error)).toContain("kerbin");
+  });
+
+  it("takes a consumer's own body from the catalog it supplies", () => {
+    const catalog: BodyCatalog = { kerbin: { mu: 3531600, radiusKm: 600 } };
+    const body = resolved({ bodyId: "kerbin", mu: null, bodyRadius: null }, catalog);
+    expect(body).toEqual({ bodyId: "kerbin", mu: 3531600, bodyRadius: 600 });
+  });
+
+  it("fails on a catalog entry that does not carry the missing value", () => {
+    const catalog: BodyCatalog = { kerbin: { mu: 3531600 } };
+    const result = resolveCentralBody({ bodyId: "kerbin", bodyRadius: null }, catalog);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toEqual({ kind: "missing-default", bodyId: "kerbin", missing: "radius" });
+  });
+
+  it("fails on a mu no orbit can be scaled by, rather than substituting one", () => {
+    // Dividing by it would make every element non-finite. Reaching for Earth
+    // instead would answer a question the file got wrong with a number that
+    // looks right.
+    for (const mu of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const result = resolveCentralBody({ bodyId: "earth", mu, bodyRadius: 6378.137 });
+      expect(result.ok).toBe(false);
+      if (result.ok) continue;
+      expect(result.error).toEqual({
+        kind: "unusable-value",
+        bodyId: "earth",
+        field: "mu",
+        value: mu,
+      });
+    }
+  });
+
+  it("fails on a radius no altitude can be measured from", () => {
+    // Altitude is `r - bodyRadius`: a negative one reads as a height above the
+    // orbit, and zero is a point mass rather than a body.
+    for (const bodyRadius of [0, -6378.137, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const result = resolveCentralBody({ bodyId: "earth", mu: 398600.4418, bodyRadius });
+      expect(result.ok).toBe(false);
+      if (result.ok) continue;
+      expect(result.error).toMatchObject({ kind: "unusable-value", field: "radius" });
+    }
+  });
+
+  it("reports the first field that cannot be resolved", () => {
+    const result = resolveCentralBody({ bodyId: "earth", mu: -1, bodyRadius: -1 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({ field: "mu" });
+  });
+});
+
+describe("DEFAULT_BODY_CATALOG", () => {
+  it("carries both constants for every body arika propagates around", () => {
+    // `arika`'s `KnownBody` has ten. A body missing one of them here would fail
+    // to resolve for a recording that leaves that value out.
+    const ids = [
+      "sun",
+      "mercury",
+      "venus",
+      "earth",
+      "moon",
+      "mars",
+      "jupiter",
+      "saturn",
+      "uranus",
+      "neptune",
+    ];
+    expect(Object.keys(DEFAULT_BODY_CATALOG).sort()).toEqual([...ids].sort());
+    for (const id of ids) {
+      const entry = DEFAULT_BODY_CATALOG[id];
+      expect(entry.mu, `${id} mu`).toBeGreaterThan(0);
+      expect(entry.radiusKm, `${id} radius`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/viewer/src/sources/centralBody.ts
+++ b/viewer/src/sources/centralBody.ts
@@ -18,7 +18,10 @@ import { type BodyCatalog, bodyIdOf, IMPLICIT_BODY_ID, resolveBodyCatalog } from
 
 /** Resolved central body constants. */
 export interface CentralBody {
-  /** The body these came from, as the source named it. */
+  /**
+   * The body these came from, as an id: the source's name trimmed and
+   * lowercased, which is what the catalog and the scene key on.
+   */
   bodyId: string;
   mu: number;
   bodyRadius: number;

--- a/viewer/src/sources/centralBody.ts
+++ b/viewer/src/sources/centralBody.ts
@@ -1,56 +1,128 @@
 /**
  * The central body constants a source is read against.
  *
- * A recording written by `orts` carries `mu` and the body radius. Anything
- * missing falls back to Earth, which is what the rest of the viewer assumes
- * when a source declares nothing.
- *
  * One module because two readers have to agree: the WASM batch that derives the
  * orbital values, and the `SimInfo` / DuckDB schema that the charts are built
  * from. A `mu` that differs between them shows the same recording two ways.
+ *
+ * Nothing here invents a constant. A source says which body it is around and may
+ * carry that body's `mu` and radius; where it carries neither, the value comes
+ * from the body's catalog entry, and where there is no entry to take it from,
+ * resolving fails rather than reading the orbit against Earth. A body that is
+ * Mars by name and Earth by radius is not a body, and the altitude measured
+ * against it (`r - bodyRadius`) is wrong by thousands of kilometres with nothing
+ * on the chart to say so.
  */
 
-/** Earth's gravitational parameter [km³/s²]. */
-export const DEFAULT_MU = 398600.4418;
-/** Earth's equatorial radius [km]. */
-export const DEFAULT_BODY_RADIUS = 6378.137;
+import { type BodyCatalog, IMPLICIT_BODY_ID, resolveBodyCatalog } from "./bodyCatalog.js";
 
 /** Resolved central body constants. */
 export interface CentralBody {
+  /** The body these came from, as the source named it. */
+  bodyId: string;
   mu: number;
   bodyRadius: number;
 }
 
+/** Which field of a central body is at issue. */
+export type CentralBodyField = "mu" | "radius";
+
+/** Why a source's central body could not be resolved. */
+export type CentralBodyError =
+  | {
+      /** The source named a body the catalog does not carry, and left a value out. */
+      kind: "unknown-body";
+      bodyId: string;
+      missing: CentralBodyField;
+    }
+  | {
+      /** The catalog carries the body but not the value the source left out. */
+      kind: "missing-default";
+      bodyId: string;
+      missing: CentralBodyField;
+    }
+  | {
+      /** The source carried the value, and it cannot be one. */
+      kind: "unusable-value";
+      bodyId: string;
+      field: CentralBodyField;
+      value: number;
+    };
+
+export type CentralBodyResult =
+  | { ok: true; body: CentralBody }
+  | { ok: false; error: CentralBodyError };
+
+/** What a source declared about the body it is around. */
+export interface DeclaredCentralBody {
+  /**
+   * The body's id, as the source named it. A source that names none is read as
+   * Earth: recordings predate the field, and their orbits are Earth's.
+   */
+  bodyId?: string | null;
+  mu?: number | null;
+  bodyRadius?: number | null;
+}
+
+/** A one-line account of why resolving failed, for an error event. */
+export function describeCentralBodyError(error: CentralBodyError): string {
+  switch (error.kind) {
+    case "unknown-body":
+      return `the recording is around "${error.bodyId}", which this viewer has no constants for, and carries no ${error.missing} of its own`;
+    case "missing-default":
+      return `the recording carries no ${error.missing}, and none is known for "${error.bodyId}"`;
+    case "unusable-value":
+      return `the recording's ${error.field} for "${error.bodyId}" is ${error.value}, which no orbit can be measured against`;
+  }
+}
+
 /**
- * Resolve `mu` and the body radius from what a source declared.
+ * Resolve the constants a source's orbits are measured against.
  *
- * A `mu` that is absent, zero, negative or non-finite cannot scale an orbit —
- * every element derived from it would come out non-finite — so it falls back to
- * Earth rather than propagating through the charts.
+ * A `mu` must be positive and finite: it scales the orbit, and every element
+ * derived from a zero, negative or non-finite one comes out non-finite. A radius
+ * must be positive and finite too — altitude is `r - bodyRadius`, so a negative
+ * one reads as a height above the orbit, and zero is a point mass rather than a
+ * body. Where the source carries such a value, that is an error and not a reason
+ * to reach for the catalog: the file says something about itself that cannot be
+ * true, and quietly substituting a default hides it.
  *
- * A negative radius falls back too: altitude is `r - bodyRadius`, so it would
- * read as a height above the orbit rather than above the surface, which is
- * plausible enough on a chart to go unnoticed. Zero stands, being a point mass
- * whose altitude is `r`.
- *
- * TODO: falling back per field is the wrong shape. A recording naming Mars with
- * no radius is read as Mars' `mu` over Earth's radius, a body that does not
- * exist. A default belongs to a body we know, and a value that is present but
- * unusable belongs in an error — which needs the constants `arika`'s
- * `KnownBody::properties` already holds, exposed through `arika-wasm`, and an
- * error path out of this layer. It reaches `useSimulationData`'s own
- * `?? 398600.4418` too, so it is a root of its own rather than part of this
- * module's.
+ * A body the catalog does not carry is fine as long as the source carries both
+ * of its constants — nothing is being invented then. It fails only where a value
+ * is missing and there is nothing to fill it from.
  */
 export function resolveCentralBody(
-  mu: number | null | undefined,
-  bodyRadius: number | null | undefined,
-): CentralBody {
-  return {
-    mu: mu != null && Number.isFinite(mu) && mu > 0 ? mu : DEFAULT_MU,
-    bodyRadius:
-      bodyRadius != null && Number.isFinite(bodyRadius) && bodyRadius >= 0
-        ? bodyRadius
-        : DEFAULT_BODY_RADIUS,
+  declared: DeclaredCentralBody,
+  catalog?: BodyCatalog,
+): CentralBodyResult {
+  const bodyId = declared.bodyId ?? IMPLICIT_BODY_ID;
+  const entry = resolveBodyCatalog(catalog)[bodyId];
+
+  const resolve = (
+    declaredValue: number | null | undefined,
+    fromCatalog: number | undefined,
+    field: CentralBodyField,
+  ): { ok: true; value: number } | { ok: false; error: CentralBodyError } => {
+    if (declaredValue != null) {
+      return Number.isFinite(declaredValue) && declaredValue > 0
+        ? { ok: true, value: declaredValue }
+        : { ok: false, error: { kind: "unusable-value", bodyId, field, value: declaredValue } };
+    }
+    if (fromCatalog != null) {
+      return { ok: true, value: fromCatalog };
+    }
+    return {
+      ok: false,
+      error: entry
+        ? { kind: "missing-default", bodyId, missing: field }
+        : { kind: "unknown-body", bodyId, missing: field },
+    };
   };
+
+  const mu = resolve(declared.mu, entry?.mu, "mu");
+  if (!mu.ok) return { ok: false, error: mu.error };
+  const radius = resolve(declared.bodyRadius, entry?.radiusKm, "radius");
+  if (!radius.ok) return { ok: false, error: radius.error };
+
+  return { ok: true, body: { bodyId, mu: mu.value, bodyRadius: radius.value } };
 }

--- a/viewer/src/sources/centralBody.ts
+++ b/viewer/src/sources/centralBody.ts
@@ -14,7 +14,12 @@
  * on the chart to say so.
  */
 
-import { type BodyCatalog, IMPLICIT_BODY_ID, resolveBodyCatalog } from "./bodyCatalog.js";
+import {
+  type BodyCatalog,
+  bodyIdOf,
+  IMPLICIT_BODY_ID,
+  resolveBodyCatalog,
+} from "./bodyCatalog.js";
 
 /** Resolved central body constants. */
 export interface CentralBody {
@@ -90,12 +95,17 @@ export function describeCentralBodyError(error: CentralBodyError): string {
  * A body the catalog does not carry is fine as long as the source carries both
  * of its constants — nothing is being invented then. It fails only where a value
  * is missing and there is nothing to fill it from.
+ *
+ * The resolved `bodyId` is the source's name as an id: lowercase, which is what
+ * the catalog and the scene's own body definitions key on, while a recording
+ * carries `arika`'s display name ("Earth").
  */
 export function resolveCentralBody(
   declared: DeclaredCentralBody,
   catalog?: BodyCatalog,
 ): CentralBodyResult {
-  const bodyId = declared.bodyId ?? IMPLICIT_BODY_ID;
+  // The name is the source's; the id is what the catalog and the scene key on.
+  const bodyId = declared.bodyId != null ? bodyIdOf(declared.bodyId) : IMPLICIT_BODY_ID;
   const entry = resolveBodyCatalog(catalog)[bodyId];
 
   const resolve = (

--- a/viewer/src/sources/centralBody.ts
+++ b/viewer/src/sources/centralBody.ts
@@ -14,12 +14,7 @@
  * on the chart to say so.
  */
 
-import {
-  type BodyCatalog,
-  bodyIdOf,
-  IMPLICIT_BODY_ID,
-  resolveBodyCatalog,
-} from "./bodyCatalog.js";
+import { type BodyCatalog, bodyIdOf, IMPLICIT_BODY_ID, resolveBodyCatalog } from "./bodyCatalog.js";
 
 /** Resolved central body constants. */
 export interface CentralBody {
@@ -47,11 +42,13 @@ export type CentralBodyError =
       missing: CentralBodyField;
     }
   | {
-      /** The source carried the value, and it cannot be one. */
+      /** The value cannot be one, whichever of the two supplied it. */
       kind: "unusable-value";
       bodyId: string;
       field: CentralBodyField;
       value: number;
+      /** `"catalog"` for a body's own constants, which a consumer may supply. */
+      origin: "source" | "catalog";
     };
 
 export type CentralBodyResult =
@@ -76,8 +73,10 @@ export function describeCentralBodyError(error: CentralBodyError): string {
       return `the recording is around "${error.bodyId}", which this viewer has no constants for, and carries no ${error.missing} of its own`;
     case "missing-default":
       return `the recording carries no ${error.missing}, and none is known for "${error.bodyId}"`;
-    case "unusable-value":
-      return `the recording's ${error.field} for "${error.bodyId}" is ${error.value}, which no orbit can be measured against`;
+    case "unusable-value": {
+      const whose = error.origin === "source" ? "the recording's" : "the catalog's";
+      return `${whose} ${error.field} for "${error.bodyId}" is ${error.value}, which no orbit can be measured against`;
+    }
   }
 }
 
@@ -108,18 +107,28 @@ export function resolveCentralBody(
   const bodyId = declared.bodyId != null ? bodyIdOf(declared.bodyId) : IMPLICIT_BODY_ID;
   const entry = resolveBodyCatalog(catalog)[bodyId];
 
+  // The same constraint whoever supplied the value. A catalog is the consumer's
+  // to write, so a `mu` of -1 in one is as unusable as a `mu` of -1 in a file,
+  // and letting it through here would be letting it into every element derived.
+  const usable = (
+    value: number,
+    field: CentralBodyField,
+    origin: "source" | "catalog",
+  ): { ok: true; value: number } | { ok: false; error: CentralBodyError } =>
+    Number.isFinite(value) && value > 0
+      ? { ok: true, value }
+      : { ok: false, error: { kind: "unusable-value", bodyId, field, value, origin } };
+
   const resolve = (
     declaredValue: number | null | undefined,
     fromCatalog: number | undefined,
     field: CentralBodyField,
   ): { ok: true; value: number } | { ok: false; error: CentralBodyError } => {
     if (declaredValue != null) {
-      return Number.isFinite(declaredValue) && declaredValue > 0
-        ? { ok: true, value: declaredValue }
-        : { ok: false, error: { kind: "unusable-value", bodyId, field, value: declaredValue } };
+      return usable(declaredValue, field, "source");
     }
     if (fromCatalog != null) {
-      return { ok: true, value: fromCatalog };
+      return usable(fromCatalog, field, "catalog");
     }
     return {
       ok: false,

--- a/viewer/src/sources/normalizeMetadata.test.ts
+++ b/viewer/src/sources/normalizeMetadata.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { CSVMetadata } from "../orbit.js";
+import type { CentralBody } from "./centralBody.js";
 import { csvMetadataToSimInfo } from "./normalizeMetadata.js";
+
+/// The resolved body the caller now supplies. Resolving it is
+/// `resolveCentralBody`'s own test; here it is just the value passed through.
+const EARTH: CentralBody = { bodyId: "earth", mu: 398600.4418, bodyRadius: 6378.137 };
 
 describe("csvMetadataToSimInfo", () => {
   const fullMetadata: CSVMetadata = {
@@ -13,7 +18,7 @@ describe("csvMetadataToSimInfo", () => {
   };
 
   it("converts full metadata to SimInfo with filename fallback", () => {
-    const info = csvMetadataToSimInfo(fullMetadata, "test.csv", 10.0);
+    const info = csvMetadataToSimInfo(fullMetadata, "test.csv", 10.0, EARTH);
     expect(info.mu).toBe(398600.4418);
     expect(info.central_body).toBe("earth");
     expect(info.central_body_radius).toBe(6378.137);
@@ -24,7 +29,7 @@ describe("csvMetadataToSimInfo", () => {
 
   it("uses satellite name from metadata when available", () => {
     const withName: CSVMetadata = { ...fullMetadata, satelliteName: "ISS" };
-    const info = csvMetadataToSimInfo(withName, "iss_orbit.csv", 10.0);
+    const info = csvMetadataToSimInfo(withName, "iss_orbit.csv", 10.0, EARTH);
     expect(info.satellites[0].name).toBe("ISS");
   });
 
@@ -37,7 +42,7 @@ describe("csvMetadataToSimInfo", () => {
       satelliteName: null,
       satellites: null,
     };
-    const info = csvMetadataToSimInfo(empty, "orbit.csv", 5.0);
+    const info = csvMetadataToSimInfo(empty, "orbit.csv", 5.0, EARTH);
     expect(info.mu).toBe(398600.4418);
     expect(info.central_body).toBe("earth");
     expect(info.central_body_radius).toBe(6378.137);
@@ -45,14 +50,14 @@ describe("csvMetadataToSimInfo", () => {
   });
 
   it("sets dt from provided value", () => {
-    const info = csvMetadataToSimInfo(fullMetadata, "test.csv", 7.5);
+    const info = csvMetadataToSimInfo(fullMetadata, "test.csv", 7.5, EARTH);
     expect(info.dt).toBe(7.5);
     expect(info.output_interval).toBe(7.5);
     expect(info.stream_interval).toBe(7.5);
   });
 
   it("satellite id is 'default' and name is filename", () => {
-    const info = csvMetadataToSimInfo(fullMetadata, "apollo11.csv", 1.0);
+    const info = csvMetadataToSimInfo(fullMetadata, "apollo11.csv", 1.0, EARTH);
     expect(info.satellites[0].id).toBe("default");
     expect(info.satellites[0].name).toBe("apollo11.csv");
     expect(info.satellites[0].perturbations).toEqual([]);
@@ -63,7 +68,7 @@ describe("csvMetadataToSimInfo", () => {
       ...fullMetadata,
       satellites: ["iss", "sso"],
     };
-    const info = csvMetadataToSimInfo(multiSat, "constellation.csv", 10.0);
+    const info = csvMetadataToSimInfo(multiSat, "constellation.csv", 10.0, EARTH);
     expect(info.satellites).toHaveLength(2);
     expect(info.satellites[0].id).toBe("iss");
     expect(info.satellites[0].name).toBe("iss");
@@ -76,7 +81,7 @@ describe("csvMetadataToSimInfo", () => {
       ...fullMetadata,
       satellites: ["iss"],
     };
-    const info = csvMetadataToSimInfo(singleSat, "iss.csv", 10.0);
+    const info = csvMetadataToSimInfo(singleSat, "iss.csv", 10.0, EARTH);
     expect(info.satellites).toHaveLength(1);
     expect(info.satellites[0].id).toBe("iss");
     expect(info.satellites[0].name).toBe("iss");
@@ -87,7 +92,7 @@ describe("csvMetadataToSimInfo", () => {
       ...fullMetadata,
       satellites: [],
     };
-    const info = csvMetadataToSimInfo(emptySats, "test.csv", 10.0);
+    const info = csvMetadataToSimInfo(emptySats, "test.csv", 10.0, EARTH);
     expect(info.satellites).toHaveLength(1);
     expect(info.satellites[0].id).toBe("default");
   });

--- a/viewer/src/sources/normalizeMetadata.ts
+++ b/viewer/src/sources/normalizeMetadata.ts
@@ -7,7 +7,7 @@
 
 import type { CSVMetadata } from "../orbit.js";
 import type { RrdMetadata } from "../wasm/rrdWasmInit.js";
-import { resolveCentralBody } from "./centralBody.js";
+import type { CentralBody } from "./centralBody.js";
 import type { SimInfo } from "./types.js";
 
 /**
@@ -17,7 +17,12 @@ import type { SimInfo } from "./types.js";
  * @param fileName - Original file name (used as satellite display name)
  * @param dt - Estimated time step between data points [s]
  */
-export function csvMetadataToSimInfo(metadata: CSVMetadata, fileName: string, dt: number): SimInfo {
+export function csvMetadataToSimInfo(
+  metadata: CSVMetadata,
+  fileName: string,
+  dt: number,
+  centralBody: CentralBody,
+): SimInfo {
   const satellites =
     metadata.satellites && metadata.satellites.length > 0
       ? metadata.satellites.map((id) => ({
@@ -39,18 +44,12 @@ export function csvMetadataToSimInfo(metadata: CSVMetadata, fileName: string, dt
           },
         ];
 
-  // Resolved once and read twice, rather than resolved per field. Each field
-  // falls back on its own, so a valid `mu` can sit beside Earth's radius, and
-  // `central_body` is the name the source gave and passes through: it can read
-  // "mars" over Earth's constants.
-  const centralBody = resolveCentralBody(metadata.mu, metadata.centralBodyRadius);
-
   return {
     mu: centralBody.mu,
     dt,
     output_interval: dt,
     stream_interval: dt,
-    central_body: metadata.centralBody ?? "earth",
+    central_body: centralBody.bodyId,
     central_body_radius: centralBody.bodyRadius,
     epoch_jd: metadata.epochJd,
     satellites,
@@ -70,6 +69,7 @@ export function rrdMetadataToSimInfo(
   fileName: string,
   dt: number,
   entityPaths: string[],
+  centralBody: CentralBody,
 ): SimInfo {
   const satellites = entityPaths.map((path) => {
     // Extract name from entity path (last segment after /sat/)
@@ -97,18 +97,12 @@ export function rrdMetadataToSimInfo(
     });
   }
 
-  // Resolved once and read twice, rather than resolved per field. Each field
-  // falls back on its own, so a valid `mu` can sit beside Earth's radius, and
-  // `central_body` is the name the source gave and passes through: it can read
-  // "mars" over Earth's constants.
-  const centralBody = resolveCentralBody(metadata.mu, metadata.body_radius);
-
   return {
     mu: centralBody.mu,
     dt,
     output_interval: dt,
     stream_interval: dt,
-    central_body: metadata.body_name ?? "earth",
+    central_body: centralBody.bodyId,
     central_body_radius: centralBody.bodyRadius,
     epoch_jd: metadata.epoch_jd ?? null,
     satellites,

--- a/viewer/src/sources/rrdOrbitDerived.test.ts
+++ b/viewer/src/sources/rrdOrbitDerived.test.ts
@@ -1,12 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_BODY_RADIUS, DEFAULT_MU } from "./centralBody.js";
 import { orbitPointToChartRow } from "./eventDispatcher.js";
-import {
-  ORBIT_DERIVED_STRIDE,
-  orbitDerivedContext,
-  packStates,
-  toOrbitPoints,
-} from "./rrdOrbitDerived.js";
+import { ORBIT_DERIVED_STRIDE, packStates, toOrbitPoints } from "./rrdOrbitDerived.js";
 import type { RrdPointOut } from "./rrdParseLogic.js";
 
 function point(overrides: Partial<RrdPointOut> = {}): RrdPointOut {
@@ -23,40 +17,6 @@ function point(overrides: Partial<RrdPointOut> = {}): RrdPointOut {
   };
 }
 
-describe("orbitDerivedContext", () => {
-  it("takes the recording's own central body constants", () => {
-    const ctx = orbitDerivedContext({ mu: 42828.37, body_radius: 3396.2 });
-    expect(ctx.mu).toBe(42828.37);
-    expect(ctx.bodyRadius).toBe(3396.2);
-  });
-
-  it("falls back to Earth when the recording carries neither", () => {
-    const ctx = orbitDerivedContext({ mu: null, body_radius: null });
-    expect(ctx.mu).toBe(DEFAULT_MU);
-    expect(ctx.bodyRadius).toBe(DEFAULT_BODY_RADIUS);
-  });
-
-  it("falls back for a mu no orbit can be scaled by", () => {
-    // A recording could carry a corrupt or placeholder value; dividing by it
-    // would make every element non-finite.
-    for (const mu of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
-      expect(orbitDerivedContext({ mu, body_radius: 6378.137 }).mu).toBe(DEFAULT_MU);
-    }
-    expect(orbitDerivedContext({ mu: DEFAULT_MU, body_radius: Number.NaN }).bodyRadius).toBe(
-      DEFAULT_BODY_RADIUS,
-    );
-  });
-
-  it("falls back for a negative radius, and keeps a zero one", () => {
-    // Altitude is `r - bodyRadius`: a negative radius reads as a height above
-    // the orbit rather than above the surface, which a chart shows without
-    // complaint. Zero is a point mass, whose altitude is `r`.
-    expect(orbitDerivedContext({ mu: DEFAULT_MU, body_radius: -6378.137 }).bodyRadius).toBe(
-      DEFAULT_BODY_RADIUS,
-    );
-    expect(orbitDerivedContext({ mu: DEFAULT_MU, body_radius: 0 }).bodyRadius).toBe(0);
-  });
-});
 
 describe("packStates", () => {
   it("lays out six values per point in order", () => {

--- a/viewer/src/sources/rrdOrbitDerived.test.ts
+++ b/viewer/src/sources/rrdOrbitDerived.test.ts
@@ -17,7 +17,6 @@ function point(overrides: Partial<RrdPointOut> = {}): RrdPointOut {
   };
 }
 
-
 describe("packStates", () => {
   it("lays out six values per point in order", () => {
     const packed = packStates([

--- a/viewer/src/sources/rrdOrbitDerived.ts
+++ b/viewer/src/sources/rrdOrbitDerived.ts
@@ -11,22 +11,10 @@
  */
 
 import type { OrbitPoint } from "../orbit.js";
-import { type CentralBody, resolveCentralBody } from "./centralBody.js";
 import type { RrdPointOut } from "./rrdParseLogic.js";
 
 /** Values `orbit_derived_batch` returns per state. */
 export const ORBIT_DERIVED_STRIDE = 10;
-
-/** The central body constants a batch is converted against. */
-export type OrbitDerivedContext = CentralBody;
-
-/** Read `mu` and the body radius out of a recording's metadata. */
-export function orbitDerivedContext(metadata: {
-  mu: number | null;
-  body_radius: number | null;
-}): OrbitDerivedContext {
-  return resolveCentralBody(metadata.mu, metadata.body_radius);
-}
 
 /** Flatten points into the `[x,y,z,vx,vy,vz, ...]` layout the batch takes. */
 export function packStates(points: readonly RrdPointOut[]): Float64Array {


### PR DESCRIPTION
viewer が中心天体の `mu` と半径を勝手に埋めるのをやめ、天体名から解決するか、解決できなければそのデータを拒否する。

viewer にデータを供給するものを source と呼ぶ（`.rrd` ファイル、CSV ファイル、`orts serve` への live WebSocket の 3 つ）。どれも「どの天体を回っているか」の名前と、その天体の `mu`（標準重力定数）と半径を持つ。持たない場合がある。

## 課題

値が欠けたとき、`mu` と半径をそれぞれ独立に地球の値へ差し替えていた。Mars を名乗ってどちらも持たない recording は「**Mars の `mu` + 地球の半径**」になる。存在しない天体で、高度 `r - 半径` が約 3000 km ずれるのに、チャートにそれを示すものが無い。

同じ形の差し替えが 3 箇所にあった。

| 箇所 | 何をしていたか |
|---|---|
| `sources/centralBody.ts` | field ごとに地球へ差し替え |
| `hooks/useSimulationData.ts` | `createOrbitSchema(mu ?? 398600.4418, bodyRadius ?? 6378.137)` |
| `hooks/useWebSocket.ts` | `central_body_radius ?? 6378.137` |

解決のタイミングも遅かった。CSV は読み込み完了時に `SimInfo` を組み立てるので、そこでエラーにしても point は既にチャートへ流れている。

## 解決の規則

既定値は viewer が定数を持っている天体にのみ属する。

- **既知の天体で値が欠けている** → その天体のカタログ値
- **未知の天体で値が両方揃っている** → 通す。何も発明していないため
- **未知の天体で値が欠けている** → エラー
- **値があって値になりえない**（`mu` が 0 以下、半径が 0 以下、いずれも非有限） → エラー。既定値で差し替えると、ファイルが自分について述べた誤りを隠す
- **天体名を持たない source** → 地球。この field より古い recording がそれに当たる

`DEFAULT_BODY_CATALOG` に arika が伝播する 10 天体の `mu` と半径を置いた（`KnownBody::properties` の値）。描画用の `BodyDefinitions` とは別で、あちらは天体の描き方（テクスチャ、色）を持ち scene が描く 4 天体だけを覆う。

天体名は id として lowercase 化する。`orts run` は arika の表示名（"Earth"、"Mars"）を recording に書き、カタログと scene の id は lowercase なので、case sensitive な lookup では既定経路の recording が「未知の天体」になっていた（Rust 側も `cli/src/commands/replay.rs` で同じ field を lowercase している）。

カタログ由来の値も source 由来と同じ制約に通す。カタログは consumer が書けるもので、そこの `mu` が -1 ならファイルの -1 と同じく使えない。

consumer が供給するカタログは field ごとに既定値へ重ねる。天体まるごと置き換えると、`{ earth: { mu } }` のように 1 つの定数だけ直したときに半径が消え、半径を書かない recording が「既定値が無い」として拒否される。key は source の天体名と同じく lowercase 化するので、`{ Kerbin: ... }` が "kerbin" と名乗る recording に答える。

## 解決の位置

metadata が届いた時点で 1 度だけ解決し、派生値と `SimInfo` の両方でその値を使う。`normalizeMetadata` は解決済みの値を引数で受ける形にしたので、2 つの読み手が別の値を使うことが型で起こらない。

解決できなかった source は止める。ファイルは worker を停止し、live WebSocket は socket を閉じる。エラーを報告して繋いだままにすると、後続の state がチャートへ届く。

`.rrd` 側の「metadata より先に chunk が来たら地球で導出する」経路も削除した。worker は metadata を先に送るので、ここに来るのは protocol violation であり、地球で計算する理由にはならない。

`useSimulationData` は解決済み `SimInfo` の field を埋めるのをやめた。schema の地球既定値は、まだ source が何も報告していない間だけ効く。

独自の天体で simulation する consumer は、その定数を adapter に渡せる。

```ts
new RrdFileAdapter(id, file, onEvent, { kerbin: { mu: 3531600, radiusKm: 600 } })
```

## テスト

viewer 491 件 pass（新規 17 件）。

`resolveCentralBody` は 13 本。既知の天体の補完、未知の天体で値が揃っている場合と欠けている場合、注入したカタログ、カタログ entry に欠けた値が無い場合、カタログ由来の不正値、部分的な上書きで残る定数、カタログ key の case、`mu` と半径の不正値、天体名の case、天体名なし、どの field が最初に失敗するか。`DEFAULT_BODY_CATALOG` が 10 天体すべてで両定数を持つことも固定した（欠けていると、その値を書かない recording が解決に失敗する）。

`.rrd` adapter は 6 本。Mars を名乗って定数を持たない recording が Mars の値で解決されること、未知の天体で値が欠けていればエラーになり point がチャートへ届かず worker が止まること、注入したカタログが効くこと、metadata より先に chunk が来た場合、WASM 読み込み中に再読み込みした場合。

WebSocket は 2 本。`central_body_radius` を持たない server の info がその天体名から解決されること、解決できない info が接続を閉じる側に倒れること。

各修正は外すとテストが落ちることを確認した。

`tsc --noEmit` と `biome check` はどちらもクリーン。

## 関連

`centralBody.ts` は #376 が作った module で、そこに集めた差し替えがこの PR の対象。カタログの値は手で書いており、`KnownBody::properties` から生成する余地は TODO に書いた。
