### PR TITLE
test(history): assert the disk read, and calibrate the scaling bars where they were measured

### DIFF
--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -113,14 +113,17 @@ pub struct HistoryBuffer {
     // gets fair coverage regardless of push order or count.
     overview_per_entity: HashMap<EntityPath, EntityOverview>,
 
-    /// How many times [`Self::load_all`] has read the segment files.
+    /// How many times [`Self::load_all`] has been called.
     ///
     /// Lets a test observe that a read stayed in memory instead of timing it.
     /// The elapsed-time version of that assertion was a proxy that reported how
     /// busy the machine was: it failed on a macOS runner at 31ms against a 10ms
     /// budget with the fast path working correctly.
+    ///
+    /// `load_all` is the one path here that opens a segment file, so counting
+    /// the calls counts the reads. A second such path would need its own count.
     #[cfg(test)]
-    disk_loads: std::cell::Cell<u32>,
+    load_all_calls: std::cell::Cell<u32>,
 }
 
 impl HistoryBuffer {
@@ -137,7 +140,7 @@ impl HistoryBuffer {
             body_radius,
             overview_per_entity: HashMap::new(),
             #[cfg(test)]
-            disk_loads: std::cell::Cell::new(0),
+            load_all_calls: std::cell::Cell::new(0),
         }
     }
 
@@ -349,7 +352,7 @@ impl HistoryBuffer {
     /// Load all data: flushed segments + in-memory buffer, sorted by time.
     pub fn load_all(&self) -> Vec<HistoryState> {
         #[cfg(test)]
-        self.disk_loads.set(self.disk_loads.get() + 1);
+        self.load_all_calls.set(self.load_all_calls.get() + 1);
 
         let mut all = Vec::new();
 
@@ -936,10 +939,10 @@ mod tests {
             "all returned states must lie in the requested window"
         );
         assert_eq!(
-            buf.disk_loads.get(),
+            buf.load_all_calls.get(),
             0,
             "query_range on a recent window fully covered by the in-memory tail \
-             must not read any of the {} segments on disk",
+             must not call load_all, whatever the {} segments on disk hold",
             buf.segment_count
         );
         cleanup_dir(&dir);
@@ -979,7 +982,7 @@ mod tests {
         // The other half of the pair: this window does read the segments, which
         // is what makes the sibling test's count of zero worth asserting.
         assert_eq!(
-            buf.disk_loads.get(),
+            buf.load_all_calls.get(),
             1,
             "a window reaching past the tail reads the segments once"
         );
@@ -1333,7 +1336,8 @@ mod tests {
     /// machine whose own cost curve for the same code is steeper: `overview()`
     /// over a 4x entity range grew 1.46x per entity on the Linux runner and
     /// 3.25-4.28x on the macOS one, across all three attempts. Its cost is
-    /// dominated by cloning every state — a `String` and a `HashMap` each — so
+    /// dominated by cloning every state — an `EntityPath` (`Vec<String>`) and a
+    /// `HashMap` each — so
     /// what the ratio measures on that runner is the allocator, and quadratic
     /// work over the same range would show 4x. No bar separates them there.
     /// Whatever `attempt` asserts about behaviour still runs on every platform.

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -124,20 +124,6 @@ pub struct HistoryBuffer {
     /// the calls counts the reads. A second such path would need its own count.
     #[cfg(test)]
     load_all_calls: std::cell::Cell<u32>,
-
-    /// How many entity buffers the last [`Self::overview`] call walked.
-    ///
-    /// The cost claim on `overview()` is that it walks each entity's buffer
-    /// once, so the work per entity stays flat as entities are added. Stated
-    /// as a count, that claim is exact and the same on every machine: `w`
-    /// entities give `w` visits, and a regression that re-scans the map gives
-    /// `w * w`. The elapsed-time ratio it replaces could only be calibrated
-    /// where its numbers were measured — over a 4x entity range the same code
-    /// rose 1.46x per entity on the Linux runner and 3.25-4.28x on the macOS
-    /// one, and quadratic work over that range shows 4x, so no bar separated
-    /// them there.
-    #[cfg(test)]
-    overview_entity_visits: std::cell::Cell<usize>,
 }
 
 impl HistoryBuffer {
@@ -155,8 +141,6 @@ impl HistoryBuffer {
             overview_per_entity: HashMap::new(),
             #[cfg(test)]
             load_all_calls: std::cell::Cell::new(0),
-            #[cfg(test)]
-            overview_entity_visits: std::cell::Cell::new(0),
         }
     }
 
@@ -212,17 +196,10 @@ impl HistoryBuffer {
     /// O(num_entities * OVERVIEW_MAX_POINTS_PER_ENTITY) regardless of how
     /// many points have been pushed or how many segments have been flushed.
     pub fn overview(&self) -> Vec<HistoryState> {
-        #[cfg(test)]
-        self.overview_entity_visits.set(0);
         let mut all: Vec<HistoryState> = self
             .overview_per_entity
             .values()
-            .flat_map(|e| {
-                #[cfg(test)]
-                self.overview_entity_visits
-                    .set(self.overview_entity_visits.get() + 1);
-                e.buffer.iter().cloned()
-            })
+            .flat_map(|e| e.buffer.iter().cloned())
             .collect();
         all.sort_by(|a, b| a.t.partial_cmp(&b.t).unwrap());
         all
@@ -906,15 +883,6 @@ mod tests {
                     ov.len() <= w * OVERVIEW_MAX_POINTS_PER_ENTITY,
                     "overview size must be bounded, got {} for {w} entities",
                     ov.len()
-                );
-                // The cost claim itself, as a count: one walk per entity, so
-                // the work per entity is flat in the entity count. This holds
-                // on every platform, where the elapsed-time ratio below can
-                // only be judged on the one its bar was measured on.
-                assert_eq!(
-                    buf.overview_entity_visits.get(),
-                    w,
-                    "overview walks each of the {w} entity buffers once"
                 );
                 cleanup_dir(&dir);
                 elapsed.as_micros()

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -112,6 +112,15 @@ pub struct HistoryBuffer {
     // on the manager task. Per-entity bookkeeping ensures every satellite
     // gets fair coverage regardless of push order or count.
     overview_per_entity: HashMap<EntityPath, EntityOverview>,
+
+    /// How many times [`Self::load_all`] has read the segment files.
+    ///
+    /// Lets a test observe that a read stayed in memory instead of timing it.
+    /// The elapsed-time version of that assertion was a proxy that reported how
+    /// busy the machine was: it failed on a macOS runner at 31ms against a 10ms
+    /// budget with the fast path working correctly.
+    #[cfg(test)]
+    disk_loads: std::cell::Cell<u32>,
 }
 
 impl HistoryBuffer {
@@ -127,6 +136,8 @@ impl HistoryBuffer {
             mu,
             body_radius,
             overview_per_entity: HashMap::new(),
+            #[cfg(test)]
+            disk_loads: std::cell::Cell::new(0),
         }
     }
 
@@ -337,6 +348,9 @@ impl HistoryBuffer {
 
     /// Load all data: flushed segments + in-memory buffer, sorted by time.
     pub fn load_all(&self) -> Vec<HistoryState> {
+        #[cfg(test)]
+        self.disk_loads.set(self.disk_loads.get() + 1);
+
         let mut all = Vec::new();
 
         for i in 0..self.segment_count {
@@ -897,9 +911,8 @@ mod tests {
     #[test]
     fn query_range_recent_window_skips_disk() {
         // Push enough to trigger many flushes, then query a window small
-        // enough to be fully covered by the in-memory tail. The query must
-        // complete in ~memory-speed time regardless of how many segments
-        // sit on disk.
+        // enough to be fully covered by the in-memory tail. The query must not
+        // read a segment, however many are on disk.
         let dir = temp_data_dir("query-range-recent");
         let mut buf = HistoryBuffer::new(1_000, dir.clone(), TEST_MU, TEST_BODY_RADIUS);
         for i in 0..20_000 {
@@ -915,20 +928,18 @@ mod tests {
         // Ask for a window fully inside the in-memory tail.
         let t_min = oldest_in_memory + 10.0;
 
-        let start = std::time::Instant::now();
         let result = buf.query_range(t_min, latest, Some(500), None);
-        let elapsed = start.elapsed();
 
         assert!(!result.is_empty(), "result should contain in-window points");
         assert!(
             result.iter().all(|s| s.t >= t_min && s.t <= latest),
             "all returned states must lie in the requested window"
         );
-        assert!(
-            elapsed.as_millis() < 10,
-            "query_range on a recent window fully covered by the in-memory \
-             tail should not touch disk; took {}ms with {} segments on disk",
-            elapsed.as_millis(),
+        assert_eq!(
+            buf.disk_loads.get(),
+            0,
+            "query_range on a recent window fully covered by the in-memory tail \
+             must not read any of the {} segments on disk",
             buf.segment_count
         );
         cleanup_dir(&dir);
@@ -965,6 +976,13 @@ mod tests {
         let max_t = result.iter().map(|s| s.t).fold(f64::NEG_INFINITY, f64::max);
         assert!(min_t < 150.0, "should include early part of window");
         assert!(max_t > 150.0, "should include late part of window");
+        // The other half of the pair: this window does read the segments, which
+        // is what makes the sibling test's count of zero worth asserting.
+        assert_eq!(
+            buf.disk_loads.get(),
+            1,
+            "a window reaching past the tail reads the segments once"
+        );
         cleanup_dir(&dir);
     }
 
@@ -1309,11 +1327,39 @@ mod tests {
     ///
     /// Each attempt is reported as it happens, so a genuine regression leaves
     /// the full trail in the log rather than only its last measurement.
+    ///
+    /// The bar is enforced on Linux, where every call site's margins were
+    /// measured, and reported elsewhere. What the retries cannot separate is a
+    /// machine whose own cost curve for the same code is steeper: `overview()`
+    /// over a 4x entity range grew 1.46x per entity on the Linux runner and
+    /// 3.25-4.28x on the macOS one, across all three attempts. Its cost is
+    /// dominated by cloning every state — a `String` and a `HashMap` each — so
+    /// what the ratio measures on that runner is the allocator, and quadratic
+    /// work over the same range would show 4x. No bar separates them there.
+    /// Whatever `attempt` asserts about behaviour still runs on every platform.
     fn assert_scaling_stable(
         label: &str,
         attempts: u32,
-        mut attempt: impl FnMut() -> Result<(), String>,
+        attempt: impl FnMut() -> Result<(), String>,
     ) {
+        judge_scaling(label, attempts, attempt, SCALING_BAR_ENFORCED);
+    }
+
+    /// Whether a bar that stays tripped fails the test on this platform.
+    const SCALING_BAR_ENFORCED: bool = cfg!(target_os = "linux");
+
+    /// The retry loop of [`assert_scaling_stable`], with the enforcement
+    /// decision passed in rather than read from the platform, so the tests below
+    /// exercise both sides of it wherever they run.
+    fn judge_scaling(
+        label: &str,
+        attempts: u32,
+        mut attempt: impl FnMut() -> Result<(), String>,
+        enforced: bool,
+    ) {
+        // One measurement is enough to report; the repetition exists to tell a
+        // busy machine from a regression, which only matters where it fails.
+        let attempts = if enforced { attempts } else { 1 };
         let mut last = String::new();
         for i in 1..=attempts {
             match attempt() {
@@ -1323,6 +1369,13 @@ mod tests {
                     last = msg;
                 }
             }
+        }
+        if !enforced {
+            eprintln!(
+                "{label}: tripped the bar, reported rather than enforced — the margins \
+                 are measured on Linux. Last — {last}"
+            );
+            return;
         }
         panic!(
             "{label}: all {attempts} attempts tripped the bar, so this is the shape of \
@@ -1438,29 +1491,58 @@ mod tests {
     fn scaling_retry_needs_every_attempt_to_trip() {
         // Trips once, then passes: the machine was busy, not the code.
         let mut calls = 0;
-        assert_scaling_stable("transient", 3, || {
-            calls += 1;
-            if calls == 1 {
-                Err("first attempt".to_string())
-            } else {
-                Ok(())
-            }
-        });
+        judge_scaling(
+            "transient",
+            3,
+            || {
+                calls += 1;
+                if calls == 1 {
+                    Err("first attempt".to_string())
+                } else {
+                    Ok(())
+                }
+            },
+            true,
+        );
         assert_eq!(calls, 2, "must stop as soon as an attempt passes");
 
         // Passes first time: no repetition at all.
         let mut calls = 0;
-        assert_scaling_stable("clean", 3, || {
-            calls += 1;
-            Ok(())
-        });
+        judge_scaling(
+            "clean",
+            3,
+            || {
+                calls += 1;
+                Ok(())
+            },
+            true,
+        );
         assert_eq!(calls, 1);
     }
 
     #[test]
     #[should_panic(expected = "all 3 attempts tripped the bar")]
     fn scaling_retry_fails_when_every_attempt_trips() {
-        assert_scaling_stable("persistent", 3, || Err("every time".to_string()));
+        judge_scaling("persistent", 3, || Err("every time".to_string()), true);
+    }
+
+    /// Where the bar is not enforced, a tripped bar is reported once.
+    ///
+    /// Measuring three times to report the same thing three times is waste, and
+    /// the repetition exists only to justify failing.
+    #[test]
+    fn an_unenforced_bar_measures_once_and_does_not_fail() {
+        let mut calls = 0;
+        judge_scaling(
+            "reported",
+            3,
+            || {
+                calls += 1;
+                Err("every time".to_string())
+            },
+            false,
+        );
+        assert_eq!(calls, 1, "one measurement is enough to report");
     }
 
     #[test]

--- a/cli/src/commands/serve/history.rs
+++ b/cli/src/commands/serve/history.rs
@@ -124,6 +124,20 @@ pub struct HistoryBuffer {
     /// the calls counts the reads. A second such path would need its own count.
     #[cfg(test)]
     load_all_calls: std::cell::Cell<u32>,
+
+    /// How many entity buffers the last [`Self::overview`] call walked.
+    ///
+    /// The cost claim on `overview()` is that it walks each entity's buffer
+    /// once, so the work per entity stays flat as entities are added. Stated
+    /// as a count, that claim is exact and the same on every machine: `w`
+    /// entities give `w` visits, and a regression that re-scans the map gives
+    /// `w * w`. The elapsed-time ratio it replaces could only be calibrated
+    /// where its numbers were measured — over a 4x entity range the same code
+    /// rose 1.46x per entity on the Linux runner and 3.25-4.28x on the macOS
+    /// one, and quadratic work over that range shows 4x, so no bar separated
+    /// them there.
+    #[cfg(test)]
+    overview_entity_visits: std::cell::Cell<usize>,
 }
 
 impl HistoryBuffer {
@@ -141,6 +155,8 @@ impl HistoryBuffer {
             overview_per_entity: HashMap::new(),
             #[cfg(test)]
             load_all_calls: std::cell::Cell::new(0),
+            #[cfg(test)]
+            overview_entity_visits: std::cell::Cell::new(0),
         }
     }
 
@@ -196,10 +212,17 @@ impl HistoryBuffer {
     /// O(num_entities * OVERVIEW_MAX_POINTS_PER_ENTITY) regardless of how
     /// many points have been pushed or how many segments have been flushed.
     pub fn overview(&self) -> Vec<HistoryState> {
+        #[cfg(test)]
+        self.overview_entity_visits.set(0);
         let mut all: Vec<HistoryState> = self
             .overview_per_entity
             .values()
-            .flat_map(|e| e.buffer.iter().cloned())
+            .flat_map(|e| {
+                #[cfg(test)]
+                self.overview_entity_visits
+                    .set(self.overview_entity_visits.get() + 1);
+                e.buffer.iter().cloned()
+            })
             .collect();
         all.sort_by(|a, b| a.t.partial_cmp(&b.t).unwrap());
         all
@@ -883,6 +906,15 @@ mod tests {
                     ov.len() <= w * OVERVIEW_MAX_POINTS_PER_ENTITY,
                     "overview size must be bounded, got {} for {w} entities",
                     ov.len()
+                );
+                // The cost claim itself, as a count: one walk per entity, so
+                // the work per entity is flat in the entity count. This holds
+                // on every platform, where the elapsed-time ratio below can
+                // only be judged on the one its bar was measured on.
+                assert_eq!(
+                    buf.overview_entity_visits.get(),
+                    w,
+                    "overview walks each of the {w} entity buffers once"
                 );
                 cleanup_dir(&dir);
                 elapsed.as_micros()


### PR DESCRIPTION
`cli/src/commands/serve/history.rs` の 2 つのテストが、`history.rs` を 1 行も触っていない PR の CI で落ちる。どちらも検査したい性質を経過時間で近似していたので、判定が runner の速さに左右されていた。

`rust-test-macos` の 266 run（2026-08-26 以降）で 2 回。落ちたのは 2 回とも別のテストで、#372 の run では `overview_multi_entity_cost_is_bounded`、#325 の run では `query_range_recent_window_skips_disk`。どちらのブランチも `history.rs` を触っていない。

## `query_range`: disk を読んだかを経過時間で判定していた

`serve` は各 step の state を、プロセスの RAM 上の buffer (`HistoryBuffer.states`) に積む。`capacity` を超えると `flush` が古い側を disk 上の segment ファイルに書き出し、buffer から外す。viewer が過去の区間を要求すると、`query_range` は buffer に残っている分で足りるかを見て、足りなければその segment を読む。

`query_range_recent_window_skips_disk` が固定したいのは「buffer に残っている分で足りる区間なら disk を読まない」。その判定が `elapsed.as_millis() < 10` だった。macOS runner での実測は 31 ms で、buffer から返す経路が正しく効いていても落ちる。速い run で通っても、それは性質が守られた証拠にならない。

disk を読む経路は `load_all` だけなので、`#[cfg(test)]` の呼び出しカウンタを持たせ、0 を要求する:

```rust
assert_eq!(
    buf.load_all_calls.get(),
    0,
    "query_range on a recent window fully covered by the in-memory tail \
     must not call load_all, whatever the {} segments on disk hold",
    buf.segment_count
);
```

対になる `query_range_historical_window_falls_back_to_disk` には 1 を要求した。カウンタが動かなくなれば後者が落ちるので、前者の 0 に意味がある。buffer から返す経路を潰す（`in_memory_sufficient = false`）と前者が落ちることも確認した。

## `overview()`: 1 機あたりのコストの比に、platform 共通の閾値がない

`overview()` は viewer の全体表示用に、各衛星の間引いた点列（1 機あたり最大
`OVERVIEW_MAX_POINTS_PER_ENTITY` = 1000 点）を 1 本に連結して時刻順に並べる。避けたい
退行は、衛星数 $w$ に対して 1 機あたりの仕事が増える形、つまり全体が $O(w^2)$ に
なること。

判定は「$w$ を 4 倍（5 → 20 機）にしたとき、1 機あたりの所要時間の比が 3.0 倍を
超えたら失敗」。この 3.0 は Linux runner の実測から決めた値（1 機あたり
173.0 / 181.1 / 251.8 µs、比 1.46 倍。16 並列の CPU 負荷下で 2.0〜2.15 倍）。同じ
コードが macOS runner では 3.25 / 4.28 / 3.33 倍を retry 3 回とも出す。連結される
state の clone（`EntityPath` = `Vec<String>` と `HashMap` を各 1 つ）が支配的なので、
この比が測っているのは実質 allocator の振る舞いで、$O(w^2)$ が示す 4 倍と重なる。
分ける数字がこの runner に存在しない。

そこで比の判定は、閾値を実測した Linux でだけ失敗扱いにし、他の platform では 1 行
報告して通す。閾値を 3.0 から 5.0 に上げる案は、$O(N^2)$ の 4 倍を通すのでテストの
目的が消える。

判定するかどうかは `judge_scaling` の引数なので、retry の仕様（1 回超えても次で
収まれば成功、3 回とも超えたら失敗）は全 platform でテストされる。計測する closure も
非 Linux で実行されるので、その中の assertion（点列の長さの上限など、比と無関係な
性質）はどこでも効く。**この節の scaling の主張は、非 Linux では検査されない**。

回数で書き換える案（`overview()` が各衛星の buffer を 1 度ずつ walk する、を counter で
数える）は実装して撤回した。counter を外側の closure に置くと現在のコード形状では
必ず $w$ になり、counter を経由しない再走査を入れても `orts-cli` は 1 件も落ちない
（出力の長さと内容も変わらない）ことを実測した。Rust の privacy は module 単位で、
この cache は 1 ファイルにあるため、将来の走査を counter 経由に強制する accessor も
書けない。全 platform で主張を検査するには、per-entity cache を独立した module に
出して buffer を数える accessor 越しにしか読めなくする必要があり、それは test 修正の
範囲を超える refactor。

## テスト

`orts-cli` の bin テスト 348 件 pass、うち `history` が 48 件。production 構成の `cargo check -p orts-cli` も通り、2 つのカウンタが `#[cfg(test)]` の内側に収まっていることを確認した。

テストだけの変更なので CHANGELOG には入れていない。
