### PR TITLE
fix(orts): size SRP shadow model to the central body radius

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -156,6 +156,13 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   占めており、writer スレッドの Arrow IPC + LZ4 は 55ms、665KB のファイル書き込みは
   0.2ms だった。batcher を迂回して chunk の境界が呼び出し側の責任になるため、
   8192 行で分割する。([#379](https://github.com/sksat/orts/pull/379))
+- SRP shadow model が中心天体の半径を使うように修正。`build_orbital_system` /
+  `build_spacecraft_dynamics` は `for_earth` で SRP を構築しており、shadow
+  半径が中心天体によらず地球の 6378 km だった — Moon 中心のシミュレーション
+  では shadow cylinder が約 3.7 倍広く、衛星を誤って eclipse 判定し SRP が
+  過小適用されていた。両 builder が共通の `build_srp` helper 経由で
+  `BodyProperties::radius` に shadow をサイズするようになった。
+  ([#385](https://github.com/sksat/orts/pull/385))
 
 #### Removed
 - **BREAKING**: `orts::tle` module を削除。TLE パースは `arika::tle`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,13 @@ section is subdivided by package.
   conversion, silently mislabeling coordinates for any `F != SimpleEci`. Latent
   (the only shipped effector is torque-only) but wrong for a translational
   effector. ([#148](https://github.com/sksat/orts/pull/148), [#103](https://github.com/sksat/orts/issues/103))
+- SRP shadow model now uses the central body's radius. `build_orbital_system` /
+  `build_spacecraft_dynamics` constructed SRP via `for_earth`, whose default
+  shadow radius is Earth's 6378 km regardless of the central body — in a
+  Moon-centered simulation the shadow cylinder was ~3.7× too wide, wrongly
+  eclipsing satellites and under-applying SRP. Both builders now size the
+  shadow to `BodyProperties::radius` via a shared `build_srp` helper.
+  ([#385](https://github.com/sksat/orts/pull/385))
 
 - A negative `sim_time` reaches the .rrd. `save_as_rrd` set the timeline through
   `set_duration_secs`, which converts via the unsigned `std::time::Duration`:

--- a/orts/src/perturbations/srp.rs
+++ b/orts/src/perturbations/srp.rs
@@ -245,6 +245,27 @@ mod tests {
     }
 
     #[test]
+    fn shadow_boundary_follows_the_configured_radius() {
+        // Satellite behind the central body, 3000 km off the shadow axis:
+        // outside a lunar shadow cylinder (r=1737.4), inside an Earth-sized one (r=6378).
+        let sat = Vector3::new(-3000.0, 3000.0, 0.0);
+        let sun = Vector3::new(sun::AU_KM, 0.0, 0.0);
+
+        let lunar = SolarRadiationPressure::for_earth(Some(0.02)).with_shadow_body(1737.4);
+        let earth_sized = SolarRadiationPressure::for_earth(Some(0.02));
+
+        assert!(
+            lunar.srp_accel(&sat, &sun).magnitude() > 0.0,
+            "sunlit past the lunar limb"
+        );
+        assert_eq!(
+            earth_sized.srp_accel(&sat, &sun).magnitude(),
+            0.0,
+            "Earth-sized shadow eclipses it"
+        );
+    }
+
+    #[test]
     fn srp_direction_away_from_sun() {
         let srp = SolarRadiationPressure {
             cr: 1.5,

--- a/orts/src/setup.rs
+++ b/orts/src/setup.rs
@@ -2,7 +2,7 @@ use nalgebra::Matrix3;
 
 use crate::orbital::gravity::{self, GravityField};
 use crate::spacecraft::SpacecraftDynamics;
-use arika::body::KnownBody;
+use arika::body::{BodyProperties, KnownBody};
 use arika::epoch::Epoch;
 
 use crate::attitude::CoupledGravityGradient;
@@ -88,6 +88,16 @@ pub fn default_third_bodies(body: &KnownBody) -> Vec<ThirdBodyGravity> {
     bodies
 }
 
+/// SRP with the shadow model sized to the actual central body,
+/// not the Earth default baked into `for_earth`.
+fn build_srp(props: &BodyProperties, sat: &SatelliteParams, am: f64) -> SolarRadiationPressure {
+    let mut srp = SolarRadiationPressure::for_earth(Some(am)).with_shadow_body(props.radius);
+    if let Some(cr) = sat.srp_cr {
+        srp = srp.with_cr(cr);
+    }
+    srp
+}
+
 /// Build an OrbitalSystem for the given body, automatically configuring gravity,
 /// third-body perturbations, drag, and SRP based on the provided parameters.
 ///
@@ -137,13 +147,8 @@ pub fn build_orbital_system(
     if epoch.is_some()
         && let Some(am) = sat.srp_area_to_mass
     {
-        let mut srp = SolarRadiationPressure::for_earth(Some(am));
-        if let Some(cr) = sat.srp_cr {
-            srp = srp.with_cr(cr);
-        }
-        system = system.with_model(srp);
+        system = system.with_model(build_srp(&props, sat, am));
     }
-
     system
 }
 
@@ -236,18 +241,13 @@ pub fn build_spacecraft_dynamics(
             (Some(shape), _) => {
                 // The shadow is cast by whatever the spacecraft orbits, so the
                 // Earth radius `for_earth` bakes in is only right for Earth.
-                // #385 is giving the cannonball arm below a `build_srp` helper
-                // that does the same thing; both arms should go through it once
-                // it lands.
+                // TODO: route this arm through `build_srp` too so both SRP
+                // paths size the shadow in one place.
                 system = system
                     .with_model(PanelSrp::for_earth(shape.clone()).with_shadow_body(props.radius));
             }
             (None, Some(am)) => {
-                let mut srp = SolarRadiationPressure::for_earth(Some(am));
-                if let Some(cr) = sat.srp_cr {
-                    srp = srp.with_cr(cr);
-                }
-                system = system.with_model(srp);
+                system = system.with_model(build_srp(&props, sat, am));
             }
             (None, None) => {}
         }
@@ -259,7 +259,6 @@ pub fn build_spacecraft_dynamics(
     if sat.disturbances.gravity_gradient {
         system = system.with_model(CoupledGravityGradient::new(mu, inertia));
     }
-
     system
 }
 
@@ -645,5 +644,22 @@ mod tests {
         let names = system.model_names();
         assert!(!names.contains(&"third_body_sun"));
         assert!(!names.contains(&"third_body_moon"));
+    }
+    #[test]
+    fn srp_shadow_radius_matches_central_body() {
+        let sat = SatelliteParams {
+            has_drag: false,
+            ballistic_coeff: None,
+            srp_area_to_mass: None,
+            srp_cr: None,
+            disturbances: DisturbanceTorques::default(),
+            shape: None,
+        };
+        let moon = KnownBody::Moon.properties();
+        let srp = build_srp(&moon, &sat, 0.02);
+        assert_eq!(srp.shadow_body_radius, Some(moon.radius));
+        let earth = KnownBody::Earth.properties();
+        let srp = build_srp(&earth, &sat, 0.02);
+        assert_eq!(srp.shadow_body_radius, Some(earth.radius));
     }
 }


### PR DESCRIPTION
SRP's shadow cylinder was always Earth-sized (6378 km) because for_earth() is used for every central body; in a lunar simulation that's a ~3.7×-too-wide shadow, so satellites are wrongly eclipsed and SRP is under-applied; fix wires the existing with_shadow_body builder to the actual body radius via a shared build_srp helper; two new tests pin the behavior (off-axis point behind the Moon is sunlit; Moon systems get 1737.4 km). If CI comes back green, PR 0 is done and we start on PR 1's failing tests (Earth third body).
