### PR TITLE
fix(ci,viewer): stop the e2e servers from downloading high-res textures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1419,6 +1419,12 @@ jobs:
         run: chmod +x ./bin/orts
 
       - name: Start WebSocket server
+        # The high-res source textures (21600x10800 for Earth alone) compete with
+        # the simulation loop for CPU while they download and decode, which starves
+        # the stream the next step waits on. Embedded 2k textures are served either
+        # way. See issue #373.
+        env:
+          ORTS_DISABLE_TEXTURE_DOWNLOAD: "1"
         run: ./bin/orts serve --sat altitude=400 --dt 1 --output-interval 10 &
 
       - name: Wait for WebSocket server to stream

--- a/viewer/tests/attitude-data.spec.ts
+++ b/viewer/tests/attitude-data.spec.ts
@@ -34,7 +34,9 @@ test.beforeAll(async () => {
   fs.writeFileSync(configPath, JSON.stringify(config));
 
   const binary = process.env.ORTS_BINARY ?? path.resolve(__dirname, "../../target/debug/orts");
-  const child = spawn(binary, ["serve", "--port", "0", "--config", configPath]);
+  const child = spawn(binary, ["serve", "--port", "0", "--config", configPath], {
+    env: { ...process.env, ORTS_DISABLE_TEXTURE_DOWNLOAD: "1" },
+  });
   ortsProcess = child;
 
   const port = await new Promise<number>((resolve, reject) => {
@@ -136,7 +138,9 @@ test("state messages without attitude config omit attitude field", async ({ page
 
   // Start a no-attitude server inline
   const binary = process.env.ORTS_BINARY ?? path.resolve(__dirname, "../../target/debug/orts");
-  const child = spawn(binary, ["serve", "--port", "0", "--sat", "altitude=400,id=no-att"]);
+  const child = spawn(binary, ["serve", "--port", "0", "--sat", "altitude=400,id=no-att"], {
+    env: { ...process.env, ORTS_DISABLE_TEXTURE_DOWNLOAD: "1" },
+  });
 
   const port = await new Promise<number>((resolve, reject) => {
     const rl = createInterface({ input: child.stderr ?? process.stdin });

--- a/viewer/tests/attitude-rendering.spec.ts
+++ b/viewer/tests/attitude-rendering.spec.ts
@@ -57,7 +57,9 @@ let configPath: string;
 /** Spawn an `orts serve` instance and resolve once it prints its ws:// URL. */
 function spawnServer(configFile: string): Promise<{ child: ChildProcess; port: number }> {
   const binary = process.env.ORTS_BINARY ?? path.resolve(__dirname, "../../target/debug/orts");
-  const child = spawn(binary, ["serve", "--port", "0", "--config", configFile]);
+  const child = spawn(binary, ["serve", "--port", "0", "--config", configFile], {
+    env: { ...process.env, ORTS_DISABLE_TEXTURE_DOWNLOAD: "1" },
+  });
   return new Promise((resolve, reject) => {
     const rl = createInterface({ input: child.stderr ?? process.stdin });
     const timeout = setTimeout(() => {

--- a/viewer/tests/bisect-perf.manual.ts
+++ b/viewer/tests/bisect-perf.manual.ts
@@ -28,17 +28,23 @@ test.beforeAll(async () => {
   }
 
   const binary = process.env.ORTS_BINARY ?? path.resolve(__dirname, "../../target/debug/orts");
-  const child = spawn(binary, [
-    "serve",
-    "--port",
-    "0",
-    "--sat",
-    "altitude=400,id=perf-test",
-    "--dt",
-    "1",
-    "--output-interval",
-    "1",
-  ]);
+  const child = spawn(
+    binary,
+    [
+      "serve",
+      "--port",
+      "0",
+      "--sat",
+      "altitude=400,id=perf-test",
+      "--dt",
+      "1",
+      "--output-interval",
+      "1",
+    ],
+    {
+      env: { ...process.env, ORTS_DISABLE_TEXTURE_DOWNLOAD: "1" },
+    },
+  );
   ortsProcess = child;
 
   const port = await new Promise<number>((resolve, reject) => {

--- a/viewer/tests/no-query-range-loop.spec.ts
+++ b/viewer/tests/no-query-range-loop.spec.ts
@@ -26,7 +26,9 @@ test.beforeAll(async () => {
   }
 
   const binary = process.env.ORTS_BINARY ?? path.resolve(__dirname, "../../target/debug/orts");
-  const child = spawn(binary, ["serve", "--port", "0", "--sat", "altitude=400,id=test"]);
+  const child = spawn(binary, ["serve", "--port", "0", "--sat", "altitude=400,id=test"], {
+    env: { ...process.env, ORTS_DISABLE_TEXTURE_DOWNLOAD: "1" },
+  });
   ortsProcess = child;
 
   const port = await new Promise<number>((resolve, reject) => {

--- a/viewer/tests/profile-bottleneck.manual.ts
+++ b/viewer/tests/profile-bottleneck.manual.ts
@@ -21,17 +21,23 @@ test.beforeAll(async () => {
   }
 
   const binary = process.env.ORTS_BINARY ?? path.resolve(__dirname, "../../target/debug/orts");
-  const child = spawn(binary, [
-    "serve",
-    "--port",
-    "0",
-    "--sat",
-    "altitude=400,id=perf-test",
-    "--dt",
-    "1",
-    "--output-interval",
-    "10",
-  ]);
+  const child = spawn(
+    binary,
+    [
+      "serve",
+      "--port",
+      "0",
+      "--sat",
+      "altitude=400,id=perf-test",
+      "--dt",
+      "1",
+      "--output-interval",
+      "10",
+    ],
+    {
+      env: { ...process.env, ORTS_DISABLE_TEXTURE_DOWNLOAD: "1" },
+    },
+  );
   ortsProcess = child;
 
   const port = await new Promise<number>((resolve, reject) => {

--- a/viewer/tests/render-perf.spec.ts
+++ b/viewer/tests/render-perf.spec.ts
@@ -36,17 +36,23 @@ test.beforeAll(async () => {
   }
 
   const binary = process.env.ORTS_BINARY ?? path.resolve(__dirname, "../../target/debug/orts");
-  const child = spawn(binary, [
-    "serve",
-    "--port",
-    "0",
-    "--sat",
-    "altitude=400,id=perf-test",
-    "--dt",
-    "1",
-    "--output-interval",
-    "1",
-  ]);
+  const child = spawn(
+    binary,
+    [
+      "serve",
+      "--port",
+      "0",
+      "--sat",
+      "altitude=400,id=perf-test",
+      "--dt",
+      "1",
+      "--output-interval",
+      "1",
+    ],
+    {
+      env: { ...process.env, ORTS_DISABLE_TEXTURE_DOWNLOAD: "1" },
+    },
+  );
   ortsProcess = child;
 
   const port = await new Promise<number>((resolve, reject) => {

--- a/viewer/tests/start-simulation.spec.ts
+++ b/viewer/tests/start-simulation.spec.ts
@@ -16,7 +16,9 @@ let wsUrl: string;
 /** Start orts in idle mode (no simulation args). */
 test.beforeAll(async () => {
   const binary = process.env.ORTS_BINARY ?? path.resolve(__dirname, "../../target/debug/orts");
-  const child = spawn(binary, ["serve", "--port", "0"]);
+  const child = spawn(binary, ["serve", "--port", "0"], {
+    env: { ...process.env, ORTS_DISABLE_TEXTURE_DOWNLOAD: "1" },
+  });
   ortsProcess = child;
 
   const port = await new Promise<number>((resolve, reject) => {

--- a/viewer/tests/ws-connect.spec.ts
+++ b/viewer/tests/ws-connect.spec.ts
@@ -18,7 +18,9 @@ test.beforeAll(async () => {
   }
 
   const binary = process.env.ORTS_BINARY ?? path.resolve(__dirname, "../../target/debug/orts");
-  const child = spawn(binary, ["serve", "--port", "0", "--sat", "altitude=400,id=test"]);
+  const child = spawn(binary, ["serve", "--port", "0", "--sat", "altitude=400,id=test"], {
+    env: { ...process.env, ORTS_DISABLE_TEXTURE_DOWNLOAD: "1" },
+  });
   ortsProcess = child;
 
   // Parse the actual port from stderr


### PR DESCRIPTION
`serve` は起動時に高解像度テクスチャ (Earth 単体で 21600×10800) を取得・デコードするタスクを走らせ、これがシミュレーションループと CPU を争う。`cli/tests/` の Rust 側 e2e は 8 箇所すべて `ORTS_DISABLE_TEXTURE_DOWNLOAD=1` を設定してこれを避けている。フラグはまさにこのために存在し、`textures.rs` のコメントもそう述べている。

`viewer-e2e` の workflow ステップと Playwright の spec は、どちらもこれを渡していなかった。

closes #373

## 症状

#65 と同じ (WebSocket は繋がるが `state` が来ない) だが、原因は別。#364 の CI ログ:

```
18:54:06 Server listening on http://localhost:9001
18:54:06 Downloading Blue Marble day (21600×10800) for 3 texture(s)...
18:54:11 Run node .github/scripts/wait-ws-stream.mjs
18:55:11 timed out after 60000ms waiting for a 'state' message
```

`wait-ws-stream.mjs` は #65 で追加された待ち合わせで、ここではテクスチャ取得がその待ち対象を starve させている。

## 変更

| 対象 | 変更 |
|---|---|
| `ci.yml` の "Start WebSocket server" | `env: ORTS_DISABLE_TEXTURE_DOWNLOAD: "1"` |
| Playwright の `spawn(binary, ["serve", ...])` 9 箇所 / 7 ファイル | 同上を spawn options に |

埋め込みの 2k テクスチャはフラグに関係なく配信されるので、レンダリング系のテストが見るものは変わらない。

`texture-lazy-load.spec.ts` は対象外にした。テクスチャ配信自体を検証するテストで、既に偽 JPEG でキャッシュを埋めてダウンロードを回避している (「To avoid depending on slow NASA downloads」)。フラグを渡すと `textures_ready` の検証が変わる。

`texture-base-url.spec.ts` は `serve` を spawn しないので対象外。

## 検証

`biome format --write viewer/tests/` を実行 (3 ファイル整形)。`biome check viewer/tests/` は変更前後どちらも 30 warnings で、私が触っていない `texture-lazy-load.spec.ts` にも 1 件出ているので既存分。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
