### PR TITLE
fix(ci): keep the Pages deploy's texture fetch alive through a bad transfer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Set up wild linker
         uses: ./.github/actions/setup-wild
 
+      # This cache is a speed-up, not a guarantee: the repository sits over the
+      # 10 GB cache limit (the per-job Cargo caches are 0.5-1.2 GB each), so LRU
+      # eviction drops the textures often enough that a deploy fetching them from
+      # NASA is the normal case rather than the exception. That is why the fetch
+      # below has to survive a bad transfer on its own. TODO: if the fetch keeps
+      # failing, publish the processed textures as a release asset and keep the
+      # NASA/USGS sources in a regeneration workflow instead of the deploy path.
       - name: Cache viewer textures (4k/8k)
         id: texture-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -63,9 +70,14 @@ jobs:
         if: steps.texture-cache.outputs.cache-hit != 'true'
         run: sudo apt-get install -y imagemagick
 
+      # One invocation for both resolutions: each source image is downloaded once
+      # and resized twice. Two invocations re-downloaded the 21600x10800 Blue
+      # Marble source for the 8k pass, doubling the exposure to hosts that drop
+      # transfers. Sun has no 8k output, so this produces exactly the seven files
+      # cached above.
       - name: Fetch viewer textures (4k/8k — skips mars to avoid 12 GB source)
         if: steps.texture-cache.outputs.cache-hit != 'true'
-        run: ./tools/fetch-textures.sh --resolution 4k --body earth,moon,sun && ./tools/fetch-textures.sh --resolution 8k --body earth,moon
+        run: ./tools/fetch-textures.sh --resolution 4k,8k --body earth,moon,sun
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain

--- a/tools/fetch-textures.sh
+++ b/tools/fetch-textures.sh
@@ -10,7 +10,7 @@
 # Sun:         NASA SDO/STEREO EUV 304Å Carrington map
 #
 # Prerequisites: curl, imagemagick (convert or magick)
-# Usage: ./tools/fetch-textures.sh [--resolution 2k|4k|8k|16k|all] [--force]
+# Usage: ./tools/fetch-textures.sh [--resolution 2k,4k,8k,16k|all] [--body earth,moon,mars,sun|all] [--force]
 
 set -euo pipefail
 
@@ -48,17 +48,17 @@ SUN_SOURCE_URL="https://svs.gsfc.nasa.gov/vis/a030000/a030300/a030362/euvi_aia30
 
 # --- Parse arguments ---
 
-RESOLUTION="all"
+RESOLUTIONS="all"
 BODIES="all"
 FORCE=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --resolution) [[ $# -ge 2 ]] || { echo "Error: --resolution requires a value" >&2; exit 1; }; RESOLUTION="$2"; shift 2 ;;
+    --resolution) [[ $# -ge 2 ]] || { echo "Error: --resolution requires a value" >&2; exit 1; }; RESOLUTIONS="$2"; shift 2 ;;
     --body)       [[ $# -ge 2 ]] || { echo "Error: --body requires a value" >&2; exit 1; }; BODIES="$2"; shift 2 ;;
     --force)      FORCE=true; shift ;;
     -h|--help)
-      echo "Usage: $0 [--resolution 2k|4k|8k|16k|all] [--body earth,moon,mars,sun|all] [--force]"
+      echo "Usage: $0 [--resolution 2k,4k,8k,16k|all] [--body earth,moon,mars,sun|all] [--force]"
       echo ""
       echo "Downloads NASA/USGS textures and converts to power-of-two JPEG."
       echo ""
@@ -69,7 +69,9 @@ while [[ $# -gt 0 ]]; do
       echo "  Sun:    sun.jpg (2k), sun_4k.jpg"
       echo ""
       echo "Options:"
-      echo "  --resolution  Which resolutions to download: 2k, 4k, 8k, 16k, or all (default: all)"
+      echo "  --resolution  Comma-separated list of resolutions: 2k,4k,8k,16k or all (default: all)"
+      echo "                One invocation covering every resolution you want downloads each"
+      echo "                source once; separate invocations re-download it per resolution"
       echo "  --body        Comma-separated list of bodies: earth,moon,mars,sun or all (default: all)"
       echo "                Tip: omit mars to skip the 12GB source download required for mars 4k/8k/16k"
       echo "  --force       Re-download even if files already exist"
@@ -79,34 +81,40 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Validate --resolution
-case "$RESOLUTION" in
-  2k|4k|8k|16k|all) ;;
-  *) echo "Error: unknown resolution '$RESOLUTION' (expected: 2k|4k|8k|16k|all)" >&2; exit 1 ;;
-esac
+# Validates a comma-separated selection and writes it back to the named variable
+# lowercased and space-stripped, so --body "Earth, Moon" works as expected and
+# include_body / include_resolution stay plain list membership tests.
+normalise_selection() {
+  local var="$1" flag="$2" allowed="$3"
+  local norm; norm=$(tr '[:upper:]' '[:lower:]' <<< "${!var}")
+  norm="${norm// /}"
+  # An empty selection would otherwise pass validation and produce nothing while
+  # exiting 0, hiding an unset variable in whatever called this.
+  [[ -n "$norm" ]] || { echo "Error: --$flag needs a value (expected: $allowed or all)" >&2; exit 1; }
+  local entry entries
+  IFS=',' read -ra entries <<< "$norm"
+  for entry in "${entries[@]}"; do
+    [[ ",$allowed,all," == *",$entry,"* ]] || {
+      echo "Error: unknown $flag '$entry' (expected: $allowed or all)" >&2; exit 1
+    }
+  done
+  if [[ "$norm" != "all" ]] && [[ ",$norm," == *",all,"* ]]; then
+    echo "Error: 'all' cannot be combined with specific values; use '--$flag all' alone" >&2; exit 1
+  fi
+  printf -v "$var" '%s' "$norm"
+}
 
-# Validate --body entries
-_bodies_norm=$(tr '[:upper:]' '[:lower:]' <<< "$BODIES")
-_bodies_norm="${_bodies_norm// /}"
-IFS=',' read -ra _BODY_LIST <<< "$_bodies_norm"
-for _b in "${_BODY_LIST[@]}"; do
-  case "$_b" in
-    earth|moon|mars|sun|all) ;;
-    *) echo "Error: unknown body '$_b' (expected: earth,moon,mars,sun or all)" >&2; exit 1 ;;
-  esac
-done
-if [[ "$_bodies_norm" != "all" ]] && [[ ",$_bodies_norm," == *",all,"* ]]; then
-  echo "Error: 'all' cannot be combined with specific bodies; use '--body all' alone" >&2; exit 1
-fi
-unset _bodies_norm _BODY_LIST _b
+normalise_selection RESOLUTIONS resolution "2k,4k,8k,16k"
+normalise_selection BODIES body "earth,moon,mars,sun"
 
 # Returns 0 if the given body should be processed.
-# Normalises case and strips spaces so --body "Earth, Moon" works as expected.
 include_body() {
-  local body; body=$(tr '[:upper:]' '[:lower:]' <<< "$1")
-  local bodies; bodies=$(tr '[:upper:]' '[:lower:]' <<< "$BODIES")
-  bodies="${bodies// /}"
-  [[ "$bodies" == "all" ]] || [[ ",$bodies," == *",$body,"* ]]
+  [[ "$BODIES" == "all" ]] || [[ ",$BODIES," == *",$1,"* ]]
+}
+
+# Returns 0 if the given resolution should be produced.
+include_resolution() {
+  [[ "$RESOLUTIONS" == "all" ]] || [[ ",$RESOLUTIONS," == *",$1,"* ]]
 }
 
 # --- Check prerequisites ---
@@ -128,11 +136,35 @@ fi
 
 # --- Helper functions ---
 
+# Retry budget for the NASA/USGS hosts, which drop connections mid-transfer and
+# go unreachable for minutes at a time. A deploy that missed the texture cache
+# has no second source, so a single bad transfer must not end the run.
+CURL_RETRIES=5
+CURL_RETRY_DELAY=5
+CURL_CONNECT_TIMEOUT=30      # curl defaults to 300s; an unreachable host would eat the budget on one attempt
+CURL_STALL_BYTES_PER_SEC=1024
+CURL_STALL_SECONDS=60        # under 1 KiB/s for a minute the transfer is stuck, not slow — fail it and let a retry resume
+
 download() {
   local url="$1" dest="$2"
   local tmp="$TEMP_DIR/$(basename "$dest").partial"
   echo "  Downloading $(basename "$dest")..."
-  curl -fSL --retry 3 --retry-delay 5 --progress-bar -o "$tmp" "$url"
+  # --retry-all-errors is what makes the retries reachable: curl treats only
+  # timeouts and a few HTTP codes as transient, so a truncated transfer
+  # (exit 18, seen on the 21600x10800 Blue Marble source) would otherwise fail
+  # on the first attempt without retrying once. -C - makes curl's own retries
+  # resume: a retry after a cut connection sends Range from what is already on
+  # disk, and every source here answers that with 206.
+  # No --retry-max-time: its timer starts before the first attempt, so a limit
+  # shorter than the transfer itself (the Blue Marble source takes minutes on a
+  # slow link, the Mars source far longer) expires before the failure it is
+  # meant to cover, leaving no retry at all. Attempts are bounded individually
+  # by the connect timeout and the stall detector instead.
+  curl -fSL \
+    --retry "$CURL_RETRIES" --retry-delay "$CURL_RETRY_DELAY" --retry-all-errors \
+    --connect-timeout "$CURL_CONNECT_TIMEOUT" \
+    --speed-limit "$CURL_STALL_BYTES_PER_SEC" --speed-time "$CURL_STALL_SECONDS" \
+    -C - --progress-bar -o "$tmp" "$url"
   mv "$tmp" "$dest"
 }
 
@@ -177,7 +209,7 @@ process_day() {
   # Download source only if we need it
   local need_download=false
   for res in 2k 4k 8k 16k; do
-    if [[ "$RESOLUTION" == "$res" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/earth_${res}.jpg"; then
+    if include_resolution "$res" && should_process "$TEXTURE_DIR/earth_${res}.jpg"; then
       need_download=true
     fi
   done
@@ -187,25 +219,25 @@ process_day() {
   echo "==> Fetching Blue Marble cloud-free day texture (21600x10800)..."
   download "$DAY_SOURCE_URL" "$src"
 
-  if [[ "$RESOLUTION" == "16k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/earth_16k.jpg"; then
+  if include_resolution 16k && should_process "$TEXTURE_DIR/earth_16k.jpg"; then
     echo "==> Creating earth_16k.jpg..."
     resize_jpeg "$src" "$TEXTURE_DIR/earth_16k.jpg" 16384 8192
     echo "  Done: $(du -h "$TEXTURE_DIR/earth_16k.jpg" | cut -f1)"
   fi
 
-  if [[ "$RESOLUTION" == "8k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/earth_8k.jpg"; then
+  if include_resolution 8k && should_process "$TEXTURE_DIR/earth_8k.jpg"; then
     echo "==> Creating earth_8k.jpg..."
     resize_jpeg "$src" "$TEXTURE_DIR/earth_8k.jpg" 8192 4096
     echo "  Done: $(du -h "$TEXTURE_DIR/earth_8k.jpg" | cut -f1)"
   fi
 
-  if [[ "$RESOLUTION" == "4k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/earth_4k.jpg"; then
+  if include_resolution 4k && should_process "$TEXTURE_DIR/earth_4k.jpg"; then
     echo "==> Creating earth_4k.jpg..."
     resize_jpeg "$src" "$TEXTURE_DIR/earth_4k.jpg" 4096 2048
     echo "  Done: $(du -h "$TEXTURE_DIR/earth_4k.jpg" | cut -f1)"
   fi
 
-  if [[ "$RESOLUTION" == "2k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/earth_2k.jpg"; then
+  if include_resolution 2k && should_process "$TEXTURE_DIR/earth_2k.jpg"; then
     echo "==> Creating earth_2k.jpg..."
     resize_jpeg "$src" "$TEXTURE_DIR/earth_2k.jpg" 2048 1024
     echo "  Done: $(du -h "$TEXTURE_DIR/earth_2k.jpg" | cut -f1)"
@@ -214,7 +246,7 @@ process_day() {
 
 # Night textures (from two different sources for 4K and 8K)
 process_night() {
-  if [[ "$RESOLUTION" == "4k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/earth_night_4k.jpg"; then
+  if include_resolution 4k && should_process "$TEXTURE_DIR/earth_night_4k.jpg"; then
     echo "==> Fetching Black Marble night texture (3600x1800)..."
     local src_low="$TEMP_DIR/night_source_low.jpg"
     download "$NIGHT_LOW_URL" "$src_low"
@@ -223,24 +255,27 @@ process_night() {
     echo "  Done: $(du -h "$TEXTURE_DIR/earth_night_4k.jpg" | cut -f1)"
   fi
 
-  if [[ "$RESOLUTION" == "8k" || "$RESOLUTION" == "16k" || "$RESOLUTION" == "all" ]]; then
+  if include_resolution 8k || include_resolution 16k; then
     local src_high="$TEMP_DIR/night_source_high.jpg"
     local need_high=false
 
-    if should_process "$TEXTURE_DIR/earth_night_8k.jpg" 2>/dev/null; then need_high=true; fi
-    if should_process "$TEXTURE_DIR/earth_night_16k.jpg" 2>/dev/null; then need_high=true; fi
+    # Only a requested resolution justifies the 13500x6750 source: without the
+    # include_resolution guard, --resolution 8k downloaded it whenever the 16k
+    # output happened to be missing, which it is on every fresh checkout.
+    if include_resolution 8k && should_process "$TEXTURE_DIR/earth_night_8k.jpg"; then need_high=true; fi
+    if include_resolution 16k && should_process "$TEXTURE_DIR/earth_night_16k.jpg"; then need_high=true; fi
 
     if [[ "$need_high" == true ]]; then
       echo "==> Fetching Black Marble night texture (13500x6750)..."
       download "$NIGHT_HIGH_URL" "$src_high"
 
-      if [[ "$RESOLUTION" == "16k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/earth_night_16k.jpg"; then
+      if include_resolution 16k && should_process "$TEXTURE_DIR/earth_night_16k.jpg"; then
         echo "==> Creating earth_night_16k.jpg..."
         resize_jpeg "$src_high" "$TEXTURE_DIR/earth_night_16k.jpg" 16384 8192
         echo "  Done: $(du -h "$TEXTURE_DIR/earth_night_16k.jpg" | cut -f1)"
       fi
 
-      if [[ "$RESOLUTION" == "8k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/earth_night_8k.jpg"; then
+      if include_resolution 8k && should_process "$TEXTURE_DIR/earth_night_8k.jpg"; then
         echo "==> Creating earth_night_8k.jpg..."
         resize_jpeg "$src_high" "$TEXTURE_DIR/earth_night_8k.jpg" 8192 4096
         echo "  Done: $(du -h "$TEXTURE_DIR/earth_night_8k.jpg" | cut -f1)"
@@ -252,14 +287,14 @@ process_night() {
 # Moon textures (NASA CGI Moon Kit — pre-rendered per resolution)
 process_moon() {
   # 2k: direct JPEG download
-  if [[ "$RESOLUTION" == "2k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/moon.jpg"; then
+  if include_resolution 2k && should_process "$TEXTURE_DIR/moon.jpg"; then
     echo "==> Fetching Moon 2K texture (LRO WAC mosaic)..."
     download "$MOON_2K_URL" "$TEXTURE_DIR/moon.jpg"
     echo "  Done: $(du -h "$TEXTURE_DIR/moon.jpg" | cut -f1)"
   fi
 
   # 4k/8k/16k: TIFF → JPEG conversion (no resize needed, NASA provides exact sizes)
-  if [[ "$RESOLUTION" == "4k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/moon_4k.jpg"; then
+  if include_resolution 4k && should_process "$TEXTURE_DIR/moon_4k.jpg"; then
     echo "==> Fetching Moon 4K texture..."
     local src="$TEMP_DIR/moon_4k.tif"
     download "$MOON_4K_URL" "$src"
@@ -268,7 +303,7 @@ process_moon() {
     echo "  Done: $(du -h "$TEXTURE_DIR/moon_4k.jpg" | cut -f1)"
   fi
 
-  if [[ "$RESOLUTION" == "8k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/moon_8k.jpg"; then
+  if include_resolution 8k && should_process "$TEXTURE_DIR/moon_8k.jpg"; then
     echo "==> Fetching Moon 8K texture..."
     local src="$TEMP_DIR/moon_8k.tif"
     download "$MOON_8K_URL" "$src"
@@ -277,7 +312,7 @@ process_moon() {
     echo "  Done: $(du -h "$TEXTURE_DIR/moon_8k.jpg" | cut -f1)"
   fi
 
-  if [[ "$RESOLUTION" == "16k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/moon_16k.jpg"; then
+  if include_resolution 16k && should_process "$TEXTURE_DIR/moon_16k.jpg"; then
     echo "==> Fetching Moon 16K texture..."
     local src="$TEMP_DIR/moon_16k.tif"
     download "$MOON_16K_URL" "$src"
@@ -291,7 +326,7 @@ process_moon() {
 # 2k uses a small preview JPEG (1024px upscaled); 4k+ uses the full GeoTIFF.
 process_mars() {
   # 2k: use preview JPEG (fast, no need for 12GB download)
-  if [[ "$RESOLUTION" == "2k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/mars.jpg"; then
+  if include_resolution 2k && should_process "$TEXTURE_DIR/mars.jpg"; then
     echo "==> Fetching Mars 2K texture (MDIM 2.1 colorized preview)..."
     local preview="$TEMP_DIR/mars_preview.jpg"
     download "$MARS_PREVIEW_URL" "$preview"
@@ -303,7 +338,7 @@ process_mars() {
   # 4k/8k/16k: full 12GB GeoTIFF
   local need_full=false
   for res in 4k 8k 16k; do
-    if [[ "$RESOLUTION" == "$res" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/mars_${res}.jpg"; then
+    if include_resolution "$res" && should_process "$TEXTURE_DIR/mars_${res}.jpg"; then
       need_full=true
     fi
   done
@@ -315,19 +350,19 @@ process_mars() {
   local src="$TEMP_DIR/mars_source.tif"
   download "$MARS_SOURCE_URL" "$src"
 
-  if [[ "$RESOLUTION" == "4k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/mars_4k.jpg"; then
+  if include_resolution 4k && should_process "$TEXTURE_DIR/mars_4k.jpg"; then
     echo "==> Creating mars_4k.jpg..."
     convert_resize_jpeg "$src" "$TEXTURE_DIR/mars_4k.jpg" 4096 2048
     echo "  Done: $(du -h "$TEXTURE_DIR/mars_4k.jpg" | cut -f1)"
   fi
 
-  if [[ "$RESOLUTION" == "8k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/mars_8k.jpg"; then
+  if include_resolution 8k && should_process "$TEXTURE_DIR/mars_8k.jpg"; then
     echo "==> Creating mars_8k.jpg..."
     convert_resize_jpeg "$src" "$TEXTURE_DIR/mars_8k.jpg" 8192 4096
     echo "  Done: $(du -h "$TEXTURE_DIR/mars_8k.jpg" | cut -f1)"
   fi
 
-  if [[ "$RESOLUTION" == "16k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/mars_16k.jpg"; then
+  if include_resolution 16k && should_process "$TEXTURE_DIR/mars_16k.jpg"; then
     echo "==> Creating mars_16k.jpg..."
     convert_resize_jpeg "$src" "$TEXTURE_DIR/mars_16k.jpg" 16384 8192
     echo "  Done: $(du -h "$TEXTURE_DIR/mars_16k.jpg" | cut -f1)"
@@ -337,10 +372,10 @@ process_mars() {
 # Sun texture (NASA SDO/STEREO — max ~4k)
 process_sun() {
   local need_download=false
-  if [[ "$RESOLUTION" == "2k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/sun.jpg"; then
+  if include_resolution 2k && should_process "$TEXTURE_DIR/sun.jpg"; then
     need_download=true
   fi
-  if [[ "$RESOLUTION" == "4k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/sun_4k.jpg"; then
+  if include_resolution 4k && should_process "$TEXTURE_DIR/sun_4k.jpg"; then
     need_download=true
   fi
 
@@ -350,13 +385,13 @@ process_sun() {
   local src="$TEMP_DIR/sun_source.tif"
   download "$SUN_SOURCE_URL" "$src"
 
-  if [[ "$RESOLUTION" == "2k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/sun.jpg"; then
+  if include_resolution 2k && should_process "$TEXTURE_DIR/sun.jpg"; then
     echo "==> Creating sun.jpg (2k)..."
     convert_resize_jpeg "$src" "$TEXTURE_DIR/sun.jpg" 2048 1024
     echo "  Done: $(du -h "$TEXTURE_DIR/sun.jpg" | cut -f1)"
   fi
 
-  if [[ "$RESOLUTION" == "4k" || "$RESOLUTION" == "all" ]] && should_process "$TEXTURE_DIR/sun_4k.jpg"; then
+  if include_resolution 4k && should_process "$TEXTURE_DIR/sun_4k.jpg"; then
     echo "==> Creating sun_4k.jpg (4k)..."
     convert_resize_jpeg "$src" "$TEXTURE_DIR/sun_4k.jpg" 4096 2048
     echo "  Done: $(du -h "$TEXTURE_DIR/sun_4k.jpg" | cut -f1)"


### PR DESCRIPTION
main の Deploy Site が 2 連続で失敗した。どちらも texture 取得ステップでの転送失敗で、コミットの内容とは無関係。fetch script のバグ修正 3 件と、転送失敗への露出を半分にする workflow の変更を入れる。

main 自体は失敗 run の再実行で緑に戻っている（run 33527029591）。この PR は再発防止。

## 1. 転送が途中で切れたら retry する

`download()` は以前から `--retry 3 --retry-delay 5` を持っていた。curl が transient と数えるのは timeout と一部の HTTP status だけなので、転送の途中切断では retry が 1 度も走らない。

実測したエラー出力（run 33527029591）:

```
#####################################   51.5%curl: (18) transfer closed with 14457934 bytes remaining to read
##[error]Process completed with exit code 18.
```

`--retry-all-errors` を付けて retry budget を届かせる。併せて各試行を個別に短く切る:

| flag | 従来の挙動 | 変更後 |
| --- | --- | --- |
| `--connect-timeout 30` | curl 既定の 300s。到達不能ホストに 132s/試行を費やし 4 試行で 9 分使って hard fail（run 33524058609、exit 28） | 30s で次の試行に移る |
| `--speed-limit 1024 --speed-time 60` | 実質停止した転送をそのまま待つ | 1 KiB/s を 60 秒下回ったら失敗させ retry に回す |
| `-C -` | retry は 0 byte から | disk 上の続きから再開する |

`-C -` は実測した。折り返しで接続を切るサーバに対して curl 内部の retry が `Range: bytes=655360-` を送り、2 MiB の結果は byte 単位で一致した。既に完全な file に対しては 416 を受けて exit 0 で終わる。

retry 窓は試行回数と各試行の上限（connect timeout と stall 検出）で与えている。`--retry-max-time` は timer が初回試行の前に始まるので、転送より短い上限だと、覆うはずの失敗が起きた時点で既に閉じている（codex の指摘を反映して外した）。

## 2. 同じ元画像を 2 回 download するのをやめる

workflow は `--resolution 4k` と `--resolution 8k` を続けて実行していた。`TEMP_DIR` は invocation ごとなので、21600x10800 の Blue Marble 元画像を pass ごとに取得する。上記の exit 18 は 1 回目の取得完了から 15 秒後、2 回目の取得で起きた。

`--resolution` を `--body` と同じ comma 区切りの list にして、workflow を 1 回の invocation にした:

```yaml
run: ./tools/fetch-textures.sh --resolution 4k,8k --body earth,moon,sun
```

元画像 1 回の取得に対して 2 回 resize する。deploy と同じ引数での実測: `Downloading day_source.jpg` は 1 回、生成物は cache step が列挙する 7 file と厳密に一致（earth_4k / earth_8k / earth_night_4k / earth_night_8k / moon_4k / moon_8k / sun_4k）。sun の元画像は 4104x2304 なので `4k,8k` でも sun_4k だけになる。

## 3. 要求していない解像度のための巨大 download をやめる

`process_night` の `need_high` は earth_night_16k.jpg が無ければ true になっていた。要求解像度を見ていないので、`--resolution 8k` を 16k 出力の無い checkout で走らせると 13500x6750 の元画像を取得して捨てる。

実測 A/B（earth_night_8k.jpg あり、earth_night_16k.jpg を退避、`--resolution 8k --body earth`）:

```
# 修正前
  earth_night_8k.jpg already exists (use --force to re-download)
==> Fetching Black Marble night texture (13500x6750)...
  Downloading night_source_high.jpg...
  earth_night_8k.jpg already exists (use --force to re-download)   # 取得したものは捨てられる

# 修正後
  earth_night_8k.jpg already exists (use --force to re-download)
==> All done!
```

## 4. 空の選択を reject する

`--resolution ""` は正規化後に entry 0 個となり、検証を通って何も生成せず exit 0 で終わっていた。呼び出し側の変数が空になったときに黙って成功する。`--body ""` も同じ穴を持っていた。両方 exit 1 にした。

```
$ ./tools/fetch-textures.sh --resolution "" --body earth
Error: --resolution needs a value (expected: 2k,4k,8k,16k or all)
$ ./tools/fetch-textures.sh --resolution 4k --body ""
Error: --body needs a value (expected: earth,moon,mars,sun or all)
```

## texture cache の現状を記録した

この step の cache は evict され続けている。repo の active cache は 12.7 GB（上限 10 GB）で、job ごとの Cargo cache が 0.5-1.2 GB ずつ占める。実測でも直近の Deploy Site の半分が cache miss で、NASA から取得するのが通常経路になっている。cache step にその事実と、取得の失敗が続く場合に加工済み texture を release asset として公開する TODO を書いた。

## 検証

- `bash -n tools/fetch-textures.sh`、`.github/workflows/deploy.yml` の YAML parse
- 上記の実測（deploy と同じ引数での完走、`-C -` の resume と byte 一致、A/B、引数検証、case/space 正規化）
- Rust / TypeScript は変更していないので cargo・pnpm の gate は対象外
- codex review 4 周（指摘 2 件を反映。3 件目の「curl の内部 retry は `-C -` でも 0 byte から始まる」は実測で否定した）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
