### PR TITLE
fix(orts): restore a component the .rrd carries on only some rows

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -64,7 +64,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   で旧振る舞いを再現しない。面が本当に不明なら `PanelOptics::absorber()` を渡す。([#377](https://github.com/sksat/orts/pull/377))
 - **BREAKING**: `EntityStore::timelines` の型が `Vec<TimeIndex>` から
   `TimelineColumn` になり、列は自分が覆う論理行を持つようになった。追加は論理行を
-  明示して検査する `ComponentColumn::push_at` を通す。`push` と `scalars_per_row`、
+  明示して検査する `ComponentColumn::push_at` を通す。`push` は削除、`scalars_per_row` と
   両 column type の `data` / `rows` field は crate 内限定 — map と data が食い違った列は、
   値を別の行の時刻で報告する。読み出しは列が `scalars` と `scalars_per_row()`、軸が
   `times`、行単位では `get_row` が格納 index、`at_logical_row` が

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -80,6 +80,12 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   20-40% 改善する。([#359](https://github.com/sksat/orts/pull/359))
 
 #### Fixed
+- `load_as_recording` が、.rrd が entity の一部の行にしか持たない component を
+  落とさず復元するようになった。列が「自分の覆う行」を持てなかった間は落とすしか
+  なかった: 欠けた行をゼロで埋めると `orts convert` の CSV にファイルが持っていない
+  値が入り、行を落とすと軌道が失われる。component の field が一部しか揃っていない行は
+  従来どおり除外し、どの行も丸ごと持たない component は報告しない。
+  ([#375](https://github.com/sksat/orts/issues/375))
 - 一部の step でしか logging されなかった component が、logging された時刻を保つ
   ようになった。`log_temporal` は行数の比較で新しい行かどうかを決めていたため、
   短い列が**先頭の**行に並んでいた: step 5 から attitude を出すと step 5〜9 が

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,13 @@ section is subdivided by package.
   0.33 m, and the three shorter Harris-Priester oracles by 20-40%. ([#359](https://github.com/sksat/orts/pull/359))
 
 #### Fixed
+- `load_as_recording` restores a component the .rrd carries on only some of an
+  entity's rows, rather than dropping it. It had to drop it while a column could
+  not say which rows it covered: filling the absent rows with zeros would have
+  put a value the file never carried into the CSV `orts convert` writes, and
+  dropping the rows would have cost the trajectory. A row holding only some of
+  the component's fields is still left out, and a component no row holds whole is
+  still not reported. ([#375](https://github.com/sksat/orts/issues/375))
 - A component logged at only some steps keeps the times it was logged at.
   `log_temporal` decided whether a call began a new row by comparing row counts,
   so a short column lined up with the *leading* rows: logging attitude from step

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,11 +75,11 @@ section is subdivided by package.
 - **BREAKING**: `EntityStore::timelines` holds `TimelineColumn` rather than
   `Vec<TimeIndex>`, and a column now carries the logical rows it covers.
   Appending goes through `ComponentColumn::push_at`, which states the row and
-  checks it; `push`, `scalars_per_row` and the `data` / `rows` fields of both
-  column types are crate-private, since a column whose map and data disagree
-  reports values at other rows' times. Read a column with `scalars`,
-  `scalars_per_row()` and an axis with `times`, or by row: `get_row` takes a
-  stored index, `at_logical_row` an entity
+  checks it; `push` is removed, and `scalars_per_row` and the `data` / `rows`
+  fields of both column types are crate-private, since a column whose map and
+  data disagree reports values at other rows' times. Read a column with
+  `scalars`, `scalars_per_row()` and an axis with `times`, or by row: `get_row`
+  takes a stored index, `at_logical_row` an entity
   row. ([#375](https://github.com/sksat/orts/issues/375))
 - `StateEffector` is now frame-generic — `StateEffector<S, F: frame::Eci =
   SimpleEci>` returning `ExternalLoads<F>`, like `Model<S, F>` — so effectors

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -1422,6 +1422,86 @@ mod tests {
         );
     }
 
+    /// The whole `orts convert` chain for a component logged at only some steps:
+    /// written to .rrd at the times it was logged, read back covering those rows,
+    /// and written to CSV with the other rows empty.
+    ///
+    /// The halves are covered separately; this is what composes them.
+    #[test]
+    fn a_sparse_component_reaches_the_csv_through_a_file() {
+        use orts::record::archetypes::OrbitalState as RecOrbitalState;
+        use orts::record::components::MtqCommand3D;
+        use orts::record::rerun_export::{load_as_recording, save_as_rrd};
+        use orts::record::timeline::TimePoint;
+
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/chain");
+        let r0 = 6778.137;
+        let v0 = (398600.4418_f64 / r0).sqrt();
+        const N: u64 = 4;
+        const FIRST: u64 = 2;
+
+        for i in 0..N {
+            let tp = TimePoint::new().with_sim_time(i as f64).with_step(i);
+            let os = RecOrbitalState::new(
+                nalgebra::Vector3::new(r0, 0.0, 0.0),
+                nalgebra::Vector3::new(0.0, v0, 0.0),
+            );
+            rec.log_orbital_state(&sat, &tp, &os);
+            if i >= FIRST {
+                rec.log_temporal(
+                    &sat,
+                    &tp,
+                    &MtqCommand3D(nalgebra::Vector3::new(i as f64, 0.0, 0.0)),
+                );
+            }
+        }
+
+        let path = std::env::temp_dir().join(format!(
+            "orts_chain_{}_{:?}.rrd",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let path_str = path.to_str().unwrap().to_string();
+        save_as_rrd(&rec, "orts-chain-test", &path_str).expect("save");
+        let loaded = load_as_recording(&path_str).expect("load");
+        let _ = std::fs::remove_file(&path);
+
+        let header = build_csv_header(&loaded, &sat, false);
+        assert!(
+            header.contains("mtq_mx"),
+            "the command column survives the file: {header}"
+        );
+        let want = header.trim_start_matches("# ").matches(',').count() + 1;
+
+        let mut out = Vec::new();
+        write_satellite_csv(&mut out, &loaded, &sat, 398600.4418, false).expect("csv");
+        let body = String::from_utf8(out).expect("utf-8");
+        let lines: Vec<&str> = body.lines().filter(|l| !l.starts_with('#')).collect();
+
+        assert_eq!(lines.len(), N as usize, "one line per step");
+        for (i, line) in lines.iter().enumerate() {
+            assert_eq!(
+                line.matches(',').count() + 1,
+                want,
+                "line {i} column count: {line}"
+            );
+            // The steps before the first command leave those fields empty; the
+            // rest carry the value logged at that step.
+            if (i as u64) < FIRST {
+                assert!(
+                    line.ends_with(",,,"),
+                    "line {i} should be empty there: {line}"
+                );
+            } else {
+                assert!(
+                    line.contains(&format!(",{:.10},", i as f64)),
+                    "line {i} should carry {i}: {line}"
+                );
+            }
+        }
+    }
+
     /// The header names every extra column, so a component with no value at a
     /// step contributes empty fields. A short line would put the remaining
     /// values under the wrong headings.

--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -525,7 +525,7 @@ mod tests {
     use crate::record::timeline::TimePoint;
 
     #[test]
-    fn component_column_push_and_get() {
+    fn component_column_push_at_and_get() {
         let mut col = ComponentColumn::new(3);
         col.push_at(&[1.0, 2.0, 3.0], 0);
         col.push_at(&[4.0, 5.0, 6.0], 1);

--- a/orts/src/record/recording.rs
+++ b/orts/src/record/recording.rs
@@ -106,16 +106,6 @@ impl ComponentColumn {
         }
     }
 
-    /// Append `scalars` as the next logical row.
-    ///
-    /// Mixing this with [`Self::push_at`] on one column would leave the row map
-    /// disagreeing with the data, so it is deliberately not public: a caller
-    /// that knows about logical rows uses `push_at`.
-    pub(crate) fn push(&mut self, scalars: &[f64]) {
-        let stored = self.num_rows();
-        self.push_at(scalars, stored);
-    }
-
     /// Append `scalars` as the entity's logical row `logical_row`.
     ///
     /// # Panics
@@ -537,8 +527,8 @@ mod tests {
     #[test]
     fn component_column_push_and_get() {
         let mut col = ComponentColumn::new(3);
-        col.push(&[1.0, 2.0, 3.0]);
-        col.push(&[4.0, 5.0, 6.0]);
+        col.push_at(&[1.0, 2.0, 3.0], 0);
+        col.push_at(&[4.0, 5.0, 6.0], 1);
 
         assert_eq!(col.num_rows(), 2);
         assert_eq!(col.get_row(0), Some([1.0, 2.0, 3.0].as_slice()));
@@ -549,8 +539,8 @@ mod tests {
     #[test]
     fn component_column_scalar() {
         let mut col = ComponentColumn::new(1);
-        col.push(&[42.0]);
-        col.push(&[99.0]);
+        col.push_at(&[42.0], 0);
+        col.push_at(&[99.0], 1);
 
         assert_eq!(col.num_rows(), 2);
         assert_eq!(col.get_row(0), Some([42.0].as_slice()));

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -1229,22 +1229,20 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
             // half a vector is not a value.
             let mut column = ComponentColumn::new(fields.len());
             // Resolve each field's column once: `get_scalar_data` formats two
-            // candidate paths per call, and this walks every row. A field with no
-            // column at all leaves the component with no whole row, which the
-            // guard below then drops.
-            let field_columns: Option<Vec<&Column>> = fields
+            // candidate paths per call, and this walks every row. `temporal` was
+            // retained on every field having a column, so each lookup is `Some`.
+            let field_columns: Vec<&Column> = fields
                 .iter()
-                .map(|field| get_scalar_data(&scalars, base, field))
+                .filter_map(|field| get_scalar_data(&scalars, base, field))
                 .collect();
-            if let Some(field_columns) = field_columns {
-                for (logical_row, &key) in row_keys.iter().enumerate() {
-                    let row: Vec<f64> = field_columns
-                        .iter()
-                        .map_while(|col| col.get(&key).copied())
-                        .collect();
-                    if row.len() == fields.len() {
-                        column.push_at(&row, logical_row);
-                    }
+            debug_assert_eq!(field_columns.len(), fields.len());
+            for (logical_row, &key) in row_keys.iter().enumerate() {
+                let row: Vec<f64> = field_columns
+                    .iter()
+                    .map_while(|col| col.get(&key).copied())
+                    .collect();
+                if row.len() == fields.len() {
+                    column.push_at(&row, logical_row);
                 }
             }
             // None of this entity's rows holds the component whole, so there is

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -1101,13 +1101,16 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
         // what row 0 means: a position from one time beside a velocity from
         // another.
         //
-        // `ComponentColumn` has no way to say "no value at this row", so a row
-        // exists only where the state components are whole. Anchoring on
-        // position and velocity keeps the trajectory intact when an optional
-        // component such as attitude was recorded at only some of the times.
-        // That component is then left out rather than filled with zeros, which
-        // downstream would read as a measured value: `orts convert` writes them
-        // to CSV and computes orbital elements from them.
+        // A row therefore exists only where the state components are whole.
+        // Anchoring on position and velocity keeps the trajectory intact when an
+        // optional component such as attitude was recorded at only some of the
+        // times; that component covers the rows it has, and `orts convert` leaves
+        // the others empty rather than writing a zero, which downstream would
+        // read as a measured value.
+        //
+        // The cost is that a time where the anchors are not whole is no row at
+        // all, so a whole optional value recorded only at such a time is not
+        // reported.
         let anchors: Vec<&(String, Vec<String>)> = {
             let state: Vec<&(String, Vec<String>)> = temporal
                 .iter()
@@ -1185,8 +1188,9 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
         // CSV path reads `SimTime` only, so filling the others changes what
         // `orts convert` reports. Left as it stands on main until the step
         // round-trip is settled with the writer.
-        // Dense over `row_keys`: every row the file carries for this entity is a
-        // row of the recording, and a component that covers only some of them
+        // Dense over `row_keys`, which is the intersection of the anchor columns'
+        // keys — so a time the file carries for this entity is a row only when
+        // the anchors are whole there. A component that covers some of those rows
         // records which ones.
         let entity_times = TimelineColumn {
             data: row_keys
@@ -1224,30 +1228,33 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
             // covers. A row where some of its fields are missing is left out —
             // half a vector is not a value.
             let mut column = ComponentColumn::new(fields.len());
-            for (logical_row, &key) in row_keys.iter().enumerate() {
-                let mut row = Vec::with_capacity(fields.len());
-                for field in fields {
-                    match get_scalar_data(&scalars, base, field).and_then(|col| col.get(&key)) {
-                        Some(&v) => row.push(v),
-                        None => break,
+            // Resolve each field's column once: `get_scalar_data` formats two
+            // candidate paths per call, and this walks every row. A field with no
+            // column at all leaves the component with no whole row, which the
+            // guard below then drops.
+            let field_columns: Option<Vec<&Column>> = fields
+                .iter()
+                .map(|field| get_scalar_data(&scalars, base, field))
+                .collect();
+            if let Some(field_columns) = field_columns {
+                for (logical_row, &key) in row_keys.iter().enumerate() {
+                    let row: Vec<f64> = field_columns
+                        .iter()
+                        .map_while(|col| col.get(&key).copied())
+                        .collect();
+                    if row.len() == fields.len() {
+                        column.push_at(&row, logical_row);
                     }
                 }
-                if row.len() == fields.len() {
-                    column.push_at(&row, logical_row);
-                }
             }
-            // The entity has rows but none of them holds this component whole, so
-            // the file carries no value to report for it. An entity with no rows
-            // at all still gets its columns, empty, so the schema survives.
+            // None of this entity's rows holds the component whole, so there is
+            // nothing to report for it. That can also happen when the file does
+            // carry a whole value, at a time that is not one of the rows — see
+            // the anchor comment above. An entity with no rows at all still gets
+            // its columns, empty, which is what keeps its schema entry.
             if !row_keys.is_empty() && column.num_rows() == 0 {
                 continue;
             }
-            // The entity has rows but none of them holds this component whole, so
-            // the file carries no value to report for it. An entity with no rows
-            // at all still gets its columns, empty, so the schema survives.
-            // The entity has rows but none of them holds this component whole, so
-            // the file carries no value to report for it. An entity with no rows
-            // at all still gets its columns, empty, so the schema survives.
 
             let comp_name: Cow<'static, str> = Cow::Owned(name.clone());
             let store = rec.entity_mut(&entity);

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -1236,6 +1236,18 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
                     column.push_at(&row, logical_row);
                 }
             }
+            // The entity has rows but none of them holds this component whole, so
+            // the file carries no value to report for it. An entity with no rows
+            // at all still gets its columns, empty, so the schema survives.
+            if !row_keys.is_empty() && column.num_rows() == 0 {
+                continue;
+            }
+            // The entity has rows but none of them holds this component whole, so
+            // the file carries no value to report for it. An entity with no rows
+            // at all still gets its columns, empty, so the schema survives.
+            // The entity has rows but none of them holds this component whole, so
+            // the file carries no value to report for it. An entity with no rows
+            // at all still gets its columns, empty, so the schema survives.
 
             let comp_name: Cow<'static, str> = Cow::Owned(name.clone());
             let store = rec.entity_mut(&entity);
@@ -2221,6 +2233,70 @@ mod tests {
             .expect("a position column");
         assert_eq!(position.get_row(0).expect("row 0"), &[100.0, 1.0, 2.0]);
         assert_eq!(position.get_row(1).expect("row 1"), &[110.0, 1.0, 2.0]);
+    }
+
+    /// A component whose fields never share a row is not reported at all.
+    ///
+    /// Restoring the rows a component covers must not turn into reporting a
+    /// component the file holds no whole value for: `qw` at one time and `qx` at
+    /// another is no quaternion at either.
+    #[test]
+    fn a_component_whose_fields_never_meet_is_not_reported() {
+        let dir = std::env::temp_dir().join(format!(
+            "orts_nomeet_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("nomeet.rrd");
+        {
+            let rec = re_sdk::RecordingStreamBuilder::new("orts-nomeet-test")
+                .save(&path)
+                .expect("recording stream");
+            // Position everywhere, so the entity has rows.
+            for t in [0.0f64, 10.0] {
+                rec.set_duration_secs("sim_time", t);
+                for (field, value) in [("x", t), ("y", 1.0), ("z", 2.0)] {
+                    rec.log(
+                        format!("/world/sat/nomeet/{field}"),
+                        &re_sdk_types::archetypes::Scalars::new([value]),
+                    )
+                    .expect("log");
+                }
+            }
+            // All four attitude fields exist, but split across the two times, so
+            // no row holds a whole quaternion.
+            for (t, fields) in [(0.0f64, ["qw", "qx"]), (10.0, ["qy", "qz"])] {
+                rec.set_duration_secs("sim_time", t);
+                for field in fields {
+                    rec.log(
+                        format!("/world/sat/nomeet/{field}"),
+                        &re_sdk_types::archetypes::Scalars::new([1.0f64]),
+                    )
+                    .expect("log");
+                }
+            }
+            rec.flush_blocking().expect("flush");
+        }
+
+        let loaded = load_as_recording(path.to_str().unwrap()).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        let store = loaded
+            .entity(&EntityPath::parse("/world/sat/nomeet"))
+            .expect("entity");
+        assert_eq!(store.num_rows, 2, "the trajectory still has its rows");
+        assert!(
+            store.columns.keys().any(|name| name.contains("Position3D")),
+            "the trajectory survives"
+        );
+        assert!(
+            !store
+                .columns
+                .keys()
+                .any(|name| name.contains("Quaternion4D")),
+            "no row holds a whole quaternion, so none is reported"
+        );
     }
 
     /// A component logged at only some steps survives a round trip through the
@@ -3552,7 +3628,7 @@ mod tests {
             let store = rec.entity_mut(&sat);
             let mut column = ComponentColumn::new(3);
             for i in 0..N {
-                column.push(&[i as f64, 0.0, 0.0]);
+                column.push_at(&[i as f64, 0.0, 0.0], i);
             }
             store.columns.insert(Position3D::component_name(), column);
             // `sim_time` holds the wrong variant, so it covers no row at all.

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -1185,10 +1185,9 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
         // CSV path reads `SimTime` only, so filling the others changes what
         // `orts convert` reports. Left as it stands on main until the step
         // round-trip is settled with the writer.
-        // Dense over `row_keys`: a component that covers only some of them is
-        // dropped below rather than restored as a sparse column, which is what
-        // this loader has always done. Restoring it belongs with the CSV path
-        // that reads these rows (#375 follow-up).
+        // Dense over `row_keys`: every row the file carries for this entity is a
+        // row of the recording, and a component that covers only some of them
+        // records which ones.
         let entity_times = TimelineColumn {
             data: row_keys
                 .iter()
@@ -1220,26 +1219,22 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
         }
 
         for (name, fields) in &temporal {
+            // A component present on only some rows keeps those rows rather than
+            // being dropped whole: the column records which logical rows it
+            // covers. A row where some of its fields are missing is left out —
+            // half a vector is not a value.
             let mut column = ComponentColumn::new(fields.len());
-            let mut whole = true;
-            for &key in &row_keys {
+            for (logical_row, &key) in row_keys.iter().enumerate() {
                 let mut row = Vec::with_capacity(fields.len());
                 for field in fields {
                     match get_scalar_data(&scalars, base, field).and_then(|col| col.get(&key)) {
                         Some(&v) => row.push(v),
-                        None => {
-                            whole = false;
-                            break;
-                        }
+                        None => break,
                     }
                 }
-                if !whole {
-                    break;
+                if row.len() == fields.len() {
+                    column.push_at(&row, logical_row);
                 }
-                column.push(&row);
-            }
-            if !whole {
-                continue;
             }
 
             let comp_name: Cow<'static, str> = Cow::Owned(name.clone());
@@ -2228,15 +2223,77 @@ mod tests {
         assert_eq!(position.get_row(1).expect("row 1"), &[110.0, 1.0, 2.0]);
     }
 
-    /// A component recorded at only some of the times is left out.
+    /// A component logged at only some steps survives a round trip through the
+    /// file with the rows it covers.
     ///
-    /// Filling its absent rows with zeros would put an attitude that was never
-    /// logged into the CSV `orts convert` writes, where a zero quaternion is
-    /// indistinguishable from a measured one. Dropping those rows instead would
-    /// cost the trajectory, so the rows follow position and velocity and the
-    /// optional component is the part that goes.
+    /// The writer places its values at the times they were logged at, and the
+    /// loader now records which rows they came back on, so `orts convert` reports
+    /// the component instead of dropping it.
     #[test]
-    fn a_partially_recorded_optional_component_is_left_out() {
+    fn a_sparse_column_round_trips() {
+        use crate::record::components::MtqCommand3D;
+
+        let mut rec = Recording::new();
+        let sat = EntityPath::parse("/world/sat/roundtrip");
+
+        const N: u64 = 6;
+        const FIRST: u64 = 3;
+        for i in 0..N {
+            let tp = TimePoint::new().with_sim_time(i as f64).with_step(i);
+            let os = OrbitalState::new(
+                Vector3::new(7000.0 + i as f64, 0.0, 0.0),
+                Vector3::new(0.0, 7.5, 0.0),
+            );
+            rec.log_orbital_state(&sat, &tp, &os);
+            if i >= FIRST {
+                rec.log_temporal(&sat, &tp, &MtqCommand3D(Vector3::new(i as f64, 0.0, 0.0)));
+            }
+        }
+
+        let path = std::env::temp_dir().join("test_orts_sparse_roundtrip.rrd");
+        let path_str = path.to_str().unwrap();
+        save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
+        let loaded = load_as_recording(path_str).expect("failed to load");
+        let _ = std::fs::remove_file(&path);
+
+        let store = loaded.entity(&sat).expect("entity");
+        assert_eq!(store.num_rows, N as usize, "every step is a row");
+
+        let mtq = store
+            .columns
+            .iter()
+            .find(|(name, _)| name.contains("MtqCommand3D"))
+            .map(|(_, c)| c)
+            .expect("the command column survives the round trip");
+        assert_eq!(mtq.num_rows(), (N - FIRST) as usize);
+        for row in 0..N as usize {
+            let want = (row >= FIRST as usize).then(|| row as f64);
+            assert_eq!(mtq.at_logical_row(row).map(|v| v[0]), want, "row {row}");
+        }
+
+        // The dense column is unchanged by the round trip.
+        let pos = store
+            .columns
+            .iter()
+            .find(|(name, _)| name.contains("Position3D"))
+            .map(|(_, c)| c)
+            .expect("a position column");
+        assert_eq!(pos.num_rows(), N as usize);
+        assert_eq!(pos.rows, RowMap::Dense);
+    }
+
+    /// A component recorded at only some of the times comes back covering those
+    /// times.
+    ///
+    /// This used to drop the component. Filling its absent rows with zeros would
+    /// have put an attitude that was never logged into the CSV `orts convert`
+    /// writes, where a zero quaternion reads as a measured one, and dropping the
+    /// rows would have cost the trajectory — so the component was the part that
+    /// went. A column now records which logical rows it covers and the CSV
+    /// leaves the others empty, so neither the attitude nor the trajectory has
+    /// to go (#375).
+    #[test]
+    fn a_partially_recorded_optional_component_covers_its_own_times() {
         let dir = std::env::temp_dir().join(format!(
             "orts_opt_{}_{:?}",
             std::process::id(),
@@ -2276,16 +2333,31 @@ mod tests {
         let entity = EntityPath::parse("/world/sat/opt");
         let store = loaded.entity(&entity).expect("entity");
         assert_eq!(store.num_rows, 2, "both positions are kept");
-        assert!(
-            store.columns.keys().any(|name| name.contains("Position3D")),
-            "the trajectory survives"
+
+        let position = store
+            .columns
+            .iter()
+            .find(|(name, _)| name.contains("Position3D"))
+            .map(|(_, c)| c)
+            .expect("the trajectory survives");
+        assert_eq!(position.num_rows(), 2);
+
+        let attitude = store
+            .columns
+            .iter()
+            .find(|(name, _)| name.contains("Quaternion4D"))
+            .map(|(_, c)| c)
+            .expect("the attitude survives, covering the time it was logged at");
+        assert_eq!(attitude.num_rows(), 1);
+        assert_eq!(
+            attitude.at_logical_row(0),
+            None,
+            "t=0 logged no attitude, and no zero stands in for it"
         );
-        assert!(
-            !store
-                .columns
-                .keys()
-                .any(|name| name.contains("Quaternion4D")),
-            "an attitude present at only one of the two times is not reported"
+        assert_eq!(
+            attitude.at_logical_row(1),
+            Some([1.0, 0.0, 0.0, 0.0].as_slice()),
+            "t=10's attitude sits on t=10's row"
         );
     }
 
@@ -3436,7 +3508,7 @@ mod tests {
         {
             let store = rec.entity_mut(&sat);
             let mut column = ComponentColumn::new(3);
-            column.push(&[1.0, 2.0, 3.0]);
+            column.push_at(&[1.0, 2.0, 3.0], 0);
             store.columns.insert(Position3D::component_name(), column);
             // A sequence on the sim-time axis, and no step axis at all.
             store.timelines.insert(

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -1230,12 +1230,16 @@ pub fn load_as_recording(path: &str) -> Result<Recording, Box<dyn std::error::Er
             let mut column = ComponentColumn::new(fields.len());
             // Resolve each field's column once: `get_scalar_data` formats two
             // candidate paths per call, and this walks every row. `temporal` was
-            // retained on every field having a column, so each lookup is `Some`.
+            // retained on every field having a column, so the count holds; a
+            // short list would build rows out of the wrong fields, so it is
+            // checked rather than assumed.
             let field_columns: Vec<&Column> = fields
                 .iter()
                 .filter_map(|field| get_scalar_data(&scalars, base, field))
                 .collect();
-            debug_assert_eq!(field_columns.len(), fields.len());
+            if field_columns.len() != fields.len() {
+                continue;
+            }
             for (logical_row, &key) in row_keys.iter().enumerate() {
                 let row: Vec<f64> = field_columns
                     .iter()

--- a/orts/src/record/rerun_export.rs
+++ b/orts/src/record/rerun_export.rs
@@ -2335,11 +2335,19 @@ mod tests {
             }
         }
 
-        let path = std::env::temp_dir().join("test_orts_sparse_roundtrip.rrd");
+        // A directory of this test's own, so parallel runs cannot meet on one
+        // path (see `load_written`).
+        let dir = std::env::temp_dir().join(format!(
+            "orts_rrd_sparse_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("sparse_roundtrip.rrd");
         let path_str = path.to_str().unwrap();
         save_as_rrd(&rec, "test-orts", path_str).expect("failed to save .rrd");
         let loaded = load_as_recording(path_str).expect("failed to load");
-        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir_all(&dir);
 
         let store = loaded.entity(&sat).expect("entity");
         assert_eq!(store.num_rows, N as usize, "every step is a row");


### PR DESCRIPTION
`load_as_recording` が、entity の一部の行にしか値が無い component を落としていた。バグ修正。

## 症状

.rrd に姿勢が t=10 だけ入っていると、`orts convert` の CSV から姿勢の列ごと消える。

## 原因

列が「どの行に値があるか」を持てなかったので、読み込み側に選択肢が 2 つしかなかった。欠けた行をゼロで埋めると、ファイルが持っていない値が CSV に入って下流が測定値として読む。行を落とすと軌道が失われる。それで component を落としていた（#366）。

#388 で列が行番号を持つようになり、CSV は欠損を空フィールドで出すので、どちらも失わずに済む。

## 変更

component は自分が値を持つ行だけを復元する。

component の field が一部しか揃っていない行は従来どおり除外する（ベクトルの半分は値ではない）。どの行も全 field を揃えていない component は報告しない。行が 1 つも無い entity は従来どおり空の列を得る（schema entry がそれで残る）。

`ComponentColumn::push` は削除した。loader が最後の呼び出し元だったので、追加は常に論理行を明示する `push_at` になる。

## 制約

`row_keys` は anchor 列（Position3D / Velocity3D）のキーの積集合なので、anchor が揃わない時刻は行にならない。姿勢だけが入っていて position が無い時刻の値は、この変更後も報告されない。コメントに明記した。

## テスト

- `a_sparse_column_round_trips` — writer が書いた疎な列が loader を通って戻る。修正なしでは component が消えて落ちる
- `a_sparse_component_reaches_the_csv_through_a_file` — save → load → CSV の全経路。指令前の step は空フィールド、以降は logging された値
- `a_component_whose_fields_never_meet_is_not_reported` — 4 field が同じ行に揃わない component は報告しない。修正なしでは落ちる
- `a_partially_recorded_optional_component_is_left_out` を `..._covers_its_own_times` に書き換え。旧挙動を固定していたテストで、doc に旧来の理由と変わった理由を残した

`-p orts --lib` は debug / release とも 788 pass、`clippy --locked --workspace -- -D warnings` は 0。

Refs #375
