### PR TITLE
feat(orts,cli): carry the integration frame across the output boundaries

### DIFF
--- a/arika/src/frame.rs
+++ b/arika/src/frame.rs
@@ -112,6 +112,27 @@ impl FrameDescriptor {
         }
     }
 
+    /// Recover a descriptor from the name [`Self::name`] writes.
+    ///
+    /// The pair is what lets a frame survive a boundary that carries no types —
+    /// an RRD's metadata, a CSV header, a WebSocket message — so a recording can
+    /// be read back in the frame it was written in.
+    pub fn from_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "SimpleEci" => FrameDescriptor::SimpleEci,
+            "SimpleEcef" => FrameDescriptor::SimpleEcef,
+            "Gcrs" => FrameDescriptor::Gcrs,
+            "Cirs" => FrameDescriptor::Cirs,
+            "Tirs" => FrameDescriptor::Tirs,
+            "Itrs" => FrameDescriptor::Itrs,
+            "Teme" => FrameDescriptor::Teme,
+            "MeanEquinoxOfDate" => FrameDescriptor::MeanEquinoxOfDate,
+            "Rsw" => FrameDescriptor::Rsw,
+            "Body" => FrameDescriptor::Body,
+            _ => return None,
+        })
+    }
+
     pub const fn category(self) -> FrameCategory {
         match self {
             FrameDescriptor::SimpleEci
@@ -705,6 +726,56 @@ impl<From: Frame, To: Frame> core::fmt::Debug for Rotation<From, To> {
 
 #[cfg(test)]
 mod tests {
+    /// Every descriptor survives the name round-trip.
+    ///
+    /// `name` and `from_name` are what carry a frame across a boundary that has
+    /// no types — an RRD's metadata, a CSV header, a WebSocket message. If a
+    /// variant is added to one arm and not the other, a recording written in that
+    /// frame reads back as `None` and the frame is silently lost. Listing every
+    /// variant here rather than iterating means adding one to the enum without
+    /// touching this test leaves the list short, which is visible in review.
+    #[test]
+    fn every_descriptor_round_trips_through_its_name() {
+        let all = [
+            FrameDescriptor::SimpleEci,
+            FrameDescriptor::SimpleEcef,
+            FrameDescriptor::Gcrs,
+            FrameDescriptor::Cirs,
+            FrameDescriptor::Tirs,
+            FrameDescriptor::Itrs,
+            FrameDescriptor::Teme,
+            FrameDescriptor::MeanEquinoxOfDate,
+            FrameDescriptor::Rsw,
+            FrameDescriptor::Body,
+        ];
+        for d in all {
+            assert_eq!(
+                FrameDescriptor::from_name(d.name()),
+                Some(d),
+                "{} does not round-trip",
+                d.name()
+            );
+        }
+    }
+
+    #[test]
+    fn from_name_rejects_what_it_did_not_write() {
+        // Lower case, a frame that does not exist, and the empty string: a
+        // recording carrying any of these is not one this build can read.
+        for name in ["simpleeci", "GCRS", "J2000", ""] {
+            assert_eq!(FrameDescriptor::from_name(name), None, "accepted {name:?}");
+        }
+    }
+
+    /// The marker types agree with the descriptors they claim.
+    #[test]
+    fn frame_descriptor_matches_the_marker_it_belongs_to() {
+        assert_eq!(SimpleEci::DESCRIPTOR, FrameDescriptor::SimpleEci);
+        assert_eq!(Gcrs::DESCRIPTOR, FrameDescriptor::Gcrs);
+        assert_eq!(SimpleEci::DESCRIPTOR.name(), SimpleEci::NAME);
+        assert_eq!(Gcrs::DESCRIPTOR.name(), Gcrs::NAME);
+    }
+
     use super::*;
     use std::f64::consts::PI;
 

--- a/cli/src/commands/replay.rs
+++ b/cli/src/commands/replay.rs
@@ -133,6 +133,13 @@ fn load_replay_data(path: &str) -> ReplayData {
         stream_interval: dt,
         central_body: central_body.clone(),
         central_body_radius: body_radius,
+        // Replayed from the recording rather than assumed: a file written before
+        // the frame was carried says nothing, and reporting that is honest where
+        // naming a default would not be. Replay only forwards samples, so it
+        // needs no frame of its own.
+        integration_frame: meta
+            .integration_frame
+            .map_or_else(|| "unknown".to_string(), |f| f.name().to_string()),
         epoch_jd: meta.epoch_jd,
         satellites,
     };

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -1,7 +1,7 @@
 use std::ops::ControlFlow;
 
 use arika::body::KnownBody;
-use arika::frame::{SimpleEci, Vec3};
+use arika::frame::{Frame, SimpleEci, Vec3};
 use orts::OrbitalState;
 use orts::group::{HasPosition, IndependentGroup, IntegratorConfig};
 use orts::orbital::kepler::KeplerianElements;
@@ -762,6 +762,10 @@ fn sim_metadata(params: &SimParams) -> orts::record::recording::SimMetadata {
         altitude: first_sat.map(|s| s.altitude(&params.body)),
         period: first_sat.map(|s| s.period),
         orbit_description: orbit_desc,
+        // Taken from the type rather than named as a literal: when the
+        // propagation frame becomes a parameter this is `F::DESCRIPTOR` and
+        // cannot drift from what was actually integrated in.
+        integration_frame: Some(<SimpleEci as Frame>::DESCRIPTOR),
     }
 }
 

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -17,6 +17,7 @@
 //! (integration error, controller fault, stream overflow / stuck peer,
 //! boundary reset) — be unit-tested in-process without a runtime.
 
+use arika::frame::{Frame, SimpleEci};
 use std::collections::{HashMap, VecDeque};
 use std::ops::ControlFlow;
 use std::sync::Arc;
@@ -1241,6 +1242,8 @@ fn build_info_message(params: &SimParams) -> WsMessage {
             .unwrap()
             .to_string(),
         central_body_radius: params.body.properties().radius,
+        // From the type, so it cannot disagree with what was integrated in.
+        integration_frame: <SimpleEci as Frame>::DESCRIPTOR.name().to_string(),
         epoch_jd: params.epoch.map(|e| e.jd()),
         satellites: satellites_info,
     }

--- a/cli/src/commands/serve/protocol.rs
+++ b/cli/src/commands/serve/protocol.rs
@@ -60,6 +60,15 @@ pub enum WsMessage {
         stream_interval: f64,
         central_body: String,
         central_body_radius: f64,
+        /// Inertial frame every `state` message in this stream is expressed in,
+        /// as [`arika::frame::FrameDescriptor::name`] spells it.
+        ///
+        /// Carried once per connection rather than per sample: the frame is
+        /// fixed for a run, and `state` is the hot path. Position, velocity and
+        /// quaternion components mean different things in different frames —
+        /// `SimpleEci` and `Gcrs` differ by ~484 arcsec at 2024 — so a client
+        /// that reads them without knowing the frame is guessing.
+        integration_frame: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
         epoch_jd: Option<f64>,
@@ -258,6 +267,7 @@ mod tests {
             stream_interval: 10.0,
             central_body: "earth".to_string(),
             central_body_radius: 6378.137,
+            integration_frame: "SimpleEci".to_string(),
             epoch_jd: Some(2460390.0),
             satellites: vec![
                 SatelliteInfo {
@@ -300,6 +310,7 @@ mod tests {
             stream_interval: 10.0,
             central_body: "earth".to_string(),
             central_body_radius: 6378.137,
+            integration_frame: "SimpleEci".to_string(),
             epoch_jd: Some(2460390.0),
             satellites: vec![SatelliteInfo {
                 id: "default".to_string(),
@@ -326,6 +337,7 @@ mod tests {
             stream_interval: 10.0,
             central_body: "earth".to_string(),
             central_body_radius: 6378.137,
+            integration_frame: "SimpleEci".to_string(),
             epoch_jd: None,
             satellites: vec![],
         };
@@ -344,6 +356,7 @@ mod tests {
             stream_interval: 10.0,
             central_body: "earth".to_string(),
             central_body_radius: 6378.137,
+            integration_frame: "SimpleEci".to_string(),
             epoch_jd: Some(2460390.0),
             satellites: vec![SatelliteInfo {
                 id: "iss".to_string(),

--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -1,3 +1,5 @@
+use arika::frame::FrameDescriptor;
+
 use std::collections::HashMap;
 
 use crate::record::archetypes::OrbitalState;
@@ -72,6 +74,13 @@ pub struct SimMetadata {
     pub period: Option<f64>,
     /// Human-readable initial orbit description (e.g. "circular at 400 km altitude").
     pub orbit_description: Option<String>,
+    /// Inertial frame the states in this recording are expressed in.
+    ///
+    /// Position and velocity components mean different things in different
+    /// frames — `SimpleEci` and `Gcrs` differ by ~484 arcsec at 2024 — so a
+    /// recording that does not say which one it used cannot be read back
+    /// unambiguously. `None` marks a recording written before this was carried.
+    pub integration_frame: Option<FrameDescriptor>,
 }
 
 impl SimMetadata {
@@ -101,6 +110,9 @@ impl SimMetadata {
         }
         if let Some(period) = self.period {
             writeln!(w, "# Period = {:.1} s ({:.1} min)", period, period / 60.0)?;
+        }
+        if let Some(frame) = self.integration_frame {
+            writeln!(w, "# integration_frame = {}", frame.name())?;
         }
         Ok(())
     }

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -1,3 +1,4 @@
+use arika::frame::FrameDescriptor;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Range;
 
@@ -291,6 +292,14 @@ pub fn save_as_rrd(
         rec.log_static(
             "meta/sim/body_name",
             &re_sdk_types::archetypes::TextDocument::new(name.as_str()),
+        )?;
+    }
+    // Recording-wide rather than per-entity: every state in a recording is
+    // propagated in one frame, and one place to check keeps the read side simple.
+    if let Some(frame) = meta.integration_frame {
+        rec.log_static(
+            "meta/sim/integration_frame",
+            &re_sdk_types::archetypes::TextDocument::new(frame.name()),
         )?;
     }
     if let Some(ref iso) = meta.epoch_iso {
@@ -676,6 +685,9 @@ pub fn load_rrd_data(path: &str) -> Result<RrdData, Box<dyn std::error::Error>> 
         period: meta_scalars.get("meta/sim/period").copied(),
         body_name: meta_texts.get("meta/sim/body_name").cloned(),
         orbit_description: meta_texts.get("meta/sim/orbit_description").cloned(),
+        integration_frame: meta_texts
+            .get("meta/sim/integration_frame")
+            .and_then(|n| FrameDescriptor::from_name(n)),
     };
 
     // Find base entity paths that have x/y/z/vx/vy/vz sub-entities.
@@ -962,6 +974,9 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
         period: meta_scalars.get("meta/sim/period").copied(),
         body_name: meta_texts.get("meta/sim/body_name").cloned(),
         orbit_description: meta_texts.get("meta/sim/orbit_description").cloned(),
+        integration_frame: meta_texts
+            .get("meta/sim/integration_frame")
+            .and_then(|n| FrameDescriptor::from_name(n)),
     };
 
     // Find all entity base paths (strip the leaf field name and leading slash)
@@ -1437,6 +1452,7 @@ mod tests {
             orbit_description: Some(
                 "Initial orbit: circular at 400 km altitude (r = 6778.137 km)".to_string(),
             ),
+            integration_frame: Some(FrameDescriptor::Gcrs),
         };
 
         // Log 3 rows with all component types
@@ -1480,6 +1496,11 @@ mod tests {
             m.orbit_description.as_deref(),
             Some("Initial orbit: circular at 400 km altitude (r = 6778.137 km)")
         );
+        // Through the file, not just the struct: the frame is written as text
+        // under `meta/sim/` and recovered by name, so either half breaking loses
+        // it. `Gcrs` rather than the default `SimpleEci`, so a write side that
+        // names a constant cannot pass this.
+        assert_eq!(m.integration_frame, Some(FrameDescriptor::Gcrs));
 
         // Find the satellite entity
         let sat_path = EntityPath::parse("/world/sat/test");

--- a/viewer/src/protocol/generated/WsMessage.ts
+++ b/viewer/src/protocol/generated/WsMessage.ts
@@ -6,7 +6,18 @@ import type { SatelliteInfo } from "./SatelliteInfo";
 /**
  * Server-to-client WebSocket message.
  */
-export type WsMessage = { "type": "info", mu: number, dt: number, output_interval: number, stream_interval: number, central_body: string, central_body_radius: number, epoch_jd?: number, satellites: Array<SatelliteInfo>, } | { "type": "state", entity_path: string, t: number, position: [number, number, number], velocity: [number, number, number], semi_major_axis: number, eccentricity: number, inclination: number, raan: number, argument_of_periapsis: number, true_anomaly: number, 
+export type WsMessage = { "type": "info", mu: number, dt: number, output_interval: number, stream_interval: number, central_body: string, central_body_radius: number, 
+/**
+ * Inertial frame every `state` message in this stream is expressed in,
+ * as [`arika::frame::FrameDescriptor::name`] spells it.
+ *
+ * Carried once per connection rather than per sample: the frame is
+ * fixed for a run, and `state` is the hot path. Position, velocity and
+ * quaternion components mean different things in different frames —
+ * `SimpleEci` and `Gcrs` differ by ~484 arcsec at 2024 — so a client
+ * that reads them without knowing the frame is guessing.
+ */
+integration_frame: string, epoch_jd?: number, satellites: Array<SatelliteInfo>, } | { "type": "state", entity_path: string, t: number, position: [number, number, number], velocity: [number, number, number], semi_major_axis: number, eccentricity: number, inclination: number, raan: number, argument_of_periapsis: number, true_anomaly: number, 
 /**
  * Pre-computed derived values for chart display (avoids client-side recomputation).
  */


### PR DESCRIPTION
orts が状態を書き出す経路 (RRD / CSV / WebSocket) に積分フレームを載せる。

position や quaternion の成分はフレームによって意味が変わる (`SimpleEci` と `Gcrs` は 2024 epoch で 484 秒角ずれる) が、どの出力もそれを言っていなかった。今は CLI が `SimpleEci` でしか積分しないので実害はない。効くのは**フレームを選べるようにした瞬間**で、それが次の PR。そこで書かれた記録を simple-ECI 前提のツールが読むと、0.13° 違う値として解釈されて誰も気づかない。

## 変更

| 対象 | 変更 |
|---|---|
| `arika::FrameDescriptor` | `from_name` を追加。`name` と対になり文字列から復元できる |
| `SimMetadata` | `integration_frame: Option<FrameDescriptor>`。`None` はこれ以前に書かれた記録 |
| CSV | `# integration_frame = SimpleEci` |
| RRD | `meta/sim/integration_frame` に static text。読み込み側 2 箇所で復元 |
| WS `Info` | `integration_frame: String` |

WS は接続時 1 回だけ送る (フレームは 1 run で固定、`state` は hot path)。RRD も recording 単位で、entity ごとには持たせない。

`run` / `serve` は値を型から取る (`<SimpleEci as Frame>::DESCRIPTOR`)。次の PR で generic になると `F::DESCRIPTOR` になるだけなので、実際に積分したフレームと食い違えない。`replay` は記録が言う値を転送し、無ければ `"unknown"` と報告する。

## テスト

- 全 10 variant が `name` → `from_name` を往復する。`from_name` の `Gcrs` arm を消すと落ちることを確認
- RRD の往復テスト (既存を拡張) は `Gcrs` を書いて実ファイルに保存し、読み戻して一致を見る。書き出しを消すと `left: None, right: Some(Gcrs)` で落ちる
- `from_name` は `"simpleeci"` / `"GCRS"` / `"J2000"` / `""` を拒否

実測: `orts run --format csv` が `# integration_frame = SimpleEci` を出し、`orts serve` の `info` が `integration_frame = "SimpleEci"` を返す。

## ゲート

`cargo test -p orts --lib` 755 passed、`-p arika --lib` 393 passed。fmt clean、clippy 0 (`--locked --workspace` と `-p arika --no-default-features` の alloc あり・なし)。TypeScript bindings 再生成済み。codex (gpt-5.5) 指摘なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
