### PR TITLE
fix(orts)!: give each column and axis the rows it covers

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -44,10 +44,11 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   で旧振る舞いを再現しない。面が本当に不明なら `PanelOptics::absorber()` を渡す。([#377](https://github.com/sksat/orts/pull/377))
 - **BREAKING**: `EntityStore::timelines` の型が `Vec<TimeIndex>` から
   `TimelineColumn` になり、列は自分が覆う論理行を持つようになった。追加は論理行を
-  明示して検査する `ComponentColumn::push_at` を通す。`push` と、両 column type の
-  `data` / `rows` field は crate 内限定 — map と data が食い違った列は、値を別の行の
-  時刻で報告する。読み出しは列が `scalars`、軸が `times`、行単位では `get_row` が
-  格納 index、`at_logical_row` が論理行。([#375](https://github.com/sksat/orts/issues/375))
+  明示して検査する `ComponentColumn::push_at` を通す。`push` と `scalars_per_row`、
+  両 column type の `data` / `rows` field は crate 内限定 — map と data が食い違った列は、
+  値を別の行の時刻で報告する。読み出しは列が `scalars` と `scalars_per_row()`、軸が
+  `times`、行単位では `get_row` が格納 index、`at_logical_row` が
+  論理行。([#375](https://github.com/sksat/orts/issues/375))
 - `StateEffector` を frame-generic 化 — `StateEffector<S, F: frame::Eci =
   SimpleEci>` で `ExternalLoads<F>` を返す (`Model<S, F>` と同様)。effector は
   host の慣性 frame で荷重を生成するようになった。既定の `F` により既存の

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -42,6 +42,11 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   なくコンパイルエラーとして出るようにするため: `Cr = 1.5` は単一の `(ρ_s, ρ_d)`
   に対応せず、力の向きがこの分解に依存するようになったので、どの既定値も face-on 以外
   で旧振る舞いを再現しない。面が本当に不明なら `PanelOptics::absorber()` を渡す。([#377](https://github.com/sksat/orts/pull/377))
+- **BREAKING**: `EntityStore::timelines` の型が `Vec<TimeIndex>` から
+  `TimelineColumn` になり、`ComponentColumn` に `rows` field が増え、
+  `ComponentColumn::push` は crate 内限定になった (新しい `push_at` と並んで
+  public だと、row map と data を desync させられる)。`get_row` は従来どおり
+  格納 index を取り、論理行の引きは `at_logical_row`。([#375](https://github.com/sksat/orts/issues/375))
 - `StateEffector` を frame-generic 化 — `StateEffector<S, F: frame::Eci =
   SimpleEci>` で `ExternalLoads<F>` を返す (`Model<S, F>` と同様)。effector は
   host の慣性 frame で荷重を生成するようになった。既定の `F` により既存の
@@ -53,6 +58,19 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   20-40% 改善する。([#359](https://github.com/sksat/orts/pull/359))
 
 #### Fixed
+- 一部の step でしか logging されなかった component が、logging された時刻を保つ
+  ようになった。`log_temporal` は行数の比較で新しい行かどうかを決めていたため、
+  短い列が**先頭の**行に並んでいた: step 5 から attitude を出すと step 5〜9 が
+  t=0〜4 として書かれていた。行は `TimePoint` で識別するようになり、
+  `ComponentColumn` と新しい `TimelineColumn` がそれぞれ自分の覆う論理行を持つ
+  (毎 step logging される列は `RowMap::Dense` なので通常ケースのコストはゼロ)。
+  「この step に値が無い」は `log_temporal` を呼ばないことで表現でき、
+  API 追加は不要。([#375](https://github.com/sksat/orts/issues/375))
+- entity の他の行が持たない軸を名指しする `TimePoint`、および軸を別の順序で
+  組んだ `TimePoint` が、行を分けたり誤配置したりしなくなった。同じ軸を同じ index で
+  名指す 2 点は、組んだ順序に関係なく 1 行。`with_*` は軸の index を置き換える
+  (2 つ目を append しない)。`+0.0` と `-0.0` は同一の瞬間で、`NaN` 時刻でも
+  component ごとでなく step ごとに 1 行になる。([#375](https://github.com/sksat/orts/issues/375))
 - .rrd の loader 2 つが、scalar 列を recording 自身の時刻 index で結合するようになった。
   一部の時刻にしか現れない component が、後の値を前の行にずらすことがなくなる。
   `load_rrd_data` は `orts replay` と `orts serve` の history 読み戻し、

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -43,10 +43,11 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   に対応せず、力の向きがこの分解に依存するようになったので、どの既定値も face-on 以外
   で旧振る舞いを再現しない。面が本当に不明なら `PanelOptics::absorber()` を渡す。([#377](https://github.com/sksat/orts/pull/377))
 - **BREAKING**: `EntityStore::timelines` の型が `Vec<TimeIndex>` から
-  `TimelineColumn` になり、`ComponentColumn` に `rows` field が増え、
-  `ComponentColumn::push` は crate 内限定になった (新しい `push_at` と並んで
-  public だと、row map と data を desync させられる)。`get_row` は従来どおり
-  格納 index を取り、論理行の引きは `at_logical_row`。([#375](https://github.com/sksat/orts/issues/375))
+  `TimelineColumn` になり、列は自分が覆う論理行を持つようになった。追加は論理行を
+  明示して検査する `ComponentColumn::push_at` を通す。`push` と、両 column type の
+  `data` / `rows` field は crate 内限定 — map と data が食い違った列は、値を別の行の
+  時刻で報告する。読み出しは列が `scalars`、軸が `times`、行単位では `get_row` が
+  格納 index、`at_logical_row` が論理行。([#375](https://github.com/sksat/orts/issues/375))
 - `StateEffector` を frame-generic 化 — `StateEffector<S, F: frame::Eci =
   SimpleEci>` で `ExternalLoads<F>` を返す (`Model<S, F>` と同様)。effector は
   host の慣性 frame で荷重を生成するようになった。既定の `F` により既存の

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,11 @@ section is subdivided by package.
 - **BREAKING**: `EntityStore::timelines` holds `TimelineColumn` rather than
   `Vec<TimeIndex>`, and a column now carries the logical rows it covers.
   Appending goes through `ComponentColumn::push_at`, which states the row and
-  checks it; `push` and the `data` / `rows` fields of both column types are
-  crate-private, since a column whose map and data disagree reports values at
-  other rows' times. Read a column with `scalars` and an axis with `times`, or
-  by row: `get_row` takes a stored index, `at_logical_row` an entity
+  checks it; `push`, `scalars_per_row` and the `data` / `rows` fields of both
+  column types are crate-private, since a column whose map and data disagree
+  reports values at other rows' times. Read a column with `scalars`,
+  `scalars_per_row()` and an axis with `times`, or by row: `get_row` takes a
+  stored index, `at_logical_row` an entity
   row. ([#375](https://github.com/sksat/orts/issues/375))
 - `StateEffector` is now frame-generic — `StateEffector<S, F: frame::Eci =
   SimpleEci>` returning `ExternalLoads<F>`, like `Model<S, F>` — so effectors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ section is subdivided by package.
   since the force direction now depends on that split, no default reproduces the
   old behaviour anywhere but face-on. Pass `PanelOptics::absorber()` when the
   surface is genuinely unknown. ([#377](https://github.com/sksat/orts/pull/377))
+- **BREAKING**: `EntityStore::timelines` holds `TimelineColumn` rather than
+  `Vec<TimeIndex>`, `ComponentColumn` gained a `rows` field, and
+  `ComponentColumn::push` is crate-private — public alongside the new `push_at`
+  it let a caller desync the row map from the data. `get_row` still takes a
+  stored index; `at_logical_row` is the entity-row lookup. ([#375](https://github.com/sksat/orts/issues/375))
 - `StateEffector` is now frame-generic — `StateEffector<S, F: frame::Eci =
   SimpleEci>` returning `ExternalLoads<F>`, like `Model<S, F>` — so effectors
   produce loads already in the host inertial frame. The defaulted `F` keeps
@@ -61,6 +66,20 @@ section is subdivided by package.
   0.33 m, and the three shorter Harris-Priester oracles by 20-40%. ([#359](https://github.com/sksat/orts/pull/359))
 
 #### Fixed
+- A component logged at only some steps keeps the times it was logged at.
+  `log_temporal` decided whether a call began a new row by comparing row counts,
+  so a short column lined up with the *leading* rows: logging attitude from step
+  5 onward wrote steps 5-9 at t=0-4. The row is now named by its `TimePoint`,
+  and `ComponentColumn` and the new `TimelineColumn` each carry which logical
+  rows they cover (`RowMap::Dense` for a column logged every step, so the common
+  case costs nothing). Skipping a component at a step is how "no value here" is
+  said, and needs no new call. ([#375](https://github.com/sksat/orts/issues/375))
+- A `TimePoint` that names an axis the entity's other rows do not, or names its
+  axes in another order, no longer splits or misplaces a row. Two points are one
+  row when they name the same axes at the same indices, whatever order they were
+  built in, and `with_*` replaces the index for an axis rather than appending a
+  second one. `+0.0` and `-0.0` are one instant, and a `NaN` time gives one row
+  per step rather than one per component. ([#375](https://github.com/sksat/orts/issues/375))
 - Both .rrd loaders join scalar columns on the recording's time index, so a
   component present at only some of the times no longer shifts its values onto
   earlier rows. `load_rrd_data` serves `orts replay` and `orts serve`'s history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,10 +50,13 @@ section is subdivided by package.
   old behaviour anywhere but face-on. Pass `PanelOptics::absorber()` when the
   surface is genuinely unknown. ([#377](https://github.com/sksat/orts/pull/377))
 - **BREAKING**: `EntityStore::timelines` holds `TimelineColumn` rather than
-  `Vec<TimeIndex>`, `ComponentColumn` gained a `rows` field, and
-  `ComponentColumn::push` is crate-private — public alongside the new `push_at`
-  it let a caller desync the row map from the data. `get_row` still takes a
-  stored index; `at_logical_row` is the entity-row lookup. ([#375](https://github.com/sksat/orts/issues/375))
+  `Vec<TimeIndex>`, and a column now carries the logical rows it covers.
+  Appending goes through `ComponentColumn::push_at`, which states the row and
+  checks it; `push` and the `data` / `rows` fields of both column types are
+  crate-private, since a column whose map and data disagree reports values at
+  other rows' times. Read a column with `scalars` and an axis with `times`, or
+  by row: `get_row` takes a stored index, `at_logical_row` an entity
+  row. ([#375](https://github.com/sksat/orts/issues/375))
 - `StateEffector` is now frame-generic — `StateEffector<S, F: frame::Eci =
   SimpleEci>` returning `ExternalLoads<F>`, like `Model<S, F>` — so effectors
   produce loads already in the host inertial frame. The defaulted `F` keeps

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -350,13 +350,16 @@ fn satellite_final_state(rec: &Recording, sat_path: &EntityPath) -> (usize, Opti
         return (0, None);
     }
     let i = samples - 1;
+    // `i` indexes the position column's stored rows; the timeline and the other
+    // columns are addressed by the entity's logical row.
+    let logical = pos_col.logical_row_of(i);
 
     let t_s = store
         .timelines
         .get(&TimelineName::SimTime)
-        .and_then(|tl| tl.get(i))
+        .and_then(|tl| tl.at_logical_row(logical))
         .map(|ti| match ti {
-            TimeIndex::Seconds(s) => *s,
+            TimeIndex::Seconds(s) => s,
             _ => 0.0,
         })
         .unwrap_or(0.0);
@@ -364,7 +367,7 @@ fn satellite_final_state(rec: &Recording, sat_path: &EntityPath) -> (usize, Opti
     let vel_row = store
         .columns
         .get(&Velocity3D::component_name())
-        .and_then(|c| c.get_row(i));
+        .and_then(|c| c.at_logical_row(logical));
     let final_state = match (pos_col.get_row(i), vel_row) {
         (Some(pos), Some(vel)) => Some(FinalState {
             t_s,
@@ -892,12 +895,17 @@ pub fn write_satellite_csv(
     let id = id.rsplit('/').next().unwrap_or("default");
 
     for i in 0..pos_col.num_rows() {
-        let t = match sim_times.get(i) {
-            Some(orts::record::timeline::TimeIndex::Seconds(s)) => *s,
+        // `i` indexes the position column's stored rows; the timeline and the
+        // other columns are addressed by the entity's logical row.
+        let logical = pos_col.logical_row_of(i);
+        let t = match sim_times.at_logical_row(logical) {
+            Some(orts::record::timeline::TimeIndex::Seconds(s)) => s,
             _ => 0.0,
         };
         let pos = pos_col.get_row(i).unwrap();
-        let vel = vel_col.get_row(i).unwrap();
+        let Some(vel) = vel_col.at_logical_row(logical) else {
+            continue;
+        };
         let pos_vec = nalgebra::Vector3::new(pos[0], pos[1], pos[2]);
         let vel_vec = nalgebra::Vector3::new(vel[0], vel[1], vel[2]);
         let elements = KeplerianElements::from_state_vector(&pos_vec, &vel_vec, mu);
@@ -924,7 +932,10 @@ pub fn write_satellite_csv(
         ));
 
         for (_name, col) in &extra_cols {
-            if let Some(row) = col.get_row(i) {
+            // TODO(#375 follow-up): a column that skipped this step contributes no
+            // cells, so the line comes out shorter than the header. `orts run` pads
+            // such components with zeros today, so no column is short in practice.
+            if let Some(row) = col.at_logical_row(logical) {
                 for val in row {
                     line.push_str(&format!(",{:.10}", val));
                 }

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -932,13 +932,16 @@ pub fn write_satellite_csv(
         ));
 
         for (_name, col) in &extra_cols {
-            // TODO(#375 follow-up): a column that skipped this step contributes no
-            // cells, so the line comes out shorter than the header. `orts run` pads
-            // such components with zeros today, so no column is short in practice.
-            if let Some(row) = col.at_logical_row(logical) {
-                for val in row {
-                    line.push_str(&format!(",{:.10}", val));
+            // The header names every extra column, so a component with no value at
+            // this step contributes empty fields rather than none: a short line
+            // would put the remaining values under the wrong headings.
+            match col.at_logical_row(logical) {
+                Some(row) => {
+                    for val in row {
+                        line.push_str(&format!(",{:.10}", val));
+                    }
                 }
+                None => line.push_str(&",".repeat(col.scalars_per_row)),
             }
         }
 
@@ -1361,6 +1364,58 @@ mod tests {
         let mut argv = vec!["orts", "--sat", "altitude=500"];
         argv.extend_from_slice(extra);
         SimArgs::try_parse_from(argv).expect("test argv should parse")
+    }
+
+    /// The header names every extra column, so a component with no value at a
+    /// step contributes empty fields. A short line would put the remaining
+    /// values under the wrong headings.
+    #[test]
+    fn a_component_missing_at_a_step_keeps_the_csv_column_count() {
+        use orts::record::archetypes::OrbitalState as RecOrbitalState;
+        use orts::record::components::MtqCommand3D;
+        use orts::record::timeline::TimePoint;
+
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/sparse");
+        let r0 = 6778.137;
+        let v0 = (398600.4418_f64 / r0).sqrt();
+
+        for i in 0..4u64 {
+            let tp = TimePoint::new().with_sim_time(i as f64).with_step(i);
+            let os = RecOrbitalState::new(
+                nalgebra::Vector3::new(r0, 0.0, 0.0),
+                nalgebra::Vector3::new(0.0, v0, 0.0),
+            );
+            rec.log_orbital_state(&sat, &tp, &os);
+            // Only the later steps carry a command.
+            if i >= 2 {
+                rec.log_temporal(
+                    &sat,
+                    &tp,
+                    &MtqCommand3D(nalgebra::Vector3::new(i as f64, 0.0, 0.0)),
+                );
+            }
+        }
+
+        let header = build_csv_header(&rec, &sat, false);
+        let want = header.trim_start_matches("# ").matches(',').count() + 1;
+
+        let mut out = Vec::new();
+        write_satellite_csv(&mut out, &rec, &sat, 398600.4418, false).expect("csv");
+        let body = String::from_utf8(out).expect("utf-8");
+
+        let lines: Vec<&str> = body.lines().filter(|l| !l.starts_with('#')).collect();
+        assert_eq!(lines.len(), 4, "one line per step");
+        for (i, line) in lines.iter().enumerate() {
+            assert_eq!(
+                line.matches(',').count() + 1,
+                want,
+                "line {i} has a different column count from the header: {line}"
+            );
+        }
+        // The steps without a command leave those fields empty.
+        assert!(lines[0].ends_with(",,,"), "line 0: {}", lines[0]);
+        assert!(!lines[2].ends_with(",,,"), "line 2: {}", lines[2]);
     }
 
     #[test]

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -948,7 +948,7 @@ pub fn write_satellite_csv(
                         line.push_str(&format!(",{:.10}", val));
                     }
                 }
-                None => line.push_str(&",".repeat(col.scalars_per_row)),
+                None => line.push_str(&",".repeat(col.scalars_per_row())),
             }
         }
 
@@ -982,7 +982,7 @@ pub fn build_csv_header(rec: &Recording, sat_path: &EntityPath, with_id: bool) -
             // Use component name as column prefix (strip "orts." prefix)
             let short = name.strip_prefix("orts.").unwrap_or(name);
             if let Some(col) = store.columns.get(name) {
-                let n = col.scalars_per_row;
+                let n = col.scalars_per_row();
                 if n == 1 {
                     header.push_str(&format!(",{short}"));
                 } else {

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -354,15 +354,20 @@ fn satellite_final_state(rec: &Recording, sat_path: &EntityPath) -> (usize, Opti
     // columns are addressed by the entity's logical row.
     let logical = pos_col.logical_row_of(i);
 
-    let t_s = store
+    // An axis need not cover every row, so this row may carry no time. The
+    // summary's `final_state` is optional; reporting the state at 0 s would put a
+    // time in it that the recording does not have.
+    let Some(t_s) = store
         .timelines
         .get(&TimelineName::SimTime)
         .and_then(|tl| tl.at_logical_row(logical))
-        .map(|ti| match ti {
-            TimeIndex::Seconds(s) => s,
-            _ => 0.0,
+        .and_then(|ti| match ti {
+            TimeIndex::Seconds(s) => Some(s),
+            TimeIndex::Sequence(_) => None,
         })
-        .unwrap_or(0.0);
+    else {
+        return (samples, None);
+    };
 
     let vel_row = store
         .columns
@@ -898,9 +903,11 @@ pub fn write_satellite_csv(
         // `i` indexes the position column's stored rows; the timeline and the
         // other columns are addressed by the entity's logical row.
         let logical = pos_col.logical_row_of(i);
+        // Empty rather than 0 when the row carries no time, as an optional
+        // component's cells are: `sim_time` need not cover every row.
         let t = match sim_times.at_logical_row(logical) {
-            Some(orts::record::timeline::TimeIndex::Seconds(s)) => s,
-            _ => 0.0,
+            Some(orts::record::timeline::TimeIndex::Seconds(s)) => format!("{s:.3}"),
+            _ => String::new(),
         };
         let pos = pos_col.get_row(i).unwrap();
         let Some(vel) = vel_col.at_logical_row(logical) else {
@@ -915,7 +922,7 @@ pub fn write_satellite_csv(
             line.push_str(&format!("{},", id));
         }
         line.push_str(&format!(
-            "{:.3},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.3},{:.10},{:.10},{:.10},{:.10},{:.10}",
+            "{},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.3},{:.10},{:.10},{:.10},{:.10},{:.10}",
             t,
             pos[0],
             pos[1],
@@ -1364,6 +1371,61 @@ mod tests {
         let mut argv = vec!["orts", "--sat", "altitude=500"];
         argv.extend_from_slice(extra);
         SimArgs::try_parse_from(argv).expect("test argv should parse")
+    }
+
+    /// A row whose `TimePoint` named no `sim_time` has no time to report, so the
+    /// CSV cell is empty and the summary's final state is left out. Reporting
+    /// either at 0 s would put a time in the output the recording does not have.
+    #[test]
+    fn a_row_with_no_sim_time_reports_no_time() {
+        use orts::record::archetypes::OrbitalState as RecOrbitalState;
+        use orts::record::timeline::TimePoint;
+
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/untimed");
+        let r0 = 6778.137;
+        let v0 = (398600.4418_f64 / r0).sqrt();
+
+        for i in 0..3u64 {
+            // The middle row and the last one name only `step`.
+            let tp = if i == 0 {
+                TimePoint::new().with_sim_time(0.0).with_step(i)
+            } else {
+                TimePoint::new().with_step(i)
+            };
+            let os = RecOrbitalState::new(
+                nalgebra::Vector3::new(r0, 0.0, 0.0),
+                nalgebra::Vector3::new(0.0, v0, 0.0),
+            );
+            rec.log_orbital_state(&sat, &tp, &os);
+        }
+
+        let mut out = Vec::new();
+        write_satellite_csv(&mut out, &rec, &sat, 398600.4418, false).expect("csv");
+        let body = String::from_utf8(out).expect("utf-8");
+        let lines: Vec<&str> = body.lines().filter(|l| !l.starts_with('#')).collect();
+
+        assert_eq!(lines.len(), 3, "every row is still written");
+        assert!(
+            lines[0].starts_with("0.000,"),
+            "the timed row carries its time: {}",
+            lines[0]
+        );
+        for i in [1, 2] {
+            assert!(
+                lines[i].starts_with(','),
+                "row {i} named no sim_time, so its time cell is empty: {}",
+                lines[i]
+            );
+        }
+
+        // The last row has no time, so there is no final state to report.
+        let (samples, final_state) = satellite_final_state(&rec, &sat);
+        assert_eq!(samples, 3);
+        assert!(
+            final_state.is_none(),
+            "a state with no time must not be reported at 0 s"
+        );
     }
 
     /// The header names every extra column, so a component with no value at a

--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -89,7 +89,16 @@ pub struct ComponentColumn {
 }
 
 impl ComponentColumn {
+    /// # Panics
+    ///
+    /// If `scalars_per_row` is zero. Rows would all be empty, so `num_rows`
+    /// would stay at zero while the row map recorded one entry per append, and
+    /// the map is what says which entity row each stored row is.
     pub fn new(scalars_per_row: usize) -> Self {
+        assert!(
+            scalars_per_row > 0,
+            "a column holds at least one scalar per row"
+        );
         ComponentColumn {
             scalars_per_row,
             data: Vec::new(),
@@ -134,11 +143,7 @@ impl ComponentColumn {
     }
 
     pub fn num_rows(&self) -> usize {
-        // checked_div yields None when scalars_per_row == 0 (avoids div-by-zero).
-        self.data
-            .len()
-            .checked_div(self.scalars_per_row)
-            .unwrap_or(0)
+        self.data.len() / self.scalars_per_row
     }
 
     /// How many scalars one row holds.
@@ -157,8 +162,10 @@ impl ComponentColumn {
     /// The `index`-th *stored* row. For a column that skipped steps this is not
     /// logical row `index`; use [`Self::at_logical_row`] for that.
     pub fn get_row(&self, index: usize) -> Option<&[f64]> {
-        let start = index * self.scalars_per_row;
-        let end = start + self.scalars_per_row;
+        // Checked: the product wraps for a large enough index, and a wrapped
+        // one lands back inside the column and reads an unrelated row.
+        let start = index.checked_mul(self.scalars_per_row)?;
+        let end = start.checked_add(self.scalars_per_row)?;
         if end <= self.data.len() {
             Some(&self.data[start..end])
         } else {
@@ -883,6 +890,32 @@ mod tests {
             "the velocity joins the row that was open when it was logged"
         );
         assert_eq!(vel.at_logical_row(1), None, "no velocity was logged for it");
+    }
+
+    #[test]
+    fn a_column_of_no_scalars_is_refused() {
+        let refused = std::panic::catch_unwind(|| ComponentColumn::new(0));
+        assert!(
+            refused.is_err(),
+            "a zero-width column could hold no row, leaving the map the only \
+             record of one"
+        );
+    }
+
+    #[test]
+    fn a_row_past_the_column_is_absent_however_far_past() {
+        let mut column = ComponentColumn::new(2);
+        column.push_at(&[1.0, 2.0], 0);
+
+        assert_eq!(column.get_row(1), None, "one row past the end");
+        // The product `index * 2` wraps to 0 here, which would read row 0.
+        let wraps_to_zero = 1usize << 63;
+        assert_eq!(column.get_row(wraps_to_zero), None, "far past the end");
+        assert_eq!(
+            column.at_logical_row(wraps_to_zero),
+            None,
+            "and the logical-row lookup says the same"
+        );
     }
 
     #[test]

--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -77,7 +77,11 @@ impl RowMap {
 #[derive(Debug, Clone)]
 pub struct ComponentColumn {
     /// Number of f64 values per row.
-    pub scalars_per_row: usize,
+    ///
+    /// Where a row starts in `data` and how many rows there are both follow from
+    /// this, so changing it after an append would move every row without the map
+    /// hearing about it.
+    pub(crate) scalars_per_row: usize,
     /// Flat storage: scalars_per_row * num_rows f64 values.
     pub(crate) data: Vec<f64>,
     /// Which logical row each stored row belongs to.
@@ -135,6 +139,11 @@ impl ComponentColumn {
             .len()
             .checked_div(self.scalars_per_row)
             .unwrap_or(0)
+    }
+
+    /// How many scalars one row holds.
+    pub fn scalars_per_row(&self) -> usize {
+        self.scalars_per_row
     }
 
     /// The flat storage, `scalars_per_row` values per stored row.
@@ -882,6 +891,7 @@ mod tests {
         column.push_at(&[1.0, 2.0], 0);
         column.push_at(&[5.0, 6.0], 5);
 
+        assert_eq!(column.scalars_per_row(), 2, "the width it was built with");
         assert_eq!(
             column.scalars(),
             [1.0, 2.0, 5.0, 6.0],

--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -480,6 +480,121 @@ mod tests {
     }
 
     #[test]
+    fn a_column_logged_every_step_needs_no_row_mapping() {
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/dense");
+
+        for i in 0..4u64 {
+            let tp = TimePoint::new().with_sim_time(i as f64).with_step(i);
+            rec.log_temporal(&sat, &tp, &Position3D(Vector3::new(i as f64, 0.0, 0.0)));
+        }
+
+        let store = rec.entity(&sat).unwrap();
+        let col = &store.columns[&Position3D::component_name()];
+        assert_eq!(
+            col.rows,
+            RowMap::Dense,
+            "the common case must not allocate a mapping"
+        );
+        assert_eq!(store.timelines[&TimelineName::SimTime].rows, RowMap::Dense);
+        for i in 0..4 {
+            assert_eq!(col.logical_row_of(i), i);
+            assert_eq!(col.at_logical_row(i), col.get_row(i));
+        }
+    }
+
+    /// Skipping a component at some steps is how "no value here" is said. Its
+    /// column records the rows it does cover, so the values stay on their own
+    /// steps instead of sliding onto the leading ones (#375).
+    #[test]
+    fn a_column_that_skips_steps_records_the_rows_it_covers() {
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/sparse");
+
+        for i in 0..6u64 {
+            let tp = TimePoint::new().with_sim_time(i as f64).with_step(i);
+            rec.log_temporal(&sat, &tp, &Position3D(Vector3::new(i as f64, 0.0, 0.0)));
+            if i >= 4 {
+                rec.log_temporal(&sat, &tp, &Velocity3D(Vector3::new(0.0, i as f64, 0.0)));
+            }
+        }
+
+        let store = rec.entity(&sat).unwrap();
+        assert_eq!(store.num_rows, 6);
+
+        let vel = &store.columns[&Velocity3D::component_name()];
+        assert_eq!(vel.num_rows(), 2);
+        assert_eq!(vel.rows, RowMap::Sparse(vec![4, 5]));
+        assert_eq!(vel.logical_row_of(0), 4);
+        assert_eq!(vel.logical_row_of(1), 5);
+
+        assert_eq!(vel.at_logical_row(4), Some([0.0, 4.0, 0.0].as_slice()));
+        assert_eq!(vel.at_logical_row(5), Some([0.0, 5.0, 0.0].as_slice()));
+        for absent in [0, 1, 2, 3] {
+            assert_eq!(
+                vel.at_logical_row(absent),
+                None,
+                "row {absent} has no velocity"
+            );
+        }
+
+        // The dense column alongside it is untouched.
+        let pos = &store.columns[&Position3D::component_name()];
+        assert_eq!(pos.rows, RowMap::Dense);
+        assert_eq!(pos.num_rows(), 6);
+    }
+
+    /// A `TimePoint` need not name every axis, so an axis can cover only some
+    /// rows. Keeping that mapping is what stops two axes of different lengths
+    /// from being read as if index 0 of each meant the same row.
+    #[test]
+    fn an_axis_records_the_rows_it_covers() {
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/axes");
+
+        for i in 0..6u64 {
+            let tp = if i < 3 {
+                TimePoint::new().with_step(i)
+            } else {
+                TimePoint::new().with_sim_time(i as f64).with_step(i)
+            };
+            rec.log_temporal(&sat, &tp, &Position3D(Vector3::new(i as f64, 0.0, 0.0)));
+        }
+
+        let store = rec.entity(&sat).unwrap();
+        assert_eq!(store.num_rows, 6);
+
+        let step = &store.timelines[&TimelineName::Step];
+        assert_eq!(step.len(), 6);
+        assert_eq!(step.rows, RowMap::Dense);
+
+        let sim = &store.timelines[&TimelineName::SimTime];
+        assert_eq!(sim.len(), 3);
+        assert_eq!(sim.rows, RowMap::Sparse(vec![3, 4, 5]));
+        assert_eq!(sim.at_logical_row(3), Some(TimeIndex::Seconds(3.0)));
+        assert_eq!(sim.at_logical_row(0), None, "row 0 named no sim_time");
+    }
+
+    /// Two calls at the same `TimePoint` fill one row, which is what lets an
+    /// archetype log several components per step.
+    #[test]
+    fn calls_at_one_time_point_share_a_row() {
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/shared");
+        let tp = TimePoint::new().with_sim_time(7.0).with_step(2);
+
+        rec.log_temporal(&sat, &tp, &Position3D(Vector3::new(1.0, 2.0, 3.0)));
+        rec.log_temporal(&sat, &tp, &Velocity3D(Vector3::new(4.0, 5.0, 6.0)));
+
+        let store = rec.entity(&sat).unwrap();
+        assert_eq!(store.num_rows, 1);
+        assert_eq!(store.timelines[&TimelineName::SimTime].len(), 1);
+        for name in [Position3D::component_name(), Velocity3D::component_name()] {
+            assert_eq!(store.columns[&name].logical_row_of(0), 0);
+        }
+    }
+
+    #[test]
     fn log_orbital_state() {
         let mut rec = Recording::new();
         let sat = EntityPath::parse("/world/sat/iss");

--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -206,9 +206,33 @@ pub struct EntityStore {
     /// assembled by hand rather than through `log_temporal` has to set this: at
     /// zero, nothing temporal is written.
     pub num_rows: usize,
-    /// The `TimePoint` of the row currently being filled. Two `log_temporal`
-    /// calls carrying the same `TimePoint` belong to one logical row.
-    last_time_point: Option<TimePoint>,
+}
+
+impl EntityStore {
+    /// The `TimePoint` of the last logical row, or `None` when there is no row.
+    ///
+    /// Read back from `timelines` rather than remembered from the last
+    /// `log_temporal`: the fields above are public, so a caller can empty a
+    /// store that has already been logged to. A remembered point would then
+    /// describe rows that are gone, and the next `log_temporal` would take the
+    /// store to be mid-row with no row to be in.
+    fn last_row_time_point(&self) -> Option<TimePoint> {
+        let last_row = self.num_rows.checked_sub(1)?;
+        // `log_temporal` pushes every axis of a point at the one row it opens
+        // for it, so in a store it built, the axes holding `last_row` are that
+        // row's point. `is_same_row` ignores axis order, so the order the map
+        // yields them in does not matter.
+        Some(
+            self.timelines
+                .iter()
+                .fold(TimePoint::new(), |point, (name, axis)| {
+                    match axis.at_logical_row(last_row) {
+                        Some(index) => point.with_axis(name.clone(), index),
+                        None => point,
+                    }
+                }),
+        )
+    }
 }
 
 /// Simulation metadata that can be embedded in a Recording.
@@ -342,8 +366,7 @@ impl Recording {
         // from row counts, which is what let a column that skipped steps line up
         // with the wrong times.
         let continues_row = store
-            .last_time_point
-            .as_ref()
+            .last_row_time_point()
             .is_some_and(|last| last.is_same_row(time_point));
         // A component logged twice at one time point is two samples of it, so the
         // second starts a row of its own at the same time rather than landing on
@@ -358,7 +381,6 @@ impl Recording {
                         && column.logical_row_of(column.num_rows() - 1) == store.num_rows - 1
                 });
         if !continues_row || row_taken {
-            store.last_time_point = Some(time_point.clone());
             let logical_row = store.num_rows;
             for (timeline_name, time_index) in time_point.indices() {
                 store
@@ -369,6 +391,8 @@ impl Recording {
             }
             store.num_rows += 1;
         }
+        // There is a row to write into either way: the branch above opened one,
+        // and `continues_row` is only true of a store that already has rows.
         let logical_row = store.num_rows - 1;
 
         store
@@ -813,6 +837,37 @@ mod tests {
             "the velocity joins the row that was open when it was logged"
         );
         assert_eq!(vel.at_logical_row(1), None, "no velocity was logged for it");
+    }
+
+    #[test]
+    fn a_cleared_store_logged_at_the_same_time_starts_over() {
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/cleared");
+        let tp = TimePoint::new().with_sim_time(1.0).with_step(0);
+
+        rec.log_temporal(&sat, &tp, &Position3D(Vector3::new(1.0, 0.0, 0.0)));
+
+        // `EntityStore`'s fields are public, so a caller can empty a store that
+        // has already been logged to.
+        let store = rec.entity_mut(&sat);
+        store.columns.clear();
+        store.timelines.clear();
+        store.num_rows = 0;
+
+        rec.log_temporal(&sat, &tp, &Position3D(Vector3::new(2.0, 0.0, 0.0)));
+
+        let store = rec.entity(&sat).unwrap();
+        assert_eq!(
+            store.num_rows, 1,
+            "the same time point opens row 0 again rather than continuing the row the clear removed"
+        );
+        let pos = &store.columns[&Position3D::component_name()];
+        assert_eq!(pos.at_logical_row(0).map(|v| v[0]), Some(2.0));
+        assert_eq!(
+            store.timelines[&TimelineName::SimTime].at_logical_row(0),
+            Some(TimeIndex::Seconds(1.0)),
+            "and the row carries its time"
+        );
     }
 
     #[test]

--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -14,7 +14,7 @@ use crate::record::timeline::{TimeIndex, TimePoint, TimelineName};
 /// keep the times they were logged at rather than lining up with the leading
 /// rows.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub enum RowMap {
+pub(crate) enum RowMap {
     #[default]
     Dense,
     /// Logical row of each stored entry, ascending.
@@ -69,14 +69,19 @@ impl RowMap {
 }
 
 /// A column of component data (SoA layout for a single component type).
+///
+/// The storage and the row map have to agree — the map is what says which
+/// entity row each stored row is — so they are written only through
+/// [`Self::push_at`], which checks. Read them with [`Self::scalars`] and the
+/// row lookups.
 #[derive(Debug, Clone)]
 pub struct ComponentColumn {
     /// Number of f64 values per row.
     pub scalars_per_row: usize,
     /// Flat storage: scalars_per_row * num_rows f64 values.
-    pub data: Vec<f64>,
+    pub(crate) data: Vec<f64>,
     /// Which logical row each stored row belongs to.
-    pub rows: RowMap,
+    pub(crate) rows: RowMap,
 }
 
 impl ComponentColumn {
@@ -132,6 +137,14 @@ impl ComponentColumn {
             .unwrap_or(0)
     }
 
+    /// The flat storage, `scalars_per_row` values per stored row.
+    ///
+    /// Stored rows, so a column that skipped steps is shorter than the entity;
+    /// [`Self::logical_row_of`] says which row each one is.
+    pub fn scalars(&self) -> &[f64] {
+        &self.data
+    }
+
     /// The `index`-th *stored* row. For a column that skipped steps this is not
     /// logical row `index`; use [`Self::at_logical_row`] for that.
     pub fn get_row(&self, index: usize) -> Option<&[f64]> {
@@ -161,10 +174,12 @@ impl ComponentColumn {
 /// A `TimePoint` need not name every axis the entity uses, so an axis can cover
 /// only some rows. Keeping the mapping here is what lets two axes that cover
 /// different rows still be read as the same entity's timeline.
+/// Written only through [`Self::push_at`], for the reason
+/// [`ComponentColumn`] is.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct TimelineColumn {
-    pub data: Vec<TimeIndex>,
-    pub rows: RowMap,
+    pub(crate) data: Vec<TimeIndex>,
+    pub(crate) rows: RowMap,
 }
 
 /// Collects a dense axis, one time per logical row.
@@ -191,6 +206,11 @@ impl TimelineColumn {
 
     pub fn len(&self) -> usize {
         self.data.len()
+    }
+
+    /// The times this axis holds, one per row it covers.
+    pub fn times(&self) -> &[TimeIndex] {
+        &self.data
     }
 
     pub fn is_empty(&self) -> bool {
@@ -854,6 +874,22 @@ mod tests {
             "the velocity joins the row that was open when it was logged"
         );
         assert_eq!(vel.at_logical_row(1), None, "no velocity was logged for it");
+    }
+
+    #[test]
+    fn a_sparse_column_reads_back_flat_and_by_row() {
+        let mut column = ComponentColumn::new(2);
+        column.push_at(&[1.0, 2.0], 0);
+        column.push_at(&[5.0, 6.0], 5);
+
+        assert_eq!(
+            column.scalars(),
+            [1.0, 2.0, 5.0, 6.0],
+            "the flat view holds the stored rows, not the skipped ones"
+        );
+        assert_eq!(column.logical_row_of(1), 5, "which row the second one is");
+        assert_eq!(column.at_logical_row(5), Some(&[5.0, 6.0][..]));
+        assert_eq!(column.at_logical_row(1), None, "no row 1 was stored");
     }
 
     #[test]

--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -102,13 +102,24 @@ impl ComponentColumn {
     ///
     /// # Panics
     ///
-    /// If `logical_row` is not greater than the one given for the previous
-    /// stored row, or does not fit in `u32`. The row lookup binary-searches, so
-    /// either would make it resolve to whichever entry the search landed on.
-    /// The column is left as it was, so a caller that catches the panic does not
-    /// go on holding scalars no row maps to.
+    /// If `scalars` is not one row wide, or if `logical_row` is not greater than
+    /// the one given for the previous stored row or does not fit in `u32`. The
+    /// row lookup binary-searches, so either row error would make it resolve to
+    /// whichever entry the search landed on. The column is left as it was, so a
+    /// caller that catches the panic does not go on holding scalars no row maps
+    /// to.
     pub fn push_at(&mut self, scalars: &[f64], logical_row: usize) {
-        debug_assert_eq!(scalars.len(), self.scalars_per_row);
+        // Checked in release too, like the row map's asserts: a short row runs
+        // into the next one's scalars. Measured before this was checked — two
+        // scalars into a three-wide column, then a whole row — the last row read
+        // back as `[9.0, 9.0, 7.0]`, and `num_rows()` had stopped agreeing with
+        // the row map.
+        assert_eq!(
+            scalars.len(),
+            self.scalars_per_row,
+            "a row of this column is {} scalars wide",
+            self.scalars_per_row
+        );
         self.rows.record(self.num_rows(), logical_row);
         self.data.extend_from_slice(scalars);
     }
@@ -843,6 +854,28 @@ mod tests {
             "the velocity joins the row that was open when it was logged"
         );
         assert_eq!(vel.at_logical_row(1), None, "no velocity was logged for it");
+    }
+
+    #[test]
+    fn a_row_of_the_wrong_width_is_refused() {
+        let mut column = ComponentColumn::new(3);
+        column.push_at(&[1.0, 2.0, 3.0], 0);
+
+        let refused = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            column.push_at(&[9.0, 9.0], 1);
+        }));
+        assert!(
+            refused.is_err(),
+            "two scalars are not a row of a three-wide column"
+        );
+        assert_eq!(column.data.len(), 3, "no partial row was appended");
+
+        column.push_at(&[7.0, 7.0, 7.0], 1);
+        assert_eq!(
+            column.at_logical_row(1),
+            Some(&[7.0, 7.0, 7.0][..]),
+            "so the next row is whole rather than carrying the refused scalars"
+        );
     }
 
     #[test]

--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -6,6 +6,53 @@ use crate::record::components::{AngularVelocity3D, Quaternion4D};
 use crate::record::entity_path::EntityPath;
 use crate::record::timeline::{TimeIndex, TimePoint, TimelineName};
 
+/// Which logical row each stored entry belongs to.
+///
+/// A component logged at every step, which is the common case, needs no mapping:
+/// stored entry `k` is logical row `k`. `Sparse` carries the mapping for a
+/// component that was logged at only some of the entity's steps, so its values
+/// keep the times they were logged at rather than lining up with the leading
+/// rows.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum RowMap {
+    #[default]
+    Dense,
+    /// Logical row of each stored entry, ascending.
+    Sparse(Vec<u32>),
+}
+
+impl RowMap {
+    /// Record that the entry at stored index `stored` is logical row `logical`,
+    /// switching away from `Dense` only once the two actually diverge.
+    fn record(&mut self, stored: usize, logical: usize) {
+        match self {
+            Self::Dense if stored == logical => {}
+            Self::Dense => {
+                let mut rows: Vec<u32> = (0..stored as u32).collect();
+                rows.push(logical as u32);
+                *self = Self::Sparse(rows);
+            }
+            Self::Sparse(rows) => rows.push(logical as u32),
+        }
+    }
+
+    /// Logical row of stored entry `stored`.
+    pub fn logical_row(&self, stored: usize) -> usize {
+        match self {
+            Self::Dense => stored,
+            Self::Sparse(rows) => rows.get(stored).map(|r| *r as usize).unwrap_or(stored),
+        }
+    }
+
+    /// Stored index holding logical row `logical`, if it holds one at all.
+    pub fn stored_index(&self, logical: usize) -> Option<usize> {
+        match self {
+            Self::Dense => Some(logical),
+            Self::Sparse(rows) => rows.binary_search(&(logical as u32)).ok(),
+        }
+    }
+}
+
 /// A column of component data (SoA layout for a single component type).
 #[derive(Debug, Clone)]
 pub struct ComponentColumn {
@@ -13,6 +60,8 @@ pub struct ComponentColumn {
     pub scalars_per_row: usize,
     /// Flat storage: scalars_per_row * num_rows f64 values.
     pub data: Vec<f64>,
+    /// Which logical row each stored row belongs to.
+    pub rows: RowMap,
 }
 
 impl ComponentColumn {
@@ -20,12 +69,20 @@ impl ComponentColumn {
         ComponentColumn {
             scalars_per_row,
             data: Vec::new(),
+            rows: RowMap::Dense,
         }
     }
 
     pub fn push(&mut self, scalars: &[f64]) {
         debug_assert_eq!(scalars.len(), self.scalars_per_row);
         self.data.extend_from_slice(scalars);
+    }
+
+    /// Append `scalars` as the entity's logical row `logical_row`.
+    pub fn push_at(&mut self, scalars: &[f64], logical_row: usize) {
+        let stored = self.num_rows();
+        self.push(scalars);
+        self.rows.record(stored, logical_row);
     }
 
     pub fn num_rows(&self) -> usize {
@@ -36,6 +93,8 @@ impl ComponentColumn {
             .unwrap_or(0)
     }
 
+    /// The `index`-th *stored* row. For a column that skipped steps this is not
+    /// logical row `index`; use [`Self::at_logical_row`] for that.
     pub fn get_row(&self, index: usize) -> Option<&[f64]> {
         let start = index * self.scalars_per_row;
         let end = start + self.scalars_per_row;
@@ -44,6 +103,64 @@ impl ComponentColumn {
         } else {
             None
         }
+    }
+
+    /// The value this column holds at the entity's logical row `logical_row`,
+    /// or `None` when the component was not logged at that step.
+    pub fn at_logical_row(&self, logical_row: usize) -> Option<&[f64]> {
+        self.get_row(self.rows.stored_index(logical_row)?)
+    }
+
+    /// Logical row of the `index`-th stored row.
+    pub fn logical_row_of(&self, index: usize) -> usize {
+        self.rows.logical_row(index)
+    }
+}
+
+/// Time indices for one axis, with the logical row each one belongs to.
+///
+/// A `TimePoint` need not name every axis the entity uses, so an axis can cover
+/// only some rows. Keeping the mapping here is what lets two axes that cover
+/// different rows still be read as the same entity's timeline.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TimelineColumn {
+    pub data: Vec<TimeIndex>,
+    pub rows: RowMap,
+}
+
+/// Collects a dense axis, one time per logical row.
+impl FromIterator<TimeIndex> for TimelineColumn {
+    fn from_iter<I: IntoIterator<Item = TimeIndex>>(iter: I) -> Self {
+        Self {
+            data: iter.into_iter().collect(),
+            rows: RowMap::Dense,
+        }
+    }
+}
+
+impl TimelineColumn {
+    pub fn push_at(&mut self, index: TimeIndex, logical_row: usize) {
+        let stored = self.data.len();
+        self.data.push(index);
+        self.rows.record(stored, logical_row);
+    }
+
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// The time this axis holds at logical row `logical_row`.
+    pub fn at_logical_row(&self, logical_row: usize) -> Option<TimeIndex> {
+        self.data.get(self.rows.stored_index(logical_row)?).copied()
+    }
+
+    /// Logical row of the `index`-th stored time.
+    pub fn logical_row_of(&self, index: usize) -> usize {
+        self.rows.logical_row(index)
     }
 }
 
@@ -54,10 +171,13 @@ pub struct EntityStore {
     pub static_data: HashMap<ComponentName, Vec<f64>>,
     /// Temporal component columns.
     pub columns: HashMap<ComponentName, ComponentColumn>,
-    /// Time indices for each timeline (parallel arrays with component columns).
-    pub timelines: HashMap<TimelineName, Vec<TimeIndex>>,
+    /// Time indices for each timeline, each carrying the logical rows it covers.
+    pub timelines: HashMap<TimelineName, TimelineColumn>,
     /// Number of temporal rows logged.
     pub num_rows: usize,
+    /// The `TimePoint` of the row currently being filled. Two `log_temporal`
+    /// calls carrying the same `TimePoint` belong to one logical row.
+    last_time_point: Option<TimePoint>,
 }
 
 /// Simulation metadata that can be embedded in a Recording.
@@ -164,10 +284,13 @@ impl Recording {
 
     /// Log temporal component data at a specific time point.
     ///
-    /// When multiple components are logged at the same time point (e.g. via
-    /// [`log_orbital_state`](Self::log_orbital_state)), the timeline indices
-    /// are pushed only once per logical time step, keeping
-    /// `timelines[*].len() == num_rows` invariant.
+    /// Calls carrying the same `TimePoint` fill one logical row, so logging
+    /// several components at one time step (e.g. via
+    /// [`log_orbital_state`](Self::log_orbital_state)) advances the row once.
+    ///
+    /// Skipping a component at some step is how "no value here" is expressed:
+    /// its column records which logical rows it does cover, so its values keep
+    /// the times they were logged at.
     pub fn log_temporal<C: Component>(
         &mut self,
         entity: &EntityPath,
@@ -184,39 +307,29 @@ impl Recording {
                 field_names: C::field_names().iter().map(|s| s.to_string()).collect(),
             });
 
-        let column = store
-            .columns
-            .entry(C::component_name())
-            .or_insert_with(|| ComponentColumn::new(C::num_scalars()));
-
-        column.push(&component.to_scalars());
-
-        // Push timeline indices only once per logical time step.
-        // After pushing component data, if any column has more rows than
-        // there are timeline entries, this is a new logical row.
-        let max_component_rows = store
-            .columns
-            .values()
-            .map(|c| c.num_rows())
-            .max()
-            .unwrap_or(0);
-        let timeline_len = store
-            .timelines
-            .values()
-            .map(|tl| tl.len())
-            .max()
-            .unwrap_or(0);
-
-        if max_component_rows > timeline_len {
+        // The row is identified by the time point itself rather than inferred
+        // from row counts, which is what let a column that skipped steps line up
+        // with the wrong times.
+        let is_new_row = store.last_time_point.as_ref() != Some(time_point);
+        if is_new_row {
+            store.last_time_point = Some(time_point.clone());
+            let logical_row = store.num_rows;
             for (timeline_name, time_index) in time_point.indices() {
                 store
                     .timelines
                     .entry(timeline_name.clone())
                     .or_default()
-                    .push(*time_index);
+                    .push_at(*time_index, logical_row);
             }
             store.num_rows += 1;
         }
+        let logical_row = store.num_rows - 1;
+
+        store
+            .columns
+            .entry(C::component_name())
+            .or_insert_with(|| ComponentColumn::new(C::num_scalars()))
+            .push_at(&component.to_scalars(), logical_row);
     }
 
     /// Convenience: log an OrbitalState archetype (position + velocity).

--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -25,6 +25,12 @@ impl RowMap {
     /// Record that the entry at stored index `stored` is logical row `logical`,
     /// switching away from `Dense` only once the two actually diverge.
     fn record(&mut self, stored: usize, logical: usize) {
+        // `stored_index` binary-searches, so the rows have to stay strictly
+        // ascending. Callers give one entry per logical row.
+        debug_assert!(
+            logical >= stored && u32::try_from(logical).is_ok(),
+            "logical row {logical} cannot be recorded at stored index {stored}"
+        );
         match self {
             Self::Dense if stored == logical => {}
             Self::Dense => {
@@ -73,15 +79,21 @@ impl ComponentColumn {
         }
     }
 
-    pub fn push(&mut self, scalars: &[f64]) {
-        debug_assert_eq!(scalars.len(), self.scalars_per_row);
-        self.data.extend_from_slice(scalars);
+    /// Append `scalars` as the next logical row.
+    ///
+    /// Mixing this with [`Self::push_at`] on one column would leave the row map
+    /// disagreeing with the data, so it is deliberately not public: a caller
+    /// that knows about logical rows uses `push_at`.
+    pub(crate) fn push(&mut self, scalars: &[f64]) {
+        let stored = self.num_rows();
+        self.push_at(scalars, stored);
     }
 
     /// Append `scalars` as the entity's logical row `logical_row`.
     pub fn push_at(&mut self, scalars: &[f64], logical_row: usize) {
+        debug_assert_eq!(scalars.len(), self.scalars_per_row);
         let stored = self.num_rows();
-        self.push(scalars);
+        self.data.extend_from_slice(scalars);
         self.rows.record(stored, logical_row);
     }
 
@@ -173,7 +185,11 @@ pub struct EntityStore {
     pub columns: HashMap<ComponentName, ComponentColumn>,
     /// Time indices for each timeline, each carrying the logical rows it covers.
     pub timelines: HashMap<TimelineName, TimelineColumn>,
-    /// Number of temporal rows logged.
+    /// Number of logical rows logged.
+    ///
+    /// The export addresses the columns and the axes by logical row, so a store
+    /// assembled by hand rather than through `log_temporal` has to set this: at
+    /// zero, nothing temporal is written.
     pub num_rows: usize,
     /// The `TimePoint` of the row currently being filled. Two `log_temporal`
     /// calls carrying the same `TimePoint` belong to one logical row.
@@ -310,11 +326,23 @@ impl Recording {
         // The row is identified by the time point itself rather than inferred
         // from row counts, which is what let a column that skipped steps line up
         // with the wrong times.
-        let is_new_row = !store
+        let continues_row = store
             .last_time_point
             .as_ref()
             .is_some_and(|last| last.is_same_row(time_point));
-        if is_new_row {
+        // A component logged twice at one time point is two samples of it, so the
+        // second starts a row of its own at the same time rather than landing on
+        // the row the first already occupies. That also keeps one entry per
+        // logical row in the column's `RowMap`.
+        let row_taken = continues_row
+            && store
+                .columns
+                .get(&C::component_name())
+                .is_some_and(|column| {
+                    column.num_rows() > 0
+                        && column.logical_row_of(column.num_rows() - 1) == store.num_rows - 1
+                });
+        if !continues_row || row_taken {
             store.last_time_point = Some(time_point.clone());
             let logical_row = store.num_rows;
             for (timeline_name, time_index) in time_point.indices() {
@@ -500,9 +528,9 @@ mod tests {
             "the common case must not allocate a mapping"
         );
         assert_eq!(store.timelines[&TimelineName::SimTime].rows, RowMap::Dense);
+        // Dense addressing means the two lookups agree and each row is itself.
         for i in 0..4 {
-            assert_eq!(col.logical_row_of(i), i);
-            assert_eq!(col.at_logical_row(i), col.get_row(i));
+            assert_eq!(col.at_logical_row(i), Some([i as f64, 0.0, 0.0].as_slice()));
         }
     }
 
@@ -655,8 +683,70 @@ mod tests {
         assert_eq!(store.num_rows, 3);
         let col = &store.columns[&Position3D::component_name()];
         assert_eq!(col.rows, RowMap::Dense);
-        for i in 0..3 {
-            assert_eq!(col.logical_row_of(i), i);
+        // Both t=0 rows are kept, in the order they were logged.
+        let times: Vec<f64> = (0..3).map(|i| col.at_logical_row(i).unwrap()[0]).collect();
+        assert_eq!(times, vec![0.0, 10.0, 0.0]);
+    }
+
+    /// `+0.0` and `-0.0` are the same instant, so they name one row. Comparing
+    /// the bit patterns would split the step and leave the CSV writer with no
+    /// velocity at the position's row.
+    #[test]
+    fn signed_zero_is_one_row() {
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/zero");
+
+        rec.log_temporal(
+            &sat,
+            &TimePoint::new().with_sim_time(0.0),
+            &Position3D(Vector3::new(1.0, 2.0, 3.0)),
+        );
+        rec.log_temporal(
+            &sat,
+            &TimePoint::new().with_sim_time(-0.0),
+            &Velocity3D(Vector3::new(4.0, 5.0, 6.0)),
+        );
+
+        assert_eq!(rec.entity(&sat).unwrap().num_rows, 1);
+    }
+
+    /// One point holds one index per axis, so a repeated `with_*` is the later
+    /// value. Two entries for one axis would be written to it twice and would
+    /// make two points that name different times compare as one row.
+    #[test]
+    fn a_repeated_axis_is_the_later_value() {
+        let tp = TimePoint::new().with_sim_time(1.0).with_sim_time(2.0);
+        assert_eq!(tp.indices().len(), 1);
+        assert_eq!(
+            tp.get(&TimelineName::SimTime),
+            Some(TimeIndex::Seconds(2.0))
+        );
+        assert!(!tp.is_same_row(&TimePoint::new().with_sim_time(1.0)));
+    }
+
+    /// Logging one component twice at a time point is two samples of it, so the
+    /// second takes a row of its own at the same time. Landing both on one row
+    /// would leave the column's row map with a repeated row, which its
+    /// binary-searched lookup cannot resolve.
+    #[test]
+    fn one_component_logged_twice_at_a_time_takes_two_rows() {
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/twice");
+        let tp = TimePoint::new().with_sim_time(4.0).with_step(1);
+
+        rec.log_temporal(&sat, &tp, &Position3D(Vector3::new(1.0, 0.0, 0.0)));
+        rec.log_temporal(&sat, &tp, &Position3D(Vector3::new(2.0, 0.0, 0.0)));
+
+        let store = rec.entity(&sat).unwrap();
+        assert_eq!(store.num_rows, 2);
+        let col = &store.columns[&Position3D::component_name()];
+        assert_eq!(col.rows, RowMap::Dense);
+        assert_eq!(col.at_logical_row(0), Some([1.0, 0.0, 0.0].as_slice()));
+        assert_eq!(col.at_logical_row(1), Some([2.0, 0.0, 0.0].as_slice()));
+        // Both rows carry the time they were logged at.
+        let axis = &store.timelines[&TimelineName::SimTime];
+        for row in 0..2 {
+            assert_eq!(axis.at_logical_row(row), Some(TimeIndex::Seconds(4.0)));
         }
     }
 

--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -105,11 +105,12 @@ impl ComponentColumn {
     /// If `logical_row` is not greater than the one given for the previous
     /// stored row, or does not fit in `u32`. The row lookup binary-searches, so
     /// either would make it resolve to whichever entry the search landed on.
+    /// The column is left as it was, so a caller that catches the panic does not
+    /// go on holding scalars no row maps to.
     pub fn push_at(&mut self, scalars: &[f64], logical_row: usize) {
         debug_assert_eq!(scalars.len(), self.scalars_per_row);
-        let stored = self.num_rows();
+        self.rows.record(self.num_rows(), logical_row);
         self.data.extend_from_slice(scalars);
-        self.rows.record(stored, logical_row);
     }
 
     pub fn num_rows(&self) -> usize {
@@ -166,10 +167,15 @@ impl FromIterator<TimeIndex> for TimelineColumn {
 }
 
 impl TimelineColumn {
+    /// Append `index` as the axis's entry for logical row `logical_row`.
+    ///
+    /// # Panics
+    ///
+    /// On the same rows [`ComponentColumn::push_at`] refuses, and likewise
+    /// without appending.
     pub fn push_at(&mut self, index: TimeIndex, logical_row: usize) {
-        let stored = self.data.len();
+        self.rows.record(self.data.len(), logical_row);
         self.data.push(index);
-        self.rows.record(stored, logical_row);
     }
 
     pub fn len(&self) -> usize {
@@ -837,6 +843,34 @@ mod tests {
             "the velocity joins the row that was open when it was logged"
         );
         assert_eq!(vel.at_logical_row(1), None, "no velocity was logged for it");
+    }
+
+    #[test]
+    fn a_refused_row_appends_nothing() {
+        let mut column = ComponentColumn::new(3);
+        column.push_at(&[1.0, 2.0, 3.0], 0);
+
+        // Rows have to ascend for the map to stay searchable, so row 0 a second
+        // time is refused.
+        let refused = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            column.push_at(&[9.0, 9.0, 9.0], 0);
+        }));
+        assert!(refused.is_err(), "the map cannot hold a repeated row");
+        assert_eq!(
+            column.num_rows(),
+            1,
+            "the refused scalars are not left in the column"
+        );
+        assert_eq!(column.at_logical_row(0), Some(&[1.0, 2.0, 3.0][..]));
+
+        let mut axis = TimelineColumn::default();
+        axis.push_at(TimeIndex::Sequence(0), 0);
+        let refused = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            axis.push_at(TimeIndex::Sequence(7), 0);
+        }));
+        assert!(refused.is_err());
+        assert_eq!(axis.len(), 1, "nor the refused time");
+        assert_eq!(axis.at_logical_row(0), Some(TimeIndex::Sequence(0)));
     }
 
     #[test]

--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -310,7 +310,10 @@ impl Recording {
         // The row is identified by the time point itself rather than inferred
         // from row counts, which is what let a column that skipped steps line up
         // with the wrong times.
-        let is_new_row = store.last_time_point.as_ref() != Some(time_point);
+        let is_new_row = !store
+            .last_time_point
+            .as_ref()
+            .is_some_and(|last| last.is_same_row(time_point));
         if is_new_row {
             store.last_time_point = Some(time_point.clone());
             let logical_row = store.num_rows;
@@ -591,6 +594,69 @@ mod tests {
         assert_eq!(store.timelines[&TimelineName::SimTime].len(), 1);
         for name in [Position3D::component_name(), Velocity3D::component_name()] {
             assert_eq!(store.columns[&name].logical_row_of(0), 0);
+        }
+    }
+
+    /// The axes of a `TimePoint` name a row regardless of the order they were
+    /// added in. Comparing the backing `Vec` would split one step into two rows
+    /// and leave position and velocity on different rows.
+    #[test]
+    fn axis_order_does_not_split_a_row() {
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/order");
+
+        let a = TimePoint::new().with_sim_time(7.0).with_step(2);
+        let b = TimePoint::new().with_step(2).with_sim_time(7.0);
+
+        rec.log_temporal(&sat, &a, &Position3D(Vector3::new(1.0, 2.0, 3.0)));
+        rec.log_temporal(&sat, &b, &Velocity3D(Vector3::new(4.0, 5.0, 6.0)));
+
+        let store = rec.entity(&sat).unwrap();
+        assert_eq!(
+            store.num_rows, 1,
+            "one step, whichever order the axes came in"
+        );
+        assert_eq!(store.timelines[&TimelineName::SimTime].len(), 1);
+        assert_eq!(
+            store.columns[&Position3D::component_name()].logical_row_of(0),
+            store.columns[&Velocity3D::component_name()].logical_row_of(0),
+        );
+    }
+
+    /// A `NaN` time is still one row per step. Comparing `NaN` by value makes
+    /// every call a new row, which would scatter one step's components.
+    #[test]
+    fn a_nan_time_still_groups_one_step() {
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/nan");
+        let tp = TimePoint::new().with_sim_time(f64::NAN).with_step(0);
+
+        rec.log_temporal(&sat, &tp, &Position3D(Vector3::new(1.0, 2.0, 3.0)));
+        rec.log_temporal(&sat, &tp, &Velocity3D(Vector3::new(4.0, 5.0, 6.0)));
+
+        let store = rec.entity(&sat).unwrap();
+        assert_eq!(store.num_rows, 1);
+    }
+
+    /// Revisiting a time already logged starts a new row rather than merging
+    /// into the earlier one, which keeps `RowMap::Sparse` ascending — its
+    /// `stored_index` lookup binary-searches.
+    #[test]
+    fn a_revisited_time_starts_a_new_row() {
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/revisit");
+
+        for t in [0.0, 10.0, 0.0] {
+            let tp = TimePoint::new().with_sim_time(t);
+            rec.log_temporal(&sat, &tp, &Position3D(Vector3::new(t, 0.0, 0.0)));
+        }
+
+        let store = rec.entity(&sat).unwrap();
+        assert_eq!(store.num_rows, 3);
+        let col = &store.columns[&Position3D::component_name()];
+        assert_eq!(col.rows, RowMap::Dense);
+        for i in 0..3 {
+            assert_eq!(col.logical_row_of(i), i);
         }
     }
 

--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -26,13 +26,14 @@ impl RowMap {
     /// switching away from `Dense` only once the two actually diverge.
     fn record(&mut self, stored: usize, logical: usize) {
         // `stored_index` binary-searches, so the rows have to stay strictly
-        // ascending, and they are stored as `u32`. A repeated row would make the
-        // search resolve to whichever entry it landed on.
-        debug_assert!(
+        // ascending, and they are stored as `u32`. Breaking either would tie a
+        // value to an unrelated row, so these hold in release too: they are two
+        // integer comparisons against the Arrow work each row already costs.
+        assert!(
             u32::try_from(logical).is_ok(),
             "logical row {logical} is past the u32 the row map stores"
         );
-        debug_assert!(
+        assert!(
             stored == 0 || logical > self.logical_row(stored - 1),
             "logical row {logical} does not follow {} at stored index {stored}",
             self.logical_row(stored.saturating_sub(1)),
@@ -99,10 +100,11 @@ impl ComponentColumn {
 
     /// Append `scalars` as the entity's logical row `logical_row`.
     ///
-    /// `logical_row` has to be greater than the one given for the previous
-    /// stored row, and within `u32`. The row lookup binary-searches, so a
-    /// repeated or out-of-order row would make it resolve to whichever entry the
-    /// search landed on. A debug build asserts both.
+    /// # Panics
+    ///
+    /// If `logical_row` is not greater than the one given for the previous
+    /// stored row, or does not fit in `u32`. The row lookup binary-searches, so
+    /// either would make it resolve to whichever entry the search landed on.
     pub fn push_at(&mut self, scalars: &[f64], logical_row: usize) {
         debug_assert_eq!(scalars.len(), self.scalars_per_row);
         let stored = self.num_rows();
@@ -775,6 +777,42 @@ mod tests {
         // 2^32 + 5 truncates to 5, which must not be read as row 5.
         assert_eq!(col.at_logical_row(1usize << 32 | 5), None);
         assert_eq!(col.rows.stored_index(1usize << 32 | 5), None);
+    }
+
+    /// A component repeated at one time point opens the next row when it is
+    /// repeated, so a component logged in between belongs to the row that was
+    /// open at the time.
+    ///
+    /// Logging `Position(p0)`, `Velocity(v1)`, `Position(p1)` at one time point
+    /// says nothing about which position `v1` goes with — no `v0` was logged —
+    /// so this records the grouping rather than leaving it unspecified.
+    #[test]
+    fn a_component_between_two_samples_joins_the_open_row() {
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/between");
+        let tp = TimePoint::new().with_sim_time(1.0).with_step(0);
+
+        rec.log_temporal(&sat, &tp, &Position3D(Vector3::new(0.0, 0.0, 0.0)));
+        rec.log_temporal(&sat, &tp, &Velocity3D(Vector3::new(1.0, 0.0, 0.0)));
+        rec.log_temporal(&sat, &tp, &Position3D(Vector3::new(2.0, 0.0, 0.0)));
+
+        let store = rec.entity(&sat).unwrap();
+        assert_eq!(
+            store.num_rows, 2,
+            "the repeated position opens a second row"
+        );
+
+        let pos = &store.columns[&Position3D::component_name()];
+        assert_eq!(pos.at_logical_row(0).map(|v| v[0]), Some(0.0));
+        assert_eq!(pos.at_logical_row(1).map(|v| v[0]), Some(2.0));
+
+        let vel = &store.columns[&Velocity3D::component_name()];
+        assert_eq!(
+            vel.at_logical_row(0).map(|v| v[0]),
+            Some(1.0),
+            "the velocity joins the row that was open when it was logged"
+        );
+        assert_eq!(vel.at_logical_row(1), None, "no velocity was logged for it");
     }
 
     #[test]

--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -54,7 +54,9 @@ impl RowMap {
     pub fn stored_index(&self, logical: usize) -> Option<usize> {
         match self {
             Self::Dense => Some(logical),
-            Self::Sparse(rows) => rows.binary_search(&(logical as u32)).ok(),
+            // A row past the `u32` the map stores is held by no entry. Casting
+            // would wrap and could match an unrelated row.
+            Self::Sparse(rows) => rows.binary_search(&u32::try_from(logical).ok()?).ok(),
         }
     }
 }
@@ -748,6 +750,20 @@ mod tests {
         for row in 0..2 {
             assert_eq!(axis.at_logical_row(row), Some(TimeIndex::Seconds(4.0)));
         }
+    }
+
+    /// A logical row past the `u32` the map stores is held by no entry. Casting
+    /// would wrap and could match an unrelated row.
+    #[test]
+    fn a_row_past_the_map_domain_is_absent() {
+        let mut col = ComponentColumn::new(1);
+        col.push_at(&[1.0], 5);
+        assert_eq!(col.rows, RowMap::Sparse(vec![5]));
+
+        assert_eq!(col.at_logical_row(5), Some([1.0].as_slice()));
+        // 2^32 + 5 truncates to 5, which must not be read as row 5.
+        assert_eq!(col.at_logical_row(1usize << 32 | 5), None);
+        assert_eq!(col.rows.stored_index(1usize << 32 | 5), None);
     }
 
     #[test]

--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -26,10 +26,16 @@ impl RowMap {
     /// switching away from `Dense` only once the two actually diverge.
     fn record(&mut self, stored: usize, logical: usize) {
         // `stored_index` binary-searches, so the rows have to stay strictly
-        // ascending. Callers give one entry per logical row.
+        // ascending, and they are stored as `u32`. A repeated row would make the
+        // search resolve to whichever entry it landed on.
         debug_assert!(
-            logical >= stored && u32::try_from(logical).is_ok(),
-            "logical row {logical} cannot be recorded at stored index {stored}"
+            u32::try_from(logical).is_ok(),
+            "logical row {logical} is past the u32 the row map stores"
+        );
+        debug_assert!(
+            stored == 0 || logical > self.logical_row(stored - 1),
+            "logical row {logical} does not follow {} at stored index {stored}",
+            self.logical_row(stored.saturating_sub(1)),
         );
         match self {
             Self::Dense if stored == logical => {}
@@ -92,6 +98,11 @@ impl ComponentColumn {
     }
 
     /// Append `scalars` as the entity's logical row `logical_row`.
+    ///
+    /// `logical_row` has to be greater than the one given for the previous
+    /// stored row, and within `u32`. The row lookup binary-searches, so a
+    /// repeated or out-of-order row would make it resolve to whichever entry the
+    /// search landed on. A debug build asserts both.
     pub fn push_at(&mut self, scalars: &[f64], logical_row: usize) {
         debug_assert_eq!(scalars.len(), self.scalars_per_row);
         let stored = self.num_rows();

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -1594,11 +1594,11 @@ mod tests {
             .get(&TimelineName::SimTime)
             .expect("SimTime timeline missing");
         assert_eq!(sim_times.len(), 3);
-        match &sim_times.data[0] {
+        match &sim_times.times()[0] {
             TimeIndex::Seconds(t) => assert!((t - 0.0).abs() < 1e-9),
             other => panic!("expected Seconds, got {:?}", other),
         }
-        match &sim_times.data[2] {
+        match &sim_times.times()[2] {
             TimeIndex::Seconds(t) => assert!((t - 20.0).abs() < 1e-9),
             other => panic!("expected Seconds, got {:?}", other),
         }
@@ -2076,7 +2076,7 @@ mod tests {
             .get(&TimelineName::SimTime)
             .expect("a sim_time timeline");
         assert_eq!(times.len(), store.num_rows, "timeline and rows must agree");
-        assert_eq!(times.data, vec![TimeIndex::Seconds(10.0)]);
+        assert_eq!(times.times(), [TimeIndex::Seconds(10.0)]);
         for (name, col) in &store.columns {
             assert_eq!(
                 col.num_rows(),

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -1254,9 +1254,7 @@ fn to_rerun_path(path: &EntityPath) -> String {
 mod tests {
     use super::*;
     use crate::record::archetypes::OrbitalState;
-    use crate::record::components::{
-        BodyRadius, GravitationalParameter, Position3D, Quaternion4D, Velocity3D,
-    };
+    use crate::record::components::{BodyRadius, GravitationalParameter, Position3D};
     use crate::record::timeline::TimePoint;
     use nalgebra::Vector3;
 

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -67,11 +67,22 @@ impl EntityIndex {
         }
     }
 
+    /// Which axes have a value on logical row `row`.
+    ///
+    /// Chunks are cut where this changes, so every row goes out on the axes that
+    /// cover it instead of the whole chunk being dropped for want of one axis.
+    fn axes_at(&self, row: usize) -> AxisMask {
+        AxisMask {
+            sim_time: self.sim_time_secs.get(row).copied().flatten().is_some(),
+            step: self.steps.get(row).copied().flatten().is_some(),
+        }
+    }
+
     /// Index columns covering exactly `logical_rows`, in that order.
     ///
     /// An axis with no value on one of those rows is left out rather than
     /// written misaligned. `None` means no axis covers them all, and the caller
-    /// must skip the chunk: `send_columns` reads an empty index list as *static*
+    /// must skip the rows: `send_columns` reads an empty index list as *static*
     /// data, which would shadow every temporal value at the same path.
     fn time_columns(&self, logical_rows: &[usize]) -> Option<Vec<TimeColumn>> {
         let mut columns = Vec::with_capacity(2);
@@ -83,6 +94,13 @@ impl EntityIndex {
         }
         (!columns.is_empty()).then_some(columns)
     }
+}
+
+/// Which of the written axes cover a row.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct AxisMask {
+    sim_time: bool,
+    step: bool,
 }
 
 /// The axis values for `rows`, or `None` if the axis misses any of them.
@@ -99,11 +117,25 @@ fn logical_rows_of(column: &ComponentColumn) -> Vec<usize> {
         .collect()
 }
 
-/// Split `n` rows into consecutive ranges of at most [`CHUNK_ROWS`].
-fn chunk_ranges(n: usize) -> impl Iterator<Item = Range<usize>> {
-    (0..n)
-        .step_by(CHUNK_ROWS)
-        .map(move |start| start..(start + CHUNK_ROWS).min(n))
+/// Split the stored rows into ranges of at most [`CHUNK_ROWS`] that also share
+/// one set of usable axes.
+///
+/// A run of rows an axis covers can end partway through a column, and one chunk
+/// carries one set of index columns, so the cut has to follow the axes.
+fn chunk_ranges_by_axes(index: &EntityIndex, logical_rows: &[usize]) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+    let mut start = 0;
+    while start < logical_rows.len() {
+        let axes = index.axes_at(logical_rows[start]);
+        let limit = (start + CHUNK_ROWS).min(logical_rows.len());
+        let mut end = start + 1;
+        while end < limit && index.axes_at(logical_rows[end]) == axes {
+            end += 1;
+        }
+        ranges.push(start..end);
+        start = end;
+    }
+    ranges
 }
 
 /// Save a Recording to a .rrd file using the Rerun SDK.
@@ -163,7 +195,7 @@ pub fn save_as_rrd(
             // a component logged at only some steps keeps its own times.
             let logical_rows = logical_rows_of(column);
 
-            for rows in chunk_ranges(column.num_rows()) {
+            for rows in chunk_ranges_by_axes(&index, &logical_rows) {
                 // Built once per chunk and cloned per field: a `TimeColumn` clone is
                 // a refcount bump on the Arrow buffer, whereas rebuilding one
                 // re-scales every timestamp.
@@ -195,7 +227,7 @@ pub fn save_as_rrd(
             // Same logical rows as the position scalars above; taking the range
             // instead would move the points off the times the scalars carry.
             let logical_rows = logical_rows_of(pos_col);
-            for rows in chunk_ranges(pos_col.num_rows()) {
+            for rows in chunk_ranges_by_axes(&index, &logical_rows) {
                 let Some(indexes) = index.time_columns(&logical_rows[rows.clone()]) else {
                     continue;
                 };
@@ -3403,12 +3435,12 @@ mod tests {
 
     /// Two axes can cover different rows: logging rows 0-4 with `step` alone and
     /// rows 5-9 with both leaves `step` over all ten rows and `sim_time` over the
-    /// last five. Each axis now carries the rows it covers, so `step` indexes every
-    /// row and `sim_time` is left out rather than pairing rows 0-4 with rows 5-9's
-    /// times. Until #375 the row count came from `sim_time`, so five rows were
-    /// written and `step` was dropped for disagreeing on length.
+    /// last five. The chunk is cut where the usable axes change, so rows 0-4 go out
+    /// on `step` and rows 5-9 on both, and every row keeps its own times. Until
+    /// #375 the row count came from `sim_time`, so only five rows were written and
+    /// `step` was dropped for disagreeing on length.
     #[test]
-    fn an_axis_that_covers_every_row_indexes_all_of_them() {
+    fn rows_are_split_where_the_usable_axes_change() {
         let mut rec = Recording::new();
         let sat = EntityPath::parse("/world/sat/divergent");
 
@@ -3437,24 +3469,37 @@ mod tests {
         let path_str = path.to_str().unwrap();
         save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
 
-        let mut seen = 0;
+        // Per path: the rows with `step` alone, then the rows with both axes.
+        let mut shapes: BTreeMap<String, Vec<(Vec<String>, usize)>> = BTreeMap::new();
         for chunk in decode_chunks(path_str) {
             let entity = chunk.entity_path().to_string();
             if !entity.starts_with("/world/sat/divergent") {
                 continue;
             }
-            seen += 1;
-            let axes: Vec<String> = chunk
+            let mut axes: Vec<String> = chunk
                 .timelines()
                 .keys()
                 .map(|name| name.as_str().to_string())
                 .collect();
-            assert_eq!(axes, vec!["step".to_string()], "{entity} axes");
-            assert_eq!(chunk.num_rows(), 10, "{entity} should keep every row");
+            axes.sort();
+            shapes
+                .entry(entity)
+                .or_default()
+                .push((axes, chunk.num_rows()));
         }
-        assert!(seen > 0, "no chunk was written for the entity");
+        assert!(!shapes.is_empty(), "no chunk was written for the entity");
+        for (entity, chunks) in &shapes {
+            assert_eq!(
+                chunks,
+                &vec![
+                    (vec!["step".to_string()], 5),
+                    (vec!["sim_time".to_string(), "step".to_string()], 5),
+                ],
+                "{entity} chunk shapes"
+            );
+        }
 
-        // Every row is there, in order, on the axis that covers all of them.
+        // No row is lost to the split, and the order holds.
         let xs = &scalars_by_path(path_str)["/world/sat/divergent/x"];
         let want: Vec<f64> = (0..10).map(|i| i as f64).collect();
         assert_eq!(xs, &want);

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -3059,6 +3059,34 @@ mod tests {
         out
     }
 
+    /// The `(sim_time, x)` of every `Points3D` row, per entity path.
+    fn timed_points_by_path(path: &str) -> BTreeMap<String, Vec<(f64, f32)>> {
+        let mut out: BTreeMap<String, Vec<(f64, f32)>> = BTreeMap::new();
+        for chunk in decode_chunks(path) {
+            let Some((_, times)) = chunk
+                .timelines()
+                .iter()
+                .find(|(name, _)| name.as_str() == "sim_time")
+            else {
+                continue;
+            };
+            let times = times.times_raw().to_vec();
+            for comp_id in chunk.components_identifiers() {
+                for row_idx in 0..chunk.num_rows() {
+                    if let Some(Ok(batch)) = chunk
+                        .component_batch::<re_sdk_types::components::Position3D>(comp_id, row_idx)
+                    {
+                        let t = times[row_idx] as f64 / 1e9;
+                        out.entry(chunk.entity_path().to_string())
+                            .or_default()
+                            .extend(batch.iter().map(|p| (t, p.0.x())));
+                    }
+                }
+            }
+        }
+        out
+    }
+
     /// A recording of `n` rows on one satellite, `x` counting up from zero so a
     /// row can be identified by its value.
     fn counted_recording(entity: &str, n: usize) -> Recording {
@@ -3334,6 +3362,65 @@ mod tests {
         );
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    /// A position column that starts late must put its `Points3D` on the times
+    /// its own rows carry. The scalar paths and the `Points3D` path are built
+    /// from the same logical rows but by separate code, so the 3D path can go
+    /// back to leading-row alignment while the scalars stay right.
+    #[test]
+    fn a_late_starting_position_keeps_its_points_on_its_own_times() {
+        use crate::record::components::{MtqCommand3D, Position3D};
+
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/late_points");
+
+        const N: u64 = 8;
+        const FIRST_POSITION_STEP: u64 = 3;
+        for i in 0..N {
+            let tp = TimePoint::new().with_sim_time(i as f64).with_step(i);
+            // Logged at every step, so the entity's rows start at step 0 and the
+            // position column is the sparse one.
+            rec.log_temporal(&sat, &tp, &MtqCommand3D(Vector3::new(i as f64, 0.0, 0.0)));
+            if i >= FIRST_POSITION_STEP {
+                rec.log_temporal(&sat, &tp, &Position3D(Vector3::new(i as f64, 0.0, 0.0)));
+            }
+        }
+
+        let dir = std::env::temp_dir().join(format!(
+            "orts_rrd_late_points_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("late_points.rrd");
+        let path_str = path.to_str().unwrap();
+        save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
+
+        let want: Vec<(f64, f64)> = (FIRST_POSITION_STEP..N)
+            .map(|i| (i as f64, i as f64))
+            .collect();
+        let scalars = timed_scalars_by_path(path_str);
+        assert_eq!(
+            scalars
+                .get("/world/sat/late_points/x")
+                .expect("x missing from the file"),
+            &want,
+            "each x should carry the sim_time of the step it was logged at"
+        );
+
+        let points = timed_points_by_path(path_str);
+        let got = points
+            .get("/world/sat/late_points")
+            .expect("Points3D missing from the file");
+        let want_points: Vec<(f64, f32)> = want.iter().map(|(t, x)| (*t, *x as f32)).collect();
+        assert_eq!(
+            got, &want_points,
+            "and each point should sit at the same time as the scalars of the \
+             row it came from"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// An entity whose only timeline carries the wrong `TimeIndex` variant has no

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -6,7 +6,9 @@ use re_chunk::TimeColumn;
 use crate::record::component::Component;
 use crate::record::components::Position3D;
 use crate::record::entity_path::EntityPath;
-use crate::record::recording::{EntityStore, Recording, SimMetadata};
+use crate::record::recording::{
+    ComponentColumn, EntityStore, Recording, RowMap, SimMetadata, TimelineColumn,
+};
 use crate::record::timeline::{TimeIndex, TimelineName};
 
 /// Rows per columnar chunk.
@@ -25,86 +27,76 @@ const CHUNK_ROWS: usize = 8192;
 /// the export has always written; `WallClock` and `Custom` timelines have no
 /// read-back contract yet.
 struct EntityIndex {
-    sim_time_secs: Option<Vec<f64>>,
-    steps: Option<Vec<i64>>,
-    /// Logical rows this index covers.
-    n_rows: usize,
+    /// `sim_time` seconds per logical row; `None` where this axis covers no row.
+    sim_time_secs: Vec<Option<f64>>,
+    /// `step` per logical row.
+    steps: Vec<Option<i64>>,
 }
 
 impl EntityIndex {
     fn from_store(store: &EntityStore) -> Self {
-        // Read both axes before choosing a row count. A `TimeColumn` carries no "no
-        // time on this row", so an axis holding the wrong `TimeIndex` variant cannot
-        // be written at all, and the row count has to come from one that can.
-        let sim_time_secs = store.timelines.get(&TimelineName::SimTime).and_then(|tl| {
-            tl.iter()
-                .map(|index| match index {
-                    TimeIndex::Seconds(t) => Some(*t),
-                    TimeIndex::Sequence(_) => None,
-                })
-                .collect::<Option<Vec<_>>>()
-        });
+        let n_rows = store.num_rows;
+        let mut sim_time_secs = vec![None; n_rows];
+        let mut steps = vec![None; n_rows];
 
-        let mut steps = store.timelines.get(&TimelineName::Step).and_then(|tl| {
-            tl.iter()
-                .map(|index| match index {
-                    TimeIndex::Sequence(s) => i64::try_from(*s).ok(),
-                    TimeIndex::Seconds(_) => None,
-                })
-                .collect::<Option<Vec<_>>>()
-        });
-
-        // Prefer `sim_time`, as the row-oriented export did, and fall back to `step`
-        // when `sim_time` cannot be written. Deriving the count from a usable axis is
-        // also what keeps the invariant below: a non-zero `n_rows` always has at
-        // least one index column to go with it.
-        let n_rows = sim_time_secs
-            .as_ref()
-            .map(Vec::len)
-            .or_else(|| steps.as_ref().map(Vec::len))
-            .unwrap_or(0);
-
-        // Two axes can cover different logical rows: `log_temporal` pushes only to
-        // the axes a `TimePoint` names, so each is packed over its own rows and the
-        // same index can mean different rows in each. A `step` axis that does not
-        // cover exactly the exported rows is dropped rather than truncated.
-        if steps.as_ref().is_some_and(|steps| steps.len() != n_rows) {
-            steps = None;
+        // Address both axes by logical row. An axis need not cover every row (a
+        // `TimePoint` need not name it), and a `TimeIndex` of the wrong variant
+        // cannot go on that axis at all, so both show up as a `None` row.
+        if let Some(axis) = store.timelines.get(&TimelineName::SimTime) {
+            for (stored, index) in axis.data.iter().enumerate() {
+                if let (TimeIndex::Seconds(t), Some(slot)) =
+                    (index, sim_time_secs.get_mut(axis.logical_row_of(stored)))
+                {
+                    *slot = Some(*t);
+                }
+            }
         }
-
-        // `send_columns` reads an empty index list as *static* data, and static data
-        // unconditionally shadows every temporal value at the same path in the
-        // viewer. `n_rows` came from a usable axis, so this cannot fire.
-        debug_assert!(
-            n_rows == 0 || sim_time_secs.is_some() || steps.is_some(),
-            "rows to export with no index column"
-        );
+        if let Some(axis) = store.timelines.get(&TimelineName::Step) {
+            for (stored, index) in axis.data.iter().enumerate() {
+                if let (TimeIndex::Sequence(s), Some(slot)) =
+                    (index, steps.get_mut(axis.logical_row_of(stored)))
+                {
+                    *slot = i64::try_from(*s).ok();
+                }
+            }
+        }
 
         Self {
             sim_time_secs,
             steps,
-            n_rows,
         }
     }
 
-    /// The `TimeColumn`s covering `rows`. `send_columns` requires every index
-    /// column to be as long as the component columns it accompanies.
-    fn time_columns(&self, rows: Range<usize>) -> Vec<TimeColumn> {
+    /// Index columns covering exactly `logical_rows`, in that order.
+    ///
+    /// An axis with no value on one of those rows is left out rather than
+    /// written misaligned. `None` means no axis covers them all, and the caller
+    /// must skip the chunk: `send_columns` reads an empty index list as *static*
+    /// data, which would shadow every temporal value at the same path.
+    fn time_columns(&self, logical_rows: &[usize]) -> Option<Vec<TimeColumn>> {
         let mut columns = Vec::with_capacity(2);
-        if let Some(secs) = &self.sim_time_secs {
-            columns.push(TimeColumn::new_duration_secs(
-                "sim_time",
-                secs[rows.clone()].iter().copied(),
-            ));
+        if let Some(secs) = gather(&self.sim_time_secs, logical_rows) {
+            columns.push(TimeColumn::new_duration_secs("sim_time", secs));
         }
-        if let Some(steps) = &self.steps {
-            columns.push(TimeColumn::new_sequence(
-                "step",
-                steps[rows].iter().copied(),
-            ));
+        if let Some(steps) = gather(&self.steps, logical_rows) {
+            columns.push(TimeColumn::new_sequence("step", steps));
         }
-        columns
+        (!columns.is_empty()).then_some(columns)
     }
+}
+
+/// The axis values for `rows`, or `None` if the axis misses any of them.
+fn gather<T: Copy>(axis: &[Option<T>], rows: &[usize]) -> Option<Vec<T>> {
+    rows.iter()
+        .map(|row| axis.get(*row).copied().flatten())
+        .collect()
+}
+
+/// The entity logical row of each stored row in `column`.
+fn logical_rows_of(column: &ComponentColumn) -> Vec<usize> {
+    (0..column.num_rows())
+        .map(|stored| column.logical_row_of(stored))
+        .collect()
 }
 
 /// Split `n` rows into consecutive ranges of at most [`CHUNK_ROWS`].
@@ -167,16 +159,17 @@ pub fn save_as_rrd(
                 .map(|field| format!("{rr_path}/{field}"))
                 .collect();
 
-            // A column with fewer rows than the entity has logical rows keeps the
-            // leading alignment it had under the row-oriented export (see #375).
-            // The `min` is also what holds the index columns to the data length.
-            let n_rows = column.num_rows().min(index.n_rows);
+            // The times come from the logical rows this column actually covers, so
+            // a component logged at only some steps keeps its own times.
+            let logical_rows = logical_rows_of(column);
 
-            for rows in chunk_ranges(n_rows) {
+            for rows in chunk_ranges(column.num_rows()) {
                 // Built once per chunk and cloned per field: a `TimeColumn` clone is
                 // a refcount bump on the Arrow buffer, whereas rebuilding one
                 // re-scales every timestamp.
-                let indexes = index.time_columns(rows.clone());
+                let Some(indexes) = index.time_columns(&logical_rows[rows.clone()]) else {
+                    continue;
+                };
                 for (k, path) in paths.iter().enumerate() {
                     let values: Vec<f64> = rows
                         .clone()
@@ -199,9 +192,13 @@ pub fn save_as_rrd(
             && pos_col.scalars_per_row >= 3
         {
             let scalars_per_row = pos_col.scalars_per_row;
-            let n_rows = pos_col.num_rows().min(index.n_rows);
-            for rows in chunk_ranges(n_rows) {
-                let indexes = index.time_columns(rows.clone());
+            // Same logical rows as the position scalars above; taking the range
+            // instead would move the points off the times the scalars carry.
+            let logical_rows = logical_rows_of(pos_col);
+            for rows in chunk_ranges(pos_col.num_rows()) {
+                let Some(indexes) = index.time_columns(&logical_rows[rows.clone()]) else {
+                    continue;
+                };
                 let points: Vec<[f32; 3]> = rows
                     .map(|i| {
                         let start = i * scalars_per_row;
@@ -838,7 +835,6 @@ pub fn load_from_rrd(path: &str) -> Result<Vec<RrdRow>, Box<dyn std::error::Erro
 ///
 /// This enables `orts convert` to produce the same CSV output as `orts run`.
 pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Error>> {
-    use crate::record::recording::ComponentColumn;
     use re_chunk::Chunk;
     use re_log_encoding::DecoderApp;
     use re_log_types::LogMsg;
@@ -1151,10 +1147,17 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
         // CSV path reads `SimTime` only, so filling the others changes what
         // `orts convert` reports. Left as it stands on main until the step
         // round-trip is settled with the writer.
-        let entity_times: Vec<TimeIndex> = row_keys
-            .iter()
-            .map(|k| TimeIndex::Seconds(k.t_secs()))
-            .collect();
+        // Dense over `row_keys`: a component that covers only some of them is
+        // dropped below rather than restored as a sparse column, which is what
+        // this loader has always done. Restoring it belongs with the CSV path
+        // that reads these rows (#375 follow-up).
+        let entity_times = TimelineColumn {
+            data: row_keys
+                .iter()
+                .map(|k| TimeIndex::Seconds(k.t_secs()))
+                .collect(),
+            rows: RowMap::Dense,
+        };
 
         for (name, fields) in &statics {
             let mut static_scalars = Vec::new();
@@ -1555,11 +1558,11 @@ mod tests {
             .get(&TimelineName::SimTime)
             .expect("SimTime timeline missing");
         assert_eq!(sim_times.len(), 3);
-        match &sim_times[0] {
+        match &sim_times.data[0] {
             TimeIndex::Seconds(t) => assert!((t - 0.0).abs() < 1e-9),
             other => panic!("expected Seconds, got {:?}", other),
         }
-        match &sim_times[2] {
+        match &sim_times.data[2] {
             TimeIndex::Seconds(t) => assert!((t - 20.0).abs() < 1e-9),
             other => panic!("expected Seconds, got {:?}", other),
         }
@@ -1958,7 +1961,7 @@ mod tests {
         assert_eq!(store.num_rows, 1, "only t=10 has a whole position");
         assert_eq!(
             store.timelines.get(&TimelineName::SimTime),
-            Some(&vec![TimeIndex::Seconds(10.0)])
+            Some(&[TimeIndex::Seconds(10.0)].into_iter().collect())
         );
         let row = column.get_row(0).expect("the one row");
         assert_eq!(
@@ -2037,7 +2040,7 @@ mod tests {
             .get(&TimelineName::SimTime)
             .expect("a sim_time timeline");
         assert_eq!(times.len(), store.num_rows, "timeline and rows must agree");
-        assert_eq!(times, &vec![TimeIndex::Seconds(10.0)]);
+        assert_eq!(times.data, vec![TimeIndex::Seconds(10.0)]);
         for (name, col) in &store.columns {
             assert_eq!(
                 col.num_rows(),
@@ -2171,7 +2174,11 @@ mod tests {
         let store = loaded.entity(&entity).expect("the parent entity");
         assert_eq!(
             store.timelines.get(&TimelineName::SimTime),
-            Some(&vec![TimeIndex::Seconds(10.0), TimeIndex::Seconds(20.0)]),
+            Some(
+                &[TimeIndex::Seconds(10.0), TimeIndex::Seconds(20.0)]
+                    .into_iter()
+                    .collect()
+            ),
             "only the parent's own times are rows"
         );
         assert_eq!(store.num_rows, 2);
@@ -2416,7 +2423,11 @@ mod tests {
         assert_eq!(store.num_rows, 2);
         assert_eq!(
             store.timelines.get(&TimelineName::SimTime),
-            Some(&vec![TimeIndex::Seconds(0.0), TimeIndex::Seconds(10.0)])
+            Some(
+                &[TimeIndex::Seconds(0.0), TimeIndex::Seconds(10.0)]
+                    .into_iter()
+                    .collect()
+            )
         );
         assert_eq!(velocity.get_row(0).expect("row 0"), &[1.0, 2.0, 3.0]);
         assert_eq!(velocity.get_row(1).expect("row 1"), &[4.0, 2.0, 3.0]);
@@ -2593,7 +2604,11 @@ mod tests {
         assert_eq!(store.num_rows, 2, "the velocity keeps both of its times");
         assert_eq!(
             store.timelines.get(&TimelineName::SimTime),
-            Some(&vec![TimeIndex::Seconds(0.0), TimeIndex::Seconds(10.0)])
+            Some(
+                &[TimeIndex::Seconds(0.0), TimeIndex::Seconds(10.0)]
+                    .into_iter()
+                    .collect()
+            )
         );
         let velocity = store
             .columns
@@ -2977,6 +2992,37 @@ mod tests {
         out
     }
 
+    /// Scalar values with the `sim_time` they were written at, per entity path.
+    fn timed_scalars_by_path(path: &str) -> BTreeMap<String, Vec<(f64, f64)>> {
+        let mut out: BTreeMap<String, Vec<(f64, f64)>> = BTreeMap::new();
+        for chunk in decode_chunks(path) {
+            let Some((_, times)) = chunk
+                .timelines()
+                .iter()
+                .find(|(name, _)| name.as_str() == "sim_time")
+            else {
+                continue;
+            };
+            let times = times.times_raw().to_vec();
+            for comp_id in chunk.components_identifiers() {
+                if !comp_id.as_str().contains("Scalar") && !comp_id.as_str().contains("scalars") {
+                    continue;
+                }
+                for row_idx in 0..chunk.num_rows() {
+                    if let Some(Ok(batch)) =
+                        chunk.component_batch::<re_sdk_types::components::Scalar>(comp_id, row_idx)
+                    {
+                        let t = times[row_idx] as f64 / 1e9;
+                        out.entry(chunk.entity_path().to_string())
+                            .or_default()
+                            .extend(batch.iter().map(|s| (t, s.0.0)));
+                    }
+                }
+            }
+        }
+        out
+    }
+
     /// A recording of `n` rows on one satellite, `x` counting up from zero so a
     /// row can be identified by its value.
     fn counted_recording(entity: &str, n: usize) -> Recording {
@@ -3215,6 +3261,45 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    /// A component logged only from a later step must be written at the times it
+    /// was logged at. The store keeps one timeline per entity and no per-column
+    /// row mapping, so a short column used to be lined up with the *leading*
+    /// timeline entries: values from steps 5-9 landed on t=0-4 (#375).
+    #[test]
+    fn a_late_starting_component_keeps_its_own_times() {
+        use crate::record::components::MtqCommand3D;
+
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/late");
+
+        const N: u64 = 10;
+        const FIRST_MTQ_STEP: u64 = 5;
+        for i in 0..N {
+            let tp = TimePoint::new().with_sim_time(i as f64).with_step(i);
+            let os = OrbitalState::new(Vector3::new(7000.0, 0.0, 0.0), Vector3::new(0.0, 7.5, 0.0));
+            rec.log_orbital_state(&sat, &tp, &os);
+            if i >= FIRST_MTQ_STEP {
+                rec.log_temporal(&sat, &tp, &MtqCommand3D(Vector3::new(i as f64, 0.0, 0.0)));
+            }
+        }
+
+        let path = std::env::temp_dir().join("test_orts_late_component.rrd");
+        let path_str = path.to_str().unwrap();
+        save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
+
+        let timed = timed_scalars_by_path(path_str);
+        let got = timed
+            .get("/world/sat/late/mtq_mx")
+            .expect("mtq_mx missing from the file");
+        let want: Vec<(f64, f64)> = (FIRST_MTQ_STEP..N).map(|i| (i as f64, i as f64)).collect();
+        assert_eq!(
+            got, &want,
+            "each mtq_mx value should carry the sim_time of the step it was logged at"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
     /// An entity whose only timeline carries the wrong `TimeIndex` variant has no
     /// usable index left. `send_columns` reads an empty index list as *static* data,
     /// and static data unconditionally shadows every temporal value at the same path
@@ -3231,9 +3316,10 @@ mod tests {
             column.push(&[1.0, 2.0, 3.0]);
             store.columns.insert(Position3D::component_name(), column);
             // A sequence on the sim-time axis, and no step axis at all.
-            store
-                .timelines
-                .insert(TimelineName::SimTime, vec![TimeIndex::Sequence(0)]);
+            store.timelines.insert(
+                TimelineName::SimTime,
+                [TimeIndex::Sequence(0)].into_iter().collect(),
+            );
             store.num_rows = 1;
         }
         rec.register_component_fields(Position3D::component_name(), vec!["x", "y", "z"]);
@@ -3276,9 +3362,10 @@ mod tests {
             store.columns.insert(Position3D::component_name(), column);
             // `sim_time` holds the wrong variant, and is a different length from
             // `step` as well, so neither its values nor its length can be used.
-            store
-                .timelines
-                .insert(TimelineName::SimTime, vec![TimeIndex::Sequence(0)]);
+            store.timelines.insert(
+                TimelineName::SimTime,
+                [TimeIndex::Sequence(0)].into_iter().collect(),
+            );
             store.timelines.insert(
                 TimelineName::Step,
                 (0..N as u64).map(TimeIndex::Sequence).collect(),
@@ -3316,14 +3403,14 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
-    /// Two timeline arrays that cover different logical rows cannot both index the
-    /// data, so the shorter axis is dropped rather than truncated. Logging rows 0-4
-    /// with `step` alone and rows 5-9 with both leaves `sim_time` 5 long and `step`
-    /// 10 long, and index 0 of each names a *different* row: `sim_time[0]` is row
-    /// 5's time while `step[0]` is row 0's step. Truncating `step` to the exported
-    /// range would therefore pair row 0-4 steps with row 5-9 times.
+    /// Two axes can cover different rows: logging rows 0-4 with `step` alone and
+    /// rows 5-9 with both leaves `step` over all ten rows and `sim_time` over the
+    /// last five. Each axis now carries the rows it covers, so `step` indexes every
+    /// row and `sim_time` is left out rather than pairing rows 0-4 with rows 5-9's
+    /// times. Until #375 the row count came from `sim_time`, so five rows were
+    /// written and `step` was dropped for disagreeing on length.
     #[test]
-    fn a_step_axis_that_covers_other_rows_is_dropped() {
+    fn an_axis_that_covers_every_row_indexes_all_of_them() {
         let mut rec = Recording::new();
         let sat = EntityPath::parse("/world/sat/divergent");
 
@@ -3342,29 +3429,37 @@ mod tests {
             rec.log_orbital_state(&sat, &tp, &os);
         }
 
-        // The premise: the axes really do diverge in this shape.
+        // The premise: the axes really do cover different rows in this shape.
         let store = rec.entity(&sat).expect("entity");
         assert_eq!(store.timelines[&TimelineName::SimTime].len(), 5);
         assert_eq!(store.timelines[&TimelineName::Step].len(), 10);
+        assert_eq!(store.num_rows, 10);
 
         let path = std::env::temp_dir().join("test_orts_divergent_axes.rrd");
         let path_str = path.to_str().unwrap();
         save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
 
+        let mut seen = 0;
         for chunk in decode_chunks(path_str) {
-            if !chunk
-                .entity_path()
-                .to_string()
-                .starts_with("/world/sat/divergent")
-            {
+            let entity = chunk.entity_path().to_string();
+            if !entity.starts_with("/world/sat/divergent") {
                 continue;
             }
-            assert!(
-                chunk.timelines().keys().all(|name| name.as_str() != "step"),
-                "{} kept a step axis covering other rows",
-                chunk.entity_path()
-            );
+            seen += 1;
+            let axes: Vec<String> = chunk
+                .timelines()
+                .keys()
+                .map(|name| name.as_str().to_string())
+                .collect();
+            assert_eq!(axes, vec!["step".to_string()], "{entity} axes");
+            assert_eq!(chunk.num_rows(), 10, "{entity} should keep every row");
         }
+        assert!(seen > 0, "no chunk was written for the entity");
+
+        // Every row is there, in order, on the axis that covers all of them.
+        let xs = &scalars_by_path(path_str)["/world/sat/divergent/x"];
+        let want: Vec<f64> = (0..10).map(|i| i as f64).collect();
+        assert_eq!(xs, &want);
 
         let _ = std::fs::remove_file(&path);
     }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -3298,8 +3298,8 @@ mod tests {
     }
 
     /// A component logged only from a later step must be written at the times it
-    /// was logged at. The store keeps one timeline per entity and no per-column
-    /// row mapping, so a short column used to be lined up with the *leading*
+    /// was logged at. The store used to keep one timeline per entity and no
+    /// per-column row mapping, so a short column lined up with the *leading*
     /// timeline entries: values from steps 5-9 landed on t=0-4 (#375).
     #[test]
     fn a_late_starting_component_keeps_its_own_times() {

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -97,7 +97,9 @@ impl EntityIndex {
 }
 
 /// Which of the written axes cover a row.
-#[derive(Clone, Copy, PartialEq, Eq)]
+///
+/// `Copy` because the loop that cuts chunks holds one while walking the rows.
+#[derive(Clone, Copy, PartialEq)]
 struct AxisMask {
     sim_time: bool,
     step: bool,
@@ -122,6 +124,10 @@ fn logical_rows_of(column: &ComponentColumn) -> Vec<usize> {
 ///
 /// A run of rows an axis covers can end partway through a column, and one chunk
 /// carries one set of index columns, so the cut has to follow the axes.
+///
+/// A recording whose `TimePoint` names different axes on every row therefore
+/// gets a chunk per row, which costs what the columnar export saved. Every
+/// caller in this repository names the same axes at every step.
 fn chunk_ranges_by_axes(index: &EntityIndex, logical_rows: &[usize]) -> Vec<Range<usize>> {
     let mut ranges = Vec::new();
     let mut start = 0;
@@ -3372,9 +3378,9 @@ mod tests {
     }
 
     /// An unusable `sim_time` axis must not take a usable `step` axis down with it.
-    /// The row count is taken from whichever axis can actually be written, so these
-    /// rows are exported on `step` alone — which is what the row-oriented export did,
-    /// since its `set_duration_secs` call was skipped on the variant mismatch while
+    /// Each axis covers the rows it can be written for, so these rows go out on
+    /// `step` alone — which is what the row-oriented export did, since its
+    /// `set_duration_secs` call was skipped on the variant mismatch while
     /// `set_time_sequence` still ran.
     #[test]
     fn a_usable_step_axis_carries_the_export_on_its_own() {
@@ -3390,8 +3396,7 @@ mod tests {
                 column.push(&[i as f64, 0.0, 0.0]);
             }
             store.columns.insert(Position3D::component_name(), column);
-            // `sim_time` holds the wrong variant, and is a different length from
-            // `step` as well, so neither its values nor its length can be used.
+            // `sim_time` holds the wrong variant, so it covers no row at all.
             store.timelines.insert(
                 TimelineName::SimTime,
                 [TimeIndex::Sequence(0)].into_iter().collect(),

--- a/orts/src/record/timeline.rs
+++ b/orts/src/record/timeline.rs
@@ -39,7 +39,7 @@ impl TimePoint {
     /// later value rather than a second entry. A second entry would be pushed to
     /// that axis twice on export, and would make two points compare as one row
     /// while naming different times.
-    fn with_axis(mut self, name: TimelineName, index: TimeIndex) -> Self {
+    pub(crate) fn with_axis(mut self, name: TimelineName, index: TimeIndex) -> Self {
         match self.indices.iter_mut().find(|(n, _)| *n == name) {
             Some(slot) => slot.1 = index,
             None => self.indices.push((name, index)),

--- a/orts/src/record/timeline.rs
+++ b/orts/src/record/timeline.rs
@@ -21,7 +21,10 @@ pub enum TimeIndex {
 }
 
 /// A point in time across all active timelines.
-#[derive(Debug, Clone)]
+///
+/// `PartialEq` is how [`Recording::log_temporal`](crate::record::recording::Recording::log_temporal)
+/// decides whether two calls belong to the same logical row.
+#[derive(Debug, Clone, PartialEq)]
 pub struct TimePoint {
     indices: Vec<(TimelineName, TimeIndex)>,
 }

--- a/orts/src/record/timeline.rs
+++ b/orts/src/record/timeline.rs
@@ -21,10 +21,7 @@ pub enum TimeIndex {
 }
 
 /// A point in time across all active timelines.
-///
-/// `PartialEq` is how [`Recording::log_temporal`](crate::record::recording::Recording::log_temporal)
-/// decides whether two calls belong to the same logical row.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct TimePoint {
     indices: Vec<(TimelineName, TimeIndex)>,
 }
@@ -63,6 +60,32 @@ impl TimePoint {
 
     pub fn indices(&self) -> &[(TimelineName, TimeIndex)] {
         &self.indices
+    }
+
+    /// Whether both points name the same axes at the same indices, and so
+    /// address the same row of an entity.
+    ///
+    /// The order the axes were added in does not matter, so
+    /// `with_sim_time(t).with_step(n)` and `with_step(n).with_sim_time(t)` are
+    /// one row. A `Seconds` axis is compared bit for bit, which keeps a `NaN`
+    /// time equal to itself: an entity logged at a `NaN` time still gets one row
+    /// per step rather than one per component.
+    pub fn is_same_row(&self, other: &TimePoint) -> bool {
+        fn same(a: &TimeIndex, b: &TimeIndex) -> bool {
+            match (a, b) {
+                (TimeIndex::Seconds(x), TimeIndex::Seconds(y)) => x.to_bits() == y.to_bits(),
+                (TimeIndex::Sequence(x), TimeIndex::Sequence(y)) => x == y,
+                _ => false,
+            }
+        }
+
+        self.indices.len() == other.indices.len()
+            && self.indices.iter().all(|(name, index)| {
+                other
+                    .indices
+                    .iter()
+                    .any(|(n, i)| n == name && same(i, index))
+            })
     }
 }
 

--- a/orts/src/record/timeline.rs
+++ b/orts/src/record/timeline.rs
@@ -33,22 +33,30 @@ impl TimePoint {
         }
     }
 
-    pub fn with_sim_time(mut self, t: f64) -> Self {
-        self.indices
-            .push((TimelineName::SimTime, TimeIndex::Seconds(t)));
+    /// Set one axis, replacing any index already given for it.
+    ///
+    /// One point holds at most one index per axis, so a repeated `with_*` is the
+    /// later value rather than a second entry. A second entry would be pushed to
+    /// that axis twice on export, and would make two points compare as one row
+    /// while naming different times.
+    fn with_axis(mut self, name: TimelineName, index: TimeIndex) -> Self {
+        match self.indices.iter_mut().find(|(n, _)| *n == name) {
+            Some(slot) => slot.1 = index,
+            None => self.indices.push((name, index)),
+        }
         self
     }
 
-    pub fn with_step(mut self, step: u64) -> Self {
-        self.indices
-            .push((TimelineName::Step, TimeIndex::Sequence(step)));
-        self
+    pub fn with_sim_time(self, t: f64) -> Self {
+        self.with_axis(TimelineName::SimTime, TimeIndex::Seconds(t))
     }
 
-    pub fn with_wall_clock(mut self, t: f64) -> Self {
-        self.indices
-            .push((TimelineName::WallClock, TimeIndex::Seconds(t)));
-        self
+    pub fn with_step(self, step: u64) -> Self {
+        self.with_axis(TimelineName::Step, TimeIndex::Sequence(step))
+    }
+
+    pub fn with_wall_clock(self, t: f64) -> Self {
+        self.with_axis(TimelineName::WallClock, TimeIndex::Seconds(t))
     }
 
     pub fn get(&self, name: &TimelineName) -> Option<TimeIndex> {
@@ -67,25 +75,29 @@ impl TimePoint {
     ///
     /// The order the axes were added in does not matter, so
     /// `with_sim_time(t).with_step(n)` and `with_step(n).with_sim_time(t)` are
-    /// one row. A `Seconds` axis is compared bit for bit, which keeps a `NaN`
-    /// time equal to itself: an entity logged at a `NaN` time still gets one row
-    /// per step rather than one per component.
+    /// one row. A `NaN` time counts as equal to itself, so an entity logged at
+    /// one gets a row per step rather than a row per component.
     pub fn is_same_row(&self, other: &TimePoint) -> bool {
         fn same(a: &TimeIndex, b: &TimeIndex) -> bool {
             match (a, b) {
-                (TimeIndex::Seconds(x), TimeIndex::Seconds(y)) => x.to_bits() == y.to_bits(),
+                // `+0.0` and `-0.0` are the same instant, and a `NaN` time is
+                // the same row as itself.
+                (TimeIndex::Seconds(x), TimeIndex::Seconds(y)) => {
+                    x == y || (x.is_nan() && y.is_nan())
+                }
                 (TimeIndex::Sequence(x), TimeIndex::Sequence(y)) => x == y,
                 _ => false,
             }
         }
 
-        self.indices.len() == other.indices.len()
-            && self.indices.iter().all(|(name, index)| {
-                other
-                    .indices
-                    .iter()
-                    .any(|(n, i)| n == name && same(i, index))
-            })
+        // One index per axis (see `with_axis`), so matching every axis of one
+        // point against the other, both ways, compares the points as a whole.
+        let covers = |a: &TimePoint, b: &TimePoint| {
+            a.indices
+                .iter()
+                .all(|(name, index)| b.get(name).is_some_and(|other| same(&other, index)))
+        };
+        covers(self, other) && covers(other, self)
     }
 }
 

--- a/orts/src/record/timeline.rs
+++ b/orts/src/record/timeline.rs
@@ -112,6 +112,23 @@ mod tests {
     use super::*;
 
     #[test]
+    fn infinite_times_group_by_sign() {
+        let at = |t: f64| TimePoint::new().with_sim_time(t).with_step(0);
+
+        assert!(
+            at(f64::INFINITY).is_same_row(&at(f64::INFINITY)),
+            "an infinite time is the same instant as itself, so components \
+             logged at it share a row"
+        );
+        assert!(at(f64::NEG_INFINITY).is_same_row(&at(f64::NEG_INFINITY)));
+        assert!(
+            !at(f64::INFINITY).is_same_row(&at(f64::NEG_INFINITY)),
+            "the two infinities are different instants"
+        );
+        assert!(!at(f64::INFINITY).is_same_row(&at(f64::MAX)));
+    }
+
+    #[test]
     fn empty_time_point() {
         let tp = TimePoint::new();
         assert!(tp.indices().is_empty());


### PR DESCRIPTION
一部の step でしか logging されなかった component が、間違った時刻で .rrd に書かれていた。

step 5 から attitude を logging すると、step 5〜9 の値が t=0〜4 として出る。

## 原因

`log_temporal` が行を「列の行数と timeline の長さの比較」で識別していた。短い列は先頭の行に並ぶ。

timeline 同士でも同じことが起きる。`TimePoint` は entity の使う全軸を名指す必要がないので、rows 0-4 を `step` だけ、rows 5-9 を `sim_time` + `step` で logging すると `sim_time` が 5 個、`step` が 10 個になり、同じ index が別の行を指す。

## 直し方

行は `TimePoint` そのもので識別する。component 列と timeline 軸が、自分が値を持つ論理行の番号を持つ。

```rust
enum RowMap { Dense, Sparse(Vec<u32>) }
```

`Dense` は「格納行 k が論理行 k」、つまり毎 step logging される列のこと。通常ケースのメモリコストはゼロで、実際にずれた列だけ `Sparse` になる。

「この step にこの component の値は無い」は `log_temporal` を呼ばないことで表せるので、API は増えない。

`save_as_rrd` は列が値を持つ行から時刻を集める。`Points3D` も position 列と同じ行を使う（scalar path だけ直すと 3D 表示がずれる）。1 chunk は 1 組の index 列しか持てないので、使える軸が変わるところで chunk を切る。上の例なら rows 0-4 が `step`、rows 5-9 が両軸の 2 chunk になる。

## API の変更（BREAKING）

- `EntityStore::timelines` の型が `Vec<TimeIndex>` から `TimelineColumn` に
- `ComponentColumn` に `rows` field
- 両 column type の `data` / `rows` / `scalars_per_row` と `ComponentColumn::push` は crate 内限定。public だと map と data が食い違った列を作れてしまい、その列は値を別の行の時刻で報告する。追加は検査付きの `push_at` を通す
- 読み出しは列が `scalars` と `scalars_per_row()`、軸が `times`。行単位では `get_row` が格納 index、`at_logical_row` が論理行
- `TimePoint::with_*` は軸の index を置き換える（2 つ目を append しない）

## 出力への影響

疎な列があるとき、CSV は欠損を空フィールドで出す。header は全 extra column を並べるので、1 フィールドも出さないと行が短くなり、残りの値が違う見出しの下に来る。

毎 step logging される列だけの recording — つまり現在の `orts run` の出力 — は 1 バイトも変わらない。

## テスト

`a_late_starting_component_keeps_its_own_times` が症状を固定する。修正前は `[(0.0, 5.0), (1.0, 6.0), ...]`、修正後は `[(5.0, 5.0), (6.0, 6.0), ...]`。

`a_late_starting_position_keeps_its_points_on_its_own_times` は `Points3D` の時刻をファイルから読み戻す。3D path を先頭行整列に戻すと `[(0.0, 3.0), (1.0, 4.0), ...]` を読んで落ちる。

モデル側に 16 本。dense が mapping を持たないこと、疎な列が値を持つ行を記録して他の行で `None` を返すこと、軸の順序で行が分かれないこと、`NaN` / `±0.0` / `±∞`、同一時刻の二重 log、時刻の再訪、拒否した行が列を変えないこと、幅の違う行の拒否（release でも）、logging 済みの store を空にしてから同じ時刻で logging すること。

`-p orts --lib` は debug / release とも 772 pass。

Refs #375
