### PR TITLE
perf(ci): spend the cache budget on the pull-request critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -842,11 +842,14 @@ jobs:
           toolchain: ${{ steps.rust-toolchain.outputs.channel }}
           targets: ${{ matrix.target }}
 
-      - name: Cache Cargo artifacts
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-        with:
-          shared-key: rust-release-${{ matrix.target }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+      # This job builds from scratch on purpose. Its six per-target Cargo caches
+      # held ~4 GB of the repository's 10 GB budget, which the whole workflow is
+      # over, so entries are evicted within minutes of being written. What the
+      # budget has to cover first is the pull-request critical path: a missing
+      # rust-windows cache costs 864 s that someone is waiting on, against
+      # ~600 s per target here (measured ~250 s cached vs ~850 s cold) on a job
+      # that runs after review, on main pushes and tags, with all six targets in
+      # parallel.
 
       # The third-party license notice is generated from build.rs via the
       # cargo-about *library* (a build-dependency of orts-cli), so no
@@ -1114,11 +1117,17 @@ jobs:
         with:
           toolchain: nightly
 
+      # Same key as the Pages deploy's site build (identical toolchain, targets
+      # and `pnpm build:site`), so the two share one entry instead of holding
+      # 0.5 GB each. The deploy on main is the producer; this job consumes, which
+      # also stops a docs-touching pull request from writing a branch-scoped
+      # 0.5 GB copy that only that branch can read.
       - name: Cache Cargo artifacts
         if: steps.changes.outputs.docs == 'true'
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          shared-key: build-site
+          shared-key: site
+          save-if: false
 
       - name: Install wasm-pack
         if: steps.changes.outputs.docs == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,10 +94,13 @@ jobs:
         with:
           toolchain: nightly
 
+      # Shared with CI's build-site job, which builds the same site with the same
+      # toolchain and only reads this entry. Keeping them on separate keys cost
+      # 0.5 GB of a 10 GB budget the pull-request jobs are already over.
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          shared-key: deploy-site
+          shared-key: site
 
       - name: Install wasm-pack
         uses: ./.github/actions/install-wasm-pack


### PR DESCRIPTION
CI の cache は上限 10 GB に対して実測 13-14 GB あり、evict され続けている。PR を待たせている cache が先に容量を確保できるよう配分を変える。

なお merge 後に測り直した結果、この変更で PR CI の所要時間は短くならないことが分かった。効くのは eviction が起きたときの再発防止だけで、代わりに main の push run が長くなる。詳細は下のコメントに記録した。

## windows の cache が復元できないと 864s 増える

rust-test-windows の step 内訳:

| | Cache Cargo artifacts | Test (all except orts) | Test (orts) | 合計 |
| --- | --- | --- | --- | --- |
| `No cache found` | 7s | 1156s | 182s | **1372s** |
| 1.2 GB 復元 | 48s | 389s | 35s | **508s** |

eviction は速い。main が 17:10:51 に保存した rust-windows cache 1.2 GB は、15 分後の `gh cache list` から消えていた。

## rust-dist の per-target cache（約 4 GB）を外す

pool 13-14 GB のうち約 4 GB がこの 6 entry で、review の後に走る job（main push と tag、6 target 並列）のもの。

外すと 1 target あたり約 600s 増える（実測: cached 約 250s、cold 約 850s）。その代わり、PR を待たせている 864s の増分が起きにくくなる。

## build-site と deploy-site の cache key を統合する

両者は同じ toolchain・同じ wasm target・同じ `pnpm build:site` で同じサイトを建てているのに、`shared-key` が別々で 0.5 GB ずつ使っていた。`site` に統合し、main の deploy を producer、CI 側を `save-if: false` の consumer にした。

docs を触った PR が「その branch しか読めない 0.5 GB」を書くのも止まる。

## 効果の見込みと、実際の結果

約 4.5 GB 空き、hot path（Rust cache 約 7 GB ＋ pnpm / Playwright）が上限内に収まる。cache key は Cargo.lock・全 Cargo.toml・rust-toolchain.toml・.cargo/config.toml を含み、1 ファイルの変更で 9 個の key が同時に変わるので、その世代交代 1 回分の空きが必要になる。

merge 後に event を揃えて測り直した結果は次の通りで、当初この欄に書いた「23 分 → 10 分」は成立しなかった。

| サンプル | n | 総時間 中央値 | windows 中央値 | cache 復元 |
| --- | --- | --- | --- | --- |
| 前 / `pull_request` | 43 | 960s | 509s | 43/43 |
| 後 / `pull_request` | 10 | 1024s | 504s | 10/10 |
| 前 / `push`(main) | 4 | 1778s | 532s | 4/4 |
| 後 / `push`(main) | 1 | 2133s | 503s | 1/1 |

## 検証

- YAML parse、`shared-key` / `save-if` の全数確認
- job / step の duration は Actions API、cache のサイズと ref は `gh cache list`
- codex review 2 周。当初は「release cadence でしか走らないので cache は一度も効かない」と書いたが、rust-dist の duration 分布を測ると復元は頻繁に起きていたので、根拠を「所要時間の交換として見合う」に書き換えた

🤖 Generated with [Claude Code](https://claude.com/claude-code)
