### PR TITLE
fix(orts-cli): install a log backend, so log:: records stop being discarded

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -161,7 +161,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - `orts run` の downlink log レコードの level を info/debug から debug/trace へ
   下げた。衛星 × outbound message × control tick ごとに出るため、logger が
   実際に動く状態では info だと fleet 規模の実行で他の診断が埋もれ、積分ループ内
-  で stderr のロックを取る書き込みが増える。
+  で stderr のロックを取る書き込みが増える。 ([#390](https://github.com/sksat/orts/pull/390))
 - `--tle` を再び TLE 専用 (2LE/3LE、`-` で stdin) とし、新規 `--omm` と
   対にした。要素セットのパースは削除した `orts::tle` でなく
   `arika::tle` / `arika::omm` を使用 (従来は `--tle` が OMM も自動受理)。([#87](https://github.com/sksat/orts/pull/87))
@@ -183,7 +183,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   サマリ、`serve --stream-stdio` の protocol) だけを運ぶ。filter は `RUST_LOG`
   で指定し、既定は `warn,orts=info` (orts は info、依存は warn)。`NO_COLOR`
   指定時と stderr が terminal でない場合は装飾を付けない。どちらも
-  `orts --help` に記載した。
+  `orts --help` に記載した。 ([#390](https://github.com/sksat/orts/pull/390))
 - `orts run --format csv --output <path>` が CSV を `<path>` に書き込むように
   なった。従来は `--format csv` の実行が `--output` に関わらず常に stdout へ
   出力し、指定パスを黙って無視していた。([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -160,8 +160,8 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 #### Changed
 - `orts run` の downlink log レコードの level を info/debug から debug/trace へ
   下げた。衛星 × outbound message × control tick ごとに出るため、logger が
-  実際に動く状態では info だと fleet 規模の実行で他の診断が埋もれ、積分ループ内
-  で stderr のロックを取る書き込みが増える。 ([#390](https://github.com/sksat/orts/pull/390))
+  実際に動く状態では info だと fleet 規模の実行で他の診断が読めなくなり、
+  積分ループ内で stderr のロックを取る書き込みが増える。 ([#390](https://github.com/sksat/orts/pull/390))
 - `--tle` を再び TLE 専用 (2LE/3LE、`-` で stdin) とし、新規 `--omm` と
   対にした。要素セットのパースは削除した `orts::tle` でなく
   `arika::tle` / `arika::omm` を使用 (従来は `--tle` が OMM も自動受理)。([#87](https://github.com/sksat/orts/pull/87))
@@ -179,8 +179,8 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   WASM plugin が WIT `host-env.log` 経由で出力した全ての行が消えていた。
   起動時に `log` 互換 bridge 付きの `tracing` subscriber を初期化するので、
   `.rrd` 記録経路で rerun の crate が出す `tracing` event も同じ経路で受け取る。
-  レコードは stderr へ出力し、stdout は従来どおりコマンドの出力 (CSV、`--json`
-  サマリ、`serve --stream-stdio` の protocol) だけを運ぶ。filter は `RUST_LOG`
+  レコードは stderr へ出力する。stdout に出るのは従来どおりコマンドの出力 (CSV、
+  `--json` サマリ、`serve --stream-stdio` の protocol) だけ。filter は `RUST_LOG`
   で指定し、既定は `warn,orts=info` (orts は info、依存は warn)。`NO_COLOR`
   指定時と stderr が terminal でない場合は装飾を付けない。どちらも
   `orts --help` に記載した。 ([#390](https://github.com/sksat/orts/pull/390))

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -158,6 +158,10 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   追加。よく使う・agent に関係する経路を端末内で発見できるようにした。([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
+- `orts run` の downlink log レコードの level を info/debug から debug/trace へ
+  下げた。衛星 × outbound message × control tick ごとに出るため、logger が
+  実際に動く状態では info だと fleet 規模の実行で他の診断が埋もれ、積分ループ内
+  で stderr のロックを取る書き込みが増える。
 - `--tle` を再び TLE 専用 (2LE/3LE、`-` で stdin) とし、新規 `--omm` と
   対にした。要素セットのパースは削除した `orts::tle` でなく
   `arika::tle` / `arika::omm` を使用 (従来は `--tle` が OMM も自動受理)。([#87](https://github.com/sksat/orts/pull/87))
@@ -169,6 +173,17 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   年に繰り上がらず拒否される。([#87](https://github.com/sksat/orts/pull/87))
 
 #### Fixed
+- log レコードがユーザーに届くようになった。CLI は logger を初期化しておらず、
+  `log` の no-op logger が全レコードを破棄していた: stream-io stdio plug の
+  displaced、stream の socket error、serve 中のシミュレーション停止、そして
+  WASM plugin が WIT `host-env.log` 経由で出力した全ての行が消えていた。
+  起動時に `log` 互換 bridge 付きの `tracing` subscriber を初期化するので、
+  `.rrd` 記録経路で rerun の crate が出す `tracing` event も同じ経路で受け取る。
+  レコードは stderr へ出力し、stdout は従来どおりコマンドの出力 (CSV、`--json`
+  サマリ、`serve --stream-stdio` の protocol) だけを運ぶ。filter は `RUST_LOG`
+  で指定し、既定は `warn,orts=info` (orts は info、依存は warn)。`NO_COLOR`
+  指定時と stderr が terminal でない場合は装飾を付けない。どちらも
+  `orts --help` に記載した。
 - `orts run --format csv --output <path>` が CSV を `<path>` に書き込むように
   なった。従来は `--format csv` の実行が `--output` に関わらず常に stdout へ
   出力し、指定パスを黙って無視していた。([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -173,17 +173,15 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   年に繰り上がらず拒否される。([#87](https://github.com/sksat/orts/pull/87))
 
 #### Fixed
-- log レコードがユーザーに届くようになった。CLI は logger を初期化しておらず、
-  `log` の no-op logger が全レコードを破棄していた: stream-io stdio plug の
-  displaced、stream の socket error、serve 中のシミュレーション停止、そして
-  WASM plugin が WIT `host-env.log` 経由で出力した全ての行が消えていた。
-  起動時に `log` 互換 bridge 付きの `tracing` subscriber を初期化するので、
-  `.rrd` 記録経路で rerun の crate が出す `tracing` event も同じ経路で受け取る。
-  レコードは stderr へ出力する。stdout に出るのは従来どおりコマンドの出力 (CSV、
-  `--json` サマリ、`serve --stream-stdio` の protocol) だけ。filter は `RUST_LOG`
-  で指定し、既定は `warn,orts=info` (orts は info、依存は warn)。`NO_COLOR`
-  指定時と stderr が terminal でない場合は装飾を付けない。どちらも
-  `orts --help` に記載した。 ([#390](https://github.com/sksat/orts/pull/390))
+- `orts` が診断ログを stderr に出力するようになった。logger を初期化していな
+  かったため `log::` の呼び出しは全て破棄されており、stream-io stdio plug の
+  displaced、stream の socket error、`serve` 中のシミュレーション停止、
+  WASM plugin が WIT `host-env.log` 経由で出力した行が、どれも表示されなかった。
+  `.rrd` を書く際に rerun の crate が出す診断も同じ出力に含まれる。level は
+  `RUST_LOG` で選び、既定は `warn,orts=info` (orts は info、依存は warn)。
+  `NO_COLOR` 指定時と stderr が terminal でない場合は装飾を付けない。どちらも
+  `orts --help` に記載がある。stdout は従来どおりコマンドの出力 (CSV、`--json`
+  サマリ、`serve --stream-stdio` の protocol) だけ。 ([#390](https://github.com/sksat/orts/pull/390))
 - `orts run --format csv --output <path>` が CSV を `<path>` に書き込むように
   なった。従来は `--format csv` の実行が `--output` に関わらず常に stdout へ
   出力し、指定パスを黙って無視していた。([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,10 @@ section is subdivided by package.
   are discoverable without leaving the terminal. ([#217](https://github.com/sksat/orts/pull/217))
 
 #### Changed
+- `orts run`'s downlink log records moved from info/debug to debug/trace. They
+  fire per satellite per outbound message per control tick, so with a backend
+  installed, info would bury every other diagnostic on a fleet-sized run and add
+  a locked stderr write inside the integration loop.
 - `--tle` is TLE-only again (2LE/3LE; `-` for stdin) and pairs with the new
   `--omm`; element-set parsing is now backed by `arika::tle` / `arika::omm`
   instead of the removed `orts::tle`. (Previously `--tle` also auto-accepted OMM.) ([#87](https://github.com/sksat/orts/pull/87))
@@ -192,6 +196,17 @@ section is subdivided by package.
   malformed field is rejected rather than rolling into another year. ([#87](https://github.com/sksat/orts/pull/87))
 
 #### Fixed
+- Log records reach the user. The CLI never installed a `log` backend, so `log`'s
+  no-op logger discarded every record: a displaced stream-io stdio plug, a stream
+  socket error, a halted served simulation, and every line a WASM plugin wrote
+  through the WIT `host-env.log` import all went nowhere. A `tracing` subscriber
+  with the `log` compatibility bridge is now installed at startup, so it also
+  receives the `tracing` events the rerun crates emit on the `.rrd` recording
+  path. Records go to stderr; stdout still carries only what a command produces
+  (CSV, the `--json` summary, the `serve --stream-stdio` protocol). `RUST_LOG`
+  sets the filter, defaulting to `warn,orts=info` — orts at info, dependencies at
+  warn — and `NO_COLOR` (or a non-terminal stderr) turns styling off. Both are
+  documented in `orts --help`.
 - `orts run --format csv --output <path>` now writes the CSV to `<path>`.
   Previously every `--format csv` run wrote to stdout regardless of `--output`,
   silently ignoring the given path. ([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,17 +196,15 @@ section is subdivided by package.
   malformed field is rejected rather than rolling into another year. ([#87](https://github.com/sksat/orts/pull/87))
 
 #### Fixed
-- Log records reach the user. The CLI never installed a `log` backend, so `log`'s
-  no-op logger discarded every record: a displaced stream-io stdio plug, a stream
-  socket error, a halted served simulation, and every line a WASM plugin wrote
-  through the WIT `host-env.log` import all went nowhere. A `tracing` subscriber
-  with the `log` compatibility bridge is now installed at startup, so it also
-  receives the `tracing` events the rerun crates emit on the `.rrd` recording
-  path. Records go to stderr; stdout still carries only what a command produces
-  (CSV, the `--json` summary, the `serve --stream-stdio` protocol). `RUST_LOG`
-  sets the filter, defaulting to `warn,orts=info` — orts at info, dependencies at
-  warn — and `NO_COLOR` (or a non-terminal stderr) turns styling off. Both are
-  documented in `orts --help`. ([#390](https://github.com/sksat/orts/pull/390))
+- `orts` now writes its diagnostics to stderr. With no `log` backend installed
+  every `log::` call was discarded, so a displaced stream-io stdio plug, a stream
+  socket error, a halted `serve` simulation, and every line a WASM plugin logged
+  through the WIT `host-env.log` import all went unreported. The diagnostics the
+  rerun crates emit while writing an `.rrd` now appear in the same output.
+  `RUST_LOG` selects the level — default `warn,orts=info`, ours at info and
+  dependencies at warn — and `NO_COLOR`, or a stderr that is not a terminal,
+  drops the styling; `orts --help` documents both. stdout is unchanged: the CSV,
+  the `--json` summary, or the `serve --stream-stdio` protocol and nothing else. ([#390](https://github.com/sksat/orts/pull/390))
 - `orts run --format csv --output <path>` now writes the CSV to `<path>`.
   Previously every `--format csv` run wrote to stdout regardless of `--output`,
   silently ignoring the given path. ([#214](https://github.com/sksat/orts/pull/214))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,7 +184,7 @@ section is subdivided by package.
 - `orts run`'s downlink log records moved from info/debug to debug/trace. They
   fire per satellite per outbound message per control tick, so with a backend
   installed, info would bury every other diagnostic on a fleet-sized run and add
-  a locked stderr write inside the integration loop.
+  a locked stderr write inside the integration loop. ([#390](https://github.com/sksat/orts/pull/390))
 - `--tle` is TLE-only again (2LE/3LE; `-` for stdin) and pairs with the new
   `--omm`; element-set parsing is now backed by `arika::tle` / `arika::omm`
   instead of the removed `orts::tle`. (Previously `--tle` also auto-accepted OMM.) ([#87](https://github.com/sksat/orts/pull/87))
@@ -206,7 +206,7 @@ section is subdivided by package.
   (CSV, the `--json` summary, the `serve --stream-stdio` protocol). `RUST_LOG`
   sets the filter, defaulting to `warn,orts=info` — orts at info, dependencies at
   warn — and `NO_COLOR` (or a non-terminal stderr) turns styling off. Both are
-  documented in `orts --help`.
+  documented in `orts --help`. ([#390](https://github.com/sksat/orts/pull/390))
 - `orts run --format csv --output <path>` now writes the CSV to `<path>`.
   Previously every `--format csv` run wrote to stdout regardless of `--output`,
   silently ignoring the given path. ([#214](https://github.com/sksat/orts/pull/214))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2889,6 +2889,8 @@ dependencies = [
  "tokio-tungstenite 0.29.0",
  "toml",
  "toml-span",
+ "tracing",
+ "tracing-subscriber",
  "ts-rs",
  "ureq",
  "utsuroi",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -34,6 +34,17 @@ tobari = { workspace = true, features = ["fetch-cssi"] }
 arika = { workspace = true, features = ["sgp4"] }
 orts.workspace = true
 log = "0.4.29"
+# The CLI's log backend. `orts-cli` and `orts` emit `log` records (a WASM
+# plugin's `host-env.log` lines among them) while the rerun crates emit
+# `tracing` events; a `tracing` subscriber with the `tracing-log` feature is the
+# one sink that receives both. rerun's `re_log` already pulls this crate with
+# these features, so it is compiled for every build either way.
+tracing-subscriber = { version = "0.3", features = [
+  "env-filter",
+  "fmt",
+  "ansi",
+  "tracing-log",
+] }
 clap.workspace = true
 tokio.workspace = true
 axum.workspace = true
@@ -69,6 +80,8 @@ codespan-reporting = "0.13"
 [dev-dependencies]
 tokio-tungstenite.workspace = true
 tempfile = "3"
+# Drives the filter with synthetic targets in the logging unit tests.
+tracing = "0.1"
 
 # cargo-binstall metadata: `cargo binstall orts-cli` (or
 # `cargo binstall --git https://github.com/sksat/orts orts-cli` while

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -34,11 +34,8 @@ tobari = { workspace = true, features = ["fetch-cssi"] }
 arika = { workspace = true, features = ["sgp4"] }
 orts.workspace = true
 log = "0.4.29"
-# The CLI's log backend. `orts-cli` and `orts` emit `log` records (a WASM
-# plugin's `host-env.log` lines among them) while the rerun crates emit
-# `tracing` events; a `tracing` subscriber with the `tracing-log` feature is the
-# one sink that receives both. rerun's `re_log` already pulls this crate with
-# these features, so it is compiled for every build either way.
+# The log backend (see cli/src/logging.rs). rerun's `re_log` already pulls this
+# crate with these features, so it costs no extra build.
 tracing-subscriber = { version = "0.3", features = [
   "env-filter",
   "fmt",

--- a/cli/README.md
+++ b/cli/README.md
@@ -17,6 +17,20 @@ orts serve                             # WebSocket server (port 9001) +
 
 See `orts --help` for the full CLI surface.
 
+## Logs
+
+Diagnostics go to stderr; stdout carries only what a command produces (CSV, the
+`--json` summary, the `serve --stream-stdio` protocol). `RUST_LOG` sets the
+filter, defaulting to `warn,orts=info` — orts at info, dependencies at warn.
+
+```
+RUST_LOG=warn orts serve --config mission.toml    # warnings and errors only
+RUST_LOG=orts=debug orts run --config mission.toml
+```
+
+A WASM plugin's own log output (the WIT `host-env.log` import) arrives under the
+same `orts` target, so `RUST_LOG=warn` silences flight-software logs too.
+
 ## Recommended install
 
 ```

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -3,16 +3,16 @@ use clap::{Parser, Subcommand, ValueEnum};
 /// orts CLI — orbital mechanics simulation tool
 #[derive(Parser, Debug)]
 #[command(name = "orts")]
-#[command(after_help = EXAMPLES)]
+#[command(after_help = AFTER_HELP)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,
 }
 
-/// Copy-pasteable examples shown at the end of `orts --help` (and `-h`).
-/// Kept here so the most common — and the most agent-relevant — workflows are
-/// discoverable without reading the docs.
-const EXAMPLES: &str = "\
+/// Copy-pasteable examples and the environment the CLI reads, shown at the end
+/// of `orts --help` (and `-h`). Kept here so the most common — and the most
+/// agent-relevant — workflows are discoverable without reading the docs.
+pub(crate) const AFTER_HELP: &str = "\
 Examples:
   # Run a simulation, recording to an .rrd file (the default)
   orts run --sat altitude=400
@@ -30,6 +30,17 @@ Examples:
 
   # Live WebSocket server + embedded 3D viewer at http://localhost:9001
   orts serve --config mission.toml
+
+Environment:
+  RUST_LOG   Log filter, default \"warn,orts=info\": orts at info, dependencies
+             at warn. Records go to stderr (stdout carries only what the
+             command produces), and a WASM plugin's own log output arrives
+             under the orts target.
+               RUST_LOG=warn            quiet — warnings and errors only
+               RUST_LOG=debug           everything, dependencies included
+               RUST_LOG=orts=debug      just ours, more detail
+  NO_COLOR   Set to any non-empty value to disable styled records. They are
+             already unstyled when stderr is not a terminal.
 ";
 
 #[derive(Subcommand, Debug)]

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -1184,16 +1184,19 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Result<Record
         // controller が msg-io 未対応なら default 実装で空。
         for (i, sat) in satellites.iter_mut().enumerate() {
             for m in sat.controller.take_outbound() {
-                // Metadata at info; the full payload only at debug — payloads
-                // can be large (binary / file-transfer), so logging them every
-                // tick at info would be noisy and IO-heavy.
-                log::info!(
+                // Both tiers sit below the default filter: this runs per
+                // satellite per outbound message per control tick, so at info
+                // a fleet-sized run would bury every other diagnostic and pay
+                // a locked stderr write inside the sim loop. Metadata at debug,
+                // the full payload only at trace — payloads can be large
+                // (binary / file-transfer).
+                log::debug!(
                     "downlink t={:.3} sat={} kind={}",
                     t + dt,
                     params.satellites[i].id,
                     m.kind
                 );
-                log::debug!(
+                log::trace!(
                     "downlink payload sat={} kind={}: {:?}",
                     params.satellites[i].id,
                     m.kind,

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -1184,12 +1184,9 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Result<Record
         // controller が msg-io 未対応なら default 実装で空。
         for (i, sat) in satellites.iter_mut().enumerate() {
             for m in sat.controller.take_outbound() {
-                // Both tiers sit below the default filter: this runs per
-                // satellite per outbound message per control tick, so at info
-                // a fleet-sized run would bury every other diagnostic and pay
-                // a locked stderr write inside the sim loop. Metadata at debug,
-                // the full payload only at trace — payloads can be large
-                // (binary / file-transfer).
+                // Both below the default filter: this runs per satellite per
+                // outbound message per control tick. Payloads can be large
+                // (binary / file-transfer), so they sit one level lower again.
                 log::debug!(
                     "downlink t={:.3} sat={} kind={}",
                     t + dt,

--- a/cli/src/logging.rs
+++ b/cli/src/logging.rs
@@ -1,27 +1,19 @@
 //! The process-wide logging backend.
 //!
-//! Two record streams have to land in one place. `orts-cli` and `orts` emit
-//! `log` records — including every line a WASM plugin writes through the WIT
-//! `host-env.log` import, which the host forwards as a `log` record — while
-//! the rerun crates that own the `.rrd` recording path emit `tracing` events.
-//! Setting a `tracing` subscriber and bridging `log` into it puts both in one
-//! place, and adds no dependency: rerun's `re_log` already compiles
-//! `tracing-subscriber` with the features used here into every build.
+//! Two record streams have to reach one place: `log` records from `orts-cli`
+//! and `orts` (a WASM plugin's `host-env.log` lines among them), and `tracing`
+//! events from the rerun crates on the `.rrd` path. A `tracing` subscriber with
+//! `log` bridged into it takes both and adds no dependency — rerun's `re_log`
+//! already builds `tracing-subscriber` with these features.
 //!
-//! A `log`-only backend would see rerun's diagnostics too, but only by
-//! accident: `tracing`'s `log` feature (enabled here through tower, not by
-//! this crate) makes a `tracing` macro emit a `log` record while no subscriber
-//! is set, and that fallback drops spans and fields. Since a subscriber *is*
-//! set here, the macros take their `tracing` branch instead — which is also
-//! why bridging `log` into `tracing` cannot recurse. `log-always`, the feature
-//! that would emit both unconditionally, is off.
+//! `tracing`'s `log` feature (on via axum's default `tower-log`) makes a
+//! `tracing` macro emit a `log` record while no subscriber is set. With one set
+//! the macros stay on `tracing`, which is why bridging `log` into it cannot
+//! recurse — `log-always`, which emits both unconditionally, would.
 //!
-//! What belongs here and what does not: a diagnostic carries a level and is
-//! addressed to whoever is debugging (`stream-io socket error on …`,
-//! `simulation halted: …`), so it goes through `log`. A command's own output is
-//! not a diagnostic — `Saved to …`, the contact-window table, the `serve`
-//! banner and the `config validate` verdict are the result the user asked for,
-//! and they stay on `eprintln!`/stdout where no filter can drop them.
+//! Diagnostics carry a level and go through `log`. A command's own output —
+//! `Saved to …`, the contact-window table, the `serve` banner, the `config
+//! validate` verdict — stays on `eprintln!`/stdout, where no filter drops it.
 
 use std::io::IsTerminal as _;
 
@@ -29,70 +21,46 @@ use tracing_subscriber::filter::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
 
-/// The filter applied when `RUST_LOG` says nothing.
+/// Filter used when `RUST_LOG` says nothing.
 ///
-/// Our own code at info, everything else at warn. The dependency tree can emit
-/// records from axum, hyper, tungstenite, ureq and wasmtime, and an info
-/// default across all of them would bury our own diagnostics. Info for ours is
-/// what makes the `serve` stream-io lifecycle (plug attached, displaced, peer
-/// connected) show up *before* something goes wrong — raising the level after a
-/// stream has gone quiet is too late to explain it.
+/// Ours at info, dependencies at warn: an info default across axum, hyper,
+/// ureq and wasmtime would bury our own records. Info for ours leaves the
+/// `serve` stream-io trail in place *before* a stream goes quiet.
 ///
-/// One directive covers everything of ours because a record's target is its
-/// module path, and both roots are `orts`: this crate builds as the `orts`
-/// binary (`[[bin]] name`), not as `orts_cli`, and the core library is `orts`
-/// too. That single root also carries plugin output, since a guest's
-/// `host-env.log` records take the target of the host module that forwards
-/// them. [`our_records_are_rooted_at_the_filtered_target`] holds the filter to
-/// that name.
-///
-/// [`our_records_are_rooted_at_the_filtered_target`]: tests::our_records_are_rooted_at_the_filtered_target
+/// One directive covers the CLI, the core library and plugin output, because
+/// targets are module paths and all three are rooted at `orts` — this crate
+/// builds as the `orts` binary, not as `orts_cli`.
 const DEFAULT_DIRECTIVES: &str = "warn,orts=info";
 
-/// The environment variable the filter is read from. `RUST_LOG` rather than an
-/// `ORTS_*` name of our own: the rerun crates in the same binary already read
-/// it, so one variable configures the whole process.
+/// `RUST_LOG` rather than an `ORTS_*` name of our own: the rerun crates in the
+/// same binary read it too, so one variable configures the whole process.
 const FILTER_ENV: &str = "RUST_LOG";
 
-/// Builds the filter from a `RUST_LOG` value, falling back to
-/// [`DEFAULT_DIRECTIVES`].
-///
-/// Takes the value as an argument rather than reading the environment so the
-/// policy is testable without mutating process-global state (`set_var` is
-/// `unsafe` in edition 2024).
-///
-/// An unset *or empty* `RUST_LOG` falls back: `RUST_LOG=` is what a shell
-/// leaves behind when a variable is cleared, and reading that as "filter
-/// everything out" would silence the CLI for a caller who meant "default".
+/// Takes the value as an argument so the policy is testable without `set_var`
+/// (`unsafe` in edition 2024). An empty value falls back as well: `RUST_LOG=`
+/// is a cleared variable, not "filter everything out".
 fn filter_from_env(rust_log: Option<&str>) -> EnvFilter {
     let directives = match rust_log {
         Some(v) if !v.trim().is_empty() => v,
         _ => DEFAULT_DIRECTIVES,
     };
-    // Lossy: an unparsable directive is reported on stderr and skipped, so a
-    // typo in `RUST_LOG` costs that directive rather than the whole run.
+    // Lossy, so a typo costs that one directive rather than the whole run.
     EnvFilter::builder().parse_lossy(directives)
 }
 
-/// Colour only when stderr is a terminal.
-///
 /// The fmt layer's own default checks `NO_COLOR` but not whether the stream is
-/// a terminal, so it would write escape codes into a redirected log file.
+/// a terminal, so it would write escape codes into a redirected log.
 fn use_ansi() -> bool {
     std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none_or(|v| v.is_empty())
 }
 
-/// Installs the backend. Call once, before anything worth logging happens.
+/// Installs the backend; call once, before anything worth logging happens.
 ///
-/// Records go to **stderr**: stdout is reserved for what a command produces —
-/// CSV from `run --output -`, the `--json` summary, and the kble-socket binary
-/// protocol under `serve --stream-stdio`, which a log line would corrupt.
+/// Records go to stderr, since stdout carries what a command produces: CSV
+/// from `run --output -`, the `--json` summary, and the kble-socket protocol
+/// under `serve --stream-stdio`.
 pub fn init() {
     let filter = filter_from_env(std::env::var(FILTER_ENV).ok().as_deref());
-    // Before the filter is moved into the subscriber: "which filter am I
-    // actually running with" is the first question when an expected record
-    // does not show up, and `RUST_LOG` is not always visible to whoever is
-    // reading the log.
     let effective_filter = filter.to_string();
 
     let subscriber = tracing_subscriber::registry().with(filter).with(
@@ -101,20 +69,17 @@ pub fn init() {
             .with_ansi(use_ansi()),
     );
 
-    // `try_init` also installs the `log` -> `tracing` bridge (tracing-subscriber's
-    // `tracing-log` feature), and does it *after* setting the global default so
-    // it can cap `log`'s max level at the filter's. That cap is what lets a
-    // filtered-out `log::trace!` inside the integration loop return without
-    // formatting its arguments.
+    // `try_init` also installs the `log` -> `tracing` bridge, capping `log`'s
+    // max level at the filter's. That cap is what lets a filtered-out
+    // `log::trace!` in the integration loop return without formatting.
     if let Err(e) = subscriber.try_init() {
         // The one diagnostic that cannot go through `log`.
         eprintln!("Warning: could not install the log backend: {e}");
         return;
     }
 
-    // Deliberately at debug, so the default filter keeps it out of every
-    // ordinary run. It goes through `log` rather than `tracing` so that a
-    // `RUST_LOG=debug` run also demonstrates the `log` bridge is live.
+    // At debug so ordinary runs stay quiet, and through `log` so that a
+    // `RUST_LOG=debug` run also shows the bridge is live.
     log::debug!(
         "orts {} starting; log filter: {effective_filter}",
         env!("CARGO_PKG_VERSION")
@@ -128,26 +93,24 @@ mod tests {
     use tracing_subscriber::Registry;
     use tracing_subscriber::filter::LevelFilter;
 
-    /// The global max level the filter admits. This is the value `try_init`
-    /// hands to the `log` bridge, so it decides which `log::` call sites can
-    /// return without formatting their arguments.
+    /// The value `try_init` hands to the `log` bridge, which decides where
+    /// `log::` call sites can return without formatting their arguments.
     fn max_level(rust_log: Option<&str>) -> Option<LevelFilter> {
         <EnvFilter as Layer<Registry>>::max_level_hint(&filter_from_env(rust_log))
     }
 
     #[test]
     fn default_directives_are_valid() {
-        // `parse`, not `parse_lossy`, so a typo in the constant fails here
-        // instead of silently dropping a directive at startup.
+        // `parse`, not `parse_lossy`: a typo in the constant fails here rather
+        // than dropping a directive at startup.
         assert!(
             EnvFilter::builder().parse(DEFAULT_DIRECTIVES).is_ok(),
             "DEFAULT_DIRECTIVES must parse: {DEFAULT_DIRECTIVES}"
         );
     }
 
-    /// Info has to reach the bridge, since our crates log there; debug and
-    /// trace must not, because `run`'s downlink records sit at those levels
-    /// inside the integration loop.
+    /// Info reaches the bridge; debug and trace must not, since `run`'s
+    /// downlink records sit there inside the integration loop.
     #[test]
     fn default_admits_info_and_stops_below_it() {
         assert_eq!(max_level(None), Some(LevelFilter::INFO));
@@ -160,11 +123,9 @@ mod tests {
         assert_eq!(max_level(Some("off")), Some(LevelFilter::OFF));
     }
 
-    /// The policy the default filter exists to express, checked per target.
-    ///
-    /// Kept in one test on a thread-local dispatcher: a callsite's `Interest`
-    /// is cached process-wide, so spreading these across tests that install
-    /// different subscribers could let one test's verdict answer another's.
+    /// Kept in one test: a callsite's `Interest` is cached process-wide, so
+    /// spreading these across tests that install different subscribers could
+    /// let one test's verdict answer another's.
     #[test]
     fn default_raises_our_crates_and_leaves_dependencies_at_warn() {
         let subscriber = tracing_subscriber::registry().with(filter_from_env(None));
@@ -192,8 +153,7 @@ mod tests {
         });
     }
 
-    /// `--help` quotes the default filter, and it is the only place a user can
-    /// discover it. Changing the constant has to change the help text too.
+    /// `--help` is the only place a user can discover the default.
     #[test]
     fn help_text_quotes_the_default_filter() {
         assert!(
@@ -202,10 +162,8 @@ mod tests {
         );
     }
 
-    /// The filter names `orts` because that is what our record targets are
-    /// rooted at. Renaming the binary, or filtering on the package name
-    /// `orts_cli` instead, would match nothing and silently discard every
-    /// record again — the exact failure this module exists to fix.
+    /// Filtering on the package name `orts_cli`, or renaming the binary, would
+    /// match nothing and silently discard every record again.
     #[test]
     fn our_records_are_rooted_at_the_filtered_target() {
         let root = module_path!()
@@ -219,7 +177,7 @@ mod tests {
         );
     }
 
-    /// `RUST_LOG=` (cleared, not unset) must mean "default", not "silence".
+    /// `RUST_LOG=` (cleared, not unset) means "default", not "silence".
     #[test]
     fn empty_rust_log_falls_back_to_the_default() {
         assert_eq!(max_level(Some("")), Some(LevelFilter::INFO));

--- a/cli/src/logging.rs
+++ b/cli/src/logging.rs
@@ -4,8 +4,17 @@
 //! `log` records — including every line a WASM plugin writes through the WIT
 //! `host-env.log` import, which the host forwards as a `log` record — while
 //! the rerun crates that own the `.rrd` recording path emit `tracing` events.
-//! A `tracing` subscriber plus the `log` compatibility bridge sees both; a
-//! `log`-only backend would leave rerun's diagnostics discarded.
+//! Setting a `tracing` subscriber and bridging `log` into it puts both in one
+//! place, and adds no dependency: rerun's `re_log` already compiles
+//! `tracing-subscriber` with the features used here into every build.
+//!
+//! A `log`-only backend would see rerun's diagnostics too, but only by
+//! accident: `tracing`'s `log` feature (enabled here through tower, not by
+//! this crate) makes a `tracing` macro emit a `log` record while no subscriber
+//! is set, and that fallback drops spans and fields. Since a subscriber *is*
+//! set here, the macros take their `tracing` branch instead — which is also
+//! why bridging `log` into `tracing` cannot recurse. `log-always`, the feature
+//! that would emit both unconditionally, is off.
 //!
 //! What belongs here and what does not: a diagnostic carries a level and is
 //! addressed to whoever is debugging (`stream-io socket error on …`,

--- a/cli/src/logging.rs
+++ b/cli/src/logging.rs
@@ -183,6 +183,16 @@ mod tests {
         });
     }
 
+    /// `--help` quotes the default filter, and it is the only place a user can
+    /// discover it. Changing the constant has to change the help text too.
+    #[test]
+    fn help_text_quotes_the_default_filter() {
+        assert!(
+            crate::cli::AFTER_HELP.contains(DEFAULT_DIRECTIVES),
+            "--help should quote `{DEFAULT_DIRECTIVES}`"
+        );
+    }
+
     /// The filter names `orts` because that is what our record targets are
     /// rooted at. Renaming the binary, or filtering on the package name
     /// `orts_cli` instead, would match nothing and silently discard every

--- a/cli/src/logging.rs
+++ b/cli/src/logging.rs
@@ -1,0 +1,209 @@
+//! The process-wide logging backend.
+//!
+//! Two record streams have to land in one place. `orts-cli` and `orts` emit
+//! `log` records — including every line a WASM plugin writes through the WIT
+//! `host-env.log` import, which the host forwards as a `log` record — while
+//! the rerun crates that own the `.rrd` recording path emit `tracing` events.
+//! A `tracing` subscriber plus the `log` compatibility bridge sees both; a
+//! `log`-only backend would leave rerun's diagnostics discarded.
+//!
+//! What belongs here and what does not: a diagnostic carries a level and is
+//! addressed to whoever is debugging (`stream-io socket error on …`,
+//! `simulation halted: …`), so it goes through `log`. A command's own output is
+//! not a diagnostic — `Saved to …`, the contact-window table, the `serve`
+//! banner and the `config validate` verdict are the result the user asked for,
+//! and they stay on `eprintln!`/stdout where no filter can drop them.
+
+use std::io::IsTerminal as _;
+
+use tracing_subscriber::filter::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt as _;
+use tracing_subscriber::util::SubscriberInitExt as _;
+
+/// The filter applied when `RUST_LOG` says nothing.
+///
+/// Our own code at info, everything else at warn. The dependency tree can emit
+/// records from axum, hyper, tungstenite, ureq and wasmtime, and an info
+/// default across all of them would bury our own diagnostics. Info for ours is
+/// what makes the `serve` stream-io lifecycle (plug attached, displaced, peer
+/// connected) show up *before* something goes wrong — raising the level after a
+/// stream has gone quiet is too late to explain it.
+///
+/// One directive covers everything of ours because a record's target is its
+/// module path, and both roots are `orts`: this crate builds as the `orts`
+/// binary (`[[bin]] name`), not as `orts_cli`, and the core library is `orts`
+/// too. That single root also carries plugin output, since a guest's
+/// `host-env.log` records take the target of the host module that forwards
+/// them. [`our_records_are_rooted_at_the_filtered_target`] holds the filter to
+/// that name.
+///
+/// [`our_records_are_rooted_at_the_filtered_target`]: tests::our_records_are_rooted_at_the_filtered_target
+const DEFAULT_DIRECTIVES: &str = "warn,orts=info";
+
+/// The environment variable the filter is read from. `RUST_LOG` rather than an
+/// `ORTS_*` name of our own: the rerun crates in the same binary already read
+/// it, so one variable configures the whole process.
+const FILTER_ENV: &str = "RUST_LOG";
+
+/// Builds the filter from a `RUST_LOG` value, falling back to
+/// [`DEFAULT_DIRECTIVES`].
+///
+/// Takes the value as an argument rather than reading the environment so the
+/// policy is testable without mutating process-global state (`set_var` is
+/// `unsafe` in edition 2024).
+///
+/// An unset *or empty* `RUST_LOG` falls back: `RUST_LOG=` is what a shell
+/// leaves behind when a variable is cleared, and reading that as "filter
+/// everything out" would silence the CLI for a caller who meant "default".
+fn filter_from_env(rust_log: Option<&str>) -> EnvFilter {
+    let directives = match rust_log {
+        Some(v) if !v.trim().is_empty() => v,
+        _ => DEFAULT_DIRECTIVES,
+    };
+    // Lossy: an unparsable directive is reported on stderr and skipped, so a
+    // typo in `RUST_LOG` costs that directive rather than the whole run.
+    EnvFilter::builder().parse_lossy(directives)
+}
+
+/// Colour only when stderr is a terminal.
+///
+/// The fmt layer's own default checks `NO_COLOR` but not whether the stream is
+/// a terminal, so it would write escape codes into a redirected log file.
+fn use_ansi() -> bool {
+    std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none_or(|v| v.is_empty())
+}
+
+/// Installs the backend. Call once, before anything worth logging happens.
+///
+/// Records go to **stderr**: stdout is reserved for what a command produces —
+/// CSV from `run --output -`, the `--json` summary, and the kble-socket binary
+/// protocol under `serve --stream-stdio`, which a log line would corrupt.
+pub fn init() {
+    let filter = filter_from_env(std::env::var(FILTER_ENV).ok().as_deref());
+    // Before the filter is moved into the subscriber: "which filter am I
+    // actually running with" is the first question when an expected record
+    // does not show up, and `RUST_LOG` is not always visible to whoever is
+    // reading the log.
+    let effective_filter = filter.to_string();
+
+    let subscriber = tracing_subscriber::registry().with(filter).with(
+        tracing_subscriber::fmt::layer()
+            .with_writer(std::io::stderr)
+            .with_ansi(use_ansi()),
+    );
+
+    // `try_init` also installs the `log` -> `tracing` bridge (tracing-subscriber's
+    // `tracing-log` feature), and does it *after* setting the global default so
+    // it can cap `log`'s max level at the filter's. That cap is what lets a
+    // filtered-out `log::trace!` inside the integration loop return without
+    // formatting its arguments.
+    if let Err(e) = subscriber.try_init() {
+        // The one diagnostic that cannot go through `log`.
+        eprintln!("Warning: could not install the log backend: {e}");
+        return;
+    }
+
+    // Deliberately at debug, so the default filter keeps it out of every
+    // ordinary run. It goes through `log` rather than `tracing` so that a
+    // `RUST_LOG=debug` run also demonstrates the `log` bridge is live.
+    log::debug!(
+        "orts {} starting; log filter: {effective_filter}",
+        env!("CARGO_PKG_VERSION")
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing_subscriber::Layer;
+    use tracing_subscriber::Registry;
+    use tracing_subscriber::filter::LevelFilter;
+
+    /// The global max level the filter admits. This is the value `try_init`
+    /// hands to the `log` bridge, so it decides which `log::` call sites can
+    /// return without formatting their arguments.
+    fn max_level(rust_log: Option<&str>) -> Option<LevelFilter> {
+        <EnvFilter as Layer<Registry>>::max_level_hint(&filter_from_env(rust_log))
+    }
+
+    #[test]
+    fn default_directives_are_valid() {
+        // `parse`, not `parse_lossy`, so a typo in the constant fails here
+        // instead of silently dropping a directive at startup.
+        assert!(
+            EnvFilter::builder().parse(DEFAULT_DIRECTIVES).is_ok(),
+            "DEFAULT_DIRECTIVES must parse: {DEFAULT_DIRECTIVES}"
+        );
+    }
+
+    /// Info has to reach the bridge, since our crates log there; debug and
+    /// trace must not, because `run`'s downlink records sit at those levels
+    /// inside the integration loop.
+    #[test]
+    fn default_admits_info_and_stops_below_it() {
+        assert_eq!(max_level(None), Some(LevelFilter::INFO));
+    }
+
+    #[test]
+    fn rust_log_replaces_the_default() {
+        assert_eq!(max_level(Some("warn")), Some(LevelFilter::WARN));
+        assert_eq!(max_level(Some("orts=trace")), Some(LevelFilter::TRACE));
+        assert_eq!(max_level(Some("off")), Some(LevelFilter::OFF));
+    }
+
+    /// The policy the default filter exists to express, checked per target.
+    ///
+    /// Kept in one test on a thread-local dispatcher: a callsite's `Interest`
+    /// is cached process-wide, so spreading these across tests that install
+    /// different subscribers could let one test's verdict answer another's.
+    #[test]
+    fn default_raises_our_crates_and_leaves_dependencies_at_warn() {
+        let subscriber = tracing_subscriber::registry().with(filter_from_env(None));
+        tracing::dispatcher::with_default(&tracing::Dispatch::new(subscriber), || {
+            assert!(
+                tracing::enabled!(target: "orts::commands::serve::stream_bridge", tracing::Level::INFO),
+                "the CLI's own info records are the stream-io lifecycle trail"
+            );
+            assert!(
+                tracing::enabled!(target: "orts::plugin::wasm::sync_host_state", tracing::Level::INFO),
+                "a WASM plugin's host-env.log records carry this target"
+            );
+            assert!(
+                !tracing::enabled!(target: "axum::serve", tracing::Level::INFO),
+                "a dependency's info would bury ours"
+            );
+            assert!(
+                tracing::enabled!(target: "axum::serve", tracing::Level::WARN),
+                "a dependency's warning still has to reach the user"
+            );
+            assert!(
+                !tracing::enabled!(target: "orts::commands::run", tracing::Level::DEBUG),
+                "run's per-tick downlink records sit at debug and must stay off"
+            );
+        });
+    }
+
+    /// The filter names `orts` because that is what our record targets are
+    /// rooted at. Renaming the binary, or filtering on the package name
+    /// `orts_cli` instead, would match nothing and silently discard every
+    /// record again — the exact failure this module exists to fix.
+    #[test]
+    fn our_records_are_rooted_at_the_filtered_target() {
+        let root = module_path!()
+            .split("::")
+            .next()
+            .expect("a module path has at least one segment");
+        assert_eq!(root, "orts", "this binary's crate name");
+        assert!(
+            DEFAULT_DIRECTIVES.contains(&format!("{root}=")),
+            "{DEFAULT_DIRECTIVES} must raise the level for `{root}`"
+        );
+    }
+
+    /// `RUST_LOG=` (cleared, not unset) must mean "default", not "silence".
+    #[test]
+    fn empty_rust_log_falls_back_to_the_default() {
+        assert_eq!(max_level(Some("")), Some(LevelFilter::INFO));
+        assert_eq!(max_level(Some("   ")), Some(LevelFilter::INFO));
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,6 +2,7 @@ mod cli;
 mod commands;
 mod config;
 mod license;
+mod logging;
 mod satellite;
 mod sim;
 mod tle;
@@ -21,6 +22,10 @@ fn exit_on_error(result: Result<(), CmdError>) {
 }
 
 fn main() {
+    // Before anything that might log. `--license-notice` exits inside the
+    // parse below, so nothing is lost by installing the backend first.
+    logging::init();
+
     // Concatenate the Rust and viewer (npm) NOTICE strings so a single
     // `--license-notice` invocation prints everything that is redistributed
     // in the binary. Built at runtime so the viewer notice can come from the

--- a/cli/tests/help_e2e.rs
+++ b/cli/tests/help_e2e.rs
@@ -28,3 +28,28 @@ fn test_top_level_help_has_examples() {
         "examples should show `orts config validate`"
     );
 }
+
+/// The log filter is only reachable through the environment, so `--help` is
+/// where someone (or an agent) has to be able to find it.
+#[test]
+fn test_top_level_help_documents_the_log_filter() {
+    let out = Command::new(env!("CARGO_BIN_EXE_orts"))
+        .arg("--help")
+        .output()
+        .expect("run orts --help");
+    assert!(out.status.success());
+    let help = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        help.contains("Environment:"),
+        "--help should include an Environment section:\n{help}"
+    );
+    assert!(
+        help.contains("RUST_LOG"),
+        "--help should name the log filter variable:\n{help}"
+    );
+    assert!(
+        help.contains("warn,orts=info"),
+        "--help should state the default filter, so the starting point is known:\n{help}"
+    );
+}

--- a/cli/tests/logging_e2e.rs
+++ b/cli/tests/logging_e2e.rs
@@ -1,20 +1,16 @@
-//! The CLI installs a `log` backend, so `log::` call sites in `orts-cli` and
-//! `orts` — the WASM guest's `host-env.log` records among them — actually
-//! reach the user instead of being discarded by `log`'s no-op logger.
+//! Drives the real binary, covering what a unit test on the filter cannot:
+//! that a backend is installed at all, that records go to stderr rather than
+//! stdout, and that `RUST_LOG` reaches it. Per-target levels are pinned in
+//! `logging.rs`.
 //!
-//! These drive the real binary, so they cover what a unit test on the filter
-//! cannot: that the backend is installed at all, that records go to stderr
-//! rather than stdout, and that `RUST_LOG` reaches it. Which target gets which
-//! level is pinned in `logging.rs`'s unit tests.
-//!
-//! The record used here is the startup line from `logging::init`, because it is
-//! the only one a plain `orts run` emits: every other call site needs either a
-//! plugin controller (a built guest component) or a live `serve` peer.
+//! These use the startup record from `logging::init`, the only one a plain
+//! `orts run` emits — every other call site needs a plugin controller (a built
+//! guest component) or a live `serve` peer.
 
 use std::process::Output;
 
-/// Substring of the startup record. Not the whole line: the assertions should
-/// survive a change of timestamp or field layout.
+/// A substring rather than the whole line, so a change of timestamp or field
+/// layout does not fail these.
 const STARTUP_RECORD: &str = "log filter:";
 
 fn run(rust_log: Option<&str>) -> Output {
@@ -30,8 +26,7 @@ fn run(rust_log: Option<&str>) -> Output {
     ]);
     match rust_log {
         Some(v) => cmd.env("RUST_LOG", v),
-        // An inherited RUST_LOG would decide the outcome instead of the
-        // default filter under test.
+        // An inherited value would decide the outcome instead of the default.
         None => cmd.env_remove("RUST_LOG"),
     };
     cmd.output().expect("failed to execute orts")
@@ -41,9 +36,8 @@ fn stderr_of(out: &Output) -> String {
     String::from_utf8_lossy(&out.stderr).into_owned()
 }
 
-/// A `log::` record reaches stderr, carrying its level and target — a `serve`
-/// operator needs to know which component spoke, and the CLI's targets are
-/// what `RUST_LOG` selects on.
+/// The level and target have to survive: an operator needs to know which
+/// component spoke, and targets are what `RUST_LOG` selects on.
 #[test]
 fn log_records_reach_stderr_with_level_and_target() {
     let out = run(Some("debug"));
@@ -67,8 +61,7 @@ fn log_records_reach_stderr_with_level_and_target() {
     );
 }
 
-/// `RUST_LOG` decides, in both directions, without a rebuild — and the
-/// built-in default is a real filter rather than "everything through".
+/// `RUST_LOG` decides in both directions, without a rebuild.
 #[test]
 fn rust_log_selects_which_records_are_emitted() {
     for filter in ["error", "warn", "off", "orts=info"] {
@@ -94,8 +87,7 @@ fn rust_log_selects_which_records_are_emitted() {
     }
 }
 
-/// The default filter stops below info, so an ordinary run gains no debug
-/// chatter from installing a backend.
+/// Installing a backend must not add debug chatter to an ordinary run.
 #[test]
 fn the_default_filter_stops_below_info() {
     let out = run(None);
@@ -107,8 +99,7 @@ fn the_default_filter_stops_below_info() {
     );
 }
 
-/// The effective filter is reported, so "why do I see no logs" is answerable
-/// from the log itself.
+/// "Why do I see no logs" should be answerable from the log itself.
 #[test]
 fn the_startup_record_names_the_filter_in_effect() {
     let stderr = stderr_of(&run(Some("orts=debug")));
@@ -118,7 +109,7 @@ fn the_startup_record_names_the_filter_in_effect() {
     );
 
     // Every directive, not just the one that let this record through: the
-    // point is to show why *other* records are missing.
+    // point is to explain why other records are missing.
     let stderr = stderr_of(&run(Some("error,orts=debug")));
     for directive in ["error", "orts=debug"] {
         assert!(
@@ -128,9 +119,8 @@ fn the_startup_record_names_the_filter_in_effect() {
     }
 }
 
-/// stdout carries what the command produces and nothing else: `orts serve
-/// --stream-stdio` puts a binary protocol there and `run --json` a parseable
-/// summary, so a log record on stdout would corrupt both.
+/// `serve --stream-stdio` puts a binary protocol on stdout and `run --json` a
+/// parseable summary; a record there would corrupt both.
 #[test]
 fn log_records_stay_off_stdout() {
     let out = run(Some("trace"));
@@ -147,8 +137,7 @@ fn log_records_stay_off_stdout() {
     }
 }
 
-/// Records are written unstyled when stderr is not a terminal, so a redirected
-/// log or a grep over it does not have to step over escape codes.
+/// A redirected log, or a grep over it, should not carry escape codes.
 #[test]
 fn records_are_unstyled_when_stderr_is_not_a_terminal() {
     let stderr = stderr_of(&run(Some("debug")));

--- a/cli/tests/logging_e2e.rs
+++ b/cli/tests/logging_e2e.rs
@@ -1,0 +1,163 @@
+//! The CLI installs a `log` backend, so `log::` call sites in `orts-cli` and
+//! `orts` — the WASM guest's `host-env.log` records among them — actually
+//! reach the user instead of being discarded by `log`'s no-op logger.
+//!
+//! These drive the real binary, so they cover what a unit test on the filter
+//! cannot: that the backend is installed at all, that records go to stderr
+//! rather than stdout, and that `RUST_LOG` reaches it. Which target gets which
+//! level is pinned in `logging.rs`'s unit tests.
+//!
+//! The record used here is the startup line from `logging::init`, because it is
+//! the only one a plain `orts run` emits: every other call site needs either a
+//! plugin controller (a built guest component) or a live `serve` peer.
+
+use std::process::Output;
+
+/// Substring of the startup record. Not the whole line: the assertions should
+/// survive a change of timestamp or field layout.
+const STARTUP_RECORD: &str = "log filter:";
+
+fn run(rust_log: Option<&str>) -> Output {
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_orts"));
+    cmd.args([
+        "run",
+        "--sat",
+        "altitude=400",
+        "--output",
+        "-",
+        "--format",
+        "csv",
+    ]);
+    match rust_log {
+        Some(v) => cmd.env("RUST_LOG", v),
+        // An inherited RUST_LOG would decide the outcome instead of the
+        // default filter under test.
+        None => cmd.env_remove("RUST_LOG"),
+    };
+    cmd.output().expect("failed to execute orts")
+}
+
+fn stderr_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+/// A `log::` record reaches stderr, carrying its level and target — a `serve`
+/// operator needs to know which component spoke, and the CLI's targets are
+/// what `RUST_LOG` selects on.
+#[test]
+fn log_records_reach_stderr_with_level_and_target() {
+    let out = run(Some("debug"));
+    let stderr = stderr_of(&out);
+    assert!(
+        out.status.success(),
+        "run failed: stderr={stderr}, stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert!(
+        stderr.contains(STARTUP_RECORD),
+        "expected a log record on stderr, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("DEBUG"),
+        "expected the record to carry its level, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("orts::logging"),
+        "expected the record to carry its target, got: {stderr}"
+    );
+}
+
+/// `RUST_LOG` decides, in both directions, without a rebuild — and the
+/// built-in default is a real filter rather than "everything through".
+#[test]
+fn rust_log_selects_which_records_are_emitted() {
+    for filter in ["error", "warn", "off", "orts=info"] {
+        let out = run(Some(filter));
+        let stderr = stderr_of(&out);
+        assert!(out.status.success(), "run failed under RUST_LOG={filter}");
+        assert!(
+            !stderr.contains(STARTUP_RECORD),
+            "RUST_LOG={filter} is above debug, so the startup record should be \
+             filtered out, got: {stderr}"
+        );
+    }
+
+    for filter in ["debug", "trace", "orts=debug"] {
+        let out = run(Some(filter));
+        let stderr = stderr_of(&out);
+        assert!(out.status.success(), "run failed under RUST_LOG={filter}");
+        assert!(
+            stderr.contains(STARTUP_RECORD),
+            "RUST_LOG={filter} admits debug, so the startup record should be \
+             emitted, got: {stderr}"
+        );
+    }
+}
+
+/// The default filter stops below info, so an ordinary run gains no debug
+/// chatter from installing a backend.
+#[test]
+fn the_default_filter_stops_below_info() {
+    let out = run(None);
+    let stderr = stderr_of(&out);
+    assert!(out.status.success(), "run failed: {stderr}");
+    assert!(
+        !stderr.contains(STARTUP_RECORD),
+        "the default filter should not admit debug records, got: {stderr}"
+    );
+}
+
+/// The effective filter is reported, so "why do I see no logs" is answerable
+/// from the log itself.
+#[test]
+fn the_startup_record_names_the_filter_in_effect() {
+    let stderr = stderr_of(&run(Some("orts=debug")));
+    assert!(
+        stderr.contains("orts=debug"),
+        "expected the record to name the filter in effect, got: {stderr}"
+    );
+
+    // Every directive, not just the one that let this record through: the
+    // point is to show why *other* records are missing.
+    let stderr = stderr_of(&run(Some("error,orts=debug")));
+    for directive in ["error", "orts=debug"] {
+        assert!(
+            stderr.contains(directive),
+            "expected the reported filter to name `{directive}`, got: {stderr}"
+        );
+    }
+}
+
+/// stdout carries what the command produces and nothing else: `orts serve
+/// --stream-stdio` puts a binary protocol there and `run --json` a parseable
+/// summary, so a log record on stdout would corrupt both.
+#[test]
+fn log_records_stay_off_stdout() {
+    let out = run(Some("trace"));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("# orts simulation"),
+        "expected CSV data on stdout, got: {stdout}"
+    );
+    for marker in [STARTUP_RECORD, "DEBUG", "TRACE", "INFO"] {
+        assert!(
+            !stdout.contains(marker),
+            "a log record reached stdout ({marker}), got: {stdout}"
+        );
+    }
+}
+
+/// Records are written unstyled when stderr is not a terminal, so a redirected
+/// log or a grep over it does not have to step over escape codes.
+#[test]
+fn records_are_unstyled_when_stderr_is_not_a_terminal() {
+    let stderr = stderr_of(&run(Some("debug")));
+    assert!(
+        stderr.contains(STARTUP_RECORD),
+        "precondition: expected a record to inspect, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains('\u{1b}'),
+        "expected no ANSI escapes on a piped stderr, got: {stderr:?}"
+    );
+}


### PR DESCRIPTION
`orts-cli` が logger を初期化していないので、`log::` の呼び出し 36 箇所 (`cli/` 21、`orts/` 15) が全て破棄されていた。**stdio plug の displaced、stream の socket error、`simulation halted` が無音。** `orts/` の 15 箇所のうち 10 箇所は WIT `host-env.log` の実装なので、**WASM plugin (FSW) のログも消えていた**。

`main` の先頭で subscriber を初期化する。`RUST_LOG` を指定しなければ、`orts` のログは info まで、依存のログは warn までが stderr に出る。この値と `RUST_LOG` の使い方は `--help` と `cli/README.md` に書いた。

## backend の選定

この binary には 2 系統の診断が流れている。orts 自身と一部の依存が出す `log` のレコードと、rerun の crate が出す `tracing` の event である。

`tracing` の macro は `log` feature が有効なとき「subscriber が未設定なら log のレコードを出す」分岐を持つ。この feature は axum の既定 `tower-log` から伝播して有効なので、`env_logger` のような `log` 専用の backend でも rerun の診断は log のレコードとして届く (必要なら自分で宣言してもよい)。ただし span と構造化 field は落ちる。

`tracing-subscriber` にしたのは依存が増えないため。rerun の `re_log` が必要な feature 付きで既に引いているので crate は 1 つも増えない (`Cargo.lock` の差分は dependency edge 2 行、`cargo build --offline` が通ることで確認)。issue #387 が挙げていた `env_logger` なら 2 つ増える。subscriber を設定すると上の分岐は tracing event 側を通るので、`log` bridge (`LogTracer`) と合わせて 2 系統が 1 つの subscriber に集まる。`log-always` は無効なので bridge が再帰することもない。

`try_init()` が `LogTracer` の max level を filter に合わせるため、filter で落ちる `log::trace!` は引数を format せずに戻る。

## level の選び方

`RUST_LOG` 未指定時の filter は `warn,orts=info`。orts を info にすると stream-io の attach / displaced / connected が記録に残り、stream が無反応になった後から突き合わせられる。依存 (axum / hyper / ureq / wasmtime) まで info にすると orts の診断が読めなくなる。

directive 1 つで足りるのは、この crate が `[[bin]] name` の `orts` としてビルドされ、core library も `orts`、guest のログの target も forward する host module のものになるため。`module_path!()` の root と定数の一致はテストで固定した。

## 出力先と level

`fmt::layer()` は何も指定しないと stdout に書くので、stderr へ明示的に向けた。stdout に出るのは CSV、`--json` サマリ、`serve --stream-stdio` の protocol である。ANSI は stderr が terminal のときだけ付ける (fmt layer は `NO_COLOR` を見るが terminal 判定はしない)。

`orts run` の downlink レコード 2 箇所は debug/trace へ下げた。衛星 × outbound message × tick ごとに出るので、info だと他の診断が読めなくなる。

level を持つ診断は `log`、コマンドの出力は `eprintln!`/stdout という基準を `logging.rs` に記録した。config 未知キーの warning はこれで `log::warn!` で書ける。

## テスト

unit 7 件で filter の per-target 挙動と `RUST_LOG` の解釈、E2E 7 件でレコードが level + target 付きで stderr に出ること、stdout に混ざらないこと、`--help` の記載を固定した。

Closes #387
