### PR TITLE
feat(viewer): draw the Sun and nadir arrows at the centred satellite

### DIFF
--- a/viewer/README.md
+++ b/viewer/README.md
@@ -84,6 +84,27 @@ in-track (`crossTrack × radial`, the velocity direction for a circular orbit),
 **+Y** is cross-track (`normalize(r × v)`, the orbit normal) and **+Z** is radial
 *outward*, so nadir points along scene **−Z**.
 
+### Reference-direction arrows
+
+`directionVectors` (`{ sun, nadir }`) draws the same arrows the attitude view
+draws, at the **centred satellite**:
+
+```tsx
+<OrbitViewer
+  centralBody={{ id: "earth", radiusKm: 6378.137 }}
+  satellites={[{ id: "sat-1", position: [7000, 0, 1500], velocity: [0, 7.5, 0] }]}
+  referenceFrame={{ center: { satelliteId: "sat-1" }, orientation: "localOrbital" }}
+  epochJd={2460000.5}
+  directionVectors={{ sun: true, nadir: true }}
+/>;
+```
+
+Omitting the prop — the default — draws none. A central-body view draws none
+either way: the body itself is on screen, so a nadir arrow repeats what the
+picture already shows, and a pair of arrows on every satellite fills the screen.
+The Sun arrow needs `epochJd`; without it the arrow is dropped rather than
+pointed at a fixed direction.
+
 ### Trails
 
 Pass `trail` (an array of points) per satellite. Trails are uploaded

--- a/viewer/README.md
+++ b/viewer/README.md
@@ -99,7 +99,8 @@ draws, at the **centred satellite**:
 />;
 ```
 
-Omitting the prop — the default — draws none. A central-body view draws none
+Omitting the prop — the default — draws none, and each field is opt-in:
+`{ sun: true }` draws the Sun and not nadir. A central-body view draws none
 either way: the body itself is on screen, so a nadir arrow repeats what the
 picture already shows, and a pair of arrows on every satellite fills the screen.
 The Sun arrow needs `epochJd`; without it the arrow is dropped rather than

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/AttitudeSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/AttitudeSceneContents.tsx
@@ -99,25 +99,20 @@ export function AttitudeSceneContents({
     ? (spanNormalizedModelScale(modelConfig, span) ?? undefined)
     : undefined;
 
-  // Whether the model is the thing on screen. Without a usable attitude a model
-  // would be drawn at its own default orientation, which reads as a measured one
-  // in a view about orientation, so a marker stands in — and one value decides
-  // both what is drawn and what the arrows have to start outside of.
-  const modelIsDrawn = modelConfig != null && quaternion != null;
+  // The attitude is this view's subject, so a missing quaternion here is always
+  // one that was refused: `AttitudeBodyState.attitude` is required, and the scene
+  // drops what it cannot use.
+  const attitudeRefused = quaternion == null;
+  // What the arrows have to start outside of, which is the model only when the
+  // model is the thing on screen.
+  const modelIsDrawn = modelConfig != null && !attitudeRefused;
 
-  // Without a usable attitude, nothing drawn may imply one. An explicit shape —
-  // or the app's default, which the `satShape` URL param persists — outranks
-  // `hasAttitude` in `resolveMarkerShape`, so the orientation-revealing cube
-  // would be drawn at identity and read as a measured attitude. The sphere is the
-  // one marker that looks the same from every side.
-  const shape: MarkerShape =
-    quaternion == null
-      ? "sphere"
-      : resolveMarkerShape({
-          override: markerShape,
-          globalDefault: defaultMarkerShape,
-          hasAttitude: true,
-        });
+  const shape: MarkerShape = resolveMarkerShape({
+    override: markerShape,
+    globalDefault: defaultMarkerShape,
+    hasAttitude: !attitudeRefused,
+    attitudeRefused,
+  });
 
   return (
     <>
@@ -144,7 +139,7 @@ export function AttitudeSceneContents({
         axisLength={axisLengthForSpan(span)}
         modelScale={modelScale}
         visualSpan={span}
-        model={modelIsDrawn}
+        attitudeRefused={attitudeRefused}
       />
 
       <DirectionArrows

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
@@ -28,7 +28,7 @@ import {
   modelBoundingRadius,
   resolveVisualSpan,
 } from "../spacecraftScale.js";
-import { finiteOrNull } from "../utils/finite.js";
+import { finiteOrNull, firstFiniteTime } from "../utils/finite.js";
 import type { TrailBufferLike } from "../utils/TrailBuffer.js";
 import { body_orientation, earth_rotation_angle } from "../wasm/arikaInit.js";
 import { CelestialBody } from "./CelestialBody.js";
@@ -461,23 +461,15 @@ export function OrbitSceneContents({
   // stays frozen), and the Sun drawn *at* the centred satellite has to be the Sun
   // at that satellite's time, not at whichever time the Map happens to yield
   // first. Falls back to the first available position for a central-body view.
-  // Iterate the Map's values directly rather than materializing an array every
-  // render just to find the first non-null entry.
-  let firstPosition: OrbitPoint | null = null;
-  if (satellitePositions) {
-    for (const p of satellitePositions.values()) {
-      if (p != null) {
-        firstPosition = p;
-        break;
-      }
-    }
-  }
+  // The Map's values are iterated directly rather than materialized into an array
+  // every render just to find one entry.
+  const fallbackTime = firstFiniteTime(satellitePositions?.values());
   const centeredPosition = centeredSatId != null ? satellitePositions?.get(centeredSatId) : null;
-  // The first *finite* time, not the first present one: `??` falls through on
-  // null and undefined, so a NaN `t` on the centred satellite would win over a
-  // usable fallback and reach the Earth rotation angle and the quantised Sun
-  // time below, both of which are WASM calls.
-  const simTime = finiteOrNull(centeredPosition?.t) ?? finiteOrNull(firstPosition?.t) ?? 0;
+  // Each candidate goes through a finite check, because `??` falls through only
+  // on null and undefined: a NaN `t` on the centred satellite would otherwise win
+  // over a usable fallback and reach the Earth rotation angle and the quantised
+  // Sun time below, both of which are WASM calls.
+  const simTime = finiteOrNull(centeredPosition?.t) ?? fallbackTime ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 
   // Earth rotation angle (ERA) via WASM — updates every frame via simTime (not quantized)

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
@@ -9,7 +9,12 @@ import {
   getBodyRadius,
 } from "../bodies.js";
 import { type DirectionVectorOptions, resolveDirectionVectors } from "../directionVectors.js";
-import { displayPosition, displayRotation, resolveDisplayFrame } from "../displayFrame.js";
+import {
+  displayPosition,
+  displayRotation,
+  resolveDisplayFrame,
+  sampleAttitude,
+} from "../displayFrame.js";
 import {
   computeSceneAmplification,
   type DisplayScaleProfile,
@@ -646,7 +651,10 @@ export function OrbitSceneContents({
             override: satelliteShapes?.get(centeredSatId),
             simShape: satelliteSimShapes?.get(centeredSatId),
             globalDefault: defaultMarkerShape,
-            hasAttitude: pos.qw != null,
+            // The same judgement the rotation makes: a sample whose quaternion
+            // names no rotation gets the sphere, not the cube that would show an
+            // orientation nobody measured.
+            hasAttitude: sampleAttitude(pos) != null,
           });
           const satName = satelliteNames?.get(centeredSatId);
           // The centred satellite is drawn exactly at the world origin, so the
@@ -802,7 +810,8 @@ export function OrbitSceneContents({
                     override: satelliteShapes?.get(satId),
                     simShape: satelliteSimShapes?.get(satId),
                     globalDefault: defaultMarkerShape,
-                    hasAttitude: pos.qw != null,
+                    // See above: the shape follows the usable attitude.
+                    hasAttitude: sampleAttitude(pos) != null,
                   })}
                 />
               )}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
@@ -28,6 +28,7 @@ import {
   modelBoundingRadius,
   resolveVisualSpan,
 } from "../spacecraftScale.js";
+import { finiteOrNull } from "../utils/finite.js";
 import type { TrailBufferLike } from "../utils/TrailBuffer.js";
 import { body_orientation, earth_rotation_angle } from "../wasm/arikaInit.js";
 import { CelestialBody } from "./CelestialBody.js";
@@ -472,7 +473,11 @@ export function OrbitSceneContents({
     }
   }
   const centeredPosition = centeredSatId != null ? satellitePositions?.get(centeredSatId) : null;
-  const simTime = centeredPosition?.t ?? firstPosition?.t ?? 0;
+  // The first *finite* time, not the first present one: `??` falls through on
+  // null and undefined, so a NaN `t` on the centred satellite would win over a
+  // usable fallback and reach the Earth rotation angle and the quantised Sun
+  // time below, both of which are WASM calls.
+  const simTime = finiteOrNull(centeredPosition?.t) ?? finiteOrNull(firstPosition?.t) ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 
   // Earth rotation angle (ERA) via WASM — updates every frame via simTime (not quantized)

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
@@ -692,11 +692,15 @@ export function OrbitSceneContents({
           // centre is never body-fixed, so the scene-level ERA plays no part.
           //
           // Nothing is drawn at all unless the frame found an origin for this
-          // spacecraft. `resolveSceneFrame` leaves that null for a position it
-          // cannot use — zero, or non-finite from a source — and the marker is
-          // then absent too, so an arrow would be pointing out the Sun beside a
-          // spacecraft that is not on screen. Nadir already needs the position;
-          // the Sun does not, which is why it has to be said here.
+          // spacecraft. `resolveSceneFrame` leaves that null for a non-finite
+          // position, and the marker is then absent too, so an arrow would be
+          // pointing out the Sun beside a spacecraft that is not on screen. Nadir
+          // already needs the position; the Sun does not, which is why it has to
+          // be said here.
+          //
+          // A finite position is placeable, the coordinate origin included: the
+          // spacecraft is drawn there and the Sun with it, and nadir alone drops
+          // out for want of a bearing.
           const arrows =
             originPosition == null
               ? []

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
@@ -476,17 +476,19 @@ export function OrbitSceneContents({
     };
   }, [lvlhActive, cameraTracking, originPosition]);
 
-  // Sim time for the Sun direction and the body rotation. The centred satellite
-  // owns it when there is one: satellites carry their own times (a terminated one
-  // stays frozen), and the Sun drawn *at* the centred satellite has to be the Sun
-  // at that satellite's time, not at whichever time the Map happens to yield
-  // first. Falls back to the first available position for a central-body view.
+  // The epoch the Sun direction and the body rotation are evaluated at.
+  //
+  // The centred satellite owns it when there is one: satellites carry their own
+  // times (a terminated one stays frozen), and the Sun drawn *at* that satellite
+  // has to be the Sun at its time. With no satellite centred the epoch is the
+  // scene's own `time`, which is what it is documented to be — reading whichever
+  // satellite the position Map yielded first is the behaviour this replaced.
+  //
+  // Each candidate goes through a finite check because `??` falls through only on
+  // null and undefined: a NaN `t` on the centred satellite would otherwise win
+  // over the scene's time and reach the Earth rotation angle and the quantised
+  // Sun time below, both of which are WASM calls.
   const centeredPosition = centeredSatId != null ? satellitePositions?.get(centeredSatId) : null;
-  // The centred satellite's own time, else the scene's. Each candidate goes
-  // through a finite check because `??` falls through only on null and undefined:
-  // a NaN `t` on the centred satellite would otherwise win over the scene's time
-  // and reach the Earth rotation angle and the quantised Sun time below, both of
-  // which are WASM calls.
   const simTime = finiteOrNull(centeredPosition?.t) ?? finiteOrNull(time) ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
@@ -461,15 +461,15 @@ export function OrbitSceneContents({
   // stays frozen), and the Sun drawn *at* the centred satellite has to be the Sun
   // at that satellite's time, not at whichever time the Map happens to yield
   // first. Falls back to the first available position for a central-body view.
-  // The Map's values are iterated directly rather than materialized into an array
-  // every render just to find one entry.
-  const fallbackTime = firstFiniteTime(satellitePositions?.values());
   const centeredPosition = centeredSatId != null ? satellitePositions?.get(centeredSatId) : null;
   // Each candidate goes through a finite check, because `??` falls through only
   // on null and undefined: a NaN `t` on the centred satellite would otherwise win
   // over a usable fallback and reach the Earth rotation angle and the quantised
-  // Sun time below, both of which are WASM calls.
-  const simTime = finiteOrNull(centeredPosition?.t) ?? fallbackTime ?? 0;
+  // Sun time below, both of which are WASM calls. The same `??` keeps the search
+  // for a fallback from running at all while the centred satellite has a time,
+  // which is every frame of a satellite-centred view.
+  const simTime =
+    finiteOrNull(centeredPosition?.t) ?? firstFiniteTime(satellitePositions?.values()) ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 
   // Earth rotation angle (ERA) via WASM — updates every frame via simTime (not quantized)

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
@@ -10,6 +10,7 @@ import {
 } from "../bodies.js";
 import { type DirectionVectorOptions, resolveDirectionVectors } from "../directionVectors.js";
 import {
+  attitudeWasRefused,
   displayPosition,
   displayRotation,
   resolveDisplayFrame,
@@ -442,15 +443,41 @@ export function OrbitSceneContents({
     return (bodyRadiusKm / centralBodyRadius) * 3;
   }, [centeredBodyId, centralBodyRadius, bodyDefinitions]);
 
+  // Whether the centred satellite's own sample claimed an orientation that could
+  // not be used. Read here as well as where the spacecraft is drawn, because the
+  // environment's scale depends on which of the model and the marker is on
+  // screen. A boolean, so the memo below re-runs when the answer changes rather
+  // than on every sample.
+  const centredAttitudeRefused =
+    isSatCentered && centeredSatId != null
+      ? (() => {
+          const sample = satellitePositions?.get(centeredSatId);
+          return sample != null && attitudeWasRefused(sample);
+        })()
+      : false;
+
   // Scene amplification: scale up environment to show correct proportions
   // relative to the satellite's exaggerated model at origin.
   const sceneAmplification = useMemo(() => {
     if (!isSatCentered || centeredSatId == null) return 1;
     // Body entities (Moon, Sun, etc.) don't need satellite amplification
     if (centeredBodyId != null) return 1;
-    const modelConfig = getSatelliteModelConfig(centeredSatId, satelliteNames?.get(centeredSatId));
+    // Sized for what is drawn: a refused attitude leaves the marker standing in,
+    // and `computeSceneAmplification` amplifies by the marker's ratio rather than
+    // the model's. Amplifying for an absent model puts Earth and the trails at
+    // proportions belonging to a spacecraft that is not on screen.
+    const modelConfig = centredAttitudeRefused
+      ? null
+      : getSatelliteModelConfig(centeredSatId, satelliteNames?.get(centeredSatId));
     return computeSceneAmplification(modelConfig, centralBodyRadius);
-  }, [isSatCentered, centeredSatId, centeredBodyId, satelliteNames, centralBodyRadius]);
+  }, [
+    isSatCentered,
+    centeredSatId,
+    centeredBodyId,
+    satelliteNames,
+    centralBodyRadius,
+    centredAttitudeRefused,
+  ]);
 
   // Effective scale radius: smaller when amplified, so positions appear larger
   const effectiveScaleRadius = centralBodyRadius / sceneAmplification;
@@ -647,9 +674,8 @@ export function OrbitSceneContents({
               </group>
             );
           }
-          // The sample's attitude decides two things here: which marker stands
-          // in for it, and whether its registered model is drawn at all.
-          const attitudeRefused = pos.qw != null && sampleAttitude(pos) == null;
+          // Resolved above, where the environment's scale reads it too.
+          const attitudeRefused = centredAttitudeRefused;
           const shape = resolveMarkerShape({
             override: satelliteShapes?.get(centeredSatId),
             simShape: satelliteSimShapes?.get(centeredSatId),
@@ -823,7 +849,7 @@ export function OrbitSceneContents({
                     // See above: the shape follows the usable attitude, and a
                     // refused one takes the sphere whatever was requested.
                     hasAttitude: sampleAttitude(pos) != null,
-                    attitudeRefused: pos.qw != null && sampleAttitude(pos) == null,
+                    attitudeRefused: attitudeWasRefused(pos),
                   })}
                 />
               )}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
@@ -28,7 +28,7 @@ import {
   modelBoundingRadius,
   resolveVisualSpan,
 } from "../spacecraftScale.js";
-import { finiteOrNull, firstFiniteTime } from "../utils/finite.js";
+import { finiteOrNull } from "../utils/finite.js";
 import type { TrailBufferLike } from "../utils/TrailBuffer.js";
 import { body_orientation, earth_rotation_angle } from "../wasm/arikaInit.js";
 import { CelestialBody } from "./CelestialBody.js";
@@ -325,6 +325,15 @@ export interface OrbitSceneContentsProps {
   trailBuffers?: Map<string, TrailBufferLike>;
   /** Per-satellite positions. */
   satellitePositions?: Map<string, OrbitPoint | null>;
+  /**
+   * The scene's elapsed seconds since the epoch — `OrbitSceneDataProps.time`.
+   *
+   * The epoch the scene itself is drawn at: the lighting, the central body's
+   * rotation, and any entity whose own sample carries no usable time. A centred
+   * satellite overrides it for its own view, because the Sun drawn *at* that
+   * satellite has to be the Sun at that satellite's time.
+   */
+  time?: number;
   /** Per-satellite visible counts (when not live). */
   trailVisibleCounts?: Map<string, number>;
   /** Per-satellite draw start indices for time-range clipping. */
@@ -379,6 +388,7 @@ export interface OrbitSceneContentsProps {
 export function OrbitSceneContents({
   trailBuffers,
   satellitePositions,
+  time = 0,
   trailVisibleCounts,
   trailDrawStarts,
   centralBody,
@@ -472,14 +482,12 @@ export function OrbitSceneContents({
   // at that satellite's time, not at whichever time the Map happens to yield
   // first. Falls back to the first available position for a central-body view.
   const centeredPosition = centeredSatId != null ? satellitePositions?.get(centeredSatId) : null;
-  // Each candidate goes through a finite check, because `??` falls through only
-  // on null and undefined: a NaN `t` on the centred satellite would otherwise win
-  // over a usable fallback and reach the Earth rotation angle and the quantised
-  // Sun time below, both of which are WASM calls. The same `??` keeps the search
-  // for a fallback from running at all while the centred satellite has a time,
-  // which is every frame of a satellite-centred view.
-  const simTime =
-    finiteOrNull(centeredPosition?.t) ?? firstFiniteTime(satellitePositions?.values()) ?? 0;
+  // The centred satellite's own time, else the scene's. Each candidate goes
+  // through a finite check because `??` falls through only on null and undefined:
+  // a NaN `t` on the centred satellite would otherwise win over the scene's time
+  // and reach the Earth rotation angle and the quantised Sun time below, both of
+  // which are WASM calls.
+  const simTime = finiteOrNull(centeredPosition?.t) ?? finiteOrNull(time) ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 
   // Earth rotation angle (ERA) via WASM — updates every frame via simTime (not quantized)

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
@@ -652,25 +652,37 @@ export function OrbitSceneContents({
           // The centred satellite is drawn exactly at the world origin, so the
           // arrows start there too. Its display frame is the scene's: a satellite
           // centre is never body-fixed, so the scene-level ERA plays no part.
-          const arrows = resolveDirectionVectors({
-            frame: sceneDisplayFrame,
-            // The direction the lights are placed along, reused rather than
-            // computed again, so the arrow and the lighting cannot disagree. The
-            // hook falls back to a fixed direction when it cannot compute one —
-            // no epoch, or a central body arika cannot place. Fine for the
-            // lights; an arrow drawn from it would claim to be a measurement.
-            sunDisplay: sunDirectionIsComputed
-              ? [sunDirection.x, sunDirection.y, sunDirection.z]
-              : null,
-            positionEci: originPosition,
-            // Here this prop is an *enable* list: the orbit view draws no arrows
-            // unless asked, so an option left out means off. `resolveDirectionVectors`
-            // reads a missing field as on, which is the attitude view's default.
-            options: {
-              sun: directionVectors?.sun === true,
-              nadir: directionVectors?.nadir === true,
-            },
-          });
+          //
+          // Nothing is drawn at all unless the frame found an origin for this
+          // spacecraft. `resolveSceneFrame` leaves that null for a position it
+          // cannot use — zero, or non-finite from a source — and the marker is
+          // then absent too, so an arrow would be pointing out the Sun beside a
+          // spacecraft that is not on screen. Nadir already needs the position;
+          // the Sun does not, which is why it has to be said here.
+          const arrows =
+            originPosition == null
+              ? []
+              : resolveDirectionVectors({
+                  frame: sceneDisplayFrame,
+                  // The direction the lights are placed along, reused rather than
+                  // computed again, so the arrow and the lighting cannot
+                  // disagree. The hook falls back to a fixed direction when it
+                  // cannot compute one — no epoch, or a central body arika cannot
+                  // place. Fine for the lights; an arrow drawn from it would
+                  // claim to be a measurement.
+                  sunDisplay: sunDirectionIsComputed
+                    ? [sunDirection.x, sunDirection.y, sunDirection.z]
+                    : null,
+                  positionEci: originPosition,
+                  // Here this prop is an *enable* list: the orbit view draws no
+                  // arrows unless asked, so an option left out means off.
+                  // `resolveDirectionVectors` reads a missing field as on, which
+                  // is the attitude view's default.
+                  options: {
+                    sun: directionVectors?.sun === true,
+                    nadir: directionVectors?.nadir === true,
+                  },
+                });
           const centredModel = getSatelliteModelConfig(centeredSatId, satName);
           const visualSpan = resolveVisualSpan({
             modelConfig: centredModel,

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
@@ -8,6 +8,7 @@ import {
   entityPathToBodyId,
   getBodyRadius,
 } from "../bodies.js";
+import { type DirectionVectorOptions, resolveDirectionVectors } from "../directionVectors.js";
 import { displayPosition, displayRotation, resolveDisplayFrame } from "../displayFrame.js";
 import {
   computeSceneAmplification,
@@ -21,13 +22,23 @@ import { DEFAULT_FRAME, isLegacyEcef, type ReferenceFrame } from "../referenceFr
 import { getSatelliteModelConfig } from "../satelliteModels.js";
 import { type MarkerShape, resolveMarkerShape } from "../satelliteShapes.js";
 import { computeCameraUp, computeLvlhAxes, type LvlhAxes, SCENE_UP } from "../sceneFrame.js";
+import {
+  defaultMarkerSize,
+  markerBoundingRadius,
+  modelBoundingRadius,
+  resolveVisualSpan,
+} from "../spacecraftScale.js";
 import type { TrailBufferLike } from "../utils/TrailBuffer.js";
 import { body_orientation, earth_rotation_angle } from "../wasm/arikaInit.js";
 import { CelestialBody } from "./CelestialBody.js";
+import { DirectionArrows } from "./DirectionArrows.js";
 import { OrbitTrail } from "./OrbitTrail.js";
 import { buildRenderEntries } from "./renderEntries.js";
 import { Satellite } from "./Satellite.js";
 import { AMBIENT_INTENSITY, SunLighting, useSunLighting } from "./SunLighting.js";
+
+/** The centred satellite sits exactly at the world origin. */
+const ORIGIN: [number, number, number] = [0, 0, 0];
 
 /** Color palette for multiple satellites. */
 const SATELLITE_COLORS = [0x00ff88, 0xff4488, 0x44aaff, 0xffaa44, 0xaa44ff];
@@ -341,6 +352,11 @@ export interface OrbitSceneContentsProps {
   controls?: boolean | Partial<OrbitControlsProps>;
   /** Render the reference axes helper. Default `true`. */
   axes?: boolean;
+  /**
+   * Reference-direction arrows to draw at the centred satellite. Omitted draws
+   * none; a central-body view draws none either way.
+   */
+  directionVectors?: DirectionVectorOptions;
 }
 
 /**
@@ -369,6 +385,7 @@ export function OrbitSceneContents({
   textureBaseUrl,
   controls = true,
   axes = true,
+  directionVectors,
 }: OrbitSceneContentsProps) {
   // Default camera package (controls + frame-aware rig). `false` opts out
   // entirely; an object enables it and is spread onto OrbitControls.
@@ -438,9 +455,13 @@ export function OrbitSceneContents({
     };
   }, [lvlhActive, cameraTracking, originPosition]);
 
-  // Determine sim time for sun direction from the first available satellite
-  // position. Iterate the Map's values directly rather than materializing an
-  // array every render just to find the first non-null entry.
+  // Sim time for the Sun direction and the body rotation. The centred satellite
+  // owns it when there is one: satellites carry their own times (a terminated one
+  // stays frozen), and the Sun drawn *at* the centred satellite has to be the Sun
+  // at that satellite's time, not at whichever time the Map happens to yield
+  // first. Falls back to the first available position for a central-body view.
+  // Iterate the Map's values directly rather than materializing an array every
+  // render just to find the first non-null entry.
   let firstPosition: OrbitPoint | null = null;
   if (satellitePositions) {
     for (const p of satellitePositions.values()) {
@@ -450,7 +471,8 @@ export function OrbitSceneContents({
       }
     }
   }
-  const simTime = firstPosition?.t ?? 0;
+  const centeredPosition = centeredSatId != null ? satellitePositions?.get(centeredSatId) : null;
+  const simTime = centeredPosition?.t ?? firstPosition?.t ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 
   // Earth rotation angle (ERA) via WASM — updates every frame via simTime (not quantized)
@@ -469,7 +491,7 @@ export function OrbitSceneContents({
 
   // Sun direction + intensity (display frame). Shared by the lights and by the
   // lit bodies below, so the scene holds them and passes them down explicitly.
-  const { sunDirection, sunIntensity, lightPosition } = useSunLighting({
+  const { sunDirection, sunDirectionIsComputed, sunIntensity, lightPosition } = useSunLighting({
     centralBody,
     epochJd,
     quantizedSimTime,
@@ -602,24 +624,73 @@ export function OrbitSceneContents({
               </group>
             );
           }
+          const shape = resolveMarkerShape({
+            override: satelliteShapes?.get(centeredSatId),
+            simShape: satelliteSimShapes?.get(centeredSatId),
+            globalDefault: defaultMarkerShape,
+            hasAttitude: pos.qw != null,
+          });
+          const satName = satelliteNames?.get(centeredSatId);
+          // The centred satellite is drawn exactly at the world origin, so the
+          // arrows start there too. Its display frame is the scene's: a satellite
+          // centre is never body-fixed, so the scene-level ERA plays no part.
+          const arrows = resolveDirectionVectors({
+            frame: sceneDisplayFrame,
+            // The direction the lights are placed along, reused rather than
+            // computed again, so the arrow and the lighting cannot disagree. The
+            // hook falls back to a fixed direction when it cannot compute one —
+            // no epoch, or a central body arika cannot place. Fine for the
+            // lights; an arrow drawn from it would claim to be a measurement.
+            sunDisplay: sunDirectionIsComputed
+              ? [sunDirection.x, sunDirection.y, sunDirection.z]
+              : null,
+            positionEci: originPosition,
+            // Here this prop is an *enable* list: the orbit view draws no arrows
+            // unless asked, so an option left out means off. `resolveDirectionVectors`
+            // reads a missing field as on, which is the attitude view's default.
+            options: {
+              sun: directionVectors?.sun === true,
+              nadir: directionVectors?.nadir === true,
+            },
+          });
+          const centredModel = getSatelliteModelConfig(centeredSatId, satName);
+          const visualSpan = resolveVisualSpan({
+            modelConfig: centredModel,
+            markerSize: defaultMarkerSize(shape),
+          });
           return (
-            <Satellite
-              position={pos}
-              scaleRadius={centralBodyRadius}
-              color={color}
-              referenceFrame={referenceFrame}
-              epochJd={epochJd ?? undefined}
-              satId={centeredSatId}
-              satName={satelliteNames?.get(centeredSatId)}
-              originPosition={originPosition}
-              lvlhAxes={lvlhAxes}
-              markerShape={resolveMarkerShape({
-                override: satelliteShapes?.get(centeredSatId),
-                simShape: satelliteSimShapes?.get(centeredSatId),
-                globalDefault: defaultMarkerShape,
-                hasAttitude: pos.qw != null,
-              })}
-            />
+            <>
+              <Satellite
+                position={pos}
+                scaleRadius={centralBodyRadius}
+                color={color}
+                referenceFrame={referenceFrame}
+                epochJd={epochJd ?? undefined}
+                satId={centeredSatId}
+                satName={satName}
+                originPosition={originPosition}
+                lvlhAxes={lvlhAxes}
+                markerShape={shape}
+              />
+              {arrows.length > 0 && (
+                <DirectionArrows
+                  position={ORIGIN}
+                  vectors={arrows}
+                  visualSpan={visualSpan}
+                  // Outside whatever is actually drawn: a cube marker's corners
+                  // stand further out than its faces, and a model is bounded by
+                  // the envelope of the cube its largest extent fits in. The
+                  // sphere's radius would leave the tail inside a model, which
+                  // reaches past half its span on a diagonal.
+                  startRadius={
+                    centredModel
+                      ? modelBoundingRadius(visualSpan)
+                      : markerBoundingRadius(shape, visualSpan)
+                  }
+                  debugId={centeredSatId}
+                />
+              )}
+            </>
           );
         })()}
 

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
@@ -252,6 +252,7 @@ function SecondaryBody({
   sunDirection,
   referenceFrame = DEFAULT_FRAME,
   epochJd,
+  sceneTime,
   originPosition = null,
   lvlhAxes = null,
   textureRevision,
@@ -264,6 +265,8 @@ function SecondaryBody({
   sunDirection?: THREE.Vector3;
   referenceFrame?: ReferenceFrame;
   epochJd?: number | null;
+  /** The scene's elapsed time, used when this body's sample carries none. */
+  sceneTime?: number;
   originPosition?: [number, number, number] | null;
   lvlhAxes?: LvlhAxes | null;
   textureRevision?: number | string;
@@ -273,11 +276,16 @@ function SecondaryBody({
   const bodyRadiusKm = getBodyRadius(bodyId, bodyDefinitions);
   const radius = bodyRadiusKm != null ? bodyRadiusKm / scaleRadius : 0.01;
 
+  // This body's own sample time when it has one, else the scene's — the same rule
+  // the satellites follow, so one bad sample cannot leave this body in a basis of
+  // its own.
+  const sampleTime = finiteOrNull(position.t) ?? finiteOrNull(sceneTime) ?? 0;
+
   // Position and orientation share one display frame (see displayFrame.ts), so
   // the mesh can never be placed in one basis and oriented in another.
   const era =
     isLegacyEcef(referenceFrame) && epochJd != null
-      ? earth_rotation_angle(epochJd, position.t)
+      ? earth_rotation_angle(epochJd, sampleTime)
       : null;
   const frame = resolveDisplayFrame(referenceFrame, { era, originPosition, lvlhAxes });
   const scenePos = displayPosition(frame, position.x, position.y, position.z, scaleRadius);
@@ -285,18 +293,16 @@ function SecondaryBody({
   // Body-fixed → inertial orientation via the IAU rotation model (arika WASM),
   // including the Three.js +Y-pole → IAU +Z-pole alignment.
   const bodyToInertial = useMemo(() => {
-    const sampleTime = finiteOrNull(position.t);
-    // A `NaN` sample time would come back as a quaternion of NaNs, and the group
-    // carrying it renders nothing at all. Without a time this body is drawn
-    // unrotated, which is what a missing epoch already gives.
-    if (epochJd == null || sampleTime == null) return undefined;
+    // The same time the position used. A `NaN` would come back as a quaternion of
+    // NaNs, and the group carrying it renders nothing at all.
+    if (epochJd == null) return undefined;
     const q = body_orientation(bodyId, epochJd, sampleTime);
     if (!q) return undefined;
     // IAU body-fixed → ECI: q = [w, x, y, z]; THREE uses (x, y, z, w)
     const iauQuat = new THREE.Quaternion(q[1], q[2], q[3], q[0]);
     const poleAlign = new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0));
     return iauQuat.multiply(poleAlign);
-  }, [bodyId, epochJd, position.t]);
+  }, [bodyId, epochJd, sampleTime]);
 
   const orientation = bodyToInertial ? displayRotation(frame).multiply(bodyToInertial) : undefined;
 
@@ -605,11 +611,9 @@ export function OrbitSceneContents({
             // Render as CelestialBody at origin with physical radius + IAU orientation
             const bodyRadiusKm = getBodyRadius(centeredBodyId, bodyDefinitions);
             const bodyRadius = bodyRadiusKm != null ? bodyRadiusKm / centralBodyRadius : 0.01;
-            const centredTime = finiteOrNull(pos.t);
+            const centredTime = finiteOrNull(pos.t) ?? simTime;
             const q =
-              epochJd != null && centredTime != null
-                ? body_orientation(centeredBodyId, epochJd, centredTime)
-                : undefined;
+              epochJd != null ? body_orientation(centeredBodyId, epochJd, centredTime) : undefined;
             const iauQuat = q
               ? new THREE.Quaternion(q[1], q[2], q[3], q[0]).multiply(
                   new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0)),
@@ -670,6 +674,7 @@ export function OrbitSceneContents({
                 color={color}
                 referenceFrame={referenceFrame}
                 epochJd={epochJd ?? undefined}
+                sceneTime={simTime}
                 satId={centeredSatId}
                 satName={satName}
                 originPosition={originPosition}
@@ -751,6 +756,7 @@ export function OrbitSceneContents({
                   sunDirection={sunDirection}
                   referenceFrame={referenceFrame}
                   epochJd={epochJd}
+                  sceneTime={simTime}
                   originPosition={lvlhActive ? originPosition : null}
                   lvlhAxes={lvlhActive ? lvlhAxes : null}
                   textureRevision={textureRevision}
@@ -765,6 +771,7 @@ export function OrbitSceneContents({
                   color={color}
                   referenceFrame={referenceFrame}
                   epochJd={epochJd ?? undefined}
+                  sceneTime={simTime}
                   satId={satId}
                   satName={satelliteNames?.get(satId)}
                   originPosition={lvlhActive ? originPosition : null}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
@@ -334,10 +334,17 @@ export interface OrbitSceneContentsProps {
   /**
    * The scene's elapsed seconds since the epoch — `OrbitSceneDataProps.time`.
    *
-   * The epoch the scene itself is drawn at: the lighting, the central body's
-   * rotation, and any entity whose own sample carries no usable time. A centred
-   * satellite overrides it for its own view, because the Sun drawn *at* that
-   * satellite has to be the Sun at that satellite's time.
+   * Where the view has no instant of its own, this is it: the lighting, the
+   * central body's rotation, and any entity whose own sample carries no usable
+   * time are all drawn here.
+   *
+   * Centring on a satellite gives the view an instant of its own — that
+   * satellite's timestamp — and everything without a time of its own follows it
+   * rather than this, including a secondary body whose sample time is unusable.
+   * The alternative reads better in isolation and worse on screen: the Sun would
+   * be placed at the centred satellite's instant while the Moon beside it was
+   * oriented for the scene's, so one view would show two moments. One instant per
+   * view is the rule, and a sample that names its own time still wins over both.
    */
   time?: number;
   /** Per-satellite visible counts (when not live). */
@@ -521,6 +528,9 @@ export function OrbitSceneContents({
   // over the scene's time and reach the Earth rotation angle and the quantised
   // Sun time below, both of which are WASM calls.
   const centeredPosition = centeredSatId != null ? satellitePositions?.get(centeredSatId) : null;
+  // The instant this view depicts, which every entity without a usable time of
+  // its own is drawn at — see the `time` prop for why they follow the centred
+  // satellite rather than the scene's declared time.
   const simTime = finiteOrNull(centeredPosition?.t) ?? finiteOrNull(time) ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
@@ -285,8 +285,12 @@ function SecondaryBody({
   // Body-fixed → inertial orientation via the IAU rotation model (arika WASM),
   // including the Three.js +Y-pole → IAU +Z-pole alignment.
   const bodyToInertial = useMemo(() => {
-    if (epochJd == null) return undefined;
-    const q = body_orientation(bodyId, epochJd, position.t);
+    const sampleTime = finiteOrNull(position.t);
+    // A `NaN` sample time would come back as a quaternion of NaNs, and the group
+    // carrying it renders nothing at all. Without a time this body is drawn
+    // unrotated, which is what a missing epoch already gives.
+    if (epochJd == null || sampleTime == null) return undefined;
+    const q = body_orientation(bodyId, epochJd, sampleTime);
     if (!q) return undefined;
     // IAU body-fixed → ECI: q = [w, x, y, z]; THREE uses (x, y, z, w)
     const iauQuat = new THREE.Quaternion(q[1], q[2], q[3], q[0]);
@@ -601,8 +605,11 @@ export function OrbitSceneContents({
             // Render as CelestialBody at origin with physical radius + IAU orientation
             const bodyRadiusKm = getBodyRadius(centeredBodyId, bodyDefinitions);
             const bodyRadius = bodyRadiusKm != null ? bodyRadiusKm / centralBodyRadius : 0.01;
+            const centredTime = finiteOrNull(pos.t);
             const q =
-              epochJd != null ? body_orientation(centeredBodyId, epochJd, pos.t) : undefined;
+              epochJd != null && centredTime != null
+                ? body_orientation(centeredBodyId, epochJd, centredTime)
+                : undefined;
             const iauQuat = q
               ? new THREE.Quaternion(q[1], q[2], q[3], q[0]).multiply(
                   new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0)),

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/OrbitSceneContents.tsx
@@ -647,10 +647,14 @@ export function OrbitSceneContents({
               </group>
             );
           }
+          // The sample's attitude decides two things here: which marker stands
+          // in for it, and whether its registered model is drawn at all.
+          const attitudeRefused = pos.qw != null && sampleAttitude(pos) == null;
           const shape = resolveMarkerShape({
             override: satelliteShapes?.get(centeredSatId),
             simShape: satelliteSimShapes?.get(centeredSatId),
             globalDefault: defaultMarkerShape,
+            attitudeRefused,
             // The same judgement the rotation makes: a sample whose quaternion
             // names no rotation gets the sphere, not the cube that would show an
             // orientation nobody measured.
@@ -691,7 +695,13 @@ export function OrbitSceneContents({
                     nadir: directionVectors?.nadir === true,
                   },
                 });
-          const centredModel = getSatelliteModelConfig(centeredSatId, satName);
+          // Not asked for when the attitude was refused: `Satellite` draws the
+          // marker instead in that case, and arrows sized from a model that is
+          // not there float outside the sphere that is — for a spacecraft the
+          // size of the ISS, well outside it.
+          const centredModel = attitudeRefused
+            ? null
+            : getSatelliteModelConfig(centeredSatId, satName);
           const visualSpan = resolveVisualSpan({
             modelConfig: centredModel,
             markerSize: defaultMarkerSize(shape),
@@ -810,8 +820,10 @@ export function OrbitSceneContents({
                     override: satelliteShapes?.get(satId),
                     simShape: satelliteSimShapes?.get(satId),
                     globalDefault: defaultMarkerShape,
-                    // See above: the shape follows the usable attitude.
+                    // See above: the shape follows the usable attitude, and a
+                    // refused one takes the sphere whatever was requested.
                     hasAttitude: sampleAttitude(pos) != null,
+                    attitudeRefused: pos.qw != null && sampleAttitude(pos) == null,
                   })}
                 />
               )}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/PrimitiveMarker.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/PrimitiveMarker.tsx
@@ -47,9 +47,17 @@ export function PrimitiveMarker({
   // Apply the body-to-display quaternion imperatively (Hamilton [w,x,y,z] →
   // Three.js (x,y,z,w)), matching SatelliteModel.tsx / BodyAxes.tsx.
   useEffect(() => {
-    if (groupRef.current && quaternion) {
+    if (!groupRef.current) return;
+    if (quaternion) {
       const [w, x, y, z] = quaternion;
       groupRef.current.quaternion.set(x, y, z, w);
+    } else {
+      // A stream can stop carrying a usable attitude — a sample whose quaternion
+      // names no rotation, or none at all after one that did. Leaving the group
+      // where the last good sample put it would show that orientation as the
+      // current one, so it goes back to unrotated, which is what "no attitude"
+      // draws from the start.
+      groupRef.current.quaternion.identity();
     }
   }, [quaternion]);
 

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/PrimitiveMarker.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/PrimitiveMarker.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import type * as THREE from "three";
+import { DEFAULT_CUBE_HALF_EXTENT } from "../spacecraftScale.js";
 
 interface PrimitiveMarkerProps {
   /** Position in scene units (already divided by scaleRadius). */
@@ -14,8 +15,12 @@ interface PrimitiveMarkerProps {
   size?: number;
 }
 
-/** Default half-extent, matching the legacy sphere marker's footprint. */
-const DEFAULT_SIZE = 0.008;
+/**
+ * Default half-extent. Larger than the sphere marker's radius: a cube read at an
+ * angle presents less silhouette than a sphere of the same radius, so matching
+ * radii would make the orientation cube look like the smaller marker.
+ */
+const DEFAULT_SIZE = DEFAULT_CUBE_HALF_EXTENT;
 
 /**
  * Per-face colors of the XYZ orientation cube, in Three.js BoxGeometry face order

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/Satellite.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/Satellite.tsx
@@ -107,7 +107,7 @@ export function Satellite({
     <SpacecraftVisual
       position={scenePos}
       quaternion={displayQuaternion(frame, rawQuaternion)}
-      model={!attitudeRefused}
+      attitudeRefused={attitudeRefused}
       satId={satId}
       satName={satName}
       color={color}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/Satellite.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/Satellite.tsx
@@ -3,7 +3,7 @@ import {
   displayQuaternion,
   type Quat,
   resolveDisplayFrame,
-  unitAttitude,
+  sampleAttitude,
 } from "../displayFrame.js";
 import type { OrbitPoint } from "../orbit.js";
 import { isLegacyEcef, type ReferenceFrame } from "../referenceFrame.js";
@@ -95,11 +95,7 @@ export function Satellite({
   // back as the identity, so the scene would report an orientation nobody
   // measured. What cannot be normalised is reported as no attitude, which draws
   // the marker unrotated — the answer a satellite without attitude already gets.
-  const rawQuaternion: Quat | undefined = unitAttitude(
-    position.qw != null
-      ? [position.qw, position.qx ?? 0, position.qy ?? 0, position.qz ?? 0]
-      : undefined,
-  );
+  const rawQuaternion: Quat | undefined = sampleAttitude(position);
 
   return (
     <SpacecraftVisual

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/Satellite.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/Satellite.tsx
@@ -8,6 +8,7 @@ import type { OrbitPoint } from "../orbit.js";
 import { isLegacyEcef, type ReferenceFrame } from "../referenceFrame.js";
 import type { MarkerShape } from "../satelliteShapes.js";
 import type { LvlhAxes } from "../sceneFrame.js";
+import { finiteOrNull } from "../utils/finite.js";
 import { earth_rotation_angle } from "../wasm/arikaInit.js";
 import { SpacecraftVisual } from "./SpacecraftVisual.js";
 
@@ -62,9 +63,15 @@ export function Satellite({
   // One display frame drives both the position and the attitude, so they can
   // never end up in different bases (the LVLH axis order and the ECEF rotation
   // used to be derived independently, and disagreed).
+  // This satellite's own sample time, which is optional per satellite and can
+  // arrive as `NaN` from a source. A non-finite time is no time: the angle
+  // computed from it is `NaN`, and while `resolveDisplayOrientation` refuses that
+  // and falls back to inertial, the fallback would be silent and this satellite
+  // would sit in a different frame from the rest of the scene.
+  const sampleTime = finiteOrNull(position.t);
   const era =
-    isLegacyEcef(referenceFrame) && epochJd != null
-      ? earth_rotation_angle(epochJd, position.t)
+    isLegacyEcef(referenceFrame) && epochJd != null && sampleTime != null
+      ? earth_rotation_angle(epochJd, sampleTime)
       : null;
   const frame = resolveDisplayFrame(referenceFrame, { era, originPosition, lvlhAxes });
 

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/Satellite.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/Satellite.tsx
@@ -1,4 +1,5 @@
 import {
+  attitudeWasRefused,
   displayPosition,
   displayQuaternion,
   type Quat,
@@ -101,7 +102,7 @@ export function Satellite({
   // as one; the same model drawn after an attitude was refused would sit at its
   // own default orientation and be read as the measurement that was refused. That
   // case gets the marker instead, which looks the same from every side.
-  const attitudeRefused = position.qw != null && rawQuaternion == null;
+  const attitudeRefused = attitudeWasRefused(position);
 
   return (
     <SpacecraftVisual

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/Satellite.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/Satellite.tsx
@@ -3,6 +3,7 @@ import {
   displayQuaternion,
   type Quat,
   resolveDisplayFrame,
+  unitAttitude,
 } from "../displayFrame.js";
 import type { OrbitPoint } from "../orbit.js";
 import { isLegacyEcef, type ReferenceFrame } from "../referenceFrame.js";
@@ -87,11 +88,18 @@ export function Satellite({
 
   const scenePos = displayPosition(frame, position.x, position.y, position.z, scaleRadius);
 
-  // Attitude quaternion as delivered: body-to-inertial, Hamilton [w, x, y, z].
-  const rawQuaternion: Quat | undefined =
+  // Attitude as delivered — body-to-inertial, Hamilton [w, x, y, z] — brought to
+  // unit norm. Three.js applies the components with `Quaternion.set`, which does
+  // not normalise: a simulator's drifting quaternion scales and skews the very
+  // marker it is meant to orient, and one that names no rotation at all is read
+  // back as the identity, so the scene would report an orientation nobody
+  // measured. What cannot be normalised is reported as no attitude, which draws
+  // the marker unrotated — the answer a satellite without attitude already gets.
+  const rawQuaternion: Quat | undefined = unitAttitude(
     position.qw != null
       ? [position.qw, position.qx ?? 0, position.qy ?? 0, position.qz ?? 0]
-      : undefined;
+      : undefined,
+  );
 
   return (
     <SpacecraftVisual

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/Satellite.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/Satellite.tsx
@@ -23,6 +23,16 @@ interface SatelliteProps {
   referenceFrame?: ReferenceFrame;
   /** Julian Date of the simulation epoch (needed for ECEF transform). */
   epochJd?: number;
+  /**
+   * The scene's own elapsed time, used when this satellite's sample carries none.
+   *
+   * `SatelliteState.time` is per satellite and documented to default to the
+   * scene's, so a sample time that is not a number is treated as absent rather
+   * than as a reason to drop the rotation: without it this marker would sit in
+   * the inertial frame while the body, the trails and every other satellite use
+   * body-fixed axes.
+   */
+  sceneTime?: number;
   /** Satellite identifier for model lookup. */
   satId?: string;
   /** Satellite display name for model lookup fallback. */
@@ -54,6 +64,7 @@ export function Satellite({
   color,
   referenceFrame = DEFAULT_REF_FRAME,
   epochJd,
+  sceneTime,
   satId,
   satName,
   originPosition = null,
@@ -63,14 +74,13 @@ export function Satellite({
   // One display frame drives both the position and the attitude, so they can
   // never end up in different bases (the LVLH axis order and the ECEF rotation
   // used to be derived independently, and disagreed).
-  // This satellite's own sample time, which is optional per satellite and can
-  // arrive as `NaN` from a source. A non-finite time is no time: the angle
-  // computed from it is `NaN`, and while `resolveDisplayOrientation` refuses that
-  // and falls back to inertial, the fallback would be silent and this satellite
-  // would sit in a different frame from the rest of the scene.
-  const sampleTime = finiteOrNull(position.t);
+  // This satellite's own sample time when it has one, else the scene's. A `NaN`
+  // would make the angle `NaN`, which `resolveDisplayOrientation` refuses — and
+  // the frame it fell back to would be inertial while the rest of the scene is
+  // body-fixed, so the marker would be drawn in a basis of its own.
+  const sampleTime = finiteOrNull(position.t) ?? finiteOrNull(sceneTime) ?? 0;
   const era =
-    isLegacyEcef(referenceFrame) && epochJd != null && sampleTime != null
+    isLegacyEcef(referenceFrame) && epochJd != null
       ? earth_rotation_angle(epochJd, sampleTime)
       : null;
   const frame = resolveDisplayFrame(referenceFrame, { era, originPosition, lvlhAxes });

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/Satellite.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/Satellite.tsx
@@ -96,11 +96,18 @@ export function Satellite({
   // measured. What cannot be normalised is reported as no attitude, which draws
   // the marker unrotated — the answer a satellite without attitude already gets.
   const rawQuaternion: Quat | undefined = sampleAttitude(position);
+  // Whether this sample claimed an orientation the viewer could not use. A model
+  // drawn for a satellite with no attitude at all is a position marker and reads
+  // as one; the same model drawn after an attitude was refused would sit at its
+  // own default orientation and be read as the measurement that was refused. That
+  // case gets the marker instead, which looks the same from every side.
+  const attitudeRefused = position.qw != null && rawQuaternion == null;
 
   return (
     <SpacecraftVisual
       position={scenePos}
       quaternion={displayQuaternion(frame, rawQuaternion)}
+      model={!attitudeRefused}
       satId={satId}
       satName={satName}
       color={color}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/SatelliteModel.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/SatelliteModel.tsx
@@ -60,7 +60,11 @@ export function SatelliteModel({
   }, [quaternion]);
 
   return (
-    <group position={position} ref={quaternion ? groupRef : undefined}>
+    // The ref is attached whether or not there is an attitude, because losing one
+    // is the case the effect above exists for: a conditional ref is detached
+    // during the commit that drops the quaternion, so the effect would find no
+    // group and the model would keep the rotation the last good sample gave it.
+    <group position={position} ref={groupRef}>
       <primitive object={cloned} scale={scale} rotation={config.rotation} />
     </group>
   );

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/SatelliteModel.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/SatelliteModel.tsx
@@ -45,9 +45,17 @@ export function SatelliteModel({
 
   // Apply body-to-inertial quaternion to the parent group
   useEffect(() => {
-    if (groupRef.current && quaternion) {
+    if (!groupRef.current) return;
+    if (quaternion) {
       const [w, x, y, z] = quaternion;
-      groupRef.current.quaternion.set(x, y, z, w); // Three.js: (x, y, z, w)
+      groupRef.current.quaternion.set(x, y, z, w);
+    } else {
+      // A stream can stop carrying a usable attitude — a sample whose quaternion
+      // names no rotation, or none at all after one that did. Leaving the group
+      // where the last good sample put it would show that orientation as the
+      // current one, so it goes back to unrotated, which is what "no attitude"
+      // draws from the start.
+      groupRef.current.quaternion.identity(); // Three.js: (x, y, z, w)
     }
   }, [quaternion]);
 

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/SpacecraftVisual.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/SpacecraftVisual.tsx
@@ -44,7 +44,8 @@ interface SpacecraftVisualProps {
   /**
    * Resolved marker shape for spacecraft without a 3D model. When omitted, falls
    * back to automatic (orientation-revealing cube when an attitude is present,
-   * else a sphere). A GLTF model, when available, always takes precedence.
+   * else a sphere). A GLTF model, when available, stands in for the marker —
+   * except for a refused attitude, which suppresses both.
    */
   markerShape?: MarkerShape;
   /** Sphere radius / cube half-extent in scene units. */
@@ -59,21 +60,23 @@ interface SpacecraftVisualProps {
    */
   visualSpan?: number;
   /**
-   * Whether a registered 3D model may stand in for the marker (default true).
+   * Whether this spacecraft claimed an orientation that could not be used
+   * (default false) — a quaternion that named no rotation, or one carrying a
+   * non-finite component.
    *
-   * A model drawn without a quaternion sits at its own default orientation, which
-   * in the orbit view is honest — the model is a position marker there, and a
-   * satellite may arrive with no attitude at all. A view whose subject *is* the
-   * orientation passes false when the attitude is unusable, so the reader gets
-   * the marker that looks the same from every side instead of a model that
-   * appears to point somewhere.
+   * Nothing drawn for such a sample may imply an orientation, so this suppresses
+   * both the registered 3D model, which would sit at its own default orientation,
+   * and the cube marker, whose faces would read as measured axes. A spacecraft
+   * that arrived with no attitude at all is a different case: there a model is a
+   * position marker and reads as one, which is the orbit view's documented
+   * behaviour.
    */
-  model?: boolean;
+  attitudeRefused?: boolean;
 }
 
 /**
  * One spacecraft as it is drawn: a 3D model when the registry knows this
- * satellite, else an orientation-revealing marker, plus its body axes.
+ * satellite and its attitude was not refused, else a marker, plus its body axes.
  *
  * Takes only display-frame values — a scene position and a body-to-display
  * quaternion — so it carries no frame semantics of its own and both the orbit
@@ -96,9 +99,9 @@ export function SpacecraftVisual({
   axisLength,
   modelScale,
   visualSpan,
-  model = true,
+  attitudeRefused = false,
 }: SpacecraftVisualProps) {
-  const modelConfig = model && satId ? getSatelliteModelConfig(satId, satName) : null;
+  const modelConfig = !attitudeRefused && satId ? getSatelliteModelConfig(satId, satName) : null;
   // The default axis length follows the scale the model is *drawn* at, not the
   // registry's: overriding one without the other would silently change the ratio
   // between a spacecraft and its axes.
@@ -136,7 +139,11 @@ export function SpacecraftVisual({
   // Pick the marker shape: caller-resolved override/default, else automatic
   // (orientation-revealing cube when attitude is present — a sphere looks identical
   // at every orientation — sphere otherwise).
-  const shape = resolveMarkerShape({ override: markerShape, hasAttitude: quaternion != null });
+  const shape = resolveMarkerShape({
+    override: markerShape,
+    hasAttitude: quaternion != null,
+    attitudeRefused,
+  });
   const fallbackMarker =
     shape === "sphere" ? (
       <SphereMarker position={position} color={color} radius={markerSize} />

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/SpacecraftVisual.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/SpacecraftVisual.tsx
@@ -2,12 +2,10 @@ import { Suspense } from "react";
 import type { Quat } from "../displayFrame.js";
 import { getSatelliteModelConfig } from "../satelliteModels.js";
 import { type MarkerShape, resolveMarkerShape } from "../satelliteShapes.js";
+import { DEFAULT_SPHERE_RADIUS } from "../spacecraftScale.js";
 import { BodyAxes } from "./BodyAxes.js";
 import { PrimitiveMarker } from "./PrimitiveMarker.js";
 import { SatelliteModel } from "./SatelliteModel.js";
-
-/** Default radius of the sphere fallback marker in scene units. */
-export const DEFAULT_SPHERE_RADIUS = 0.005;
 
 interface SphereMarkerProps {
   position: [number, number, number];

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/debug/directionVectors.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/debug/directionVectors.ts
@@ -8,10 +8,12 @@ export interface DebugDirectionVector {
   /** Unit vector from the arrow's origin to its head, in world (scene) axes. */
   direction: [number, number, number];
   /**
-   * World distance from the origin to the head [scene units].
+   * World distance from the arrow's origin to its head's centre [scene units].
    *
-   * Where the arrow reaches, which moves with the radius its tail starts at —
-   * the marker's or, when one is drawn, the model's. Measured from the scene
+   * How far the arrow reaches, which moves with the radius its tail starts at —
+   * the marker's, or the model's when one is drawn. Reported unnormalised so a
+   * test can pin the proportions as well: it is `startOffset + length -
+   * headLength / 2` for the spacecraft's apparent size. Measured from the scene
    * graph like the direction, so a test comparing two scenes reads the geometry
    * rather than the number that was passed in.
    */

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/displayFrame.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/displayFrame.ts
@@ -121,18 +121,6 @@ export function resolveDisplayFrame(
 const UNIT_QUATERNION_TOLERANCE = 1e-9;
 
 /**
- * A caller's attitude as a unit quaternion, or undefined when it does not name a
- * rotation.
- *
- * Three.js applies the components with `Quaternion.set`, which does not
- * normalise: a non-unit quaternion scales and skews the very spacecraft it is
- * meant to orient, and a non-finite component spreads through the scene
- * matrices. A simulator's attitude drifts off unit norm as it integrates, so the
- * fix is to normalise what can be normalised and reject the rest — an unusable
- * attitude then reads as *no* attitude, which the views already draw (no body
- * axes, and the marker that looks the same from every side).
- */
-/**
  * The attitude carried by an orbit sample, brought to unit norm, or undefined.
  *
  * Samples arrive as loose components rather than a tuple, and two decisions read
@@ -148,6 +136,37 @@ export function sampleAttitude(sample: {
 }): Quat | undefined {
   if (sample.qw == null) return undefined;
   return unitAttitude([sample.qw, sample.qx ?? 0, sample.qy ?? 0, sample.qz ?? 0]);
+}
+
+/**
+ * A caller's attitude as a unit quaternion, or undefined when it does not name a
+ * rotation.
+ *
+ * Three.js applies the components with `Quaternion.set`, which does not
+ * normalise: a non-unit quaternion scales and skews the very spacecraft it is
+ * meant to orient, and a non-finite component spreads through the scene
+ * matrices. A simulator's attitude drifts off unit norm as it integrates, so the
+ * fix is to normalise what can be normalised and reject the rest — an unusable
+ * attitude then reads as *no* attitude, which the views already draw (no body
+ * axes, and the marker that looks the same from every side).
+ */
+/**
+ * Whether a sample claimed an orientation the viewer could not use.
+ *
+ * The distinction this draws is between a spacecraft that carries no attitude —
+ * ordinary in the orbit view, where the marker is a position marker — and one
+ * whose quaternion named no rotation or arrived non-finite. Three consequences
+ * follow from the second, and they have to agree: the registered model is not
+ * drawn, the marker takes the shape that shows no orientation, and the
+ * environment is amplified for whichever of the two is on screen.
+ */
+export function attitudeWasRefused(sample: {
+  qw?: number | null;
+  qx?: number | null;
+  qy?: number | null;
+  qz?: number | null;
+}): boolean {
+  return sample.qw != null && sampleAttitude(sample) == null;
 }
 
 export function unitAttitude(attitude: Quat | undefined): Quat | undefined {

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/displayFrame.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/displayFrame.ts
@@ -145,18 +145,6 @@ export function sampleAttitude(sample: {
 }
 
 /**
- * A caller's attitude as a unit quaternion, or undefined when it does not name a
- * rotation.
- *
- * Three.js applies the components with `Quaternion.set`, which does not
- * normalise: a non-unit quaternion scales and skews the very spacecraft it is
- * meant to orient, and a non-finite component spreads through the scene
- * matrices. A simulator's attitude drifts off unit norm as it integrates, so the
- * fix is to normalise what can be normalised and reject the rest — an unusable
- * attitude then reads as *no* attitude, which the views already draw (no body
- * axes, and the marker that looks the same from every side).
- */
-/**
  * Whether a sample claimed an orientation the viewer could not use.
  *
  * The distinction this draws is between a spacecraft that carries no attitude —
@@ -180,6 +168,18 @@ export function attitudeWasRefused(sample: {
   return claimed && sampleAttitude(sample) == null;
 }
 
+/**
+ * A caller's attitude as a unit quaternion, or undefined when it does not name a
+ * rotation.
+ *
+ * Three.js applies the components with `Quaternion.set`, which does not
+ * normalise: a non-unit quaternion scales and skews the very spacecraft it is
+ * meant to orient, and a non-finite component spreads through the scene
+ * matrices. A simulator's attitude drifts off unit norm as it integrates, so the
+ * fix is to normalise what can be normalised and reject the rest — an unusable
+ * attitude then reads as *no* attitude, which the views already draw (no body
+ * axes, and the marker that looks the same from every side).
+ */
 export function unitAttitude(attitude: Quat | undefined): Quat | undefined {
   if (attitude == null) return undefined;
   const [w, x, y, z] = attitude;

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/displayFrame.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/displayFrame.ts
@@ -172,7 +172,12 @@ export function attitudeWasRefused(sample: {
   qy?: number | null;
   qz?: number | null;
 }): boolean {
-  return sample.qw != null && sampleAttitude(sample) == null;
+  // Any component is the claim, not `qw` alone. Now that a rotation needs the
+  // complete tuple, a sample carrying only `qx` is rejected as a rotation — and
+  // keying the refusal on `qw` would call that "no attitude at all", which draws
+  // the registered model at its own orientation and amplifies the scene for it.
+  const claimed = sample.qw != null || sample.qx != null || sample.qy != null || sample.qz != null;
+  return claimed && sampleAttitude(sample) == null;
 }
 
 export function unitAttitude(attitude: Quat | undefined): Quat | undefined {

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/displayFrame.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/displayFrame.ts
@@ -132,6 +132,24 @@ const UNIT_QUATERNION_TOLERANCE = 1e-9;
  * attitude then reads as *no* attitude, which the views already draw (no body
  * axes, and the marker that looks the same from every side).
  */
+/**
+ * The attitude carried by an orbit sample, brought to unit norm, or undefined.
+ *
+ * Samples arrive as loose components rather than a tuple, and two decisions read
+ * them: the rotation applied to the marker, and whether the marker is the shape
+ * that reveals an orientation. Both go through here so they cannot disagree —
+ * a sample the rotation refuses must not be drawn as an oriented cube.
+ */
+export function sampleAttitude(sample: {
+  qw?: number | null;
+  qx?: number | null;
+  qy?: number | null;
+  qz?: number | null;
+}): Quat | undefined {
+  if (sample.qw == null) return undefined;
+  return unitAttitude([sample.qw, sample.qx ?? 0, sample.qy ?? 0, sample.qz ?? 0]);
+}
+
 export function unitAttitude(attitude: Quat | undefined): Quat | undefined {
   if (attitude == null) return undefined;
   const [w, x, y, z] = attitude;

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/displayFrame.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/displayFrame.ts
@@ -134,8 +134,14 @@ export function sampleAttitude(sample: {
   qy?: number | null;
   qz?: number | null;
 }): Quat | undefined {
-  if (sample.qw == null) return undefined;
-  return unitAttitude([sample.qw, sample.qx ?? 0, sample.qy ?? 0, sample.qz ?? 0]);
+  // All four components or none. Filling the missing ones with zero turns a
+  // sample such as `{ qw: 0.5 }` into the identity once normalised, which draws an
+  // orientation nobody supplied — and `hasQuaternion` in `orbit.ts`, which decides
+  // whether two samples can be slerped, already requires the complete tuple.
+  if (sample.qw == null || sample.qx == null || sample.qy == null || sample.qz == null) {
+    return undefined;
+  }
+  return unitAttitude([sample.qw, sample.qx, sample.qy, sample.qz]);
 }
 
 /**

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/lib/OrbitScene.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/lib/OrbitScene.tsx
@@ -4,6 +4,7 @@ import { OrbitSceneContents } from "../components/OrbitSceneContents.js";
 import { IS_DEV } from "../env.js";
 import type { OrbitPoint } from "../orbit.js";
 import type { MarkerShape } from "../satelliteShapes.js";
+import { finiteOrNull } from "../utils/finite.js";
 import { useArikaReady } from "../wasm/useArikaReady.js";
 import { toOrbitPoint } from "./adapt.js";
 import { resolveFrameContext } from "./frameContext.js";
@@ -54,8 +55,18 @@ export function OrbitScene({
   controls = true,
   axes = true,
 }: OrbitSceneProps) {
+  // The epoch, brought to a number the WASM can be called with.
+  //
+  // `??` and `!= null` stop at null and undefined, so `NaN` counts as supplied:
+  // `Number()` on a broken CSV header gives one, and so does a JSON field that
+  // arrived as a string. It would load arika and then reach every call the scene
+  // makes with it — the Sun's direction, the Earth rotation angle, a body's
+  // orientation — where an invalid transform spreads through the scene matrices
+  // instead of the documented epoch-less fallback being used. `AttitudeScene`
+  // normalises at this same seam.
+  const epoch = finiteOrNull(epochJd);
   // Only load the arika WASM when an epoch is supplied (Sun/rotation features).
-  const arikaReady = useArikaReady(epochJd != null);
+  const arikaReady = useArikaReady(epoch != null);
 
   // Body definitions: consumer-supplied bodies merged over the built-in defaults.
   const bodyDefinitions = useMemo(() => resolveBodyDefinitions(bodies), [bodies]);
@@ -142,7 +153,7 @@ export function OrbitScene({
 
   // Only hand the scene an epoch once arika is loaded; otherwise its Sun/rotation
   // calls would run before the WASM is ready. Default lighting is used until then.
-  const effectiveEpochJd = arikaReady ? (epochJd ?? null) : null;
+  const effectiveEpochJd = arikaReady ? epoch : null;
 
   // Dev/E2E-only: expose per-satellite trail buffer state so E2E can prove that
   // advancing `time` (or appending points) does not rebuild the trail — a stable

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/lib/OrbitScene.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/lib/OrbitScene.tsx
@@ -163,6 +163,7 @@ export function OrbitScene({
 
   return (
     <OrbitSceneContents
+      time={time}
       trailBuffers={trailBuffers}
       satellitePositions={satellitePositions}
       satelliteNames={satelliteNames}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/lib/OrbitScene.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/lib/OrbitScene.tsx
@@ -50,6 +50,7 @@ export function OrbitScene({
   textureVersion,
   defaultMarkerShape,
   atmosphereScale,
+  directionVectors,
   controls = true,
   axes = true,
 }: OrbitSceneProps) {
@@ -178,6 +179,7 @@ export function OrbitScene({
       physicalScale={physicalScale}
       textureBaseUrl={textureBaseUrl}
       textureRevision={textureVersion}
+      directionVectors={directionVectors}
       controls={controls}
       axes={axes}
     />

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/lib/types.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/lib/types.ts
@@ -194,6 +194,21 @@ export interface OrbitSceneDataProps {
    * thickness (useful satellite-centred); `"auto"` (default) picks per view.
    */
   atmosphereScale?: "visual" | "physical" | "auto";
+  /**
+   * Reference-direction arrows (Sun, nadir) to draw. Omitted — the default —
+   * draws none, and each field is opt-in: `{ sun: true }` draws the Sun alone.
+   * (The attitude view reads the same type the other way round, drawing every
+   * direction it can unless one is switched off, because arrows are what that
+   * view is for.)
+   *
+   * Drawn only when the reference frame is centred on a satellite, and only at
+   * that satellite. This view can hold many satellites, and a pair of arrows on
+   * each of them fills the screen; in a central-body view the body itself is on
+   * screen, so a nadir arrow repeats what the picture already shows. To annotate
+   * a satellite other than the centred one, ask for a scene-level target — a
+   * per-satellite flag would put the scene's display policy in the data.
+   */
+  directionVectors?: DirectionVectorOptions;
 }
 
 /**

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/orbit.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/orbit.ts
@@ -139,6 +139,19 @@ export function updateOrbitTrail(line: THREE.Line, visibleCount: number, totalCo
   line.geometry.setDrawRange(0, clamped);
 }
 
+/**
+ * A point's quaternion at unit norm, or its components unchanged when they do not
+ * describe a length that can be divided by (zero, or non-finite).
+ *
+ * Callers must have checked {@link hasQuaternion} first.
+ */
+function unitOrAsGiven(p: OrbitPoint): THREE.Quaternion {
+  const [w, x, y, z] = [p.qw as number, p.qx as number, p.qy as number, p.qz as number];
+  const n = Math.hypot(w, x, y, z);
+  if (!(Number.isFinite(n) && n > 0)) return new THREE.Quaternion(x, y, z, w);
+  return new THREE.Quaternion(x / n, y / n, z / n, w / n);
+}
+
 /** Whether a point carries a complete quaternion (all of qw/qx/qy/qz). */
 function hasQuaternion(p: OrbitPoint): boolean {
   return p.qw != null && p.qx != null && p.qy != null && p.qz != null;
@@ -170,8 +183,19 @@ export function lerpPoint(a: OrbitPoint, b: OrbitPoint, frac: number): OrbitPoin
   // on both points — guarding on qw alone would let a partial one (missing
   // qx/qy/qz, which Three defaults to 0) build an un-normalized rotation.
   if (hasQuaternion(a) && hasQuaternion(b)) {
-    const qa = new THREE.Quaternion(a.qx, a.qy, a.qz, a.qw);
-    const qb = new THREE.Quaternion(b.qx, b.qy, b.qz, b.qw);
+    // Slerp assumes unit quaternions, and a simulator's attitude drifts off unit
+    // norm as it integrates. Equal norms cancel — scaling both endpoints by 2
+    // reproduces the unit result to 1e-16 — but unequal ones bend the path: norms
+    // of 1 and 2 put the halfway rotation 1.2e-1 off in each component, and a
+    // drift of a thousandth 1.9e-4 off. Normalising afterwards cannot recover it,
+    // because the error is in which rotation was chosen, not in its length.
+    //
+    // What cannot be normalised is passed through as it came, so the display
+    // frame still sees an attitude to refuse rather than one this function
+    // invented: `THREE.Quaternion.normalize` turns a zero quaternion into the
+    // identity, which would be exactly that invention.
+    const qa = unitOrAsGiven(a);
+    const qb = unitOrAsGiven(b);
     // Ensure shortest-path interpolation
     if (qa.dot(qb) < 0) {
       qb.set(-qb.x, -qb.y, -qb.z, -qb.w);

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/orbit.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/orbit.ts
@@ -140,15 +140,15 @@ export function updateOrbitTrail(line: THREE.Line, visibleCount: number, totalCo
 }
 
 /**
- * A point's quaternion at unit norm, or its components unchanged when they do not
- * describe a length that can be divided by (zero, or non-finite).
+ * A point's quaternion at unit norm, or null when its components do not describe
+ * a length that can be divided by (zero, or non-finite).
  *
  * Callers must have checked {@link hasQuaternion} first.
  */
-function unitOrAsGiven(p: OrbitPoint): THREE.Quaternion {
+function unitQuaternion(p: OrbitPoint): THREE.Quaternion | null {
   const [w, x, y, z] = [p.qw as number, p.qx as number, p.qy as number, p.qz as number];
   const n = Math.hypot(w, x, y, z);
-  if (!(Number.isFinite(n) && n > 0)) return new THREE.Quaternion(x, y, z, w);
+  if (!(Number.isFinite(n) && n > 0)) return null;
   return new THREE.Quaternion(x / n, y / n, z / n, w / n);
 }
 
@@ -194,17 +194,32 @@ export function lerpPoint(a: OrbitPoint, b: OrbitPoint, frac: number): OrbitPoin
     // frame still sees an attitude to refuse rather than one this function
     // invented: `THREE.Quaternion.normalize` turns a zero quaternion into the
     // identity, which would be exactly that invention.
-    const qa = unitOrAsGiven(a);
-    const qb = unitOrAsGiven(b);
-    // Ensure shortest-path interpolation
-    if (qa.dot(qb) < 0) {
-      qb.set(-qb.x, -qb.y, -qb.z, -qb.w);
+    const qa = unitQuaternion(a);
+    const qb = unitQuaternion(b);
+    if (qa != null && qb != null) {
+      // Ensure shortest-path interpolation
+      if (qa.dot(qb) < 0) {
+        qb.set(-qb.x, -qb.y, -qb.z, -qb.w);
+      }
+      qa.slerp(qb, frac);
+      result.qw = qa.w;
+      result.qx = qa.x;
+      result.qy = qa.y;
+      result.qz = qa.z;
+    } else {
+      // An endpoint the display frame refuses cannot be interpolated through.
+      // Slerp from a zero quaternion returns a multiple of the *other* endpoint —
+      // measured at a quarter of the way along, the result normalises to that
+      // endpoint's rotation exactly — so the refused sample would be presented as
+      // a measurement taken next door. The refusal is carried instead, and the
+      // exact endpoints keep their own values, which is what a reader at a
+      // sample's own timestamp should see.
+      const source = frac <= 0 ? a : frac >= 1 ? b : qa == null ? a : b;
+      result.qw = source.qw;
+      result.qx = source.qx;
+      result.qy = source.qy;
+      result.qz = source.qz;
     }
-    qa.slerp(qb, frac);
-    result.qw = qa.w;
-    result.qx = qa.x;
-    result.qy = qa.y;
-    result.qz = qa.z;
     // Angular velocity: linear interpolation
     result.wx = (a.wx ?? 0) * inv + (b.wx ?? 0) * frac;
     result.wy = (a.wy ?? 0) * inv + (b.wy ?? 0) * frac;

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/orbit.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/orbit.ts
@@ -1,4 +1,5 @@
 import * as THREE from "three";
+import { sampleAttitude } from "./displayFrame.js";
 
 /**
  * Earth radius in km -- used as the scene scale factor.
@@ -140,16 +141,22 @@ export function updateOrbitTrail(line: THREE.Line, visibleCount: number, totalCo
 }
 
 /**
- * A point's quaternion at unit norm, or null when its components do not describe
- * a length that can be divided by (zero, or non-finite).
+ * A point's quaternion at unit norm, or null when the display frame would refuse
+ * it.
  *
- * Callers must have checked {@link hasQuaternion} first.
+ * Asked of `sampleAttitude`, which is what the marker's rotation goes through, so
+ * the interpolation and the drawing agree on which samples name a rotation.
+ * Dividing by a finite positive norm is not enough on its own: at subnormal
+ * magnitudes `Math.hypot` answers the smallest number there is, so
+ * `[5e-324, 5e-324, 0, 0]` divides to `[1, 1, 0, 0]` — norm 1.414, which slerp
+ * would carry as a rotation. `unitAttitude` checks the result rather than the
+ * input, and this now inherits that.
  */
 function unitQuaternion(p: OrbitPoint): THREE.Quaternion | null {
-  const [w, x, y, z] = [p.qw as number, p.qx as number, p.qy as number, p.qz as number];
-  const n = Math.hypot(w, x, y, z);
-  if (!(Number.isFinite(n) && n > 0)) return null;
-  return new THREE.Quaternion(x / n, y / n, z / n, w / n);
+  const unit = sampleAttitude(p);
+  if (unit == null) return null;
+  const [w, x, y, z] = unit;
+  return new THREE.Quaternion(x, y, z, w);
 }
 
 /** Whether a point carries a complete quaternion (all of qw/qx/qy/qz). */

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/satelliteShapes.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/satelliteShapes.ts
@@ -16,18 +16,28 @@ export function isMarkerShape(value: string): value is MarkerShape {
 
 /**
  * Resolve the marker shape for a satellite. Precedence (most specific first):
+ *   0. `attitudeRefused` — the sphere, whatever was asked for
  *   1. `override`     — per-satellite viewer choice
  *   2. `simShape`     — shape declared by the simulation (via SatelliteInfo)
  *   3. `globalDefault`— viewer-wide default
  *   4. automatic      — orientation cube when attitude is present, else sphere
  * A null/undefined value at any level falls through to the next.
+ *
+ * `attitudeRefused` says the sample carried an attitude the viewer could not use.
+ * It outranks the requests above because the cube's faces show which way the body
+ * points: drawn at the identity it would answer a question the data could not,
+ * and the sphere is the one marker that looks the same from every side. A
+ * satellite with no attitude at all is not this case — there the requested shape
+ * stands, as it always has.
  */
 export function resolveMarkerShape(opts: {
   override?: MarkerShape | null;
   simShape?: MarkerShape | null;
   globalDefault?: MarkerShape | null;
   hasAttitude: boolean;
+  attitudeRefused?: boolean;
 }): MarkerShape {
+  if (opts.attitudeRefused) return "sphere";
   if (opts.override) return opts.override;
   if (opts.simShape) return opts.simShape;
   if (opts.globalDefault) return opts.globalDefault;

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/spacecraftScale.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/spacecraftScale.ts
@@ -5,6 +5,19 @@ import type { MarkerShape } from "./satelliteShapes.js";
 /** Apparent size of the spacecraft in a scene that has no other length scale. */
 export const NOMINAL_SPACECRAFT_SPAN = 1;
 
+/**
+ * Marker half-extents in the orbit view, whose scene unit is the central body's
+ * radius. Here rather than in the marker components because the *span* they
+ * imply is what the axes and arrows are sized from.
+ */
+export const DEFAULT_SPHERE_RADIUS = 0.005;
+export const DEFAULT_CUBE_HALF_EXTENT = 0.008;
+
+/** Marker half-extent for a shape, in the orbit view's scene units. */
+export function defaultMarkerSize(shape: MarkerShape): number {
+  return shape === "sphere" ? DEFAULT_SPHERE_RADIUS : DEFAULT_CUBE_HALF_EXTENT;
+}
+
 /** Body-axis length, as a ratio of the spacecraft's apparent size. */
 const AXIS_LENGTH_RATIO = 0.75;
 

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/utils/finite.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/utils/finite.ts
@@ -1,21 +1,3 @@
 export function finiteOrNull(value: number | null | undefined): number | null {
   return value != null && Number.isFinite(value) ? value : null;
 }
-
-/**
- * The first finite `t` among these samples, or null if none has one.
- *
- * Scanning for a usable time rather than for the first sample that exists: a
- * satellite whose `t` is `NaN` would otherwise end the search and leave the
- * caller with no time at all, while a later satellite carries a good one.
- */
-export function firstFiniteTime(
-  samples: Iterable<{ t?: number } | null | undefined> | null | undefined,
-): number | null {
-  if (samples == null) return null;
-  for (const sample of samples) {
-    const t = finiteOrNull(sample?.t);
-    if (t != null) return t;
-  }
-  return null;
-}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/utils/finite.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/utils/finite.ts
@@ -1,3 +1,21 @@
 export function finiteOrNull(value: number | null | undefined): number | null {
   return value != null && Number.isFinite(value) ? value : null;
 }
+
+/**
+ * The first finite `t` among these samples, or null if none has one.
+ *
+ * Scanning for a usable time rather than for the first sample that exists: a
+ * satellite whose `t` is `NaN` would otherwise end the search and leave the
+ * caller with no time at all, while a later satellite carries a good one.
+ */
+export function firstFiniteTime(
+  samples: Iterable<{ t?: number } | null | undefined> | null | undefined,
+): number | null {
+  if (samples == null) return null;
+  for (const sample of samples) {
+    const t = finiteOrNull(sample?.t);
+    if (t != null) return t;
+  }
+  return null;
+}

--- a/viewer/fixtures/orbit-viewer.html
+++ b/viewer/fixtures/orbit-viewer.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>OrbitViewer fixture</title>
+    <style>
+      html,
+      body,
+      #root {
+        margin: 0;
+        width: 100%;
+        height: 100%;
+        background: #05070d;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/fixtures/orbitViewer.tsx"></script>
+  </body>
+</html>

--- a/viewer/fixtures/orbitViewer.tsx
+++ b/viewer/fixtures/orbitViewer.tsx
@@ -18,10 +18,12 @@
  * | frame   | `inertial` (default) / `localOrbital` / `bodyFixed`             |
  * | epoch   | epoch JD (UTC); omitted means no epoch                         |
  * | arrows  | `sun` / `nadir` / `sun,nadir` (default) / `none`               |
+ * | att     | attitude `w,x,y,z` given to every satellite; makes the display   |
+ * |         | frame readable through the rendered world quaternion            |
  */
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import type { SatelliteState, Vec3, ViewerReferenceFrame } from "../src/lib/index.js";
+import type { Quat, SatelliteState, Vec3, ViewerReferenceFrame } from "../src/lib/index.js";
 import { isArikaReady, OrbitViewer } from "../src/lib/index.js";
 
 const params = new URLSearchParams(window.location.search);
@@ -44,6 +46,12 @@ function vec3(text: string): Vec3 {
  * `nan` is spelled out rather than written as a literal, because a URL carrying
  * `NaN` through `Number()` is exactly the shape a failed parse upstream has.
  */
+const attitudeParam = params.get("att")?.split(",").map(Number);
+const attitude: Quat | undefined =
+  attitudeParam?.length === 4
+    ? [attitudeParam[0], attitudeParam[1], attitudeParam[2], attitudeParam[3]]
+    : undefined;
+
 const satellites: SatelliteState[] = (params.get("sats") ?? "0:7000,0,0:0,7.546,0")
   .split(";")
   .map((group, i) => {
@@ -52,6 +60,7 @@ const satellites: SatelliteState[] = (params.get("sats") ?? "0:7000,0,0:0,7.546,
       id: `fixture-sat-${i}`,
       position: vec3(position ?? "7000,0,0"),
       velocity: velocity == null ? undefined : vec3(velocity),
+      attitude,
       time: time === "nan" ? Number.NaN : Number(time ?? 0),
     };
   });

--- a/viewer/fixtures/orbitViewer.tsx
+++ b/viewer/fixtures/orbitViewer.tsx
@@ -17,7 +17,8 @@
  * | centre  | index into `sats` to centre on; omitted centres the central body |
  * | frame   | `inertial` (default) / `localOrbital` / `bodyFixed`             |
  * | epoch   | epoch JD (UTC); omitted means no epoch                         |
- * | arrows  | `sun` / `nadir` / `sun,nadir` (default) / `none`               |
+ * | arrows  | `sun` / `nadir` / `sun,nadir`; omitted leaves the prop out, which |
+ * |         | is the documented default of drawing none                        |
  * | att     | attitude `w,x,y,z` given to every satellite; makes the display   |
  * |         | frame readable through the rendered world quaternion            |
  * | t       | the scene's elapsed seconds — the epoch a central-body view uses |
@@ -76,7 +77,7 @@ const referenceFrame: ViewerReferenceFrame =
         orientation: orientation === "localOrbital" ? "localOrbital" : "inertial",
       };
 
-const arrows = params.get("arrows") ?? "sun,nadir";
+const arrows = params.get("arrows");
 const epoch = params.get("epoch");
 const sceneTime = params.get("t");
 
@@ -88,10 +89,11 @@ createRoot(document.getElementById("root") as HTMLElement).render(
       referenceFrame={referenceFrame}
       epochJd={epoch == null ? undefined : Number(epoch)}
       time={sceneTime == null ? undefined : Number(sceneTime)}
-      directionVectors={{
-        sun: arrows.includes("sun"),
-        nadir: arrows.includes("nadir"),
-      }}
+      directionVectors={
+        arrows == null
+          ? undefined
+          : { sun: arrows.includes("sun"), nadir: arrows.includes("nadir") }
+      }
     />
   </StrictMode>,
 );

--- a/viewer/fixtures/orbitViewer.tsx
+++ b/viewer/fixtures/orbitViewer.tsx
@@ -1,0 +1,85 @@
+/**
+ * Mounts the published {@link OrbitViewer} with satellites taken from the URL,
+ * so a test can put the scene in a state a live `orts serve` run cannot produce.
+ *
+ * The app's own E2E covers the app against a real server, where every satellite
+ * shares one clock and every sample is a number. What that cannot reach is the
+ * state the public props allow: satellites at *different* times (a terminated one
+ * frozen at its last sample), or a `time` that arrived as `NaN` from a source.
+ * Both decide which epoch the Sun and the body rotations are evaluated at, so
+ * they need a fixture.
+ *
+ *   /fixtures/orbit-viewer.html?sats=0:7000,0,0:0,7.546,0&epoch=2460000.5
+ *
+ * | param   | meaning                                                        |
+ * |---------|----------------------------------------------------------------|
+ * | sats    | `;`-separated satellites, each `t:x,y,z:vx,vy,vz` (t may be `nan`) |
+ * | centre  | index into `sats` to centre on; omitted centres the central body |
+ * | frame   | `inertial` (default) / `localOrbital` / `bodyFixed`             |
+ * | epoch   | epoch JD (UTC); omitted means no epoch                         |
+ * | arrows  | `sun` / `nadir` / `sun,nadir` (default) / `none`               |
+ */
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import type { SatelliteState, Vec3, ViewerReferenceFrame } from "../src/lib/index.js";
+import { isArikaReady, OrbitViewer } from "../src/lib/index.js";
+
+const params = new URLSearchParams(window.location.search);
+
+declare global {
+  interface Window {
+    __fixture_arika_ready?: () => boolean;
+  }
+}
+window.__fixture_arika_ready = () => isArikaReady();
+
+function vec3(text: string): Vec3 {
+  const parts = text.split(",").map(Number);
+  return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+}
+
+/**
+ * One satellite per `;`-separated group, as `t:position:velocity`.
+ *
+ * `nan` is spelled out rather than written as a literal, because a URL carrying
+ * `NaN` through `Number()` is exactly the shape a failed parse upstream has.
+ */
+const satellites: SatelliteState[] = (params.get("sats") ?? "0:7000,0,0:0,7.546,0")
+  .split(";")
+  .map((group, i) => {
+    const [time, position, velocity] = group.split(":");
+    return {
+      id: `fixture-sat-${i}`,
+      position: vec3(position ?? "7000,0,0"),
+      velocity: velocity == null ? undefined : vec3(velocity),
+      time: time === "nan" ? Number.NaN : Number(time ?? 0),
+    };
+  });
+
+const centre = params.get("centre");
+const orientation = params.get("frame") ?? "inertial";
+const referenceFrame: ViewerReferenceFrame =
+  centre == null
+    ? { center: "centralBody", orientation: orientation === "bodyFixed" ? "bodyFixed" : "inertial" }
+    : {
+        center: { satelliteId: satellites[Number(centre)]?.id ?? satellites[0].id },
+        orientation: orientation === "localOrbital" ? "localOrbital" : "inertial",
+      };
+
+const arrows = params.get("arrows") ?? "sun,nadir";
+const epoch = params.get("epoch");
+
+createRoot(document.getElementById("root") as HTMLElement).render(
+  <StrictMode>
+    <OrbitViewer
+      centralBody={{ id: "earth", radiusKm: 6378.137 }}
+      satellites={satellites}
+      referenceFrame={referenceFrame}
+      epochJd={epoch == null ? undefined : Number(epoch)}
+      directionVectors={{
+        sun: arrows.includes("sun"),
+        nadir: arrows.includes("nadir"),
+      }}
+    />
+  </StrictMode>,
+);

--- a/viewer/fixtures/orbitViewer.tsx
+++ b/viewer/fixtures/orbitViewer.tsx
@@ -27,7 +27,7 @@
  * | shape   | marker shape forced on every satellite (`axes-cube` / `sphere`)  |
  * | name    | display name of every satellite — `ISS` resolves a model config   |
  */
-import { StrictMode } from "react";
+import { StrictMode, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import type { Quat, SatelliteState, Vec3, ViewerReferenceFrame } from "../src/lib/index.js";
 import { isArikaReady, OrbitViewer } from "../src/lib/index.js";
@@ -37,6 +37,16 @@ const params = new URLSearchParams(window.location.search);
 declare global {
   interface Window {
     __fixture_arika_ready?: () => boolean;
+    /**
+     * Replace every satellite's attitude after mount, or withdraw it with `null`.
+     *
+     * The one prop this fixture does not take from the URL alone. Some behaviour
+     * is reachable only by *losing* a usable attitude: a group that keeps the
+     * rotation its last good sample gave it renders identically to a correct one
+     * until the sample stops carrying it, so a scene mounted in its final state
+     * cannot tell the two apart.
+     */
+    __fixture_set_attitude?: (attitude: Quat | null) => void;
   }
 }
 window.__fixture_arika_ready = () => isArikaReady();
@@ -87,8 +97,23 @@ const arrows = params.get("arrows");
 const epoch = params.get("epoch");
 const sceneTime = params.get("t");
 
-createRoot(document.getElementById("root") as HTMLElement).render(
-  <StrictMode>
+/** The scene, plus the one prop a test can change after mount. */
+function Fixture() {
+  // `undefined` means "as the URL gave it"; a value or `null` means a test has
+  // taken over, `null` withdrawing the attitude entirely.
+  const [override, setOverride] = useState<Quat | null | undefined>(undefined);
+  useEffect(() => {
+    window.__fixture_set_attitude = (attitude) => setOverride(attitude);
+    return () => {
+      window.__fixture_set_attitude = undefined;
+    };
+  }, []);
+  const shown =
+    override === undefined
+      ? satellites
+      : satellites.map((sat) => ({ ...sat, attitude: override ?? undefined }));
+
+  return (
     <OrbitViewer
       centralBody={{
         id: params.get("body") ?? "earth",
@@ -96,7 +121,7 @@ createRoot(document.getElementById("root") as HTMLElement).render(
         // and the scene needs one to scale itself by.
         radiusKm: Number(params.get("radius") ?? 6378.137),
       }}
-      satellites={satellites}
+      satellites={shown}
       referenceFrame={referenceFrame}
       epochJd={epoch == null ? undefined : Number(epoch)}
       time={sceneTime == null ? undefined : Number(sceneTime)}
@@ -106,5 +131,11 @@ createRoot(document.getElementById("root") as HTMLElement).render(
           : { sun: arrows.includes("sun"), nadir: arrows.includes("nadir") }
       }
     />
+  );
+}
+
+createRoot(document.getElementById("root") as HTMLElement).render(
+  <StrictMode>
+    <Fixture />
   </StrictMode>,
 );

--- a/viewer/fixtures/orbitViewer.tsx
+++ b/viewer/fixtures/orbitViewer.tsx
@@ -24,6 +24,7 @@
  * | t       | the scene's elapsed seconds — the epoch a central-body view uses |
  * | body    | central body id (default `earth`)                                |
  * | radius  | central body radius in km (default Earth's)                      |
+ * | shape   | marker shape forced on every satellite (`axes-cube` / `sphere`)  |
  */
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
@@ -65,6 +66,7 @@ const satellites: SatelliteState[] = (params.get("sats") ?? "0:7000,0,0:0,7.546,
       position: vec3(position ?? "7000,0,0"),
       velocity: velocity == null ? undefined : vec3(velocity),
       attitude,
+      markerShape: (params.get("shape") as SatelliteState["markerShape"]) ?? undefined,
       time: time === "nan" ? Number.NaN : Number(time ?? 0),
     };
   });

--- a/viewer/fixtures/orbitViewer.tsx
+++ b/viewer/fixtures/orbitViewer.tsx
@@ -22,6 +22,8 @@
  * | att     | attitude `w,x,y,z` given to every satellite; makes the display   |
  * |         | frame readable through the rendered world quaternion            |
  * | t       | the scene's elapsed seconds — the epoch a central-body view uses |
+ * | body    | central body id (default `earth`)                                |
+ * | radius  | central body radius in km (default Earth's)                      |
  */
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
@@ -84,7 +86,12 @@ const sceneTime = params.get("t");
 createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>
     <OrbitViewer
-      centralBody={{ id: "earth", radiusKm: 6378.137 }}
+      centralBody={{
+        id: params.get("body") ?? "earth",
+        // Given explicitly: a body arika does not model has no radius to resolve,
+        // and the scene needs one to scale itself by.
+        radiusKm: Number(params.get("radius") ?? 6378.137),
+      }}
       satellites={satellites}
       referenceFrame={referenceFrame}
       epochJd={epoch == null ? undefined : Number(epoch)}

--- a/viewer/fixtures/orbitViewer.tsx
+++ b/viewer/fixtures/orbitViewer.tsx
@@ -20,6 +20,7 @@
  * | arrows  | `sun` / `nadir` / `sun,nadir` (default) / `none`               |
  * | att     | attitude `w,x,y,z` given to every satellite; makes the display   |
  * |         | frame readable through the rendered world quaternion            |
+ * | t       | the scene's elapsed seconds — the epoch a central-body view uses |
  */
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
@@ -77,6 +78,7 @@ const referenceFrame: ViewerReferenceFrame =
 
 const arrows = params.get("arrows") ?? "sun,nadir";
 const epoch = params.get("epoch");
+const sceneTime = params.get("t");
 
 createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>
@@ -85,6 +87,7 @@ createRoot(document.getElementById("root") as HTMLElement).render(
       satellites={satellites}
       referenceFrame={referenceFrame}
       epochJd={epoch == null ? undefined : Number(epoch)}
+      time={sceneTime == null ? undefined : Number(sceneTime)}
       directionVectors={{
         sun: arrows.includes("sun"),
         nadir: arrows.includes("nadir"),

--- a/viewer/fixtures/orbitViewer.tsx
+++ b/viewer/fixtures/orbitViewer.tsx
@@ -25,6 +25,7 @@
  * | body    | central body id (default `earth`)                                |
  * | radius  | central body radius in km (default Earth's)                      |
  * | shape   | marker shape forced on every satellite (`axes-cube` / `sphere`)  |
+ * | name    | display name of every satellite — `ISS` resolves a model config   |
  */
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
@@ -67,6 +68,7 @@ const satellites: SatelliteState[] = (params.get("sats") ?? "0:7000,0,0:0,7.546,
       velocity: velocity == null ? undefined : vec3(velocity),
       attitude,
       markerShape: (params.get("shape") as SatelliteState["markerShape"]) ?? undefined,
+      name: params.get("name") ?? undefined,
       time: time === "nan" ? Number.NaN : Number(time ?? 0),
     };
   });

--- a/viewer/fixtures/test-spacecraft.gltf
+++ b/viewer/fixtures/test-spacecraft.gltf
@@ -1,0 +1,64 @@
+{
+  "asset": {
+    "version": "2.0",
+    "generator": "orts viewer test fixture"
+  },
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "mesh": 0,
+      "name": "test-spacecraft"
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0
+          }
+        }
+      ]
+    }
+  ],
+  "buffers": [
+    {
+      "byteLength": 36,
+      "uri": "data:application/octet-stream;base64,AAAAvwAAAL8AAAAAAAAAPwAAAL8AAAAAAAAAAAAAAD8AAAAA"
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 36,
+      "target": 34962
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3",
+      "min": [
+        -0.5,
+        -0.5,
+        0.0
+      ],
+      "max": [
+        0.5,
+        0.5,
+        0.0
+      ]
+    }
+  ]
+}

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -377,14 +377,11 @@ export function App() {
         time: pos.t,
         // All four components or none, matching `hasQuaternion` in `orbit.ts`.
         //
-        // No source sets some components and not others: the rrd decoder yields
-        // four or none, and the WS payload carries the tuple as one value. What
-        // this cannot pass on is a *refusal* — `SatelliteState.attitude` is
-        // `Quat | undefined`, so an unusable attitude arrives here as a complete
-        // non-finite tuple and leaves as `undefined`, and a satellite read as
-        // having no attitude keeps its registered model as a position marker
-        // where a refused one is replaced. Tracked in #451 with the other places
-        // that judgement is re-derived.
+        // A complete tuple passes through whatever it holds, zero and non-finite
+        // included, and the scene reads the refusal back off it — so an unusable
+        // attitude does reach the scene as one. What cannot arrive is a *partly*
+        // decoded tuple, and no source produces one: the rrd decoder yields four
+        // components or none, and the WS payload carries the tuple as one value.
         attitude:
           pos.qw != null && pos.qx != null && pos.qy != null && pos.qz != null
             ? [pos.qw, pos.qx, pos.qy, pos.qz]

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -385,6 +385,10 @@ export function App() {
         // standing as a position marker, where a refused one would replace it. To
         // pass the distinction through, the public type would have to gain a way
         // to express it; that is an API question rather than a fix here.
+        //
+        // Reaching it takes a corrupt file: the only source that assigns these
+        // components one by one is the rrd parser, from a `quaternion` column it
+        // expects to be four long, and the WS payload carries the tuple whole.
         attitude:
           pos.qw != null && pos.qx != null && pos.qy != null && pos.qz != null
             ? [pos.qw, pos.qx, pos.qy, pos.qz]

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -377,18 +377,15 @@ export function App() {
         time: pos.t,
         // All four components or none, matching `hasQuaternion` in `orbit.ts`.
         //
-        // A partly decoded sample is passed on as *no* attitude, which is the one
-        // thing `SatelliteState.attitude` can say: being `Quat | undefined`, it
-        // has no way to carry "an attitude arrived and could not be used". The
-        // scene's own classifier draws that distinction, and the difference shows
-        // for a satellite with a registered model — no attitude leaves the model
-        // standing as a position marker, where a refused one would replace it. To
-        // pass the distinction through, the public type would have to gain a way
-        // to express it; that is an API question rather than a fix here.
-        //
-        // Reaching it takes a corrupt file: the only source that assigns these
-        // components one by one is the rrd parser, from a `quaternion` column it
-        // expects to be four long, and the WS payload carries the tuple whole.
+        // Reaching the partial case would need a source that sets some components
+        // and not others, and none does: the rrd parser turns a `quaternion`
+        // column of the wrong length into four `NaN`s, so the claim arrives whole
+        // and the scene refuses it, and the WS payload carries the tuple as one
+        // value. That matters because `SatelliteState.attitude` is
+        // `Quat | undefined` and could not pass a partial claim on — a sample
+        // reduced to "no attitude" leaves a registered model standing as a
+        // position marker, where a refused one replaces it with the marker that
+        // shows no orientation.
         attitude:
           pos.qw != null && pos.qx != null && pos.qy != null && pos.qz != null
             ? [pos.qw, pos.qx, pos.qy, pos.qz]

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -16,7 +16,7 @@ import { CSV_SOURCE_ID, RRD_SOURCE_ID, useFileSource } from "./hooks/useFileSour
 import { useRealtimePlayback } from "./hooks/useRealtimePlayback.js";
 import { useSimInfoDerived } from "./hooks/useSimInfoDerived.js";
 import { useSimulationData } from "./hooks/useSimulationData.js";
-import { OrbitScene, type SatelliteState } from "./lib/index.js";
+import { type DirectionVectorOptions, OrbitScene, type SatelliteState } from "./lib/index.js";
 import type { ClientMessage } from "./protocol/generated/ClientMessage.js";
 import { DEFAULT_FRAME, type ReferenceFrame } from "./referenceFrame.js";
 import { type MarkerShape, readSatShapeParam, writeSatShapeParam } from "./satelliteShapes.js";
@@ -37,6 +37,13 @@ const DEFAULT_WS_URL: string = resolveDefaultWsUrl({
 
 // Build-time texture base URL — present when VITE_TEXTURE_BASE_URL is set at Vite startup.
 const VITE_TEXTURE_BASE_URL = import.meta.env.VITE_TEXTURE_BASE_URL;
+
+/**
+ * Reference-direction arrows the app asks for. The scene draws them only at a
+ * centred satellite, so a central-body view is unaffected. Module-level so the
+ * prop keeps one identity across renders.
+ */
+const DIRECTION_VECTORS: DirectionVectorOptions = { sun: true, nadir: true };
 
 export function App() {
   // WASM initialization (must complete before rendering ECEF transforms)
@@ -487,6 +494,7 @@ export function App() {
             epochJd={epochJd ?? undefined}
             time={snapshot.currentTime}
             defaultMarkerShape={defaultMarkerShape}
+            directionVectors={DIRECTION_VECTORS}
             atmosphereScale="visual"
             textureVersion={textureRevision}
             textureBaseUrl={textureBaseUrl}

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -377,15 +377,14 @@ export function App() {
         time: pos.t,
         // All four components or none, matching `hasQuaternion` in `orbit.ts`.
         //
-        // Reaching the partial case would need a source that sets some components
-        // and not others, and none does: the rrd parser turns a `quaternion`
-        // column of the wrong length into four `NaN`s, so the claim arrives whole
-        // and the scene refuses it, and the WS payload carries the tuple as one
-        // value. That matters because `SatelliteState.attitude` is
-        // `Quat | undefined` and could not pass a partial claim on — a sample
-        // reduced to "no attitude" leaves a registered model standing as a
-        // position marker, where a refused one replaces it with the marker that
-        // shows no orientation.
+        // No source sets some components and not others: the rrd decoder yields
+        // four or none, and the WS payload carries the tuple as one value. What
+        // this cannot pass on is a *refusal* — `SatelliteState.attitude` is
+        // `Quat | undefined`, so an unusable attitude arrives here as a complete
+        // non-finite tuple and leaves as `undefined`, and a satellite read as
+        // having no attitude keeps its registered model as a position marker
+        // where a refused one is replaced. Tracked in #451 with the other places
+        // that judgement is re-derived.
         attitude:
           pos.qw != null && pos.qx != null && pos.qy != null && pos.qz != null
             ? [pos.qw, pos.qx, pos.qy, pos.qz]

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -375,6 +375,16 @@ export function App() {
         // The interpolated point's own time — clamped for terminated/out-of-span
         // satellites — so its body-fixed marker transform uses the right epoch.
         time: pos.t,
+        // All four components or none, matching `hasQuaternion` in `orbit.ts`.
+        //
+        // A partly decoded sample is passed on as *no* attitude, which is the one
+        // thing `SatelliteState.attitude` can say: being `Quat | undefined`, it
+        // has no way to carry "an attitude arrived and could not be used". The
+        // scene's own classifier draws that distinction, and the difference shows
+        // for a satellite with a registered model — no attitude leaves the model
+        // standing as a position marker, where a refused one would replace it. To
+        // pass the distinction through, the public type would have to gain a way
+        // to express it; that is an API question rather than a fix here.
         attitude:
           pos.qw != null && pos.qx != null && pos.qy != null && pos.qz != null
             ? [pos.qw, pos.qx, pos.qy, pos.qz]

--- a/viewer/src/components/AttitudeSceneContents.tsx
+++ b/viewer/src/components/AttitudeSceneContents.tsx
@@ -99,25 +99,20 @@ export function AttitudeSceneContents({
     ? (spanNormalizedModelScale(modelConfig, span) ?? undefined)
     : undefined;
 
-  // Whether the model is the thing on screen. Without a usable attitude a model
-  // would be drawn at its own default orientation, which reads as a measured one
-  // in a view about orientation, so a marker stands in — and one value decides
-  // both what is drawn and what the arrows have to start outside of.
-  const modelIsDrawn = modelConfig != null && quaternion != null;
+  // The attitude is this view's subject, so a missing quaternion here is always
+  // one that was refused: `AttitudeBodyState.attitude` is required, and the scene
+  // drops what it cannot use.
+  const attitudeRefused = quaternion == null;
+  // What the arrows have to start outside of, which is the model only when the
+  // model is the thing on screen.
+  const modelIsDrawn = modelConfig != null && !attitudeRefused;
 
-  // Without a usable attitude, nothing drawn may imply one. An explicit shape —
-  // or the app's default, which the `satShape` URL param persists — outranks
-  // `hasAttitude` in `resolveMarkerShape`, so the orientation-revealing cube
-  // would be drawn at identity and read as a measured attitude. The sphere is the
-  // one marker that looks the same from every side.
-  const shape: MarkerShape =
-    quaternion == null
-      ? "sphere"
-      : resolveMarkerShape({
-          override: markerShape,
-          globalDefault: defaultMarkerShape,
-          hasAttitude: true,
-        });
+  const shape: MarkerShape = resolveMarkerShape({
+    override: markerShape,
+    globalDefault: defaultMarkerShape,
+    hasAttitude: !attitudeRefused,
+    attitudeRefused,
+  });
 
   return (
     <>
@@ -144,7 +139,7 @@ export function AttitudeSceneContents({
         axisLength={axisLengthForSpan(span)}
         modelScale={modelScale}
         visualSpan={span}
-        model={modelIsDrawn}
+        attitudeRefused={attitudeRefused}
       />
 
       <DirectionArrows

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -28,7 +28,7 @@ import {
   modelBoundingRadius,
   resolveVisualSpan,
 } from "../spacecraftScale.js";
-import { finiteOrNull } from "../utils/finite.js";
+import { finiteOrNull, firstFiniteTime } from "../utils/finite.js";
 import type { TrailBufferLike } from "../utils/TrailBuffer.js";
 import { body_orientation, earth_rotation_angle } from "../wasm/arikaInit.js";
 import { CelestialBody } from "./CelestialBody.js";
@@ -461,23 +461,15 @@ export function OrbitSceneContents({
   // stays frozen), and the Sun drawn *at* the centred satellite has to be the Sun
   // at that satellite's time, not at whichever time the Map happens to yield
   // first. Falls back to the first available position for a central-body view.
-  // Iterate the Map's values directly rather than materializing an array every
-  // render just to find the first non-null entry.
-  let firstPosition: OrbitPoint | null = null;
-  if (satellitePositions) {
-    for (const p of satellitePositions.values()) {
-      if (p != null) {
-        firstPosition = p;
-        break;
-      }
-    }
-  }
+  // The Map's values are iterated directly rather than materialized into an array
+  // every render just to find one entry.
+  const fallbackTime = firstFiniteTime(satellitePositions?.values());
   const centeredPosition = centeredSatId != null ? satellitePositions?.get(centeredSatId) : null;
-  // The first *finite* time, not the first present one: `??` falls through on
-  // null and undefined, so a NaN `t` on the centred satellite would win over a
-  // usable fallback and reach the Earth rotation angle and the quantised Sun
-  // time below, both of which are WASM calls.
-  const simTime = finiteOrNull(centeredPosition?.t) ?? finiteOrNull(firstPosition?.t) ?? 0;
+  // Each candidate goes through a finite check, because `??` falls through only
+  // on null and undefined: a NaN `t` on the centred satellite would otherwise win
+  // over a usable fallback and reach the Earth rotation angle and the quantised
+  // Sun time below, both of which are WASM calls.
+  const simTime = finiteOrNull(centeredPosition?.t) ?? fallbackTime ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 
   // Earth rotation angle (ERA) via WASM — updates every frame via simTime (not quantized)

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -9,7 +9,12 @@ import {
   getBodyRadius,
 } from "../bodies.js";
 import { type DirectionVectorOptions, resolveDirectionVectors } from "../directionVectors.js";
-import { displayPosition, displayRotation, resolveDisplayFrame } from "../displayFrame.js";
+import {
+  displayPosition,
+  displayRotation,
+  resolveDisplayFrame,
+  sampleAttitude,
+} from "../displayFrame.js";
 import {
   computeSceneAmplification,
   type DisplayScaleProfile,
@@ -646,7 +651,10 @@ export function OrbitSceneContents({
             override: satelliteShapes?.get(centeredSatId),
             simShape: satelliteSimShapes?.get(centeredSatId),
             globalDefault: defaultMarkerShape,
-            hasAttitude: pos.qw != null,
+            // The same judgement the rotation makes: a sample whose quaternion
+            // names no rotation gets the sphere, not the cube that would show an
+            // orientation nobody measured.
+            hasAttitude: sampleAttitude(pos) != null,
           });
           const satName = satelliteNames?.get(centeredSatId);
           // The centred satellite is drawn exactly at the world origin, so the
@@ -802,7 +810,8 @@ export function OrbitSceneContents({
                     override: satelliteShapes?.get(satId),
                     simShape: satelliteSimShapes?.get(satId),
                     globalDefault: defaultMarkerShape,
-                    hasAttitude: pos.qw != null,
+                    // See above: the shape follows the usable attitude.
+                    hasAttitude: sampleAttitude(pos) != null,
                   })}
                 />
               )}

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -8,6 +8,7 @@ import {
   entityPathToBodyId,
   getBodyRadius,
 } from "../bodies.js";
+import { type DirectionVectorOptions, resolveDirectionVectors } from "../directionVectors.js";
 import { displayPosition, displayRotation, resolveDisplayFrame } from "../displayFrame.js";
 import {
   computeSceneAmplification,
@@ -21,13 +22,18 @@ import { DEFAULT_FRAME, isLegacyEcef, type ReferenceFrame } from "../referenceFr
 import { getSatelliteModelConfig } from "../satelliteModels.js";
 import { type MarkerShape, resolveMarkerShape } from "../satelliteShapes.js";
 import { computeCameraUp, computeLvlhAxes, type LvlhAxes, SCENE_UP } from "../sceneFrame.js";
+import { defaultMarkerSize, resolveVisualSpan } from "../spacecraftScale.js";
 import type { TrailBufferLike } from "../utils/TrailBuffer.js";
 import { body_orientation, earth_rotation_angle } from "../wasm/arikaInit.js";
 import { CelestialBody } from "./CelestialBody.js";
+import { DirectionArrows } from "./DirectionArrows.js";
 import { OrbitTrail } from "./OrbitTrail.js";
 import { buildRenderEntries } from "./renderEntries.js";
 import { Satellite } from "./Satellite.js";
 import { AMBIENT_INTENSITY, SunLighting, useSunLighting } from "./SunLighting.js";
+
+/** The centred satellite sits exactly at the world origin. */
+const ORIGIN: [number, number, number] = [0, 0, 0];
 
 /** Color palette for multiple satellites. */
 const SATELLITE_COLORS = [0x00ff88, 0xff4488, 0x44aaff, 0xffaa44, 0xaa44ff];
@@ -341,6 +347,11 @@ export interface OrbitSceneContentsProps {
   controls?: boolean | Partial<OrbitControlsProps>;
   /** Render the reference axes helper. Default `true`. */
   axes?: boolean;
+  /**
+   * Reference-direction arrows to draw at the centred satellite. Omitted draws
+   * none; a central-body view draws none either way.
+   */
+  directionVectors?: DirectionVectorOptions;
 }
 
 /**
@@ -369,6 +380,7 @@ export function OrbitSceneContents({
   textureBaseUrl,
   controls = true,
   axes = true,
+  directionVectors,
 }: OrbitSceneContentsProps) {
   // Default camera package (controls + frame-aware rig). `false` opts out
   // entirely; an object enables it and is spread onto OrbitControls.
@@ -438,9 +450,13 @@ export function OrbitSceneContents({
     };
   }, [lvlhActive, cameraTracking, originPosition]);
 
-  // Determine sim time for sun direction from the first available satellite
-  // position. Iterate the Map's values directly rather than materializing an
-  // array every render just to find the first non-null entry.
+  // Sim time for the Sun direction and the body rotation. The centred satellite
+  // owns it when there is one: satellites carry their own times (a terminated one
+  // stays frozen), and the Sun drawn *at* the centred satellite has to be the Sun
+  // at that satellite's time, not at whichever time the Map happens to yield
+  // first. Falls back to the first available position for a central-body view.
+  // Iterate the Map's values directly rather than materializing an array every
+  // render just to find the first non-null entry.
   let firstPosition: OrbitPoint | null = null;
   if (satellitePositions) {
     for (const p of satellitePositions.values()) {
@@ -450,7 +466,8 @@ export function OrbitSceneContents({
       }
     }
   }
-  const simTime = firstPosition?.t ?? 0;
+  const centeredPosition = centeredSatId != null ? satellitePositions?.get(centeredSatId) : null;
+  const simTime = centeredPosition?.t ?? firstPosition?.t ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 
   // Earth rotation angle (ERA) via WASM — updates every frame via simTime (not quantized)
@@ -469,7 +486,7 @@ export function OrbitSceneContents({
 
   // Sun direction + intensity (display frame). Shared by the lights and by the
   // lit bodies below, so the scene holds them and passes them down explicitly.
-  const { sunDirection, sunIntensity, lightPosition } = useSunLighting({
+  const { sunDirection, sunDirectionEci, sunIntensity, lightPosition } = useSunLighting({
     centralBody,
     epochJd,
     quantizedSimTime,
@@ -602,24 +619,49 @@ export function OrbitSceneContents({
               </group>
             );
           }
+          const shape = resolveMarkerShape({
+            override: satelliteShapes?.get(centeredSatId),
+            simShape: satelliteSimShapes?.get(centeredSatId),
+            globalDefault: defaultMarkerShape,
+            hasAttitude: pos.qw != null,
+          });
+          const satName = satelliteNames?.get(centeredSatId);
+          // The centred satellite is drawn exactly at the world origin, so the
+          // arrows start there too. Its display frame is the scene's: a satellite
+          // centre is never body-fixed, so the scene-level ERA plays no part.
+          const arrows = resolveDirectionVectors({
+            frame: sceneDisplayFrame,
+            sunEci: epochJd != null ? sunDirectionEci : null,
+            positionEci: originPosition,
+            options: directionVectors,
+          });
+          const visualSpan = resolveVisualSpan({
+            modelConfig: getSatelliteModelConfig(centeredSatId, satName),
+            markerSize: defaultMarkerSize(shape),
+          });
           return (
-            <Satellite
-              position={pos}
-              scaleRadius={centralBodyRadius}
-              color={color}
-              referenceFrame={referenceFrame}
-              epochJd={epochJd ?? undefined}
-              satId={centeredSatId}
-              satName={satelliteNames?.get(centeredSatId)}
-              originPosition={originPosition}
-              lvlhAxes={lvlhAxes}
-              markerShape={resolveMarkerShape({
-                override: satelliteShapes?.get(centeredSatId),
-                simShape: satelliteSimShapes?.get(centeredSatId),
-                globalDefault: defaultMarkerShape,
-                hasAttitude: pos.qw != null,
-              })}
-            />
+            <>
+              <Satellite
+                position={pos}
+                scaleRadius={centralBodyRadius}
+                color={color}
+                referenceFrame={referenceFrame}
+                epochJd={epochJd ?? undefined}
+                satId={centeredSatId}
+                satName={satName}
+                originPosition={originPosition}
+                lvlhAxes={lvlhAxes}
+                markerShape={shape}
+              />
+              {directionVectors != null && (
+                <DirectionArrows
+                  position={ORIGIN}
+                  vectors={arrows}
+                  visualSpan={visualSpan}
+                  debugId={centeredSatId}
+                />
+              )}
+            </>
           );
         })()}
 

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -28,6 +28,7 @@ import {
   modelBoundingRadius,
   resolveVisualSpan,
 } from "../spacecraftScale.js";
+import { finiteOrNull } from "../utils/finite.js";
 import type { TrailBufferLike } from "../utils/TrailBuffer.js";
 import { body_orientation, earth_rotation_angle } from "../wasm/arikaInit.js";
 import { CelestialBody } from "./CelestialBody.js";
@@ -472,7 +473,11 @@ export function OrbitSceneContents({
     }
   }
   const centeredPosition = centeredSatId != null ? satellitePositions?.get(centeredSatId) : null;
-  const simTime = centeredPosition?.t ?? firstPosition?.t ?? 0;
+  // The first *finite* time, not the first present one: `??` falls through on
+  // null and undefined, so a NaN `t` on the centred satellite would win over a
+  // usable fallback and reach the Earth rotation angle and the quantised Sun
+  // time below, both of which are WASM calls.
+  const simTime = finiteOrNull(centeredPosition?.t) ?? finiteOrNull(firstPosition?.t) ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 
   // Earth rotation angle (ERA) via WASM — updates every frame via simTime (not quantized)

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -692,11 +692,15 @@ export function OrbitSceneContents({
           // centre is never body-fixed, so the scene-level ERA plays no part.
           //
           // Nothing is drawn at all unless the frame found an origin for this
-          // spacecraft. `resolveSceneFrame` leaves that null for a position it
-          // cannot use — zero, or non-finite from a source — and the marker is
-          // then absent too, so an arrow would be pointing out the Sun beside a
-          // spacecraft that is not on screen. Nadir already needs the position;
-          // the Sun does not, which is why it has to be said here.
+          // spacecraft. `resolveSceneFrame` leaves that null for a non-finite
+          // position, and the marker is then absent too, so an arrow would be
+          // pointing out the Sun beside a spacecraft that is not on screen. Nadir
+          // already needs the position; the Sun does not, which is why it has to
+          // be said here.
+          //
+          // A finite position is placeable, the coordinate origin included: the
+          // spacecraft is drawn there and the Sun with it, and nadir alone drops
+          // out for want of a bearing.
           const arrows =
             originPosition == null
               ? []

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -476,17 +476,19 @@ export function OrbitSceneContents({
     };
   }, [lvlhActive, cameraTracking, originPosition]);
 
-  // Sim time for the Sun direction and the body rotation. The centred satellite
-  // owns it when there is one: satellites carry their own times (a terminated one
-  // stays frozen), and the Sun drawn *at* the centred satellite has to be the Sun
-  // at that satellite's time, not at whichever time the Map happens to yield
-  // first. Falls back to the first available position for a central-body view.
+  // The epoch the Sun direction and the body rotation are evaluated at.
+  //
+  // The centred satellite owns it when there is one: satellites carry their own
+  // times (a terminated one stays frozen), and the Sun drawn *at* that satellite
+  // has to be the Sun at its time. With no satellite centred the epoch is the
+  // scene's own `time`, which is what it is documented to be — reading whichever
+  // satellite the position Map yielded first is the behaviour this replaced.
+  //
+  // Each candidate goes through a finite check because `??` falls through only on
+  // null and undefined: a NaN `t` on the centred satellite would otherwise win
+  // over the scene's time and reach the Earth rotation angle and the quantised
+  // Sun time below, both of which are WASM calls.
   const centeredPosition = centeredSatId != null ? satellitePositions?.get(centeredSatId) : null;
-  // The centred satellite's own time, else the scene's. Each candidate goes
-  // through a finite check because `??` falls through only on null and undefined:
-  // a NaN `t` on the centred satellite would otherwise win over the scene's time
-  // and reach the Earth rotation angle and the quantised Sun time below, both of
-  // which are WASM calls.
   const simTime = finiteOrNull(centeredPosition?.t) ?? finiteOrNull(time) ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -461,15 +461,15 @@ export function OrbitSceneContents({
   // stays frozen), and the Sun drawn *at* the centred satellite has to be the Sun
   // at that satellite's time, not at whichever time the Map happens to yield
   // first. Falls back to the first available position for a central-body view.
-  // The Map's values are iterated directly rather than materialized into an array
-  // every render just to find one entry.
-  const fallbackTime = firstFiniteTime(satellitePositions?.values());
   const centeredPosition = centeredSatId != null ? satellitePositions?.get(centeredSatId) : null;
   // Each candidate goes through a finite check, because `??` falls through only
   // on null and undefined: a NaN `t` on the centred satellite would otherwise win
   // over a usable fallback and reach the Earth rotation angle and the quantised
-  // Sun time below, both of which are WASM calls.
-  const simTime = finiteOrNull(centeredPosition?.t) ?? fallbackTime ?? 0;
+  // Sun time below, both of which are WASM calls. The same `??` keeps the search
+  // for a fallback from running at all while the centred satellite has a time,
+  // which is every frame of a satellite-centred view.
+  const simTime =
+    finiteOrNull(centeredPosition?.t) ?? firstFiniteTime(satellitePositions?.values()) ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 
   // Earth rotation angle (ERA) via WASM — updates every frame via simTime (not quantized)

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -486,14 +486,13 @@ export function OrbitSceneContents({
 
   // Sun direction + intensity (display frame). Shared by the lights and by the
   // lit bodies below, so the scene holds them and passes them down explicitly.
-  const { sunDirection, sunDirectionEci, sunDirectionIsComputed, sunIntensity, lightPosition } =
-    useSunLighting({
-      centralBody,
-      epochJd,
-      quantizedSimTime,
-      displayFrame: sceneDisplayFrame,
-      sceneAmplification,
-    });
+  const { sunDirection, sunDirectionIsComputed, sunIntensity, lightPosition } = useSunLighting({
+    centralBody,
+    epochJd,
+    quantizedSimTime,
+    displayFrame: sceneDisplayFrame,
+    sceneAmplification,
+  });
 
   // Earth rotation angle for the mesh: ERA in ECI, 0 in ECEF (Earth is static)
   const earthRotation = isEcef ? 0 : era;
@@ -632,10 +631,14 @@ export function OrbitSceneContents({
           // centre is never body-fixed, so the scene-level ERA plays no part.
           const arrows = resolveDirectionVectors({
             frame: sceneDisplayFrame,
-            // The hook falls back to a fixed direction when it cannot compute
-            // one — no epoch, or a central body arika cannot place. Fine for the
+            // The direction the lights are placed along, reused rather than
+            // computed again, so the arrow and the lighting cannot disagree. The
+            // hook falls back to a fixed direction when it cannot compute one —
+            // no epoch, or a central body arika cannot place. Fine for the
             // lights; an arrow drawn from it would claim to be a measurement.
-            sunEci: sunDirectionIsComputed ? sunDirectionEci : null,
+            sunDisplay: sunDirectionIsComputed
+              ? [sunDirection.x, sunDirection.y, sunDirection.z]
+              : null,
             positionEci: originPosition,
             // Here this prop is an *enable* list: the orbit view draws no arrows
             // unless asked, so an option left out means off. `resolveDirectionVectors`

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -486,13 +486,14 @@ export function OrbitSceneContents({
 
   // Sun direction + intensity (display frame). Shared by the lights and by the
   // lit bodies below, so the scene holds them and passes them down explicitly.
-  const { sunDirection, sunDirectionEci, sunIntensity, lightPosition } = useSunLighting({
-    centralBody,
-    epochJd,
-    quantizedSimTime,
-    displayFrame: sceneDisplayFrame,
-    sceneAmplification,
-  });
+  const { sunDirection, sunDirectionEci, sunDirectionIsComputed, sunIntensity, lightPosition } =
+    useSunLighting({
+      centralBody,
+      epochJd,
+      quantizedSimTime,
+      displayFrame: sceneDisplayFrame,
+      sceneAmplification,
+    });
 
   // Earth rotation angle for the mesh: ERA in ECI, 0 in ECEF (Earth is static)
   const earthRotation = isEcef ? 0 : era;
@@ -631,9 +632,18 @@ export function OrbitSceneContents({
           // centre is never body-fixed, so the scene-level ERA plays no part.
           const arrows = resolveDirectionVectors({
             frame: sceneDisplayFrame,
-            sunEci: epochJd != null ? sunDirectionEci : null,
+            // The hook falls back to a fixed direction when it cannot compute
+            // one — no epoch, or a central body arika cannot place. Fine for the
+            // lights; an arrow drawn from it would claim to be a measurement.
+            sunEci: sunDirectionIsComputed ? sunDirectionEci : null,
             positionEci: originPosition,
-            options: directionVectors,
+            // Here this prop is an *enable* list: the orbit view draws no arrows
+            // unless asked, so an option left out means off. `resolveDirectionVectors`
+            // reads a missing field as on, which is the attitude view's default.
+            options: {
+              sun: directionVectors?.sun === true,
+              nadir: directionVectors?.nadir === true,
+            },
           });
           const centredModel = getSatelliteModelConfig(centeredSatId, satName);
           const visualSpan = resolveVisualSpan({
@@ -654,7 +664,7 @@ export function OrbitSceneContents({
                 lvlhAxes={lvlhAxes}
                 markerShape={shape}
               />
-              {directionVectors != null && (
+              {arrows.length > 0 && (
                 <DirectionArrows
                   position={ORIGIN}
                   vectors={arrows}

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -22,7 +22,7 @@ import { DEFAULT_FRAME, isLegacyEcef, type ReferenceFrame } from "../referenceFr
 import { getSatelliteModelConfig } from "../satelliteModels.js";
 import { type MarkerShape, resolveMarkerShape } from "../satelliteShapes.js";
 import { computeCameraUp, computeLvlhAxes, type LvlhAxes, SCENE_UP } from "../sceneFrame.js";
-import { defaultMarkerSize, resolveVisualSpan } from "../spacecraftScale.js";
+import { defaultMarkerSize, markerBoundingRadius, resolveVisualSpan } from "../spacecraftScale.js";
 import type { TrailBufferLike } from "../utils/TrailBuffer.js";
 import { body_orientation, earth_rotation_angle } from "../wasm/arikaInit.js";
 import { CelestialBody } from "./CelestialBody.js";
@@ -635,8 +635,9 @@ export function OrbitSceneContents({
             positionEci: originPosition,
             options: directionVectors,
           });
+          const centredModel = getSatelliteModelConfig(centeredSatId, satName);
           const visualSpan = resolveVisualSpan({
-            modelConfig: getSatelliteModelConfig(centeredSatId, satName),
+            modelConfig: centredModel,
             markerSize: defaultMarkerSize(shape),
           });
           return (
@@ -658,6 +659,9 @@ export function OrbitSceneContents({
                   position={ORIGIN}
                   vectors={arrows}
                   visualSpan={visualSpan}
+                  // A cube marker's corners stand further out than its faces; the
+                  // arrows start outside whichever shape is actually drawn.
+                  startRadius={markerBoundingRadius(centredModel ? null : shape, visualSpan)}
                   debugId={centeredSatId}
                 />
               )}

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -22,7 +22,12 @@ import { DEFAULT_FRAME, isLegacyEcef, type ReferenceFrame } from "../referenceFr
 import { getSatelliteModelConfig } from "../satelliteModels.js";
 import { type MarkerShape, resolveMarkerShape } from "../satelliteShapes.js";
 import { computeCameraUp, computeLvlhAxes, type LvlhAxes, SCENE_UP } from "../sceneFrame.js";
-import { defaultMarkerSize, markerBoundingRadius, resolveVisualSpan } from "../spacecraftScale.js";
+import {
+  defaultMarkerSize,
+  markerBoundingRadius,
+  modelBoundingRadius,
+  resolveVisualSpan,
+} from "../spacecraftScale.js";
 import type { TrailBufferLike } from "../utils/TrailBuffer.js";
 import { body_orientation, earth_rotation_angle } from "../wasm/arikaInit.js";
 import { CelestialBody } from "./CelestialBody.js";
@@ -672,9 +677,16 @@ export function OrbitSceneContents({
                   position={ORIGIN}
                   vectors={arrows}
                   visualSpan={visualSpan}
-                  // A cube marker's corners stand further out than its faces; the
-                  // arrows start outside whichever shape is actually drawn.
-                  startRadius={markerBoundingRadius(centredModel ? null : shape, visualSpan)}
+                  // Outside whatever is actually drawn: a cube marker's corners
+                  // stand further out than its faces, and a model is bounded by
+                  // the envelope of the cube its largest extent fits in. The
+                  // sphere's radius would leave the tail inside a model, which
+                  // reaches past half its span on a diagonal.
+                  startRadius={
+                    centredModel
+                      ? modelBoundingRadius(visualSpan)
+                      : markerBoundingRadius(shape, visualSpan)
+                  }
                   debugId={centeredSatId}
                 />
               )}

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -10,6 +10,7 @@ import {
 } from "../bodies.js";
 import { type DirectionVectorOptions, resolveDirectionVectors } from "../directionVectors.js";
 import {
+  attitudeWasRefused,
   displayPosition,
   displayRotation,
   resolveDisplayFrame,
@@ -442,15 +443,41 @@ export function OrbitSceneContents({
     return (bodyRadiusKm / centralBodyRadius) * 3;
   }, [centeredBodyId, centralBodyRadius, bodyDefinitions]);
 
+  // Whether the centred satellite's own sample claimed an orientation that could
+  // not be used. Read here as well as where the spacecraft is drawn, because the
+  // environment's scale depends on which of the model and the marker is on
+  // screen. A boolean, so the memo below re-runs when the answer changes rather
+  // than on every sample.
+  const centredAttitudeRefused =
+    isSatCentered && centeredSatId != null
+      ? (() => {
+          const sample = satellitePositions?.get(centeredSatId);
+          return sample != null && attitudeWasRefused(sample);
+        })()
+      : false;
+
   // Scene amplification: scale up environment to show correct proportions
   // relative to the satellite's exaggerated model at origin.
   const sceneAmplification = useMemo(() => {
     if (!isSatCentered || centeredSatId == null) return 1;
     // Body entities (Moon, Sun, etc.) don't need satellite amplification
     if (centeredBodyId != null) return 1;
-    const modelConfig = getSatelliteModelConfig(centeredSatId, satelliteNames?.get(centeredSatId));
+    // Sized for what is drawn: a refused attitude leaves the marker standing in,
+    // and `computeSceneAmplification` amplifies by the marker's ratio rather than
+    // the model's. Amplifying for an absent model puts Earth and the trails at
+    // proportions belonging to a spacecraft that is not on screen.
+    const modelConfig = centredAttitudeRefused
+      ? null
+      : getSatelliteModelConfig(centeredSatId, satelliteNames?.get(centeredSatId));
     return computeSceneAmplification(modelConfig, centralBodyRadius);
-  }, [isSatCentered, centeredSatId, centeredBodyId, satelliteNames, centralBodyRadius]);
+  }, [
+    isSatCentered,
+    centeredSatId,
+    centeredBodyId,
+    satelliteNames,
+    centralBodyRadius,
+    centredAttitudeRefused,
+  ]);
 
   // Effective scale radius: smaller when amplified, so positions appear larger
   const effectiveScaleRadius = centralBodyRadius / sceneAmplification;
@@ -647,9 +674,8 @@ export function OrbitSceneContents({
               </group>
             );
           }
-          // The sample's attitude decides two things here: which marker stands
-          // in for it, and whether its registered model is drawn at all.
-          const attitudeRefused = pos.qw != null && sampleAttitude(pos) == null;
+          // Resolved above, where the environment's scale reads it too.
+          const attitudeRefused = centredAttitudeRefused;
           const shape = resolveMarkerShape({
             override: satelliteShapes?.get(centeredSatId),
             simShape: satelliteSimShapes?.get(centeredSatId),
@@ -823,7 +849,7 @@ export function OrbitSceneContents({
                     // See above: the shape follows the usable attitude, and a
                     // refused one takes the sphere whatever was requested.
                     hasAttitude: sampleAttitude(pos) != null,
-                    attitudeRefused: pos.qw != null && sampleAttitude(pos) == null,
+                    attitudeRefused: attitudeWasRefused(pos),
                   })}
                 />
               )}

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -28,7 +28,7 @@ import {
   modelBoundingRadius,
   resolveVisualSpan,
 } from "../spacecraftScale.js";
-import { finiteOrNull, firstFiniteTime } from "../utils/finite.js";
+import { finiteOrNull } from "../utils/finite.js";
 import type { TrailBufferLike } from "../utils/TrailBuffer.js";
 import { body_orientation, earth_rotation_angle } from "../wasm/arikaInit.js";
 import { CelestialBody } from "./CelestialBody.js";
@@ -325,6 +325,15 @@ export interface OrbitSceneContentsProps {
   trailBuffers?: Map<string, TrailBufferLike>;
   /** Per-satellite positions. */
   satellitePositions?: Map<string, OrbitPoint | null>;
+  /**
+   * The scene's elapsed seconds since the epoch — `OrbitSceneDataProps.time`.
+   *
+   * The epoch the scene itself is drawn at: the lighting, the central body's
+   * rotation, and any entity whose own sample carries no usable time. A centred
+   * satellite overrides it for its own view, because the Sun drawn *at* that
+   * satellite has to be the Sun at that satellite's time.
+   */
+  time?: number;
   /** Per-satellite visible counts (when not live). */
   trailVisibleCounts?: Map<string, number>;
   /** Per-satellite draw start indices for time-range clipping. */
@@ -379,6 +388,7 @@ export interface OrbitSceneContentsProps {
 export function OrbitSceneContents({
   trailBuffers,
   satellitePositions,
+  time = 0,
   trailVisibleCounts,
   trailDrawStarts,
   centralBody,
@@ -472,14 +482,12 @@ export function OrbitSceneContents({
   // at that satellite's time, not at whichever time the Map happens to yield
   // first. Falls back to the first available position for a central-body view.
   const centeredPosition = centeredSatId != null ? satellitePositions?.get(centeredSatId) : null;
-  // Each candidate goes through a finite check, because `??` falls through only
-  // on null and undefined: a NaN `t` on the centred satellite would otherwise win
-  // over a usable fallback and reach the Earth rotation angle and the quantised
-  // Sun time below, both of which are WASM calls. The same `??` keeps the search
-  // for a fallback from running at all while the centred satellite has a time,
-  // which is every frame of a satellite-centred view.
-  const simTime =
-    finiteOrNull(centeredPosition?.t) ?? firstFiniteTime(satellitePositions?.values()) ?? 0;
+  // The centred satellite's own time, else the scene's. Each candidate goes
+  // through a finite check because `??` falls through only on null and undefined:
+  // a NaN `t` on the centred satellite would otherwise win over the scene's time
+  // and reach the Earth rotation angle and the quantised Sun time below, both of
+  // which are WASM calls.
+  const simTime = finiteOrNull(centeredPosition?.t) ?? finiteOrNull(time) ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 
   // Earth rotation angle (ERA) via WASM — updates every frame via simTime (not quantized)

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -652,25 +652,37 @@ export function OrbitSceneContents({
           // The centred satellite is drawn exactly at the world origin, so the
           // arrows start there too. Its display frame is the scene's: a satellite
           // centre is never body-fixed, so the scene-level ERA plays no part.
-          const arrows = resolveDirectionVectors({
-            frame: sceneDisplayFrame,
-            // The direction the lights are placed along, reused rather than
-            // computed again, so the arrow and the lighting cannot disagree. The
-            // hook falls back to a fixed direction when it cannot compute one —
-            // no epoch, or a central body arika cannot place. Fine for the
-            // lights; an arrow drawn from it would claim to be a measurement.
-            sunDisplay: sunDirectionIsComputed
-              ? [sunDirection.x, sunDirection.y, sunDirection.z]
-              : null,
-            positionEci: originPosition,
-            // Here this prop is an *enable* list: the orbit view draws no arrows
-            // unless asked, so an option left out means off. `resolveDirectionVectors`
-            // reads a missing field as on, which is the attitude view's default.
-            options: {
-              sun: directionVectors?.sun === true,
-              nadir: directionVectors?.nadir === true,
-            },
-          });
+          //
+          // Nothing is drawn at all unless the frame found an origin for this
+          // spacecraft. `resolveSceneFrame` leaves that null for a position it
+          // cannot use — zero, or non-finite from a source — and the marker is
+          // then absent too, so an arrow would be pointing out the Sun beside a
+          // spacecraft that is not on screen. Nadir already needs the position;
+          // the Sun does not, which is why it has to be said here.
+          const arrows =
+            originPosition == null
+              ? []
+              : resolveDirectionVectors({
+                  frame: sceneDisplayFrame,
+                  // The direction the lights are placed along, reused rather than
+                  // computed again, so the arrow and the lighting cannot
+                  // disagree. The hook falls back to a fixed direction when it
+                  // cannot compute one — no epoch, or a central body arika cannot
+                  // place. Fine for the lights; an arrow drawn from it would
+                  // claim to be a measurement.
+                  sunDisplay: sunDirectionIsComputed
+                    ? [sunDirection.x, sunDirection.y, sunDirection.z]
+                    : null,
+                  positionEci: originPosition,
+                  // Here this prop is an *enable* list: the orbit view draws no
+                  // arrows unless asked, so an option left out means off.
+                  // `resolveDirectionVectors` reads a missing field as on, which
+                  // is the attitude view's default.
+                  options: {
+                    sun: directionVectors?.sun === true,
+                    nadir: directionVectors?.nadir === true,
+                  },
+                });
           const centredModel = getSatelliteModelConfig(centeredSatId, satName);
           const visualSpan = resolveVisualSpan({
             modelConfig: centredModel,

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -252,6 +252,7 @@ function SecondaryBody({
   sunDirection,
   referenceFrame = DEFAULT_FRAME,
   epochJd,
+  sceneTime,
   originPosition = null,
   lvlhAxes = null,
   textureRevision,
@@ -264,6 +265,8 @@ function SecondaryBody({
   sunDirection?: THREE.Vector3;
   referenceFrame?: ReferenceFrame;
   epochJd?: number | null;
+  /** The scene's elapsed time, used when this body's sample carries none. */
+  sceneTime?: number;
   originPosition?: [number, number, number] | null;
   lvlhAxes?: LvlhAxes | null;
   textureRevision?: number | string;
@@ -273,11 +276,16 @@ function SecondaryBody({
   const bodyRadiusKm = getBodyRadius(bodyId, bodyDefinitions);
   const radius = bodyRadiusKm != null ? bodyRadiusKm / scaleRadius : 0.01;
 
+  // This body's own sample time when it has one, else the scene's — the same rule
+  // the satellites follow, so one bad sample cannot leave this body in a basis of
+  // its own.
+  const sampleTime = finiteOrNull(position.t) ?? finiteOrNull(sceneTime) ?? 0;
+
   // Position and orientation share one display frame (see displayFrame.ts), so
   // the mesh can never be placed in one basis and oriented in another.
   const era =
     isLegacyEcef(referenceFrame) && epochJd != null
-      ? earth_rotation_angle(epochJd, position.t)
+      ? earth_rotation_angle(epochJd, sampleTime)
       : null;
   const frame = resolveDisplayFrame(referenceFrame, { era, originPosition, lvlhAxes });
   const scenePos = displayPosition(frame, position.x, position.y, position.z, scaleRadius);
@@ -285,18 +293,16 @@ function SecondaryBody({
   // Body-fixed → inertial orientation via the IAU rotation model (arika WASM),
   // including the Three.js +Y-pole → IAU +Z-pole alignment.
   const bodyToInertial = useMemo(() => {
-    const sampleTime = finiteOrNull(position.t);
-    // A `NaN` sample time would come back as a quaternion of NaNs, and the group
-    // carrying it renders nothing at all. Without a time this body is drawn
-    // unrotated, which is what a missing epoch already gives.
-    if (epochJd == null || sampleTime == null) return undefined;
+    // The same time the position used. A `NaN` would come back as a quaternion of
+    // NaNs, and the group carrying it renders nothing at all.
+    if (epochJd == null) return undefined;
     const q = body_orientation(bodyId, epochJd, sampleTime);
     if (!q) return undefined;
     // IAU body-fixed → ECI: q = [w, x, y, z]; THREE uses (x, y, z, w)
     const iauQuat = new THREE.Quaternion(q[1], q[2], q[3], q[0]);
     const poleAlign = new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0));
     return iauQuat.multiply(poleAlign);
-  }, [bodyId, epochJd, position.t]);
+  }, [bodyId, epochJd, sampleTime]);
 
   const orientation = bodyToInertial ? displayRotation(frame).multiply(bodyToInertial) : undefined;
 
@@ -605,11 +611,9 @@ export function OrbitSceneContents({
             // Render as CelestialBody at origin with physical radius + IAU orientation
             const bodyRadiusKm = getBodyRadius(centeredBodyId, bodyDefinitions);
             const bodyRadius = bodyRadiusKm != null ? bodyRadiusKm / centralBodyRadius : 0.01;
-            const centredTime = finiteOrNull(pos.t);
+            const centredTime = finiteOrNull(pos.t) ?? simTime;
             const q =
-              epochJd != null && centredTime != null
-                ? body_orientation(centeredBodyId, epochJd, centredTime)
-                : undefined;
+              epochJd != null ? body_orientation(centeredBodyId, epochJd, centredTime) : undefined;
             const iauQuat = q
               ? new THREE.Quaternion(q[1], q[2], q[3], q[0]).multiply(
                   new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0)),
@@ -670,6 +674,7 @@ export function OrbitSceneContents({
                 color={color}
                 referenceFrame={referenceFrame}
                 epochJd={epochJd ?? undefined}
+                sceneTime={simTime}
                 satId={centeredSatId}
                 satName={satName}
                 originPosition={originPosition}
@@ -751,6 +756,7 @@ export function OrbitSceneContents({
                   sunDirection={sunDirection}
                   referenceFrame={referenceFrame}
                   epochJd={epochJd}
+                  sceneTime={simTime}
                   originPosition={lvlhActive ? originPosition : null}
                   lvlhAxes={lvlhActive ? lvlhAxes : null}
                   textureRevision={textureRevision}
@@ -765,6 +771,7 @@ export function OrbitSceneContents({
                   color={color}
                   referenceFrame={referenceFrame}
                   epochJd={epochJd ?? undefined}
+                  sceneTime={simTime}
                   satId={satId}
                   satName={satelliteNames?.get(satId)}
                   originPosition={lvlhActive ? originPosition : null}

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -334,10 +334,17 @@ export interface OrbitSceneContentsProps {
   /**
    * The scene's elapsed seconds since the epoch — `OrbitSceneDataProps.time`.
    *
-   * The epoch the scene itself is drawn at: the lighting, the central body's
-   * rotation, and any entity whose own sample carries no usable time. A centred
-   * satellite overrides it for its own view, because the Sun drawn *at* that
-   * satellite has to be the Sun at that satellite's time.
+   * Where the view has no instant of its own, this is it: the lighting, the
+   * central body's rotation, and any entity whose own sample carries no usable
+   * time are all drawn here.
+   *
+   * Centring on a satellite gives the view an instant of its own — that
+   * satellite's timestamp — and everything without a time of its own follows it
+   * rather than this, including a secondary body whose sample time is unusable.
+   * The alternative reads better in isolation and worse on screen: the Sun would
+   * be placed at the centred satellite's instant while the Moon beside it was
+   * oriented for the scene's, so one view would show two moments. One instant per
+   * view is the rule, and a sample that names its own time still wins over both.
    */
   time?: number;
   /** Per-satellite visible counts (when not live). */
@@ -521,6 +528,9 @@ export function OrbitSceneContents({
   // over the scene's time and reach the Earth rotation angle and the quantised
   // Sun time below, both of which are WASM calls.
   const centeredPosition = centeredSatId != null ? satellitePositions?.get(centeredSatId) : null;
+  // The instant this view depicts, which every entity without a usable time of
+  // its own is drawn at — see the `time` prop for why they follow the centred
+  // satellite rather than the scene's declared time.
   const simTime = finiteOrNull(centeredPosition?.t) ?? finiteOrNull(time) ?? 0;
   const quantizedSimTime = Math.floor(simTime / 60) * 60;
 

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -285,8 +285,12 @@ function SecondaryBody({
   // Body-fixed → inertial orientation via the IAU rotation model (arika WASM),
   // including the Three.js +Y-pole → IAU +Z-pole alignment.
   const bodyToInertial = useMemo(() => {
-    if (epochJd == null) return undefined;
-    const q = body_orientation(bodyId, epochJd, position.t);
+    const sampleTime = finiteOrNull(position.t);
+    // A `NaN` sample time would come back as a quaternion of NaNs, and the group
+    // carrying it renders nothing at all. Without a time this body is drawn
+    // unrotated, which is what a missing epoch already gives.
+    if (epochJd == null || sampleTime == null) return undefined;
+    const q = body_orientation(bodyId, epochJd, sampleTime);
     if (!q) return undefined;
     // IAU body-fixed → ECI: q = [w, x, y, z]; THREE uses (x, y, z, w)
     const iauQuat = new THREE.Quaternion(q[1], q[2], q[3], q[0]);
@@ -601,8 +605,11 @@ export function OrbitSceneContents({
             // Render as CelestialBody at origin with physical radius + IAU orientation
             const bodyRadiusKm = getBodyRadius(centeredBodyId, bodyDefinitions);
             const bodyRadius = bodyRadiusKm != null ? bodyRadiusKm / centralBodyRadius : 0.01;
+            const centredTime = finiteOrNull(pos.t);
             const q =
-              epochJd != null ? body_orientation(centeredBodyId, epochJd, pos.t) : undefined;
+              epochJd != null && centredTime != null
+                ? body_orientation(centeredBodyId, epochJd, centredTime)
+                : undefined;
             const iauQuat = q
               ? new THREE.Quaternion(q[1], q[2], q[3], q[0]).multiply(
                   new THREE.Quaternion().setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0)),

--- a/viewer/src/components/OrbitSceneContents.tsx
+++ b/viewer/src/components/OrbitSceneContents.tsx
@@ -647,10 +647,14 @@ export function OrbitSceneContents({
               </group>
             );
           }
+          // The sample's attitude decides two things here: which marker stands
+          // in for it, and whether its registered model is drawn at all.
+          const attitudeRefused = pos.qw != null && sampleAttitude(pos) == null;
           const shape = resolveMarkerShape({
             override: satelliteShapes?.get(centeredSatId),
             simShape: satelliteSimShapes?.get(centeredSatId),
             globalDefault: defaultMarkerShape,
+            attitudeRefused,
             // The same judgement the rotation makes: a sample whose quaternion
             // names no rotation gets the sphere, not the cube that would show an
             // orientation nobody measured.
@@ -691,7 +695,13 @@ export function OrbitSceneContents({
                     nadir: directionVectors?.nadir === true,
                   },
                 });
-          const centredModel = getSatelliteModelConfig(centeredSatId, satName);
+          // Not asked for when the attitude was refused: `Satellite` draws the
+          // marker instead in that case, and arrows sized from a model that is
+          // not there float outside the sphere that is — for a spacecraft the
+          // size of the ISS, well outside it.
+          const centredModel = attitudeRefused
+            ? null
+            : getSatelliteModelConfig(centeredSatId, satName);
           const visualSpan = resolveVisualSpan({
             modelConfig: centredModel,
             markerSize: defaultMarkerSize(shape),
@@ -810,8 +820,10 @@ export function OrbitSceneContents({
                     override: satelliteShapes?.get(satId),
                     simShape: satelliteSimShapes?.get(satId),
                     globalDefault: defaultMarkerShape,
-                    // See above: the shape follows the usable attitude.
+                    // See above: the shape follows the usable attitude, and a
+                    // refused one takes the sphere whatever was requested.
                     hasAttitude: sampleAttitude(pos) != null,
+                    attitudeRefused: pos.qw != null && sampleAttitude(pos) == null,
                   })}
                 />
               )}

--- a/viewer/src/components/PrimitiveMarker.tsx
+++ b/viewer/src/components/PrimitiveMarker.tsx
@@ -15,7 +15,11 @@ interface PrimitiveMarkerProps {
   size?: number;
 }
 
-/** Default half-extent, matching the legacy sphere marker's footprint. */
+/**
+ * Default half-extent. Larger than the sphere marker's radius: a cube read at an
+ * angle presents less silhouette than a sphere of the same radius, so matching
+ * radii would make the orientation cube look like the smaller marker.
+ */
 const DEFAULT_SIZE = DEFAULT_CUBE_HALF_EXTENT;
 
 /**

--- a/viewer/src/components/PrimitiveMarker.tsx
+++ b/viewer/src/components/PrimitiveMarker.tsx
@@ -47,9 +47,17 @@ export function PrimitiveMarker({
   // Apply the body-to-display quaternion imperatively (Hamilton [w,x,y,z] →
   // Three.js (x,y,z,w)), matching SatelliteModel.tsx / BodyAxes.tsx.
   useEffect(() => {
-    if (groupRef.current && quaternion) {
+    if (!groupRef.current) return;
+    if (quaternion) {
       const [w, x, y, z] = quaternion;
       groupRef.current.quaternion.set(x, y, z, w);
+    } else {
+      // A stream can stop carrying a usable attitude — a sample whose quaternion
+      // names no rotation, or none at all after one that did. Leaving the group
+      // where the last good sample put it would show that orientation as the
+      // current one, so it goes back to unrotated, which is what "no attitude"
+      // draws from the start.
+      groupRef.current.quaternion.identity();
     }
   }, [quaternion]);
 

--- a/viewer/src/components/PrimitiveMarker.tsx
+++ b/viewer/src/components/PrimitiveMarker.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import type * as THREE from "three";
+import { DEFAULT_CUBE_HALF_EXTENT } from "../spacecraftScale.js";
 
 interface PrimitiveMarkerProps {
   /** Position in scene units (already divided by scaleRadius). */
@@ -15,7 +16,7 @@ interface PrimitiveMarkerProps {
 }
 
 /** Default half-extent, matching the legacy sphere marker's footprint. */
-const DEFAULT_SIZE = 0.008;
+const DEFAULT_SIZE = DEFAULT_CUBE_HALF_EXTENT;
 
 /**
  * Per-face colors of the XYZ orientation cube, in Three.js BoxGeometry face order

--- a/viewer/src/components/Satellite.tsx
+++ b/viewer/src/components/Satellite.tsx
@@ -107,7 +107,7 @@ export function Satellite({
     <SpacecraftVisual
       position={scenePos}
       quaternion={displayQuaternion(frame, rawQuaternion)}
-      model={!attitudeRefused}
+      attitudeRefused={attitudeRefused}
       satId={satId}
       satName={satName}
       color={color}

--- a/viewer/src/components/Satellite.tsx
+++ b/viewer/src/components/Satellite.tsx
@@ -3,7 +3,7 @@ import {
   displayQuaternion,
   type Quat,
   resolveDisplayFrame,
-  unitAttitude,
+  sampleAttitude,
 } from "../displayFrame.js";
 import type { OrbitPoint } from "../orbit.js";
 import { isLegacyEcef, type ReferenceFrame } from "../referenceFrame.js";
@@ -95,11 +95,7 @@ export function Satellite({
   // back as the identity, so the scene would report an orientation nobody
   // measured. What cannot be normalised is reported as no attitude, which draws
   // the marker unrotated — the answer a satellite without attitude already gets.
-  const rawQuaternion: Quat | undefined = unitAttitude(
-    position.qw != null
-      ? [position.qw, position.qx ?? 0, position.qy ?? 0, position.qz ?? 0]
-      : undefined,
-  );
+  const rawQuaternion: Quat | undefined = sampleAttitude(position);
 
   return (
     <SpacecraftVisual

--- a/viewer/src/components/Satellite.tsx
+++ b/viewer/src/components/Satellite.tsx
@@ -8,6 +8,7 @@ import type { OrbitPoint } from "../orbit.js";
 import { isLegacyEcef, type ReferenceFrame } from "../referenceFrame.js";
 import type { MarkerShape } from "../satelliteShapes.js";
 import type { LvlhAxes } from "../sceneFrame.js";
+import { finiteOrNull } from "../utils/finite.js";
 import { earth_rotation_angle } from "../wasm/arikaInit.js";
 import { SpacecraftVisual } from "./SpacecraftVisual.js";
 
@@ -62,9 +63,15 @@ export function Satellite({
   // One display frame drives both the position and the attitude, so they can
   // never end up in different bases (the LVLH axis order and the ECEF rotation
   // used to be derived independently, and disagreed).
+  // This satellite's own sample time, which is optional per satellite and can
+  // arrive as `NaN` from a source. A non-finite time is no time: the angle
+  // computed from it is `NaN`, and while `resolveDisplayOrientation` refuses that
+  // and falls back to inertial, the fallback would be silent and this satellite
+  // would sit in a different frame from the rest of the scene.
+  const sampleTime = finiteOrNull(position.t);
   const era =
-    isLegacyEcef(referenceFrame) && epochJd != null
-      ? earth_rotation_angle(epochJd, position.t)
+    isLegacyEcef(referenceFrame) && epochJd != null && sampleTime != null
+      ? earth_rotation_angle(epochJd, sampleTime)
       : null;
   const frame = resolveDisplayFrame(referenceFrame, { era, originPosition, lvlhAxes });
 

--- a/viewer/src/components/Satellite.tsx
+++ b/viewer/src/components/Satellite.tsx
@@ -1,4 +1,5 @@
 import {
+  attitudeWasRefused,
   displayPosition,
   displayQuaternion,
   type Quat,
@@ -101,7 +102,7 @@ export function Satellite({
   // as one; the same model drawn after an attitude was refused would sit at its
   // own default orientation and be read as the measurement that was refused. That
   // case gets the marker instead, which looks the same from every side.
-  const attitudeRefused = position.qw != null && rawQuaternion == null;
+  const attitudeRefused = attitudeWasRefused(position);
 
   return (
     <SpacecraftVisual

--- a/viewer/src/components/Satellite.tsx
+++ b/viewer/src/components/Satellite.tsx
@@ -3,6 +3,7 @@ import {
   displayQuaternion,
   type Quat,
   resolveDisplayFrame,
+  unitAttitude,
 } from "../displayFrame.js";
 import type { OrbitPoint } from "../orbit.js";
 import { isLegacyEcef, type ReferenceFrame } from "../referenceFrame.js";
@@ -87,11 +88,18 @@ export function Satellite({
 
   const scenePos = displayPosition(frame, position.x, position.y, position.z, scaleRadius);
 
-  // Attitude quaternion as delivered: body-to-inertial, Hamilton [w, x, y, z].
-  const rawQuaternion: Quat | undefined =
+  // Attitude as delivered — body-to-inertial, Hamilton [w, x, y, z] — brought to
+  // unit norm. Three.js applies the components with `Quaternion.set`, which does
+  // not normalise: a simulator's drifting quaternion scales and skews the very
+  // marker it is meant to orient, and one that names no rotation at all is read
+  // back as the identity, so the scene would report an orientation nobody
+  // measured. What cannot be normalised is reported as no attitude, which draws
+  // the marker unrotated — the answer a satellite without attitude already gets.
+  const rawQuaternion: Quat | undefined = unitAttitude(
     position.qw != null
       ? [position.qw, position.qx ?? 0, position.qy ?? 0, position.qz ?? 0]
-      : undefined;
+      : undefined,
+  );
 
   return (
     <SpacecraftVisual

--- a/viewer/src/components/Satellite.tsx
+++ b/viewer/src/components/Satellite.tsx
@@ -23,6 +23,16 @@ interface SatelliteProps {
   referenceFrame?: ReferenceFrame;
   /** Julian Date of the simulation epoch (needed for ECEF transform). */
   epochJd?: number;
+  /**
+   * The scene's own elapsed time, used when this satellite's sample carries none.
+   *
+   * `SatelliteState.time` is per satellite and documented to default to the
+   * scene's, so a sample time that is not a number is treated as absent rather
+   * than as a reason to drop the rotation: without it this marker would sit in
+   * the inertial frame while the body, the trails and every other satellite use
+   * body-fixed axes.
+   */
+  sceneTime?: number;
   /** Satellite identifier for model lookup. */
   satId?: string;
   /** Satellite display name for model lookup fallback. */
@@ -54,6 +64,7 @@ export function Satellite({
   color,
   referenceFrame = DEFAULT_REF_FRAME,
   epochJd,
+  sceneTime,
   satId,
   satName,
   originPosition = null,
@@ -63,14 +74,13 @@ export function Satellite({
   // One display frame drives both the position and the attitude, so they can
   // never end up in different bases (the LVLH axis order and the ECEF rotation
   // used to be derived independently, and disagreed).
-  // This satellite's own sample time, which is optional per satellite and can
-  // arrive as `NaN` from a source. A non-finite time is no time: the angle
-  // computed from it is `NaN`, and while `resolveDisplayOrientation` refuses that
-  // and falls back to inertial, the fallback would be silent and this satellite
-  // would sit in a different frame from the rest of the scene.
-  const sampleTime = finiteOrNull(position.t);
+  // This satellite's own sample time when it has one, else the scene's. A `NaN`
+  // would make the angle `NaN`, which `resolveDisplayOrientation` refuses — and
+  // the frame it fell back to would be inertial while the rest of the scene is
+  // body-fixed, so the marker would be drawn in a basis of its own.
+  const sampleTime = finiteOrNull(position.t) ?? finiteOrNull(sceneTime) ?? 0;
   const era =
-    isLegacyEcef(referenceFrame) && epochJd != null && sampleTime != null
+    isLegacyEcef(referenceFrame) && epochJd != null
       ? earth_rotation_angle(epochJd, sampleTime)
       : null;
   const frame = resolveDisplayFrame(referenceFrame, { era, originPosition, lvlhAxes });

--- a/viewer/src/components/Satellite.tsx
+++ b/viewer/src/components/Satellite.tsx
@@ -96,11 +96,18 @@ export function Satellite({
   // measured. What cannot be normalised is reported as no attitude, which draws
   // the marker unrotated — the answer a satellite without attitude already gets.
   const rawQuaternion: Quat | undefined = sampleAttitude(position);
+  // Whether this sample claimed an orientation the viewer could not use. A model
+  // drawn for a satellite with no attitude at all is a position marker and reads
+  // as one; the same model drawn after an attitude was refused would sit at its
+  // own default orientation and be read as the measurement that was refused. That
+  // case gets the marker instead, which looks the same from every side.
+  const attitudeRefused = position.qw != null && rawQuaternion == null;
 
   return (
     <SpacecraftVisual
       position={scenePos}
       quaternion={displayQuaternion(frame, rawQuaternion)}
+      model={!attitudeRefused}
       satId={satId}
       satName={satName}
       color={color}

--- a/viewer/src/components/SatelliteModel.tsx
+++ b/viewer/src/components/SatelliteModel.tsx
@@ -60,7 +60,11 @@ export function SatelliteModel({
   }, [quaternion]);
 
   return (
-    <group position={position} ref={quaternion ? groupRef : undefined}>
+    // The ref is attached whether or not there is an attitude, because losing one
+    // is the case the effect above exists for: a conditional ref is detached
+    // during the commit that drops the quaternion, so the effect would find no
+    // group and the model would keep the rotation the last good sample gave it.
+    <group position={position} ref={groupRef}>
       <primitive object={cloned} scale={scale} rotation={config.rotation} />
     </group>
   );

--- a/viewer/src/components/SatelliteModel.tsx
+++ b/viewer/src/components/SatelliteModel.tsx
@@ -45,9 +45,17 @@ export function SatelliteModel({
 
   // Apply body-to-inertial quaternion to the parent group
   useEffect(() => {
-    if (groupRef.current && quaternion) {
+    if (!groupRef.current) return;
+    if (quaternion) {
       const [w, x, y, z] = quaternion;
-      groupRef.current.quaternion.set(x, y, z, w); // Three.js: (x, y, z, w)
+      groupRef.current.quaternion.set(x, y, z, w);
+    } else {
+      // A stream can stop carrying a usable attitude — a sample whose quaternion
+      // names no rotation, or none at all after one that did. Leaving the group
+      // where the last good sample put it would show that orientation as the
+      // current one, so it goes back to unrotated, which is what "no attitude"
+      // draws from the start.
+      groupRef.current.quaternion.identity(); // Three.js: (x, y, z, w)
     }
   }, [quaternion]);
 

--- a/viewer/src/components/SpacecraftVisual.tsx
+++ b/viewer/src/components/SpacecraftVisual.tsx
@@ -44,7 +44,8 @@ interface SpacecraftVisualProps {
   /**
    * Resolved marker shape for spacecraft without a 3D model. When omitted, falls
    * back to automatic (orientation-revealing cube when an attitude is present,
-   * else a sphere). A GLTF model, when available, always takes precedence.
+   * else a sphere). A GLTF model, when available, stands in for the marker —
+   * except for a refused attitude, which suppresses both.
    */
   markerShape?: MarkerShape;
   /** Sphere radius / cube half-extent in scene units. */
@@ -59,21 +60,23 @@ interface SpacecraftVisualProps {
    */
   visualSpan?: number;
   /**
-   * Whether a registered 3D model may stand in for the marker (default true).
+   * Whether this spacecraft claimed an orientation that could not be used
+   * (default false) — a quaternion that named no rotation, or one carrying a
+   * non-finite component.
    *
-   * A model drawn without a quaternion sits at its own default orientation, which
-   * in the orbit view is honest — the model is a position marker there, and a
-   * satellite may arrive with no attitude at all. A view whose subject *is* the
-   * orientation passes false when the attitude is unusable, so the reader gets
-   * the marker that looks the same from every side instead of a model that
-   * appears to point somewhere.
+   * Nothing drawn for such a sample may imply an orientation, so this suppresses
+   * both the registered 3D model, which would sit at its own default orientation,
+   * and the cube marker, whose faces would read as measured axes. A spacecraft
+   * that arrived with no attitude at all is a different case: there a model is a
+   * position marker and reads as one, which is the orbit view's documented
+   * behaviour.
    */
-  model?: boolean;
+  attitudeRefused?: boolean;
 }
 
 /**
  * One spacecraft as it is drawn: a 3D model when the registry knows this
- * satellite, else an orientation-revealing marker, plus its body axes.
+ * satellite and its attitude was not refused, else a marker, plus its body axes.
  *
  * Takes only display-frame values — a scene position and a body-to-display
  * quaternion — so it carries no frame semantics of its own and both the orbit
@@ -96,9 +99,9 @@ export function SpacecraftVisual({
   axisLength,
   modelScale,
   visualSpan,
-  model = true,
+  attitudeRefused = false,
 }: SpacecraftVisualProps) {
-  const modelConfig = model && satId ? getSatelliteModelConfig(satId, satName) : null;
+  const modelConfig = !attitudeRefused && satId ? getSatelliteModelConfig(satId, satName) : null;
   // The default axis length follows the scale the model is *drawn* at, not the
   // registry's: overriding one without the other would silently change the ratio
   // between a spacecraft and its axes.
@@ -136,7 +139,11 @@ export function SpacecraftVisual({
   // Pick the marker shape: caller-resolved override/default, else automatic
   // (orientation-revealing cube when attitude is present — a sphere looks identical
   // at every orientation — sphere otherwise).
-  const shape = resolveMarkerShape({ override: markerShape, hasAttitude: quaternion != null });
+  const shape = resolveMarkerShape({
+    override: markerShape,
+    hasAttitude: quaternion != null,
+    attitudeRefused,
+  });
   const fallbackMarker =
     shape === "sphere" ? (
       <SphereMarker position={position} color={color} radius={markerSize} />

--- a/viewer/src/components/SpacecraftVisual.tsx
+++ b/viewer/src/components/SpacecraftVisual.tsx
@@ -2,12 +2,10 @@ import { Suspense } from "react";
 import type { Quat } from "../displayFrame.js";
 import { getSatelliteModelConfig } from "../satelliteModels.js";
 import { type MarkerShape, resolveMarkerShape } from "../satelliteShapes.js";
+import { DEFAULT_SPHERE_RADIUS } from "../spacecraftScale.js";
 import { BodyAxes } from "./BodyAxes.js";
 import { PrimitiveMarker } from "./PrimitiveMarker.js";
 import { SatelliteModel } from "./SatelliteModel.js";
-
-/** Default radius of the sphere fallback marker in scene units. */
-export const DEFAULT_SPHERE_RADIUS = 0.005;
 
 interface SphereMarkerProps {
   position: [number, number, number];

--- a/viewer/src/debug/directionVectors.ts
+++ b/viewer/src/debug/directionVectors.ts
@@ -23,10 +23,12 @@ export interface DebugDirectionVector {
   /** Unit vector from the arrow's origin to its head, in world (scene) axes. */
   direction: [number, number, number];
   /**
-   * World distance from the origin to the head [scene units].
+   * World distance from the arrow's origin to its head's centre [scene units].
    *
-   * Where the arrow reaches, which moves with the radius its tail starts at —
-   * the marker's or, when one is drawn, the model's. Measured from the scene
+   * How far the arrow reaches, which moves with the radius its tail starts at —
+   * the marker's, or the model's when one is drawn. Reported unnormalised so a
+   * test can pin the proportions as well: it is `startOffset + length -
+   * headLength / 2` for the spacecraft's apparent size. Measured from the scene
    * graph like the direction, so a test comparing two scenes reads the geometry
    * rather than the number that was passed in.
    */

--- a/viewer/src/displayFrame.test.ts
+++ b/viewer/src/displayFrame.test.ts
@@ -595,6 +595,14 @@ describe("sampleAttitude on an incomplete sample", () => {
     // The sample claimed one — `qw` is there — and the viewer cannot use it, which
     // is the state that suppresses the model and the orientation-revealing cube.
     expect(attitudeWasRefused({ qw: 0.5 })).toBe(true);
+    // Any component is the claim, `qw` included but not required — a sample that
+    // carries one of the others is a partly decoded attitude, not an absent one,
+    // and reading it as absent would leave a registered model on screen at its own
+    // orientation with the scene amplified to match.
+    expect(attitudeWasRefused({ qx: 0.5 })).toBe(true);
+    expect(attitudeWasRefused({ qy: Number.NaN })).toBe(true);
+    expect(attitudeWasRefused({ qz: 0 })).toBe(true);
+    expect(attitudeWasRefused({ qx: 0, qy: 0, qz: 0 })).toBe(true);
     // Nothing claimed, nothing refused.
     expect(attitudeWasRefused({})).toBe(false);
     expect(attitudeWasRefused({ qw: 1, qx: 0, qy: 0, qz: 0 })).toBe(false);

--- a/viewer/src/displayFrame.test.ts
+++ b/viewer/src/displayFrame.test.ts
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 import { describe, expect, it } from "vitest";
 import {
+  attitudeWasRefused,
   type DisplayFrame,
   type DisplayFrameInputs,
   type DisplayOrientation,
@@ -12,6 +13,7 @@ import {
   type Quat,
   resolveDisplayFrame,
   resolveDisplayOrientation,
+  sampleAttitude,
   trailTransformKey,
   unitAttitude,
   type Vec3,
@@ -574,5 +576,27 @@ describe("trail transform key", () => {
         ),
       ),
     ).toBe(true);
+  });
+});
+
+describe("sampleAttitude on an incomplete sample", () => {
+  it("refuses a quaternion that is missing components", () => {
+    // Zero-filling would make each of these the identity after normalisation, so
+    // a sample carrying one number would be drawn as a measured orientation.
+    expect(sampleAttitude({ qw: 0.5 })).toBeUndefined();
+    expect(sampleAttitude({ qw: 1, qx: 0 })).toBeUndefined();
+    expect(sampleAttitude({ qw: 1, qx: 0, qy: 0 })).toBeUndefined();
+    // A complete tuple still resolves, including one that needs normalising.
+    expect(sampleAttitude({ qw: 1, qx: 0, qy: 0, qz: 0 })).toEqual([1, 0, 0, 0]);
+    expect(sampleAttitude({ qw: 2, qx: 0, qy: 0, qz: 0 })).toEqual([1, 0, 0, 0]);
+  });
+
+  it("counts an incomplete quaternion as an attitude that was refused", () => {
+    // The sample claimed one — `qw` is there — and the viewer cannot use it, which
+    // is the state that suppresses the model and the orientation-revealing cube.
+    expect(attitudeWasRefused({ qw: 0.5 })).toBe(true);
+    // Nothing claimed, nothing refused.
+    expect(attitudeWasRefused({})).toBe(false);
+    expect(attitudeWasRefused({ qw: 1, qx: 0, qy: 0, qz: 0 })).toBe(false);
   });
 });

--- a/viewer/src/displayFrame.ts
+++ b/viewer/src/displayFrame.ts
@@ -193,7 +193,12 @@ export function attitudeWasRefused(sample: {
   qy?: number | null;
   qz?: number | null;
 }): boolean {
-  return sample.qw != null && sampleAttitude(sample) == null;
+  // Any component is the claim, not `qw` alone. Now that a rotation needs the
+  // complete tuple, a sample carrying only `qx` is rejected as a rotation — and
+  // keying the refusal on `qw` would call that "no attitude at all", which draws
+  // the registered model at its own orientation and amplifies the scene for it.
+  const claimed = sample.qw != null || sample.qx != null || sample.qy != null || sample.qz != null;
+  return claimed && sampleAttitude(sample) == null;
 }
 
 export function unitAttitude(attitude: Quat | undefined): Quat | undefined {

--- a/viewer/src/displayFrame.ts
+++ b/viewer/src/displayFrame.ts
@@ -142,18 +142,6 @@ export function resolveDisplayFrame(
 const UNIT_QUATERNION_TOLERANCE = 1e-9;
 
 /**
- * A caller's attitude as a unit quaternion, or undefined when it does not name a
- * rotation.
- *
- * Three.js applies the components with `Quaternion.set`, which does not
- * normalise: a non-unit quaternion scales and skews the very spacecraft it is
- * meant to orient, and a non-finite component spreads through the scene
- * matrices. A simulator's attitude drifts off unit norm as it integrates, so the
- * fix is to normalise what can be normalised and reject the rest — an unusable
- * attitude then reads as *no* attitude, which the views already draw (no body
- * axes, and the marker that looks the same from every side).
- */
-/**
  * The attitude carried by an orbit sample, brought to unit norm, or undefined.
  *
  * Samples arrive as loose components rather than a tuple, and two decisions read
@@ -169,6 +157,37 @@ export function sampleAttitude(sample: {
 }): Quat | undefined {
   if (sample.qw == null) return undefined;
   return unitAttitude([sample.qw, sample.qx ?? 0, sample.qy ?? 0, sample.qz ?? 0]);
+}
+
+/**
+ * A caller's attitude as a unit quaternion, or undefined when it does not name a
+ * rotation.
+ *
+ * Three.js applies the components with `Quaternion.set`, which does not
+ * normalise: a non-unit quaternion scales and skews the very spacecraft it is
+ * meant to orient, and a non-finite component spreads through the scene
+ * matrices. A simulator's attitude drifts off unit norm as it integrates, so the
+ * fix is to normalise what can be normalised and reject the rest — an unusable
+ * attitude then reads as *no* attitude, which the views already draw (no body
+ * axes, and the marker that looks the same from every side).
+ */
+/**
+ * Whether a sample claimed an orientation the viewer could not use.
+ *
+ * The distinction this draws is between a spacecraft that carries no attitude —
+ * ordinary in the orbit view, where the marker is a position marker — and one
+ * whose quaternion named no rotation or arrived non-finite. Three consequences
+ * follow from the second, and they have to agree: the registered model is not
+ * drawn, the marker takes the shape that shows no orientation, and the
+ * environment is amplified for whichever of the two is on screen.
+ */
+export function attitudeWasRefused(sample: {
+  qw?: number | null;
+  qx?: number | null;
+  qy?: number | null;
+  qz?: number | null;
+}): boolean {
+  return sample.qw != null && sampleAttitude(sample) == null;
 }
 
 export function unitAttitude(attitude: Quat | undefined): Quat | undefined {

--- a/viewer/src/displayFrame.ts
+++ b/viewer/src/displayFrame.ts
@@ -153,6 +153,24 @@ const UNIT_QUATERNION_TOLERANCE = 1e-9;
  * attitude then reads as *no* attitude, which the views already draw (no body
  * axes, and the marker that looks the same from every side).
  */
+/**
+ * The attitude carried by an orbit sample, brought to unit norm, or undefined.
+ *
+ * Samples arrive as loose components rather than a tuple, and two decisions read
+ * them: the rotation applied to the marker, and whether the marker is the shape
+ * that reveals an orientation. Both go through here so they cannot disagree —
+ * a sample the rotation refuses must not be drawn as an oriented cube.
+ */
+export function sampleAttitude(sample: {
+  qw?: number | null;
+  qx?: number | null;
+  qy?: number | null;
+  qz?: number | null;
+}): Quat | undefined {
+  if (sample.qw == null) return undefined;
+  return unitAttitude([sample.qw, sample.qx ?? 0, sample.qy ?? 0, sample.qz ?? 0]);
+}
+
 export function unitAttitude(attitude: Quat | undefined): Quat | undefined {
   if (attitude == null) return undefined;
   const [w, x, y, z] = attitude;

--- a/viewer/src/displayFrame.ts
+++ b/viewer/src/displayFrame.ts
@@ -155,8 +155,14 @@ export function sampleAttitude(sample: {
   qy?: number | null;
   qz?: number | null;
 }): Quat | undefined {
-  if (sample.qw == null) return undefined;
-  return unitAttitude([sample.qw, sample.qx ?? 0, sample.qy ?? 0, sample.qz ?? 0]);
+  // All four components or none. Filling the missing ones with zero turns a
+  // sample such as `{ qw: 0.5 }` into the identity once normalised, which draws an
+  // orientation nobody supplied — and `hasQuaternion` in `orbit.ts`, which decides
+  // whether two samples can be slerped, already requires the complete tuple.
+  if (sample.qw == null || sample.qx == null || sample.qy == null || sample.qz == null) {
+    return undefined;
+  }
+  return unitAttitude([sample.qw, sample.qx, sample.qy, sample.qz]);
 }
 
 /**

--- a/viewer/src/displayFrame.ts
+++ b/viewer/src/displayFrame.ts
@@ -166,18 +166,6 @@ export function sampleAttitude(sample: {
 }
 
 /**
- * A caller's attitude as a unit quaternion, or undefined when it does not name a
- * rotation.
- *
- * Three.js applies the components with `Quaternion.set`, which does not
- * normalise: a non-unit quaternion scales and skews the very spacecraft it is
- * meant to orient, and a non-finite component spreads through the scene
- * matrices. A simulator's attitude drifts off unit norm as it integrates, so the
- * fix is to normalise what can be normalised and reject the rest — an unusable
- * attitude then reads as *no* attitude, which the views already draw (no body
- * axes, and the marker that looks the same from every side).
- */
-/**
  * Whether a sample claimed an orientation the viewer could not use.
  *
  * The distinction this draws is between a spacecraft that carries no attitude —
@@ -201,6 +189,18 @@ export function attitudeWasRefused(sample: {
   return claimed && sampleAttitude(sample) == null;
 }
 
+/**
+ * A caller's attitude as a unit quaternion, or undefined when it does not name a
+ * rotation.
+ *
+ * Three.js applies the components with `Quaternion.set`, which does not
+ * normalise: a non-unit quaternion scales and skews the very spacecraft it is
+ * meant to orient, and a non-finite component spreads through the scene
+ * matrices. A simulator's attitude drifts off unit norm as it integrates, so the
+ * fix is to normalise what can be normalised and reject the rest — an unusable
+ * attitude then reads as *no* attitude, which the views already draw (no body
+ * axes, and the marker that looks the same from every side).
+ */
 export function unitAttitude(attitude: Quat | undefined): Quat | undefined {
   if (attitude == null) return undefined;
   const [w, x, y, z] = attitude;

--- a/viewer/src/lib/OrbitScene.tsx
+++ b/viewer/src/lib/OrbitScene.tsx
@@ -4,6 +4,7 @@ import { OrbitSceneContents } from "../components/OrbitSceneContents.js";
 import { IS_DEV } from "../env.js";
 import type { OrbitPoint } from "../orbit.js";
 import type { MarkerShape } from "../satelliteShapes.js";
+import { finiteOrNull } from "../utils/finite.js";
 import { useArikaReady } from "../wasm/useArikaReady.js";
 import { toOrbitPoint } from "./adapt.js";
 import { resolveFrameContext } from "./frameContext.js";
@@ -54,8 +55,18 @@ export function OrbitScene({
   controls = true,
   axes = true,
 }: OrbitSceneProps) {
+  // The epoch, brought to a number the WASM can be called with.
+  //
+  // `??` and `!= null` stop at null and undefined, so `NaN` counts as supplied:
+  // `Number()` on a broken CSV header gives one, and so does a JSON field that
+  // arrived as a string. It would load arika and then reach every call the scene
+  // makes with it — the Sun's direction, the Earth rotation angle, a body's
+  // orientation — where an invalid transform spreads through the scene matrices
+  // instead of the documented epoch-less fallback being used. `AttitudeScene`
+  // normalises at this same seam.
+  const epoch = finiteOrNull(epochJd);
   // Only load the arika WASM when an epoch is supplied (Sun/rotation features).
-  const arikaReady = useArikaReady(epochJd != null);
+  const arikaReady = useArikaReady(epoch != null);
 
   // Body definitions: consumer-supplied bodies merged over the built-in defaults.
   const bodyDefinitions = useMemo(() => resolveBodyDefinitions(bodies), [bodies]);
@@ -142,7 +153,7 @@ export function OrbitScene({
 
   // Only hand the scene an epoch once arika is loaded; otherwise its Sun/rotation
   // calls would run before the WASM is ready. Default lighting is used until then.
-  const effectiveEpochJd = arikaReady ? (epochJd ?? null) : null;
+  const effectiveEpochJd = arikaReady ? epoch : null;
 
   // Dev/E2E-only: expose per-satellite trail buffer state so E2E can prove that
   // advancing `time` (or appending points) does not rebuild the trail — a stable

--- a/viewer/src/lib/OrbitScene.tsx
+++ b/viewer/src/lib/OrbitScene.tsx
@@ -163,6 +163,7 @@ export function OrbitScene({
 
   return (
     <OrbitSceneContents
+      time={time}
       trailBuffers={trailBuffers}
       satellitePositions={satellitePositions}
       satelliteNames={satelliteNames}

--- a/viewer/src/lib/OrbitScene.tsx
+++ b/viewer/src/lib/OrbitScene.tsx
@@ -50,6 +50,7 @@ export function OrbitScene({
   textureVersion,
   defaultMarkerShape,
   atmosphereScale,
+  directionVectors,
   controls = true,
   axes = true,
 }: OrbitSceneProps) {
@@ -178,6 +179,7 @@ export function OrbitScene({
       physicalScale={physicalScale}
       textureBaseUrl={textureBaseUrl}
       textureRevision={textureVersion}
+      directionVectors={directionVectors}
       controls={controls}
       axes={axes}
     />

--- a/viewer/src/lib/types.ts
+++ b/viewer/src/lib/types.ts
@@ -213,7 +213,10 @@ export interface OrbitSceneDataProps {
   atmosphereScale?: "visual" | "physical" | "auto";
   /**
    * Reference-direction arrows (Sun, nadir) to draw. Omitted — the default —
-   * draws none.
+   * draws none, and each field is opt-in: `{ sun: true }` draws the Sun alone.
+   * (The attitude view reads the same type the other way round, drawing every
+   * direction it can unless one is switched off, because arrows are what that
+   * view is for.)
    *
    * Drawn only when the reference frame is centred on a satellite, and only at
    * that satellite. This view can hold many satellites, and a pair of arrows on

--- a/viewer/src/lib/types.ts
+++ b/viewer/src/lib/types.ts
@@ -211,6 +211,18 @@ export interface OrbitSceneDataProps {
    * thickness (useful satellite-centred); `"auto"` (default) picks per view.
    */
   atmosphereScale?: "visual" | "physical" | "auto";
+  /**
+   * Reference-direction arrows (Sun, nadir) to draw. Omitted — the default —
+   * draws none.
+   *
+   * Drawn only when the reference frame is centred on a satellite, and only at
+   * that satellite. This view can hold many satellites, and a pair of arrows on
+   * each of them fills the screen; in a central-body view the body itself is on
+   * screen, so a nadir arrow repeats what the picture already shows. To annotate
+   * a satellite other than the centred one, ask for a scene-level target — a
+   * per-satellite flag would put the scene's display policy in the data.
+   */
+  directionVectors?: DirectionVectorOptions;
 }
 
 /**

--- a/viewer/src/orbit.test.ts
+++ b/viewer/src/orbit.test.ts
@@ -52,6 +52,70 @@ describe("lerpPoint quaternion handling", () => {
     expect(r.qz).toBeUndefined();
   });
 
+  it("interpolates the same rotation whatever norms the endpoints drifted to", () => {
+    // A simulator's attitude drifts off unit norm as it integrates, and the two
+    // endpoints drift by different amounts. Slerp assumes unit inputs, so the
+    // rotation it picks depends on the ratio between the norms — normalising the
+    // result afterwards cannot recover it, because what went wrong is which
+    // rotation was chosen, not how long it is.
+    const unit = lerpPoint(
+      pt({ qw: 1, qx: 0, qy: 0, qz: 0 }),
+      pt({ qw: S, qx: 0, qy: 0, qz: S }),
+      0.5,
+    );
+    const scaled = (ka: number, kb: number) =>
+      lerpPoint(
+        pt({ qw: 1 * ka, qx: 0, qy: 0, qz: 0 }),
+        pt({ qw: S * kb, qx: 0, qy: 0, qz: S * kb }),
+        0.5,
+      );
+
+    // Measured against the raw-endpoint slerp this replaces: norms of 1 and 2 put
+    // each component 1.2e-1 out, and a drift of a thousandth 1.9e-4 out.
+    for (const [ka, kb] of [
+      [2, 2],
+      [1, 2],
+      [2, 1],
+      [1.001, 1],
+      [0.5, 1],
+    ]) {
+      const r = scaled(ka, kb);
+      const norm = Math.hypot(r.qw as number, r.qx as number, r.qy as number, r.qz as number);
+      expect(norm, `norms ${ka}/${kb} should give a unit result`).toBeCloseTo(1, 9);
+      for (const [name, got, want] of [
+        ["qw", r.qw, unit.qw],
+        ["qx", r.qx, unit.qx],
+        ["qy", r.qy, unit.qy],
+        ["qz", r.qz, unit.qz],
+      ] as const) {
+        expect(got as number, `${name} for norms ${ka}/${kb}`).toBeCloseTo(want as number, 9);
+      }
+    }
+  });
+
+  it("hands a quaternion it cannot normalise on unchanged", () => {
+    // Zero and non-finite quaternions are attitudes the display frame refuses.
+    // Normalising here would have to invent one — `THREE.Quaternion.normalize`
+    // answers the identity for a zero input — and the refusal would be lost.
+    const zero = lerpPoint(
+      pt({ qw: 0, qx: 0, qy: 0, qz: 0 }),
+      pt({ qw: S, qx: 0, qy: 0, qz: S }),
+      0,
+    );
+    expect(Math.hypot(zero.qw as number, zero.qx as number, zero.qy as number, zero.qz as number)) //
+      .toBeCloseTo(0, 9);
+
+    const nonFinite = lerpPoint(
+      pt({ qw: Number.NaN, qx: 0, qy: 0, qz: 0 }),
+      pt({ qw: S, qx: 0, qy: 0, qz: S }),
+      0.5,
+    );
+    expect(
+      [nonFinite.qw, nonFinite.qx, nonFinite.qy, nonFinite.qz].some((c) => !Number.isFinite(c)),
+      "a non-finite endpoint stays non-finite rather than becoming a rotation",
+    ).toBe(true);
+  });
+
   it("interpolates the non-quaternion fields regardless", () => {
     const r = lerpPoint(pt({ t: 0, x: 0 }), pt({ t: 10, x: 100 }), 0.3);
     expect(r.t).toBeCloseTo(3);

--- a/viewer/src/orbit.test.ts
+++ b/viewer/src/orbit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { sampleAttitude } from "./displayFrame.js";
 import { lerpPoint, type OrbitPoint } from "./orbit.js";
 
 /** A minimal OrbitPoint with all required fields zeroed; override as needed. */
@@ -93,27 +94,46 @@ describe("lerpPoint quaternion handling", () => {
     }
   });
 
-  it("hands a quaternion it cannot normalise on unchanged", () => {
-    // Zero and non-finite quaternions are attitudes the display frame refuses.
-    // Normalising here would have to invent one — `THREE.Quaternion.normalize`
-    // answers the identity for a zero input — and the refusal would be lost.
-    const zero = lerpPoint(
+  it("keeps a refused endpoint refused at every fraction between the samples", () => {
+    // The interior is the case that matters, and testing only the endpoint hid
+    // this: slerp from a zero quaternion returns a multiple of the *other*
+    // endpoint, so a quarter of the way along the result normalised to that
+    // endpoint's rotation exactly — a refused sample presented as a measurement
+    // taken next door. Normalising the zero endpoint instead is no answer:
+    // `THREE.Quaternion.normalize` answers the identity for it, which invents a
+    // rotation of its own.
+    const valid = pt({ qw: S, qx: 0, qy: 0, qz: S });
+    for (const refused of [
       pt({ qw: 0, qx: 0, qy: 0, qz: 0 }),
-      pt({ qw: S, qx: 0, qy: 0, qz: S }),
-      0,
-    );
-    expect(Math.hypot(zero.qw as number, zero.qx as number, zero.qy as number, zero.qz as number)) //
-      .toBeCloseTo(0, 9);
-
-    const nonFinite = lerpPoint(
       pt({ qw: Number.NaN, qx: 0, qy: 0, qz: 0 }),
-      pt({ qw: S, qx: 0, qy: 0, qz: S }),
-      0.5,
-    );
-    expect(
-      [nonFinite.qw, nonFinite.qx, nonFinite.qy, nonFinite.qz].some((c) => !Number.isFinite(c)),
-      "a non-finite endpoint stays non-finite rather than becoming a rotation",
-    ).toBe(true);
+      pt({ qw: Number.POSITIVE_INFINITY, qx: 0, qy: 0, qz: 0 }),
+    ]) {
+      for (const frac of [0, 0.25, 0.5, 0.75]) {
+        const r = lerpPoint(refused, valid, frac);
+        expect(
+          sampleAttitude(r),
+          `frac ${frac} should carry no usable attitude away from a refused sample`,
+        ).toBeUndefined();
+      }
+      // The far endpoint is exact, which is what a reader at that sample's own
+      // timestamp should see. Compared componentwise: normalising a unit
+      // quaternion moves its last bit (measured 0.7071067811865475 for `S`).
+      const atFar = sampleAttitude(lerpPoint(refused, valid, 1));
+      expect(atFar, "the valid endpoint keeps its own attitude").not.toBeUndefined();
+      for (const [i, want] of [S, 0, 0, S].entries()) {
+        expect((atFar as number[])[i]).toBeCloseTo(want, 12);
+      }
+      // And in the other order, so the refusal is not tied to being first.
+      for (const frac of [0.25, 0.5, 0.75, 1]) {
+        expect(sampleAttitude(lerpPoint(valid, refused, frac)), `reversed frac ${frac}`) //
+          .toBeUndefined();
+      }
+      const atNear = sampleAttitude(lerpPoint(valid, refused, 0));
+      expect(atNear, "and in the other order").not.toBeUndefined();
+      for (const [i, want] of [S, 0, 0, S].entries()) {
+        expect((atNear as number[])[i]).toBeCloseTo(want, 12);
+      }
+    }
   });
 
   it("interpolates the non-quaternion fields regardless", () => {

--- a/viewer/src/orbit.test.ts
+++ b/viewer/src/orbit.test.ts
@@ -107,6 +107,10 @@ describe("lerpPoint quaternion handling", () => {
       pt({ qw: 0, qx: 0, qy: 0, qz: 0 }),
       pt({ qw: Number.NaN, qx: 0, qy: 0, qz: 0 }),
       pt({ qw: Number.POSITIVE_INFINITY, qx: 0, qy: 0, qz: 0 }),
+      // Subnormal components: the norm is finite and positive, so dividing by it
+      // looks safe, but `Math.hypot` answers the smallest number there is and the
+      // components divide to 1 apiece — norm 1.414, refused at the display.
+      pt({ qw: Number.MIN_VALUE, qx: Number.MIN_VALUE, qy: 0, qz: 0 }),
     ]) {
       for (const frac of [0, 0.25, 0.5, 0.75]) {
         const r = lerpPoint(refused, valid, frac);

--- a/viewer/src/orbit.ts
+++ b/viewer/src/orbit.ts
@@ -139,6 +139,19 @@ export function updateOrbitTrail(line: THREE.Line, visibleCount: number, totalCo
   line.geometry.setDrawRange(0, clamped);
 }
 
+/**
+ * A point's quaternion at unit norm, or its components unchanged when they do not
+ * describe a length that can be divided by (zero, or non-finite).
+ *
+ * Callers must have checked {@link hasQuaternion} first.
+ */
+function unitOrAsGiven(p: OrbitPoint): THREE.Quaternion {
+  const [w, x, y, z] = [p.qw as number, p.qx as number, p.qy as number, p.qz as number];
+  const n = Math.hypot(w, x, y, z);
+  if (!(Number.isFinite(n) && n > 0)) return new THREE.Quaternion(x, y, z, w);
+  return new THREE.Quaternion(x / n, y / n, z / n, w / n);
+}
+
 /** Whether a point carries a complete quaternion (all of qw/qx/qy/qz). */
 function hasQuaternion(p: OrbitPoint): boolean {
   return p.qw != null && p.qx != null && p.qy != null && p.qz != null;
@@ -170,8 +183,19 @@ export function lerpPoint(a: OrbitPoint, b: OrbitPoint, frac: number): OrbitPoin
   // on both points — guarding on qw alone would let a partial one (missing
   // qx/qy/qz, which Three defaults to 0) build an un-normalized rotation.
   if (hasQuaternion(a) && hasQuaternion(b)) {
-    const qa = new THREE.Quaternion(a.qx, a.qy, a.qz, a.qw);
-    const qb = new THREE.Quaternion(b.qx, b.qy, b.qz, b.qw);
+    // Slerp assumes unit quaternions, and a simulator's attitude drifts off unit
+    // norm as it integrates. Equal norms cancel — scaling both endpoints by 2
+    // reproduces the unit result to 1e-16 — but unequal ones bend the path: norms
+    // of 1 and 2 put the halfway rotation 1.2e-1 off in each component, and a
+    // drift of a thousandth 1.9e-4 off. Normalising afterwards cannot recover it,
+    // because the error is in which rotation was chosen, not in its length.
+    //
+    // What cannot be normalised is passed through as it came, so the display
+    // frame still sees an attitude to refuse rather than one this function
+    // invented: `THREE.Quaternion.normalize` turns a zero quaternion into the
+    // identity, which would be exactly that invention.
+    const qa = unitOrAsGiven(a);
+    const qb = unitOrAsGiven(b);
     // Ensure shortest-path interpolation
     if (qa.dot(qb) < 0) {
       qb.set(-qb.x, -qb.y, -qb.z, -qb.w);

--- a/viewer/src/orbit.ts
+++ b/viewer/src/orbit.ts
@@ -140,15 +140,15 @@ export function updateOrbitTrail(line: THREE.Line, visibleCount: number, totalCo
 }
 
 /**
- * A point's quaternion at unit norm, or its components unchanged when they do not
- * describe a length that can be divided by (zero, or non-finite).
+ * A point's quaternion at unit norm, or null when its components do not describe
+ * a length that can be divided by (zero, or non-finite).
  *
  * Callers must have checked {@link hasQuaternion} first.
  */
-function unitOrAsGiven(p: OrbitPoint): THREE.Quaternion {
+function unitQuaternion(p: OrbitPoint): THREE.Quaternion | null {
   const [w, x, y, z] = [p.qw as number, p.qx as number, p.qy as number, p.qz as number];
   const n = Math.hypot(w, x, y, z);
-  if (!(Number.isFinite(n) && n > 0)) return new THREE.Quaternion(x, y, z, w);
+  if (!(Number.isFinite(n) && n > 0)) return null;
   return new THREE.Quaternion(x / n, y / n, z / n, w / n);
 }
 
@@ -194,17 +194,32 @@ export function lerpPoint(a: OrbitPoint, b: OrbitPoint, frac: number): OrbitPoin
     // frame still sees an attitude to refuse rather than one this function
     // invented: `THREE.Quaternion.normalize` turns a zero quaternion into the
     // identity, which would be exactly that invention.
-    const qa = unitOrAsGiven(a);
-    const qb = unitOrAsGiven(b);
-    // Ensure shortest-path interpolation
-    if (qa.dot(qb) < 0) {
-      qb.set(-qb.x, -qb.y, -qb.z, -qb.w);
+    const qa = unitQuaternion(a);
+    const qb = unitQuaternion(b);
+    if (qa != null && qb != null) {
+      // Ensure shortest-path interpolation
+      if (qa.dot(qb) < 0) {
+        qb.set(-qb.x, -qb.y, -qb.z, -qb.w);
+      }
+      qa.slerp(qb, frac);
+      result.qw = qa.w;
+      result.qx = qa.x;
+      result.qy = qa.y;
+      result.qz = qa.z;
+    } else {
+      // An endpoint the display frame refuses cannot be interpolated through.
+      // Slerp from a zero quaternion returns a multiple of the *other* endpoint —
+      // measured at a quarter of the way along, the result normalises to that
+      // endpoint's rotation exactly — so the refused sample would be presented as
+      // a measurement taken next door. The refusal is carried instead, and the
+      // exact endpoints keep their own values, which is what a reader at a
+      // sample's own timestamp should see.
+      const source = frac <= 0 ? a : frac >= 1 ? b : qa == null ? a : b;
+      result.qw = source.qw;
+      result.qx = source.qx;
+      result.qy = source.qy;
+      result.qz = source.qz;
     }
-    qa.slerp(qb, frac);
-    result.qw = qa.w;
-    result.qx = qa.x;
-    result.qy = qa.y;
-    result.qz = qa.z;
     // Angular velocity: linear interpolation
     result.wx = (a.wx ?? 0) * inv + (b.wx ?? 0) * frac;
     result.wy = (a.wy ?? 0) * inv + (b.wy ?? 0) * frac;

--- a/viewer/src/orbit.ts
+++ b/viewer/src/orbit.ts
@@ -1,4 +1,5 @@
 import * as THREE from "three";
+import { sampleAttitude } from "./displayFrame.js";
 
 /**
  * Earth radius in km -- used as the scene scale factor.
@@ -140,16 +141,22 @@ export function updateOrbitTrail(line: THREE.Line, visibleCount: number, totalCo
 }
 
 /**
- * A point's quaternion at unit norm, or null when its components do not describe
- * a length that can be divided by (zero, or non-finite).
+ * A point's quaternion at unit norm, or null when the display frame would refuse
+ * it.
  *
- * Callers must have checked {@link hasQuaternion} first.
+ * Asked of `sampleAttitude`, which is what the marker's rotation goes through, so
+ * the interpolation and the drawing agree on which samples name a rotation.
+ * Dividing by a finite positive norm is not enough on its own: at subnormal
+ * magnitudes `Math.hypot` answers the smallest number there is, so
+ * `[5e-324, 5e-324, 0, 0]` divides to `[1, 1, 0, 0]` — norm 1.414, which slerp
+ * would carry as a rotation. `unitAttitude` checks the result rather than the
+ * input, and this now inherits that.
  */
 function unitQuaternion(p: OrbitPoint): THREE.Quaternion | null {
-  const [w, x, y, z] = [p.qw as number, p.qx as number, p.qy as number, p.qz as number];
-  const n = Math.hypot(w, x, y, z);
-  if (!(Number.isFinite(n) && n > 0)) return null;
-  return new THREE.Quaternion(x / n, y / n, z / n, w / n);
+  const unit = sampleAttitude(p);
+  if (unit == null) return null;
+  const [w, x, y, z] = unit;
+  return new THREE.Quaternion(x, y, z, w);
 }
 
 /** Whether a point carries a complete quaternion (all of qw/qx/qy/qz). */

--- a/viewer/src/satelliteShapes.test.ts
+++ b/viewer/src/satelliteShapes.test.ts
@@ -76,3 +76,32 @@ describe("satShape URL param", () => {
     expect(readSatShapeParam()).toBeNull();
   });
 });
+
+describe("a refused attitude", () => {
+  it("takes the sphere over every request for a shape", () => {
+    // The cube's faces answer "which way is the body pointing", and a sample
+    // whose attitude the viewer could not use has no answer. So this outranks
+    // the per-satellite override, the simulation's declaration and the global
+    // default alike.
+    for (const requested of ["axes-cube", "sphere"] as const) {
+      expect(
+        resolveMarkerShape({ override: requested, hasAttitude: true, attitudeRefused: true }),
+      ).toBe("sphere");
+      expect(
+        resolveMarkerShape({ simShape: requested, hasAttitude: true, attitudeRefused: true }),
+      ).toBe("sphere");
+      expect(
+        resolveMarkerShape({ globalDefault: requested, hasAttitude: true, attitudeRefused: true }),
+      ).toBe("sphere");
+    }
+  });
+
+  it("leaves a satellite with no attitude alone", () => {
+    // Not the same case: nothing was claimed, so a requested cube still stands —
+    // in the orbit view the marker is a position marker and reads as one.
+    expect(
+      resolveMarkerShape({ override: "axes-cube", hasAttitude: false, attitudeRefused: false }),
+    ).toBe("axes-cube");
+    expect(resolveMarkerShape({ override: "axes-cube", hasAttitude: false })).toBe("axes-cube");
+  });
+});

--- a/viewer/src/satelliteShapes.ts
+++ b/viewer/src/satelliteShapes.ts
@@ -27,18 +27,28 @@ export function isMarkerShape(value: string): value is MarkerShape {
 
 /**
  * Resolve the marker shape for a satellite. Precedence (most specific first):
+ *   0. `attitudeRefused` — the sphere, whatever was asked for
  *   1. `override`     — per-satellite viewer choice
  *   2. `simShape`     — shape declared by the simulation (via SatelliteInfo)
  *   3. `globalDefault`— viewer-wide default
  *   4. automatic      — orientation cube when attitude is present, else sphere
  * A null/undefined value at any level falls through to the next.
+ *
+ * `attitudeRefused` says the sample carried an attitude the viewer could not use.
+ * It outranks the requests above because the cube's faces show which way the body
+ * points: drawn at the identity it would answer a question the data could not,
+ * and the sphere is the one marker that looks the same from every side. A
+ * satellite with no attitude at all is not this case — there the requested shape
+ * stands, as it always has.
  */
 export function resolveMarkerShape(opts: {
   override?: MarkerShape | null;
   simShape?: MarkerShape | null;
   globalDefault?: MarkerShape | null;
   hasAttitude: boolean;
+  attitudeRefused?: boolean;
 }): MarkerShape {
+  if (opts.attitudeRefused) return "sphere";
   if (opts.override) return opts.override;
   if (opts.simShape) return opts.simShape;
   if (opts.globalDefault) return opts.globalDefault;

--- a/viewer/src/sources/rrdParseLogic.test.ts
+++ b/viewer/src/sources/rrdParseLogic.test.ts
@@ -35,23 +35,15 @@ describe("rowToPoint", () => {
     expect(attitudeWasRefused(point)).toBe(false);
   });
 
-  it("turns a quaternion column of the wrong length into a refused attitude", () => {
-    // The distinction this keeps: a column that is present but malformed is an
-    // attitude the file *claimed*. Assigning the components it happens to have
-    // would leave a partial sample, which reads downstream as no attitude at all
-    // — and a satellite with no attitude keeps its registered 3D model, drawn at
-    // the model's own orientation with the scene scaled to it. So the claim has
-    // to survive the decode, and `NaN` is what these components are.
-    for (const quaternion of [[1], [1, 0], [1, 0, 0], [1, 0, 0, 0, 0]]) {
-      const point = rowToPoint(row({ quaternion }));
-      expect(
-        [point.qw, point.qx, point.qy, point.qz].every((c) => Number.isNaN(c)),
-        `all four components should be NaN for a column of length ${quaternion.length}`,
-      ).toBe(true);
-      // Which is what the display frame reads as a refusal rather than an absence.
-      expect(sampleAttitude(point)).toBeUndefined();
-      expect(attitudeWasRefused(point)).toBe(true);
-    }
+  it("carries a non-finite quaternion through as an attitude to refuse", () => {
+    // The reachable malformed case: the decoder yields four components or none, so
+    // a row cannot arrive partly decoded — but a complete tuple can hold `NaN`,
+    // which a diverged simulation writes. It has to stay a claim, because a
+    // satellite read as having no attitude keeps its registered 3D model, drawn at
+    // the model's own orientation with the scene scaled to it.
+    const point = rowToPoint(row({ quaternion: [Number.NaN, 0, 0, 0] }));
+    expect(sampleAttitude(point)).toBeUndefined();
+    expect(attitudeWasRefused(point)).toBe(true);
   });
 
   it("copies the angular velocity when the row carries one", () => {

--- a/viewer/src/sources/rrdParseLogic.test.ts
+++ b/viewer/src/sources/rrdParseLogic.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { attitudeWasRefused, sampleAttitude } from "../displayFrame.js";
+import { type RrdRowIn, rowToPoint } from "./rrdParseLogic.js";
+
+function row(overrides: Partial<RrdRowIn> = {}): RrdRowIn {
+  return {
+    t: 0,
+    x: 7000,
+    y: 0,
+    z: 0,
+    vx: 0,
+    vy: 7.546,
+    vz: 0,
+    entity_path: "/world/sat/one",
+    ...overrides,
+  };
+}
+
+describe("rowToPoint", () => {
+  it("carries a complete quaternion through unchanged", () => {
+    const point = rowToPoint(row({ quaternion: [1, 0, 0, 0] }));
+    expect([point.qw, point.qx, point.qy, point.qz]).toEqual([1, 0, 0, 0]);
+    expect(sampleAttitude(point)).toEqual([1, 0, 0, 0]);
+    expect(attitudeWasRefused(point)).toBe(false);
+  });
+
+  it("leaves a row with no attitude column without one", () => {
+    const point = rowToPoint(row());
+    expect([point.qw, point.qx, point.qy, point.qz]).toEqual([
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    ]);
+    expect(attitudeWasRefused(point)).toBe(false);
+  });
+
+  it("turns a quaternion column of the wrong length into a refused attitude", () => {
+    // The distinction this keeps: a column that is present but malformed is an
+    // attitude the file *claimed*. Assigning the components it happens to have
+    // would leave a partial sample, which reads downstream as no attitude at all
+    // — and a satellite with no attitude keeps its registered 3D model, drawn at
+    // the model's own orientation with the scene scaled to it. So the claim has
+    // to survive the decode, and `NaN` is what these components are.
+    for (const quaternion of [[1], [1, 0], [1, 0, 0], [1, 0, 0, 0, 0]]) {
+      const point = rowToPoint(row({ quaternion }));
+      expect(
+        [point.qw, point.qx, point.qy, point.qz].every((c) => Number.isNaN(c)),
+        `all four components should be NaN for a column of length ${quaternion.length}`,
+      ).toBe(true);
+      // Which is what the display frame reads as a refusal rather than an absence.
+      expect(sampleAttitude(point)).toBeUndefined();
+      expect(attitudeWasRefused(point)).toBe(true);
+    }
+  });
+
+  it("copies the angular velocity when the row carries one", () => {
+    const point = rowToPoint(row({ angular_velocity: [0.1, 0.2, 0.3] }));
+    expect([point.wx, point.wy, point.wz]).toEqual([0.1, 0.2, 0.3]);
+    expect(rowToPoint(row()).wx).toBeUndefined();
+  });
+
+  it("passes the state and the entity path straight through", () => {
+    const point = rowToPoint(row({ t: 42, x: 1, y: 2, z: 3, vx: 4, vy: 5, vz: 6 }));
+    expect([point.t, point.x, point.y, point.z]).toEqual([42, 1, 2, 3]);
+    expect([point.vx, point.vy, point.vz]).toEqual([4, 5, 6]);
+    expect(point.entityPath).toBe("/world/sat/one");
+  });
+});

--- a/viewer/src/sources/rrdParseLogic.ts
+++ b/viewer/src/sources/rrdParseLogic.ts
@@ -47,8 +47,9 @@ export interface RrdRowIn {
   vy: number;
   vz: number;
   entity_path: string | null;
-  quaternion?: ArrayLike<number> | null;
-  angular_velocity?: ArrayLike<number> | null;
+  /** Four components or nothing — see {@link rowToPoint}. */
+  quaternion?: readonly [number, number, number, number] | null;
+  angular_velocity?: readonly [number, number, number] | null;
 }
 
 /**
@@ -70,19 +71,16 @@ export function rowToPoint(row: RrdRowIn): RrdPointOut {
     entityPath: row.entity_path,
   };
 
-  // Attitude is optional, and arrives whole or not at all. A `quaternion` column
-  // that is present but not four long would otherwise leave the missing
-  // components undefined, and a sample carrying only some of them reads
-  // downstream as no attitude — which lets a registered model stand at its own
-  // orientation, with the scene scaled to that model. `NaN` is what those
-  // components are; the display frame refuses them, and the spacecraft gets the
-  // marker that shows no orientation.
+  // Attitude is optional, and arrives whole or not at all: the decoder builds
+  // `Some([qw?, qx?, qy?, qz?])`, so a row missing any one component yields
+  // `None` rather than a short list (`rrd-wasm/src/lib.rs`). A complete tuple can
+  // still carry `NaN` — a diverged simulation writes one — and that reaches the
+  // display frame as an attitude to refuse, which is the behaviour wanted.
   if (row.quaternion) {
-    const complete = row.quaternion.length === 4;
-    point.qw = complete ? row.quaternion[0] : Number.NaN;
-    point.qx = complete ? row.quaternion[1] : Number.NaN;
-    point.qy = complete ? row.quaternion[2] : Number.NaN;
-    point.qz = complete ? row.quaternion[3] : Number.NaN;
+    point.qw = row.quaternion[0];
+    point.qx = row.quaternion[1];
+    point.qy = row.quaternion[2];
+    point.qz = row.quaternion[3];
   }
   if (row.angular_velocity) {
     point.wx = row.angular_velocity[0];

--- a/viewer/src/sources/rrdParseLogic.ts
+++ b/viewer/src/sources/rrdParseLogic.ts
@@ -36,3 +36,58 @@ export interface RrdPointOut {
   wy?: number;
   wz?: number;
 }
+
+/** One decoded row as rrd-wasm hands it over. */
+export interface RrdRowIn {
+  t: number;
+  x: number;
+  y: number;
+  z: number;
+  vx: number;
+  vy: number;
+  vz: number;
+  entity_path: string | null;
+  quaternion?: ArrayLike<number> | null;
+  angular_velocity?: ArrayLike<number> | null;
+}
+
+/**
+ * One decoded row as a point the viewer can draw.
+ *
+ * Lives here rather than in the worker so the boundary can be tested: what a
+ * malformed row turns into is the whole question, and a worker's message handler
+ * is not reachable from a unit test.
+ */
+export function rowToPoint(row: RrdRowIn): RrdPointOut {
+  const point: RrdPointOut = {
+    t: row.t,
+    x: row.x,
+    y: row.y,
+    z: row.z,
+    vx: row.vx,
+    vy: row.vy,
+    vz: row.vz,
+    entityPath: row.entity_path,
+  };
+
+  // Attitude is optional, and arrives whole or not at all. A `quaternion` column
+  // that is present but not four long would otherwise leave the missing
+  // components undefined, and a sample carrying only some of them reads
+  // downstream as no attitude — which lets a registered model stand at its own
+  // orientation, with the scene scaled to that model. `NaN` is what those
+  // components are; the display frame refuses them, and the spacecraft gets the
+  // marker that shows no orientation.
+  if (row.quaternion) {
+    const complete = row.quaternion.length === 4;
+    point.qw = complete ? row.quaternion[0] : Number.NaN;
+    point.qx = complete ? row.quaternion[1] : Number.NaN;
+    point.qy = complete ? row.quaternion[2] : Number.NaN;
+    point.qz = complete ? row.quaternion[3] : Number.NaN;
+  }
+  if (row.angular_velocity) {
+    point.wx = row.angular_velocity[0];
+    point.wy = row.angular_velocity[1];
+    point.wz = row.angular_velocity[2];
+  }
+  return point;
+}

--- a/viewer/src/sources/rrdParseWorker.ts
+++ b/viewer/src/sources/rrdParseWorker.ts
@@ -41,12 +41,19 @@ self.onmessage = async (e: MessageEvent<RrdWorkerInput>) => {
         entityPath: row.entity_path,
       };
 
-      // Attitude data (optional)
+      // Attitude data (optional). A column that is present but not four long
+      // would leave the missing components undefined, and a sample carrying only
+      // some of them reads downstream as no attitude at all — which lets a
+      // registered model stand at its own orientation, and scales the scene to
+      // that model. The claim arrives whole instead: `NaN` is what those
+      // components are, the display frame refuses them, and the spacecraft gets
+      // the marker that shows no orientation.
       if (row.quaternion) {
-        point.qw = row.quaternion[0];
-        point.qx = row.quaternion[1];
-        point.qy = row.quaternion[2];
-        point.qz = row.quaternion[3];
+        const complete = row.quaternion.length === 4;
+        point.qw = complete ? row.quaternion[0] : Number.NaN;
+        point.qx = complete ? row.quaternion[1] : Number.NaN;
+        point.qy = complete ? row.quaternion[2] : Number.NaN;
+        point.qz = complete ? row.quaternion[3] : Number.NaN;
       }
       if (row.angular_velocity) {
         point.wx = row.angular_velocity[0];

--- a/viewer/src/sources/rrdParseWorker.ts
+++ b/viewer/src/sources/rrdParseWorker.ts
@@ -6,7 +6,12 @@
  */
 
 import { initRrdWasm, parseRrd } from "../wasm/rrdWasmInit.js";
-import type { RrdPointOut, RrdWorkerInput, RrdWorkerMessage } from "./rrdParseLogic.js";
+import {
+  type RrdPointOut,
+  type RrdWorkerInput,
+  type RrdWorkerMessage,
+  rowToPoint,
+} from "./rrdParseLogic.js";
 
 const CHUNK_SIZE = 5000;
 
@@ -30,38 +35,7 @@ self.onmessage = async (e: MessageEvent<RrdWorkerInput>) => {
     let chunk: RrdPointOut[] = [];
 
     for (const row of data.rows) {
-      const point: RrdPointOut = {
-        t: row.t,
-        x: row.x,
-        y: row.y,
-        z: row.z,
-        vx: row.vx,
-        vy: row.vy,
-        vz: row.vz,
-        entityPath: row.entity_path,
-      };
-
-      // Attitude data (optional). A column that is present but not four long
-      // would leave the missing components undefined, and a sample carrying only
-      // some of them reads downstream as no attitude at all — which lets a
-      // registered model stand at its own orientation, and scales the scene to
-      // that model. The claim arrives whole instead: `NaN` is what those
-      // components are, the display frame refuses them, and the spacecraft gets
-      // the marker that shows no orientation.
-      if (row.quaternion) {
-        const complete = row.quaternion.length === 4;
-        point.qw = complete ? row.quaternion[0] : Number.NaN;
-        point.qx = complete ? row.quaternion[1] : Number.NaN;
-        point.qy = complete ? row.quaternion[2] : Number.NaN;
-        point.qz = complete ? row.quaternion[3] : Number.NaN;
-      }
-      if (row.angular_velocity) {
-        point.wx = row.angular_velocity[0];
-        point.wy = row.angular_velocity[1];
-        point.wz = row.angular_velocity[2];
-      }
-
-      chunk.push(point);
+      chunk.push(rowToPoint(row));
 
       if (chunk.length >= CHUNK_SIZE) {
         post({ type: "chunk", points: chunk, done: false });

--- a/viewer/src/spacecraftScale.test.ts
+++ b/viewer/src/spacecraftScale.test.ts
@@ -5,6 +5,9 @@ import {
   axisLengthForSpan,
   cameraDistanceForSpan,
   DEFAULT_CAMERA_FOV_DEGREES,
+  DEFAULT_CUBE_HALF_EXTENT,
+  DEFAULT_SPHERE_RADIUS,
+  defaultMarkerSize,
   drawnExtentForSpan,
   frameAxisLengthForSpan,
   initialCameraDistance,
@@ -61,6 +64,16 @@ describe("resolveVisualSpan", () => {
   it("uses the marker footprint when there is no model", () => {
     expect(resolveVisualSpan({ modelConfig: null, markerSize: 0.005 })).toBeCloseTo(0.01, 12);
     expect(resolveVisualSpan({ markerSize: 0.008 })).toBeCloseTo(0.016, 12);
+  });
+});
+
+describe("defaultMarkerSize", () => {
+  it("gives each marker shape its own footprint", () => {
+    // The sphere and the orientation cube are drawn at different sizes, and the
+    // span a caller derives from them differs accordingly.
+    expect(defaultMarkerSize("sphere")).toBeCloseTo(DEFAULT_SPHERE_RADIUS, 12);
+    expect(defaultMarkerSize("axes-cube")).toBeCloseTo(DEFAULT_CUBE_HALF_EXTENT, 12);
+    expect(defaultMarkerSize("axes-cube")).toBeGreaterThan(defaultMarkerSize("sphere"));
   });
 });
 

--- a/viewer/src/spacecraftScale.ts
+++ b/viewer/src/spacecraftScale.ts
@@ -20,6 +20,19 @@ import type { MarkerShape } from "./satelliteShapes.js";
 /** Apparent size of the spacecraft in a scene that has no other length scale. */
 export const NOMINAL_SPACECRAFT_SPAN = 1;
 
+/**
+ * Marker half-extents in the orbit view, whose scene unit is the central body's
+ * radius. Here rather than in the marker components because the *span* they
+ * imply is what the axes and arrows are sized from.
+ */
+export const DEFAULT_SPHERE_RADIUS = 0.005;
+export const DEFAULT_CUBE_HALF_EXTENT = 0.008;
+
+/** Marker half-extent for a shape, in the orbit view's scene units. */
+export function defaultMarkerSize(shape: MarkerShape): number {
+  return shape === "sphere" ? DEFAULT_SPHERE_RADIUS : DEFAULT_CUBE_HALF_EXTENT;
+}
+
 /** Body-axis length, as a ratio of the spacecraft's apparent size. */
 const AXIS_LENGTH_RATIO = 0.75;
 

--- a/viewer/src/utils/finite.test.ts
+++ b/viewer/src/utils/finite.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { finiteOrNull } from "./finite.js";
+import { finiteOrNull, firstFiniteTime } from "./finite.js";
 
 describe("finiteOrNull", () => {
   it("keeps zero, which a falsy check would drop", () => {
@@ -23,5 +23,26 @@ describe("finiteOrNull", () => {
   it("passes absence through unchanged", () => {
     expect(finiteOrNull(null)).toBeNull();
     expect(finiteOrNull(undefined)).toBeNull();
+  });
+});
+
+describe("firstFiniteTime", () => {
+  it("skips a sample whose time is not a number and keeps looking", () => {
+    // The case the scene got wrong twice: one satellite's `t` is NaN while
+    // another carries a good time, and stopping at the first sample that exists
+    // leaves the scene with no time rather than that one.
+    expect(firstFiniteTime([{ t: Number.NaN }, { t: 120 }])).toBe(120);
+    expect(firstFiniteTime([null, undefined, { t: Number.POSITIVE_INFINITY }, { t: 7 }])).toBe(7);
+  });
+
+  it("takes the first finite time it finds", () => {
+    expect(firstFiniteTime([{ t: 0 }, { t: 120 }])).toBe(0);
+    expect(firstFiniteTime([{ t: -30 }, { t: 120 }])).toBe(-30);
+  });
+
+  it("reports none when nothing carries a time", () => {
+    expect(firstFiniteTime(undefined)).toBeNull();
+    expect(firstFiniteTime([])).toBeNull();
+    expect(firstFiniteTime([null, { t: Number.NaN }, {}])).toBeNull();
   });
 });

--- a/viewer/src/utils/finite.test.ts
+++ b/viewer/src/utils/finite.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { finiteOrNull, firstFiniteTime } from "./finite.js";
+import { finiteOrNull } from "./finite.js";
 
 describe("finiteOrNull", () => {
   it("keeps zero, which a falsy check would drop", () => {
@@ -23,26 +23,5 @@ describe("finiteOrNull", () => {
   it("passes absence through unchanged", () => {
     expect(finiteOrNull(null)).toBeNull();
     expect(finiteOrNull(undefined)).toBeNull();
-  });
-});
-
-describe("firstFiniteTime", () => {
-  it("skips a sample whose time is not a number and keeps looking", () => {
-    // The case the scene got wrong twice: one satellite's `t` is NaN while
-    // another carries a good time, and stopping at the first sample that exists
-    // leaves the scene with no time rather than that one.
-    expect(firstFiniteTime([{ t: Number.NaN }, { t: 120 }])).toBe(120);
-    expect(firstFiniteTime([null, undefined, { t: Number.POSITIVE_INFINITY }, { t: 7 }])).toBe(7);
-  });
-
-  it("takes the first finite time it finds", () => {
-    expect(firstFiniteTime([{ t: 0 }, { t: 120 }])).toBe(0);
-    expect(firstFiniteTime([{ t: -30 }, { t: 120 }])).toBe(-30);
-  });
-
-  it("reports none when nothing carries a time", () => {
-    expect(firstFiniteTime(undefined)).toBeNull();
-    expect(firstFiniteTime([])).toBeNull();
-    expect(firstFiniteTime([null, { t: Number.NaN }, {}])).toBeNull();
   });
 });

--- a/viewer/src/utils/finite.ts
+++ b/viewer/src/utils/finite.ts
@@ -12,3 +12,21 @@
 export function finiteOrNull(value: number | null | undefined): number | null {
   return value != null && Number.isFinite(value) ? value : null;
 }
+
+/**
+ * The first finite `t` among these samples, or null if none has one.
+ *
+ * Scanning for a usable time rather than for the first sample that exists: a
+ * satellite whose `t` is `NaN` would otherwise end the search and leave the
+ * caller with no time at all, while a later satellite carries a good one.
+ */
+export function firstFiniteTime(
+  samples: Iterable<{ t?: number } | null | undefined> | null | undefined,
+): number | null {
+  if (samples == null) return null;
+  for (const sample of samples) {
+    const t = finiteOrNull(sample?.t);
+    if (t != null) return t;
+  }
+  return null;
+}

--- a/viewer/src/utils/finite.ts
+++ b/viewer/src/utils/finite.ts
@@ -12,21 +12,3 @@
 export function finiteOrNull(value: number | null | undefined): number | null {
   return value != null && Number.isFinite(value) ? value : null;
 }
-
-/**
- * The first finite `t` among these samples, or null if none has one.
- *
- * Scanning for a usable time rather than for the first sample that exists: a
- * satellite whose `t` is `NaN` would otherwise end the search and leave the
- * caller with no time at all, while a later satellite carries a good one.
- */
-export function firstFiniteTime(
-  samples: Iterable<{ t?: number } | null | undefined> | null | undefined,
-): number | null {
-  if (samples == null) return null;
-  for (const sample of samples) {
-    const t = finiteOrNull(sample?.t);
-    if (t != null) return t;
-  }
-  return null;
-}

--- a/viewer/tests/attitude-viewer-public.spec.ts
+++ b/viewer/tests/attitude-viewer-public.spec.ts
@@ -73,8 +73,17 @@ async function sceneInventory(page: Page) {
   return await page.evaluate((id) => {
     const w = window as unknown as {
       __debug_sat_quat_registry?: Map<string, () => { parent: unknown } | null>;
+      __debug_direction_vector_registry?: Map<
+        string,
+        () => { origin: { parent: unknown } | null }[]
+      >;
     };
-    const start = w.__debug_sat_quat_registry?.get(id)?.();
+    // The arrows' registry is the way in when the attitude was refused: no
+    // attitude hook is registered then, and walking `.parent` from either
+    // reaches the same scene root.
+    const start =
+      w.__debug_sat_quat_registry?.get(id)?.() ??
+      w.__debug_direction_vector_registry?.get(id)?.()?.[0]?.origin;
     if (start == null) return null;
     type Node = {
       type: string;
@@ -212,6 +221,21 @@ test("an unusable attitude draws no orientation at all", async ({ page }) => {
   await expectArrows(page, ["sun"]);
   const quat = await page.evaluate((id) => window.__debug_get_sat_world_quat?.(id) ?? null, SAT);
   expect(quat, "no body axes are registered without an attitude").toBeNull();
+
+  // The cube was asked for by name, so declining to choose it is not enough: the
+  // request has to be refused. Here the sphere can be named as well as the cube
+  // denied — the attitude scene holds no central body, so a sphere in it is the
+  // marker.
+  const inventory = await sceneInventory(page);
+  expect(inventory, "the scene graph should be reachable").not.toBeNull();
+  expect(
+    inventory?.meshGeometries,
+    "a requested cube is refused with no attitude to show",
+  ).not.toContain("BoxGeometry");
+  expect(
+    inventory?.meshGeometries,
+    "the marker that looks the same from every side stands in",
+  ).toContain("SphereGeometry");
 });
 
 test("body-fixed rotates the spacecraft about the scene's polar axis", async ({ page }) => {

--- a/viewer/tests/orbit-direction-vectors.spec.ts
+++ b/viewer/tests/orbit-direction-vectors.spec.ts
@@ -230,12 +230,14 @@ test("centred satellite gets Sun and nadir arrows, in the local-orbital basis", 
   // The head's distance from the origin pins the rendered proportions, which the
   // normalised direction cannot: this satellite has no 3D model, so it is drawn
   // as the orientation cube (half-extent 0.008 → apparent size 0.016), and the
-  // head's centre sits at `startOffset + length - headLength / 2` = 1.9 spans.
-  const EXPECTED_HEAD_DISTANCE = 1.9 * 0.016;
+  // head's centre sits at `startOffset + length - headLength / 2`. The centred
+  // satellite draws the cube marker, whose corners stand at sqrt(3)/2 of the
+  // span, so the tail starts there: sqrt(3)/2 + 1.5 - 0.1 = 2.266 spans.
+  const EXPECTED_HEAD_DISTANCE = (Math.sqrt(3) / 2 + 1.5 - 0.1) * 0.016;
   for (const v of vectors) {
     expect(
       v.distance,
-      `${v.kind} arrow's head should sit 1.9 spans out; a different distance means the ` +
+      `${v.kind} arrow's head should sit 2.266 spans out; a different distance means the ` +
         `offset or the arrow proportions changed`,
     ).toBeCloseTo(EXPECTED_HEAD_DISTANCE, 6);
   }

--- a/viewer/tests/orbit-direction-vectors.spec.ts
+++ b/viewer/tests/orbit-direction-vectors.spec.ts
@@ -48,10 +48,18 @@ let configPath: string;
 function spawnServer(configFile: string): Promise<{ child: ChildProcess; port: number }> {
   const binary = process.env.ORTS_BINARY ?? path.resolve(__dirname, "../../target/debug/orts");
   const child = spawn(binary, ["serve", "--port", "0", "--config", configFile], {
+    // stderr is where the server announces its URL. Named explicitly so the
+    // reader below cannot end up on the runner's own stdin, which never ends.
+    stdio: ["ignore", "ignore", "pipe"],
     env: { ...process.env, ORTS_DISABLE_TEXTURE_DOWNLOAD: "1" },
   });
   return new Promise((resolve, reject) => {
-    const rl = createInterface({ input: child.stderr ?? process.stdin });
+    const serverLog = child.stderr;
+    if (serverLog == null) {
+      reject(new Error("orts serve was spawned without a stderr pipe"));
+      return;
+    }
+    const rl = createInterface({ input: serverLog });
     const onError = (err: Error) => {
       settle();
       reject(err);

--- a/viewer/tests/orbit-direction-vectors.spec.ts
+++ b/viewer/tests/orbit-direction-vectors.spec.ts
@@ -52,25 +52,41 @@ function spawnServer(configFile: string): Promise<{ child: ChildProcess; port: n
   });
   return new Promise((resolve, reject) => {
     const rl = createInterface({ input: child.stderr ?? process.stdin });
+    const onError = (err: Error) => {
+      settle();
+      reject(err);
+    };
+    const onExit = (code: number | null) => {
+      settle();
+      reject(new Error(`orts exited with code ${code} before listening`));
+    };
     const timeout = setTimeout(() => {
-      rl.close();
+      settle();
+      // Nothing else will: `beforeAll` throws before it can record the child, so
+      // `afterAll` has nothing to kill and the server would outlive the run.
+      child.kill("SIGTERM");
       reject(new Error("Timed out waiting for orts server to start"));
     }, 30000);
+    /**
+     * Stop watching for the startup line. The readline interface stays attached
+     * on purpose: it is what drains the child's stderr, and a paused pipe fills
+     * up and blocks the server on its next log line.
+     */
+    function settle() {
+      clearTimeout(timeout);
+      rl.removeAllListeners("line");
+      child.off("error", onError);
+      child.off("exit", onExit);
+    }
     rl.on("line", (line) => {
       const match = line.match(/ws:\/\/localhost:(\d+)/);
       if (match) {
-        clearTimeout(timeout);
+        settle();
         resolve({ child, port: parseInt(match[1], 10) });
       }
     });
-    child.on("error", (err) => {
-      clearTimeout(timeout);
-      reject(err);
-    });
-    child.on("exit", (code) => {
-      clearTimeout(timeout);
-      reject(new Error(`orts exited with code ${code} before listening`));
-    });
+    child.on("error", onError);
+    child.on("exit", onExit);
   });
 }
 

--- a/viewer/tests/orbit-direction-vectors.spec.ts
+++ b/viewer/tests/orbit-direction-vectors.spec.ts
@@ -1,0 +1,223 @@
+/**
+ * E2E for the reference-direction arrows in the *orbit* view.
+ *
+ * The arrows are drawn only at a centred satellite: this view can hold many
+ * satellites, and a pair of arrows on each of them fills the screen; in a
+ * central-body view the body itself is on screen, so a nadir arrow repeats what
+ * the picture already shows. Both halves of that rule are asserted here.
+ *
+ * Directions are read from the live Three.js scene graph via
+ * `window.__debug_get_direction_vectors(id)`, which measures each arrow as the
+ * unit vector from its origin to its head. Reading the resolved input instead
+ * would pass even with the geometry's own axis, the rotation onto it, or the
+ * head's placement wrong — and an arrow is a few triangles on a dark background,
+ * so a pixel test on it would fail for reasons unrelated to the geometry.
+ *
+ * The satellite is on an equatorial circular orbit, so in the satellite-centred
+ * local-orbital view — whose basis is [in-track, cross-track, radial] = scene
+ * [X, Y, Z] — nadir is exactly scene -Z, at every orbital phase. That invariant
+ * is what catches a nadir arrow built from a different axis order than the
+ * positions use.
+ */
+import { type ChildProcess, spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const SAT_ID = "dir-test";
+/** Entity path the viewer keys the satellite by (`/world/sat/{id}`). */
+const SAT_ENTITY_PATH = `/world/sat/${SAT_ID}`;
+
+interface DrawnVector {
+  kind: string;
+  direction: [number, number, number];
+  /** Distance from the arrow's origin to its head's centre, in scene units. */
+  distance: number;
+}
+
+let ortsProcess: ChildProcess | undefined;
+let wsUrl: string;
+let configPath: string;
+
+/** Spawn an `orts serve` instance and resolve once it prints its ws:// URL. */
+function spawnServer(configFile: string): Promise<{ child: ChildProcess; port: number }> {
+  const binary = process.env.ORTS_BINARY ?? path.resolve(__dirname, "../../target/debug/orts");
+  const child = spawn(binary, ["serve", "--port", "0", "--config", configFile], {
+    env: { ...process.env, ORTS_DISABLE_TEXTURE_DOWNLOAD: "1" },
+  });
+  return new Promise((resolve, reject) => {
+    const rl = createInterface({ input: child.stderr ?? process.stdin });
+    const timeout = setTimeout(() => {
+      rl.close();
+      reject(new Error("Timed out waiting for orts server to start"));
+    }, 30000);
+    rl.on("line", (line) => {
+      const match = line.match(/ws:\/\/localhost:(\d+)/);
+      if (match) {
+        clearTimeout(timeout);
+        resolve({ child, port: parseInt(match[1], 10) });
+      }
+    });
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+    child.on("exit", (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`orts exited with code ${code} before listening`));
+    });
+  });
+}
+
+test.beforeAll(async () => {
+  const config = {
+    body: "earth",
+    dt: 1.0,
+    output_interval: 10,
+    satellites: [
+      {
+        id: SAT_ID,
+        name: "Direction Vector Test",
+        orbit: { type: "circular", altitude: 500 },
+        attitude: {
+          mass: 500,
+          inertia_diag: [100, 100, 50],
+          initial_angular_velocity: [0, 0, 0],
+        },
+      },
+    ],
+  };
+  configPath = path.join(os.tmpdir(), `orts-direction-vectors-e2e-${Date.now()}.json`);
+  fs.writeFileSync(configPath, JSON.stringify(config));
+
+  const { child, port } = await spawnServer(configPath);
+  ortsProcess = child;
+  wsUrl = `ws://localhost:${port}/ws`;
+  console.log(`orts direction-vector server started at ${wsUrl}`);
+});
+
+test.afterAll(async () => {
+  if (ortsProcess && !ortsProcess.killed) {
+    ortsProcess.kill("SIGTERM");
+  }
+  if (configPath) {
+    try {
+      fs.unlinkSync(configPath);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+/** Connect the viewer to the test server through the normal UI path. */
+async function connect(page: import("@playwright/test").Page) {
+  await page.goto("/?noAutoConnect=1");
+  await page.locator('[data-testid="ws-url-input"]').fill(wsUrl);
+  await page.locator('[data-testid="ws-connect-btn"]').click();
+  await expect(page.locator('[data-testid="ws-status-text"]')).toContainText("Connected", {
+    timeout: 15000,
+  });
+  await expect(page.locator("canvas").first()).toBeVisible();
+  await page.waitForFunction(
+    () =>
+      typeof (window as unknown as Record<string, unknown>).__debug_get_sat_world_quat ===
+      "function",
+    { timeout: 15000 },
+  );
+}
+
+/** Read the drawn arrows, retrying while the scene graph settles. */
+async function drawnVectors(
+  page: import("@playwright/test").Page,
+  id: string,
+  { expectSome }: { expectSome: boolean },
+): Promise<DrawnVector[] | null> {
+  return page.evaluate(
+    async ([entityId, wantSome]) => {
+      const w = window as unknown as Record<string, unknown>;
+      const get = w.__debug_get_direction_vectors as
+        | ((
+            id: string,
+          ) => { kind: string; direction: [number, number, number]; distance: number }[] | null)
+        | undefined;
+      if (!get) return null;
+      for (let i = 0; i < 40; i++) {
+        const drawn = get(entityId as string);
+        if (!wantSome) {
+          // Absence has to settle too: give the scene the same window to draw
+          // something before concluding it drew nothing.
+          if (i === 39) return drawn ?? [];
+        } else if (drawn != null && drawn.length > 0) {
+          return drawn;
+        }
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      return get(entityId as string) ?? [];
+    },
+    [id, expectSome] as [string, boolean],
+  );
+}
+
+test("centred satellite gets Sun and nadir arrows, in the local-orbital basis", async ({
+  page,
+}) => {
+  await connect(page);
+
+  // Centre on the satellite; the selector defaults a satellite centre to LVLH.
+  await page
+    .locator('[data-testid="frame-selector-select"]')
+    .selectOption(`satellite:${SAT_ENTITY_PATH}`);
+  await expect(page.locator('[data-testid="frame-orientation-lvlh"]')).toBeVisible();
+
+  const vectors = await drawnVectors(page, SAT_ENTITY_PATH, { expectSome: true });
+  expect(vectors, "the debug hook should expose the drawn arrows").not.toBeNull();
+  if (vectors == null) return;
+
+  expect(
+    vectors.map((v) => v.kind).sort(),
+    "both reference directions should be drawn once the epoch and position are known",
+  ).toEqual(["nadir", "sun"]);
+
+  const nadir = vectors.find((v) => v.kind === "nadir")?.direction;
+  expect(nadir).toBeDefined();
+  if (nadir == null) return;
+
+  // [in-track, cross-track, radial] = scene [X, Y, Z], so the central body is
+  // exactly along scene -Z whatever the orbital phase.
+  expect(
+    nadir[2],
+    `nadir should point along scene -Z in the local-orbital view, got ` +
+      `(${nadir.map((c) => c.toFixed(3)).join(", ")}). A non-Z direction means the arrow ` +
+      `was built from a different axis order than the positions use.`,
+  ).toBeLessThan(-0.99);
+  expect(Math.abs(nadir[0]), "nadir should have no in-track component").toBeLessThan(0.02);
+  expect(Math.abs(nadir[1]), "nadir should have no cross-track component").toBeLessThan(0.02);
+
+  // The head's distance from the origin pins the rendered proportions, which the
+  // normalised direction cannot: this satellite has no 3D model, so it is drawn
+  // as the orientation cube (half-extent 0.008 → apparent size 0.016), and the
+  // head's centre sits at `startOffset + length - headLength / 2` = 1.9 spans.
+  const EXPECTED_HEAD_DISTANCE = 1.9 * 0.016;
+  for (const v of vectors) {
+    expect(
+      v.distance,
+      `${v.kind} arrow's head should sit 1.9 spans out; a different distance means the ` +
+        `offset or the arrow proportions changed`,
+    ).toBeCloseTo(EXPECTED_HEAD_DISTANCE, 6);
+  }
+});
+
+test("a central-body view draws no arrows", async ({ page }) => {
+  // The body is on screen there, so a nadir arrow repeats the picture; and with
+  // many satellites a pair of arrows on each would fill the screen.
+  await connect(page);
+  await expect(page.locator('[data-testid="frame-selector-select"]')).toHaveValue("central_body");
+
+  const vectors = await drawnVectors(page, SAT_ENTITY_PATH, { expectSome: false });
+  expect(vectors ?? [], "no arrows should be registered for a central-body view").toHaveLength(0);
+});

--- a/viewer/tests/orbit-direction-vectors.spec.ts
+++ b/viewer/tests/orbit-direction-vectors.spec.ts
@@ -179,14 +179,16 @@ async function drawnVectors(
         const drawn = read();
         if (!wantSome) {
           // Absence has to settle too: give the scene the same window to draw
-          // something before concluding it drew nothing.
-          if (i === 39) return drawn ?? [];
+          // something before concluding it drew nothing. `null` is returned as
+          // it is — a missing hook is a different fact from an empty list, and
+          // coercing it here would make the caller's null check unfailable.
+          if (i === 39) return drawn;
         } else if (drawn != null && drawn.length > 0) {
           return drawn;
         }
         await new Promise((r) => setTimeout(r, 100));
       }
-      return read() ?? [];
+      return read();
     },
     [id, expectSome] as [string, boolean],
   );

--- a/viewer/tests/orbit-direction-vectors.spec.ts
+++ b/viewer/tests/orbit-direction-vectors.spec.ts
@@ -159,10 +159,10 @@ async function connect(page: import("@playwright/test").Page) {
 async function drawnVectors(
   page: import("@playwright/test").Page,
   id: string,
-  { expectSome }: { expectSome: boolean },
+  { expectKinds }: { expectKinds: readonly string[] },
 ): Promise<DrawnVector[] | null> {
   return page.evaluate(
-    async ([entityId, wantSome]) => {
+    async ([entityId, wanted]) => {
       const w = window as unknown as Record<string, unknown>;
       // Re-read the hook each pass: it is installed when the arrows first mount,
       // which can be after the connection is up. Reading it once and giving up
@@ -175,22 +175,27 @@ async function drawnVectors(
               ) => { kind: string; direction: [number, number, number]; distance: number }[] | null)
             | undefined
         )?.(entityId as string) ?? null;
+      const wantedKinds = wanted as readonly string[];
       for (let i = 0; i < 40; i++) {
         const drawn = read();
-        if (!wantSome) {
+        if (wantedKinds.length === 0) {
           // Absence has to settle too: give the scene the same window to draw
           // something before concluding it drew nothing. `null` is returned as
           // it is — a missing hook is a different fact from an empty list, and
           // coercing it here would make the caller's null check unfailable.
           if (i === 39) return drawn;
-        } else if (drawn != null && drawn.length > 0) {
+        } else if (drawn != null && wantedKinds.every((k) => drawn.some((d) => d.kind === k))) {
+          // Wait for the *named* arrows, not for any arrow: nadir needs nothing
+          // but a position, while the Sun waits on the WASM ephemeris, so a
+          // caller asserting both would otherwise read the moment nadir alone
+          // had arrived.
           return drawn;
         }
         await new Promise((r) => setTimeout(r, 100));
       }
       return read();
     },
-    [id, expectSome] as [string, boolean],
+    [id, expectKinds] as [string, readonly string[]],
   );
 }
 
@@ -205,7 +210,7 @@ test("centred satellite gets Sun and nadir arrows, in the local-orbital basis", 
     .selectOption(`satellite:${SAT_ENTITY_PATH}`);
   await expect(page.locator('[data-testid="frame-orientation-lvlh"]')).toBeVisible();
 
-  const vectors = await drawnVectors(page, SAT_ENTITY_PATH, { expectSome: true });
+  const vectors = await drawnVectors(page, SAT_ENTITY_PATH, { expectKinds: ["sun", "nadir"] });
   expect(vectors, "the debug hook should expose the drawn arrows").not.toBeNull();
   if (vectors == null) return;
 
@@ -256,13 +261,13 @@ test("a central-body view draws no arrows", async ({ page }) => {
   await page
     .locator('[data-testid="frame-selector-select"]')
     .selectOption(`satellite:${SAT_ENTITY_PATH}`);
-  const drawn = await drawnVectors(page, SAT_ENTITY_PATH, { expectSome: true });
+  const drawn = await drawnVectors(page, SAT_ENTITY_PATH, { expectKinds: ["sun", "nadir"] });
   expect(drawn?.length ?? 0, "arrows should be drawn while a satellite is centred").toBeGreaterThan(
     0,
   );
 
   await page.locator('[data-testid="frame-selector-select"]').selectOption("central_body");
-  const vectors = await drawnVectors(page, SAT_ENTITY_PATH, { expectSome: false });
+  const vectors = await drawnVectors(page, SAT_ENTITY_PATH, { expectKinds: [] });
   // `null` is the expected state, not merely an acceptable one: with nothing to
   // draw the scene does not mount `DirectionArrows` at all, so the hook is gone.
   // Collapsing null and [] here would also accept a component still mounted and

--- a/viewer/tests/orbit-direction-vectors.spec.ts
+++ b/viewer/tests/orbit-direction-vectors.spec.ts
@@ -263,5 +263,9 @@ test("a central-body view draws no arrows", async ({ page }) => {
 
   await page.locator('[data-testid="frame-selector-select"]').selectOption("central_body");
   const vectors = await drawnVectors(page, SAT_ENTITY_PATH, { expectSome: false });
-  expect(vectors ?? [], "no arrows should be registered for a central-body view").toHaveLength(0);
+  // `null` is the expected state, not merely an acceptable one: with nothing to
+  // draw the scene does not mount `DirectionArrows` at all, so the hook is gone.
+  // Collapsing null and [] here would also accept a component still mounted and
+  // registering an empty list, which is a different scene.
+  expect(vectors, "the arrows' hook should be gone in a central-body view").toBeNull();
 });

--- a/viewer/tests/orbit-direction-vectors.spec.ts
+++ b/viewer/tests/orbit-direction-vectors.spec.ts
@@ -176,14 +176,22 @@ async function drawnVectors(
             | undefined
         )?.(entityId as string) ?? null;
       const wantedKinds = wanted as readonly string[];
-      for (let i = 0; i < 40; i++) {
+      // Waiting for an arrow to appear needs a window as long as the slowest
+      // thing it waits on: the Sun's direction comes from the arika WASM, and
+      // `OrbitScene` passes no epoch until that module resolves, which on a cold
+      // CI run takes longer than mounting the scene does. Concluding that nothing
+      // is drawn needs only the scene to settle — the caller has already drawn
+      // the arrows in this same document, so a slow module cannot make that
+      // conclusion arrive for the wrong reason.
+      const passes = wantedKinds.length === 0 ? 40 : 150;
+      for (let i = 0; i < passes; i++) {
         const drawn = read();
         if (wantedKinds.length === 0) {
-          // Absence has to settle too: give the scene the same window to draw
-          // something before concluding it drew nothing. `null` is returned as
-          // it is — a missing hook is a different fact from an empty list, and
-          // coercing it here would make the caller's null check unfailable.
-          if (i === 39) return drawn;
+          // Absence has to settle too: give the scene a window to draw something
+          // before concluding it drew nothing. `null` is returned as it is — a
+          // missing hook is a different fact from an empty list, and coercing it
+          // here would make the caller's null check unfailable.
+          if (i === passes - 1) return drawn;
         } else if (drawn != null && wantedKinds.every((k) => drawn.some((d) => d.kind === k))) {
           // Wait for the *named* arrows, not for any arrow: nadir needs nothing
           // but a position, while the Sun waits on the WASM ephemeris, so a

--- a/viewer/tests/orbit-direction-vectors.spec.ts
+++ b/viewer/tests/orbit-direction-vectors.spec.ts
@@ -237,8 +237,19 @@ test("a central-body view draws no arrows", async ({ page }) => {
   // The body is on screen there, so a nadir arrow repeats the picture; and with
   // many satellites a pair of arrows on each would fill the screen.
   await connect(page);
-  await expect(page.locator('[data-testid="frame-selector-select"]')).toHaveValue("central_body");
 
+  // Draw them first. Asserting the absence straight away would also pass if the
+  // arrows had never been reachable at all — the hook is only installed once they
+  // mount, and it is never installed in a central-body view.
+  await page
+    .locator('[data-testid="frame-selector-select"]')
+    .selectOption(`satellite:${SAT_ENTITY_PATH}`);
+  const drawn = await drawnVectors(page, SAT_ENTITY_PATH, { expectSome: true });
+  expect(drawn?.length ?? 0, "arrows should be drawn while a satellite is centred").toBeGreaterThan(
+    0,
+  );
+
+  await page.locator('[data-testid="frame-selector-select"]').selectOption("central_body");
   const vectors = await drawnVectors(page, SAT_ENTITY_PATH, { expectSome: false });
   expect(vectors ?? [], "no arrows should be registered for a central-body view").toHaveLength(0);
 });

--- a/viewer/tests/orbit-direction-vectors.spec.ts
+++ b/viewer/tests/orbit-direction-vectors.spec.ts
@@ -140,14 +140,19 @@ async function drawnVectors(
   return page.evaluate(
     async ([entityId, wantSome]) => {
       const w = window as unknown as Record<string, unknown>;
-      const get = w.__debug_get_direction_vectors as
-        | ((
-            id: string,
-          ) => { kind: string; direction: [number, number, number]; distance: number }[] | null)
-        | undefined;
-      if (!get) return null;
+      // Re-read the hook each pass: it is installed when the arrows first mount,
+      // which can be after the connection is up. Reading it once and giving up
+      // would make this pass or fail on scene-mount timing.
+      const read = () =>
+        (
+          w.__debug_get_direction_vectors as
+            | ((
+                id: string,
+              ) => { kind: string; direction: [number, number, number]; distance: number }[] | null)
+            | undefined
+        )?.(entityId as string) ?? null;
       for (let i = 0; i < 40; i++) {
-        const drawn = get(entityId as string);
+        const drawn = read();
         if (!wantSome) {
           // Absence has to settle too: give the scene the same window to draw
           // something before concluding it drew nothing.
@@ -157,7 +162,7 @@ async function drawnVectors(
         }
         await new Promise((r) => setTimeout(r, 100));
       }
-      return get(entityId as string) ?? [];
+      return read() ?? [];
     },
     [id, expectSome] as [string, boolean],
   );

--- a/viewer/tests/orbit-viewer-public.spec.ts
+++ b/viewer/tests/orbit-viewer-public.spec.ts
@@ -402,7 +402,12 @@ test("an unusable attitude gets the marker that shows no orientation", async ({ 
   // faces show which way the body points, and a sphere when it has none. That
   // choice has to follow the *usable* attitude: a zero quaternion drawn as a cube
   // shows an orientation nobody measured.
-  await open(page, `sats=0:${SAT_A}&centre=0&epoch=${EPOCH}&att=0,0,0,0&arrows=sun,nadir`);
+  // The cube is *asked for* here, which is the harder half: the resolver has to
+  // refuse a request, not merely decline to choose the cube on its own.
+  await open(
+    page,
+    `sats=0:${SAT_A}&centre=0&epoch=${EPOCH}&att=0,0,0,0&shape=axes-cube&arrows=sun,nadir`,
+  );
   await arrowsAt(page, 0, ["nadir", "sun"]);
   const refused = await meshGeometries(page, "fixture-sat-0");
   expect(refused, "the scene graph should be reachable").not.toBeNull();

--- a/viewer/tests/orbit-viewer-public.spec.ts
+++ b/viewer/tests/orbit-viewer-public.spec.ts
@@ -114,3 +114,40 @@ test("a satellite whose time is not a number still leaves a drawable scene", asy
     expect(arrow.distance, `${arrow.kind} arrow should have a length`).toBeGreaterThan(0);
   }
 });
+
+test("a satellite with no usable time stays in the scene's frame", async ({ page }) => {
+  // A body-fixed view rotates everything by the Earth rotation angle at the
+  // scene's time. A satellite whose own `time` is `NaN` has to be rotated the
+  // same way — dropping the rotation for it would leave that one marker in the
+  // inertial frame while the body, the trails and every other satellite are
+  // body-fixed, which is a picture of two conventions at once.
+  const attitude = "0.7071067811865476,0,0,0.7071067811865476";
+  const worldQuat = async () => {
+    const q = await page.evaluate(
+      (id) => window.__debug_get_sat_world_quat?.(id) ?? null,
+      "fixture-sat-0",
+    );
+    if (q == null) throw new Error("no rendered attitude");
+    return q;
+  };
+
+  await open(page, `sats=nan:${SAT_A}&frame=bodyFixed&epoch=${EPOCH}&att=${attitude}&arrows=none`);
+  await expect.poll(async () => (await worldQuat()) != null, { timeout: 15000 }).toBe(true);
+  const withoutTime = await worldQuat();
+
+  // The scene's own time is what it falls back to, and with this one satellite
+  // carrying no usable time that is 0 — so a satellite explicitly at 0 has to
+  // come out identical.
+  await open(page, `sats=0:${SAT_A}&frame=bodyFixed&epoch=${EPOCH}&att=${attitude}&arrows=none`);
+  const atZero = await worldQuat();
+  for (const i of [0, 1, 2, 3]) {
+    expect(withoutTime[i], `quaternion component ${i}`).toBeCloseTo(atZero[i], 6);
+  }
+
+  // And the inertial frame gives a different quaternion, so the comparison above
+  // is not satisfied by any rotation at all.
+  await open(page, `sats=0:${SAT_A}&frame=inertial&epoch=${EPOCH}&att=${attitude}&arrows=none`);
+  const inertial = await worldQuat();
+  const same = [0, 1, 2, 3].every((i) => Math.abs(inertial[i] - atZero[i]) < 1e-6);
+  expect(same, "the body-fixed frame should not equal the inertial one").toBe(false);
+});

--- a/viewer/tests/orbit-viewer-public.spec.ts
+++ b/viewer/tests/orbit-viewer-public.spec.ts
@@ -241,11 +241,20 @@ test("a central-body view is drawn at the scene's time, not a satellite's", asyn
   // The central body's rendered rotation is what reports the epoch the scene
   // chose — a satellite's own rotation would not, since each marker turns by its
   // own sample time.
+  // The body's hook is installed before the WASM is ready, and until it is the
+  // body is drawn unrotated. Reading then would compare the fallback against the
+  // fallback, so each read waits for a rotation to have been applied — the same
+  // reason `rotatedQuat` above waits.
+  const identity: [number, number, number, number] = [0, 0, 0, 1];
   const earthQuat = async () => {
     await expect
-      .poll(() => page.evaluate(() => window.__debug_get_earth_world_quat?.() != null), {
-        timeout: 15000,
-      })
+      .poll(
+        async () => {
+          const q = await page.evaluate(() => window.__debug_get_earth_world_quat?.() ?? null);
+          return q != null && [0, 1, 2, 3].some((i) => Math.abs(q[i] - identity[i]) > 1e-6);
+        },
+        { timeout: 15000 },
+      )
       .toBe(true);
     const q = await page.evaluate(() => window.__debug_get_earth_world_quat?.() ?? null);
     if (q == null) throw new Error("no rendered central body");

--- a/viewer/tests/orbit-viewer-public.spec.ts
+++ b/viewer/tests/orbit-viewer-public.spec.ts
@@ -113,6 +113,47 @@ async function meshGeometries(page: Page, id: string): Promise<string[] | null> 
   }, id);
 }
 
+/**
+ * How far the central body sits from the centred spacecraft, in scene units.
+ *
+ * Centring converts positions with a radius the amplification divides, so this
+ * distance is where the chosen amplification shows up in the rendered graph. Read
+ * off the largest sphere, which is the body itself — the markers are far smaller.
+ */
+async function centralBodyDistance(page: Page, id: string): Promise<number | null> {
+  return await page.evaluate((satId) => {
+    const w = window as unknown as {
+      __debug_direction_vector_registry?: Map<
+        string,
+        () => { origin: { parent: unknown } | null }[]
+      >;
+    };
+    const start = w.__debug_direction_vector_registry?.get(satId)?.()?.[0]?.origin;
+    if (start == null) return null;
+    type Node = {
+      type: string;
+      parent: Node | null;
+      children: Node[];
+      matrixWorld: { elements: number[] };
+      geometry?: { type?: string; parameters?: { radius?: number } };
+    };
+    let root = start as unknown as Node;
+    while (root.parent != null) root = root.parent;
+    let largest: { radius: number; node: Node } | null = null;
+    const walk = (node: Node) => {
+      if (node.geometry?.type === "SphereGeometry") {
+        const r = node.geometry.parameters?.radius;
+        if (r != null && (largest == null || r > largest.radius)) largest = { radius: r, node };
+      }
+      for (const child of node.children) walk(child);
+    };
+    walk(root);
+    if (largest == null) return null;
+    const e = (largest as { node: Node }).node.matrixWorld.elements;
+    return Math.hypot(e[12], e[13], e[14]);
+  }, id);
+}
+
 function sunDirection(arrows: Drawn[]): [number, number, number] {
   const sun = arrows.find((a) => a.kind === "sun");
   if (sun == null) throw new Error("no Sun arrow was drawn");
@@ -425,4 +466,43 @@ test("an unusable attitude gets the marker that shows no orientation", async ({ 
   await arrowsAt(page, 0, ["nadir", "sun"]);
   const usable = await meshGeometries(page, "fixture-sat-0");
   expect(usable, "a usable attitude draws the cube").toContain("BoxGeometry");
+});
+
+test("the environment is scaled for the spacecraft that is drawn", async ({ page }) => {
+  // Centring on a satellite amplifies everything around it, because its model is
+  // drawn far larger than scale — the ratio keeps Earth and the trails at the
+  // right proportions *relative to that model*. A registered spacecraft whose
+  // attitude was refused is drawn as the marker instead, and the marker's ratio
+  // is a different number, so the amplification has to follow which of the two
+  // arrived.
+  // Local-orbital, because that is the frame in which the amplification reaches
+  // the graph: the scene applies it as the environment group's scale, and leaves
+  // that at 1 in the inertial frame (measured: the body sits at 1.0975 either way
+  // there, and at 2157.6 or 3500 here).
+  const centred = `centre=0&frame=localOrbital&epoch=${EPOCH}&arrows=sun,nadir`;
+
+  await open(page, `sats=0:${SAT_A}&${centred}&name=ISS&att=1,0,0,0`);
+  await arrowsAt(page, 0, ["nadir", "sun"]);
+  const model = await centralBodyDistance(page, "fixture-sat-0");
+  expect(model, "the central body should be in the scene").not.toBeNull();
+  expect(model, "and drawn away from the centred spacecraft").toBeGreaterThan(0);
+
+  // No registered name, so no model config resolves and the marker stands in.
+  // This is the amplification a refused attitude has to land on.
+  await open(page, `sats=0:${SAT_A}&${centred}&att=1,0,0,0`);
+  await arrowsAt(page, 0, ["nadir", "sun"]);
+  const marker = await centralBodyDistance(page, "fixture-sat-0");
+
+  // The two ratios differ, without which the assertion below would hold whatever
+  // the scene did.
+  expect((model as number) / (marker as number)).not.toBeCloseTo(1, 6);
+
+  await open(page, `sats=0:${SAT_A}&${centred}&name=ISS&att=0,0,0,0`);
+  await arrowsAt(page, 0, ["nadir", "sun"]);
+  const refused = await centralBodyDistance(page, "fixture-sat-0");
+  // A ratio, so compare relatively: the distances run to thousands of units.
+  expect(
+    (refused as number) / (marker as number),
+    "a refused attitude scales the scene for the marker it draws",
+  ).toBeCloseTo(1, 6);
 });

--- a/viewer/tests/orbit-viewer-public.spec.ts
+++ b/viewer/tests/orbit-viewer-public.spec.ts
@@ -286,3 +286,31 @@ test("no arrows are drawn at a centred spacecraft that has no position", async (
   await open(page, `sats=0:${SAT_A}&centre=0&epoch=${EPOCH}&att=1,0,0,0&arrows=sun,nadir`);
   await arrowsAt(page, 0, ["nadir", "sun"]);
 });
+
+test("an attitude that names no rotation is refused, not applied", async ({ page }) => {
+  // `SatelliteState.attitude` reaches Three.js through `Quaternion.set`, which
+  // does not normalise: a zero quaternion names no rotation, and applying it
+  // collapses the marker it was meant to orient. The attitude view already
+  // refuses one; the orbit view handed it straight through.
+  await open(page, `sats=0:${SAT_A}&centre=0&epoch=${EPOCH}&att=0,0,0,0&arrows=sun,nadir`);
+
+  // The arrows are the proof of mount here: they depend on the position, not on
+  // the attitude, so they are drawn either way.
+  await arrowsAt(page, 0, ["nadir", "sun"]);
+
+  const quat = await page.evaluate(
+    (id) => window.__debug_get_sat_world_quat?.(id) ?? null,
+    "fixture-sat-0",
+  );
+  expect(quat, "no orientation is registered for an attitude that names none").toBeNull();
+
+  // A usable attitude is still applied, so the check above is not refusing
+  // everything.
+  await open(page, `sats=0:${SAT_A}&centre=0&epoch=${EPOCH}&att=1,0,0,0&arrows=sun,nadir`);
+  await expect
+    .poll(
+      () => page.evaluate((id) => window.__debug_get_sat_world_quat?.(id) != null, "fixture-sat-0"),
+      { timeout: 15000 },
+    )
+    .toBe(true);
+});

--- a/viewer/tests/orbit-viewer-public.spec.ts
+++ b/viewer/tests/orbit-viewer-public.spec.ts
@@ -261,6 +261,15 @@ test("a satellite with no usable time stays in the scene's frame", async ({ page
   // The inertial frame leaves the attitude as supplied, which is what the wait
   // above rules out for the two body-fixed reads.
   await open(page, `sats=0:${SAT_A}&frame=inertial&epoch=${EPOCH}&att=${attitude}&arrows=none`);
+  // `open()` waits for the canvas and for arika, not for the effect that registers
+  // this hook, so the read has to wait for the hook itself — as the body-fixed
+  // reads above do for their own reason.
+  await expect
+    .poll(
+      () => page.evaluate((id) => window.__debug_get_sat_world_quat?.(id) != null, "fixture-sat-0"),
+      { timeout: 15000 },
+    )
+    .toBe(true);
   const inertial = await page.evaluate(
     (id) => window.__debug_get_sat_world_quat?.(id) ?? null,
     "fixture-sat-0",

--- a/viewer/tests/orbit-viewer-public.spec.ts
+++ b/viewer/tests/orbit-viewer-public.spec.ts
@@ -253,3 +253,36 @@ test("the Sun arrow is left out where the direction would be a guess", async ({ 
   await open(page, `sats=0:${SAT_A}&centre=0&frame=localOrbital&epoch=${EPOCH}&arrows=sun,nadir`);
   await arrowsAt(page, 0, ["nadir", "sun"]);
 });
+
+test("no arrows are drawn at a centred spacecraft that has no position", async ({ page }) => {
+  // A position that cannot be used — non-finite from a source — leaves the frame
+  // without an origin for this spacecraft, and the marker is not drawn either.
+  // Nadir needs that position and drops itself, but the Sun's direction does not,
+  // so without the gate an arrow points out the Sun beside nothing at all.
+  await open(page, `sats=0:nan,0,0:0,7.546,0&centre=0&epoch=${EPOCH}&att=1,0,0,0&arrows=sun,nadir`);
+
+  // The scene is up: this satellite registers its attitude hook whether or not
+  // its position can be used.
+  await expect
+    .poll(
+      () => page.evaluate((id) => window.__debug_get_sat_world_quat?.(id) != null, "fixture-sat-0"),
+      { timeout: 15000 },
+    )
+    .toBe(true);
+
+  const drawn = await page.evaluate(
+    (satId) =>
+      (
+        window as unknown as {
+          __debug_get_direction_vectors?: (id: string) => unknown[] | null;
+        }
+      ).__debug_get_direction_vectors?.(satId) ?? null,
+    "fixture-sat-0",
+  );
+  expect(drawn, "an unplaceable spacecraft gets no arrows").toBeNull();
+
+  // The same scene with a usable position draws both, so the assertion above is
+  // not passing for want of arrows anywhere.
+  await open(page, `sats=0:${SAT_A}&centre=0&epoch=${EPOCH}&att=1,0,0,0&arrows=sun,nadir`);
+  await arrowsAt(page, 0, ["nadir", "sun"]);
+});

--- a/viewer/tests/orbit-viewer-public.spec.ts
+++ b/viewer/tests/orbit-viewer-public.spec.ts
@@ -154,6 +154,44 @@ async function centralBodyDistance(page: Page, id: string): Promise<number | nul
   }, id);
 }
 
+/**
+ * Rotation of the group holding the cube marker, read from the live graph.
+ *
+ * Not through the attitude hook: that is registered by the body axes, which are
+ * gone the moment the attitude is, and this is about what remains on screen
+ * afterwards.
+ */
+async function cubeGroupRotation(page: Page, id: string): Promise<number[] | null> {
+  return await page.evaluate((satId) => {
+    const w = window as unknown as {
+      __debug_direction_vector_registry?: Map<
+        string,
+        () => { origin: { parent: unknown } | null }[]
+      >;
+    };
+    const start = w.__debug_direction_vector_registry?.get(satId)?.()?.[0]?.origin;
+    if (start == null) return null;
+    type Node = {
+      type: string;
+      parent: Node | null;
+      children: Node[];
+      quaternion: { x: number; y: number; z: number; w: number };
+      geometry?: { type?: string };
+    };
+    let root = start as unknown as Node;
+    while (root.parent != null) root = root.parent;
+    let found: Node | null = null;
+    const walk = (node: Node) => {
+      if (node.geometry?.type === "BoxGeometry" && node.parent != null) found = node.parent;
+      for (const child of node.children) walk(child);
+    };
+    walk(root);
+    if (found == null) return null;
+    const q = (found as Node).quaternion;
+    return [q.w, q.x, q.y, q.z];
+  }, id);
+}
+
 function sunDirection(arrows: Drawn[]): [number, number, number] {
   const sun = arrows.find((a) => a.kind === "sun");
   if (sun == null) throw new Error("no Sun arrow was drawn");
@@ -514,4 +552,42 @@ test("the environment is scaled for the spacecraft that is drawn", async ({ page
     (refused as number) / (marker as number),
     "a refused attitude scales the scene for the marker it draws",
   ).toBeCloseTo(1, 6);
+});
+
+test("a marker that keeps its cube gives up its rotation with the attitude", async ({ page }) => {
+  // The reset that runs when an attitude stops being usable is only observable
+  // where the same object stays on screen across the change. An explicit
+  // `axes-cube` is that case: the request outranks the automatic choice, so the
+  // cube is still drawn once the attitude is gone, and it must not go on showing
+  // the orientation the last usable sample gave it.
+  await open(
+    page,
+    `sats=0:${SAT_A}&centre=0&shape=axes-cube&att=${Math.SQRT1_2},0,0,${Math.SQRT1_2}&arrows=nadir`,
+  );
+  await arrowsAt(page, 0, ["nadir"]);
+
+  const rotated = await cubeGroupRotation(page, "fixture-sat-0");
+  expect(rotated, "the cube should be in the scene").not.toBeNull();
+  // 90° about Z, as supplied.
+  expect(rotated?.[0] ?? 0, "w").toBeCloseTo(Math.SQRT1_2, 6);
+  expect(rotated?.[3] ?? 0, "z").toBeCloseTo(Math.SQRT1_2, 6);
+
+  await page.evaluate(() => window.__fixture_set_attitude?.(null));
+
+  await expect
+    .poll(
+      async () => {
+        const q = await cubeGroupRotation(page, "fixture-sat-0");
+        return q == null ? null : Math.abs(q[0] - 1) < 1e-6 && Math.abs(q[3]) < 1e-6;
+      },
+      { timeout: 15000 },
+    )
+    .toBe(true);
+
+  // Still the cube: the shape follows the request, and it is the rotation alone
+  // that the withdrawal took away.
+  const geometries = await meshGeometries(page, "fixture-sat-0");
+  expect(geometries, "an explicitly requested cube stays without an attitude").toContain(
+    "BoxGeometry",
+  );
 });

--- a/viewer/tests/orbit-viewer-public.spec.ts
+++ b/viewer/tests/orbit-viewer-public.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * The published `OrbitViewer`, in states a live run cannot produce.
+ *
+ * `orbit-direction-vectors.spec.ts` drives the app against a real `orts serve`,
+ * where every satellite shares one clock and every sample is a number. The public
+ * props allow neither: `SatelliteState.time` is per satellite, and it can arrive
+ * as `NaN` from a source whose parse failed. Both decide the epoch the Sun and
+ * the body rotations are evaluated at, so both are driven from a fixture here.
+ *
+ * Assertions read the rendered scene through the dev hooks rather than pixels.
+ * See .claude/skills/playwright-viewer-testing.
+ */
+import { expect, type Page, test } from "@playwright/test";
+
+/** Epoch used wherever the Sun has to be computable (UTC JD). */
+const EPOCH = 2460000.5;
+
+/** Equatorial circular orbit at +X, and a second one a quarter turn along. */
+const SAT_A = "7000,0,0:0,7.546,0";
+const SAT_B = "0,7000,0:-7.546,0,0";
+
+/**
+ * Ninety days in seconds. The Sun moves about a degree a day, so two scenes
+ * evaluated this far apart cannot be confused for each other — a difference of
+ * minutes would be within the noise of an assertion.
+ */
+const LATER = 90 * 86400;
+
+type Drawn = { kind: string; direction: [number, number, number]; distance: number };
+
+async function open(page: Page, query: string) {
+  await page.goto(`/fixtures/orbit-viewer.html?${query}`, { waitUntil: "load" });
+  await expect(page.locator("canvas")).toBeVisible();
+  await expect
+    .poll(() => page.evaluate(() => window.__fixture_arika_ready?.() ?? false), { timeout: 15000 })
+    .toBe(true);
+}
+
+/** The arrows drawn at satellite `index`, once the named kinds are all there. */
+async function arrowsAt(page: Page, index: number, kinds: string[]): Promise<Drawn[]> {
+  const id = `fixture-sat-${index}`;
+  await expect
+    .poll(
+      async () => {
+        const drawn = await page.evaluate(
+          (satId) =>
+            (
+              window as unknown as {
+                __debug_get_direction_vectors?: (id: string) => Drawn[] | null;
+              }
+            ).__debug_get_direction_vectors?.(satId) ?? null,
+          id,
+        );
+        return drawn == null ? null : drawn.map((d) => d.kind).sort();
+      },
+      { timeout: 15000 },
+    )
+    .toEqual([...kinds].sort());
+  return await page.evaluate(
+    (satId) =>
+      (
+        window as unknown as {
+          __debug_get_direction_vectors?: (id: string) => Drawn[] | null;
+        }
+      ).__debug_get_direction_vectors?.(satId) ?? [],
+    id,
+  );
+}
+
+function sunDirection(arrows: Drawn[]): [number, number, number] {
+  const sun = arrows.find((a) => a.kind === "sun");
+  if (sun == null) throw new Error("no Sun arrow was drawn");
+  return sun.direction;
+}
+
+test("the Sun is drawn at the centred satellite's own time", async ({ page }) => {
+  // Two satellites at times ninety days apart, centred on the second. The Sun
+  // has to be the Sun at *that* satellite's time: the scene used to take
+  // whichever time the position Map yielded first, which is the other one.
+  await open(page, `sats=0:${SAT_A};${LATER}:${SAT_B}&centre=1&epoch=${EPOCH}&arrows=sun`);
+  const centred = sunDirection(await arrowsAt(page, 1, ["sun"]));
+
+  // The same satellite alone, at the same time: the direction to compare with.
+  await open(page, `sats=${LATER}:${SAT_B}&centre=0&epoch=${EPOCH}&arrows=sun`);
+  const alone = sunDirection(await arrowsAt(page, 0, ["sun"]));
+
+  for (const axis of [0, 1, 2]) {
+    expect(
+      centred[axis],
+      `Sun component ${axis} should match the centred satellite's time`,
+    ).toBeCloseTo(alone[axis], 6);
+  }
+
+  // And the other satellite's time really does give a different Sun, so the
+  // comparison above could have failed.
+  await open(page, `sats=0:${SAT_B}&centre=0&epoch=${EPOCH}&arrows=sun`);
+  const atZero = sunDirection(await arrowsAt(page, 0, ["sun"]));
+  const cosine = atZero[0] * alone[0] + atZero[1] * alone[1] + atZero[2] * alone[2];
+  expect(cosine, "ninety days apart the Sun is nowhere near the same place").toBeLessThan(0.5);
+});
+
+test("a satellite whose time is not a number still leaves a drawable scene", async ({ page }) => {
+  // `SatelliteState.time` reaching the scene as `NaN` is what a failed parse
+  // upstream looks like. It decides the epoch of the Earth rotation angle and of
+  // the body orientations, and a NaN there renders nothing at all — a group
+  // carrying a NaN quaternion disappears.
+  await open(page, `sats=nan:${SAT_A}&centre=0&frame=localOrbital&epoch=${EPOCH}`);
+  const arrows = await arrowsAt(page, 0, ["nadir", "sun"]);
+  for (const arrow of arrows) {
+    expect(
+      arrow.direction.every(Number.isFinite),
+      `${arrow.kind} arrow's direction should be finite`,
+    ).toBe(true);
+    expect(arrow.distance, `${arrow.kind} arrow should have a length`).toBeGreaterThan(0);
+  }
+});

--- a/viewer/tests/orbit-viewer-public.spec.ts
+++ b/viewer/tests/orbit-viewer-public.spec.ts
@@ -151,3 +151,41 @@ test("a satellite with no usable time stays in the scene's frame", async ({ page
   const same = [0, 1, 2, 3].every((i) => Math.abs(inertial[i] - atZero[i]) < 1e-6);
   expect(same, "the body-fixed frame should not equal the inertial one").toBe(false);
 });
+
+test("a central-body view is drawn at the scene's time, not a satellite's", async ({ page }) => {
+  // With no satellite centred there is nothing for the Sun to be drawn *at*, so
+  // the epoch belongs to the scene: `OrbitSceneDataProps.time` drives the
+  // lighting and the central body's rotation. The scene used to take whichever
+  // time the position Map yielded first instead.
+  //
+  // The central body's rendered rotation is what reports the epoch the scene
+  // chose — a satellite's own rotation would not, since each marker turns by its
+  // own sample time.
+  const earthQuat = async () => {
+    await expect
+      .poll(() => page.evaluate(() => window.__debug_get_earth_world_quat?.() != null), {
+        timeout: 15000,
+      })
+      .toBe(true);
+    const q = await page.evaluate(() => window.__debug_get_earth_world_quat?.() ?? null);
+    if (q == null) throw new Error("no rendered central body");
+    return q;
+  };
+
+  await open(page, `sats=0:${SAT_A}&epoch=${EPOCH}&t=0&arrows=none`);
+  const sceneAtZero = await earthQuat();
+
+  // The satellites are ninety days along while the scene is still at zero. The
+  // central body has to be where the scene's time puts it.
+  await open(page, `sats=${LATER}:${SAT_A};${LATER}:${SAT_B}&epoch=${EPOCH}&t=0&arrows=none`);
+  const satellitesLater = await earthQuat();
+  for (const i of [0, 1, 2, 3]) {
+    expect(satellitesLater[i], `quaternion component ${i}`).toBeCloseTo(sceneAtZero[i], 6);
+  }
+
+  // And the scene's own time does move it, so the comparison could have failed.
+  await open(page, `sats=0:${SAT_A}&epoch=${EPOCH}&t=${LATER}&arrows=none`);
+  const sceneLater = await earthQuat();
+  const same = [0, 1, 2, 3].every((i) => Math.abs(sceneLater[i] - sceneAtZero[i]) < 1e-6);
+  expect(same, "ninety days of rotation should not leave the body where it was").toBe(false);
+});

--- a/viewer/tests/orbit-viewer-public.spec.ts
+++ b/viewer/tests/orbit-viewer-public.spec.ts
@@ -74,6 +74,45 @@ async function arrowsAt(page: Page, index: number, kinds: string[]): Promise<Dra
   );
 }
 
+/**
+ * Mesh geometries in the scene, from the live graph.
+ *
+ * Entered through the arrows' own registry rather than the attitude one: a
+ * spacecraft whose attitude was refused registers no attitude hook, which is the
+ * case this is here to read. Walking `.parent` from either reaches the scene
+ * root — `canvas.__r3f` is null. See .claude/skills/playwright-viewer-testing.
+ */
+async function meshGeometries(page: Page, id: string): Promise<string[] | null> {
+  return await page.evaluate((satId) => {
+    const w = window as unknown as {
+      __debug_direction_vector_registry?: Map<
+        string,
+        () => { origin: { parent: unknown } | null }[]
+      >;
+      __debug_sat_quat_registry?: Map<string, () => { parent: unknown } | null>;
+    };
+    const start =
+      w.__debug_direction_vector_registry?.get(satId)?.()?.[0]?.origin ??
+      w.__debug_sat_quat_registry?.get(satId)?.();
+    if (start == null) return null;
+    type Node = {
+      type: string;
+      parent: Node | null;
+      children: Node[];
+      geometry?: { type?: string };
+    };
+    let root = start as unknown as Node;
+    while (root.parent != null) root = root.parent;
+    const out: string[] = [];
+    const walk = (node: Node) => {
+      if (node.type === "Mesh") out.push(node.geometry?.type ?? "?");
+      for (const child of node.children) walk(child);
+    };
+    walk(root);
+    return out;
+  }, id);
+}
+
 function sunDirection(arrows: Drawn[]): [number, number, number] {
   const sun = arrows.find((a) => a.kind === "sun");
   if (sun == null) throw new Error("no Sun arrow was drawn");
@@ -122,40 +161,74 @@ test("a satellite whose time is not a number still leaves a drawable scene", asy
   }
 });
 
+/**
+ * The rendered attitude of `id`, once a frame rotation has been applied to it.
+ *
+ * A body-fixed frame turns the scene by the Earth rotation angle, and that angle
+ * comes from the WASM: for a render or two after the module is ready the frame is
+ * still the inertial fallback, and the quaternion read then is the attitude as
+ * supplied. Waiting for it to differ from `supplied` is what makes the two
+ * documents comparable — reading straight after readiness catches whichever
+ * render happened to be current.
+ */
+async function rotatedQuat(
+  page: Page,
+  id: string,
+  supplied: [number, number, number, number],
+): Promise<[number, number, number, number]> {
+  await expect
+    .poll(
+      async () => {
+        const q = await page.evaluate(
+          (satId) => window.__debug_get_sat_world_quat?.(satId) ?? null,
+          id,
+        );
+        if (q == null) return false;
+        return [0, 1, 2, 3].some((i) => Math.abs(q[i] - supplied[i]) > 1e-6);
+      },
+      { timeout: 15000 },
+    )
+    .toBe(true);
+  const q = await page.evaluate((satId) => window.__debug_get_sat_world_quat?.(satId) ?? null, id);
+  if (q == null) throw new Error("no rendered attitude");
+  return q;
+}
+
 test("a satellite with no usable time stays in the scene's frame", async ({ page }) => {
   // A body-fixed view rotates everything by the Earth rotation angle at the
   // scene's time. A satellite whose own `time` is `NaN` has to be rotated the
   // same way — dropping the rotation for it would leave that one marker in the
   // inertial frame while the body, the trails and every other satellite are
   // body-fixed, which is a picture of two conventions at once.
+  // +90° about Z, as [w, x, y, z] for the fixture and as Three's [x, y, z, w] for
+  // the comparison below.
   const attitude = "0.7071067811865476,0,0,0.7071067811865476";
-  const worldQuat = async () => {
-    const q = await page.evaluate(
-      (id) => window.__debug_get_sat_world_quat?.(id) ?? null,
-      "fixture-sat-0",
-    );
-    if (q == null) throw new Error("no rendered attitude");
-    return q;
-  };
+  const supplied: [number, number, number, number] = [0, 0, Math.SQRT1_2, Math.SQRT1_2];
 
   await open(page, `sats=nan:${SAT_A}&frame=bodyFixed&epoch=${EPOCH}&att=${attitude}&arrows=none`);
-  await expect.poll(async () => (await worldQuat()) != null, { timeout: 15000 }).toBe(true);
-  const withoutTime = await worldQuat();
+  const withoutTime = await rotatedQuat(page, "fixture-sat-0", supplied);
 
   // The scene's own time is what it falls back to, and with this one satellite
   // carrying no usable time that is 0 — so a satellite explicitly at 0 has to
   // come out identical.
   await open(page, `sats=0:${SAT_A}&frame=bodyFixed&epoch=${EPOCH}&att=${attitude}&arrows=none`);
-  const atZero = await worldQuat();
+  const atZero = await rotatedQuat(page, "fixture-sat-0", supplied);
   for (const i of [0, 1, 2, 3]) {
     expect(withoutTime[i], `quaternion component ${i}`).toBeCloseTo(atZero[i], 6);
   }
 
-  // And the inertial frame gives a different quaternion, so the comparison above
-  // is not satisfied by any rotation at all.
+  // The inertial frame leaves the attitude as supplied, which is what the wait
+  // above rules out for the two body-fixed reads.
   await open(page, `sats=0:${SAT_A}&frame=inertial&epoch=${EPOCH}&att=${attitude}&arrows=none`);
-  const inertial = await worldQuat();
-  const same = [0, 1, 2, 3].every((i) => Math.abs(inertial[i] - atZero[i]) < 1e-6);
+  const inertial = await page.evaluate(
+    (id) => window.__debug_get_sat_world_quat?.(id) ?? null,
+    "fixture-sat-0",
+  );
+  expect(inertial, "the inertial frame renders the attitude as given").not.toBeNull();
+  for (const i of [0, 1, 2, 3]) {
+    expect(inertial?.[i], `inertial component ${i}`).toBeCloseTo(supplied[i], 6);
+  }
+  const same = [0, 1, 2, 3].every((i) => Math.abs((inertial?.[i] ?? 0) - atZero[i]) < 1e-6);
   expect(same, "the body-fixed frame should not equal the inertial one").toBe(false);
 });
 
@@ -313,4 +386,29 @@ test("an attitude that names no rotation is refused, not applied", async ({ page
       { timeout: 15000 },
     )
     .toBe(true);
+});
+
+test("an unusable attitude gets the marker that shows no orientation", async ({ page }) => {
+  // The automatic marker is a cube when a satellite has attitude, because its
+  // faces show which way the body points, and a sphere when it has none. That
+  // choice has to follow the *usable* attitude: a zero quaternion drawn as a cube
+  // shows an orientation nobody measured.
+  await open(page, `sats=0:${SAT_A}&centre=0&epoch=${EPOCH}&att=0,0,0,0&arrows=sun,nadir`);
+  await arrowsAt(page, 0, ["nadir", "sun"]);
+  const refused = await meshGeometries(page, "fixture-sat-0");
+  expect(refused, "the scene graph should be reachable").not.toBeNull();
+  // The cube is the discriminator. A sphere would be the other half of the
+  // statement, but the central body draws spheres too and this inventory cannot
+  // tell them apart from a marker's — so the absence of the cube is what is
+  // asserted, and the presence of one below.
+  expect(refused, "an unusable attitude draws no orientation-revealing cube").not.toContain(
+    "BoxGeometry",
+  );
+
+  // A usable one does get the cube, so the check above is not describing every
+  // scene.
+  await open(page, `sats=0:${SAT_A}&centre=0&epoch=${EPOCH}&att=1,0,0,0&arrows=sun,nadir`);
+  await arrowsAt(page, 0, ["nadir", "sun"]);
+  const usable = await meshGeometries(page, "fixture-sat-0");
+  expect(usable, "a usable attitude draws the cube").toContain("BoxGeometry");
 });

--- a/viewer/tests/orbit-viewer-public.spec.ts
+++ b/viewer/tests/orbit-viewer-public.spec.ts
@@ -10,6 +10,8 @@
  * Assertions read the rendered scene through the dev hooks rather than pixels.
  * See .claude/skills/playwright-viewer-testing.
  */
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect, type Page, test } from "@playwright/test";
 
 /** Epoch used wherever the Sun has to be computable (UTC JD). */
@@ -590,4 +592,90 @@ test("a marker that keeps its cube gives up its rotation with the attitude", asy
   expect(geometries, "an explicitly requested cube stays without an attitude").toContain(
     "BoxGeometry",
   );
+});
+
+/**
+ * A glTF served in place of the registry's model.
+ *
+ * The registry points at a GLB on an external host, which does load under test —
+ * but a test that depends on someone else's server fails for reasons that have
+ * nothing to do with the viewer. This one triangle stands in: `GLTFLoader` reads
+ * JSON as readily as the binary container, and what the test needs from a model
+ * is that it be a loaded object with a group above it.
+ */
+const STAND_IN_MODEL = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../fixtures/test-spacecraft.gltf",
+);
+
+/** Every ancestor rotation above the loaded model, innermost first. */
+async function modelAncestorRotations(page: Page): Promise<number[][] | null> {
+  return await page.evaluate(() => {
+    const w = window as unknown as {
+      __debug_direction_vector_registry?: Map<
+        string,
+        () => { origin: { parent: unknown } | null }[]
+      >;
+    };
+    const start = w.__debug_direction_vector_registry?.get("fixture-sat-0")?.()?.[0]?.origin;
+    if (start == null) return null;
+    type Node = {
+      name?: string;
+      type: string;
+      parent: Node | null;
+      children: Node[];
+      quaternion: { x: number; y: number; z: number; w: number };
+    };
+    let root = start as unknown as Node;
+    while (root.parent != null) root = root.parent;
+    let mesh: Node | null = null;
+    const walk = (node: Node) => {
+      if (node.name === "test-spacecraft") mesh = node;
+      for (const child of node.children) walk(child);
+    };
+    walk(root);
+    if (mesh == null) return null;
+    const out: number[][] = [];
+    for (let n: Node | null = mesh; n != null; n = n.parent) {
+      out.push([n.quaternion.w, n.quaternion.x, n.quaternion.y, n.quaternion.z]);
+    }
+    return out;
+  });
+}
+
+test("a model gives up its rotation when the attitude stops being usable", async ({ page }) => {
+  // The registered-model path, which is where this matters most: the model is not
+  // replaced when its attitude goes — a spacecraft with no attitude is drawn as a
+  // position marker, which is the documented behaviour — so the same object stays
+  // on screen and would go on showing the orientation the last usable sample gave
+  // it. The marker case is covered above; this is the one whose ref used to be
+  // detached before the reset could run.
+  await page.route("**/*.glb", (route) =>
+    route.fulfill({ path: STAND_IN_MODEL, contentType: "model/gltf+json" }),
+  );
+
+  const supplied = [Math.SQRT1_2, 0, 0, Math.SQRT1_2];
+  await open(page, `sats=0:${SAT_A}&centre=0&name=ISS&att=${supplied.join(",")}&arrows=nadir`);
+  await arrowsAt(page, 0, ["nadir"]);
+
+  const carries = (rotations: number[][] | null) =>
+    rotations?.some((q) => q.every((c, i) => Math.abs(c - supplied[i]) < 1e-6)) ?? false;
+
+  // The model has to arrive before anything can be said about its rotation.
+  await expect
+    .poll(async () => carries(await modelAncestorRotations(page)), { timeout: 20000 })
+    .toBe(true);
+
+  await page.evaluate(() => window.__fixture_set_attitude?.(null));
+
+  await expect
+    .poll(
+      async () => {
+        const rotations = await modelAncestorRotations(page);
+        // Still loaded, and no ancestor carries the withdrawn rotation any more.
+        return rotations != null && !carries(rotations);
+      },
+      { timeout: 15000 },
+    )
+    .toBe(true);
 });

--- a/viewer/tests/orbit-viewer-public.spec.ts
+++ b/viewer/tests/orbit-viewer-public.spec.ts
@@ -104,7 +104,7 @@ test("a satellite whose time is not a number still leaves a drawable scene", asy
   // upstream looks like. It decides the epoch of the Earth rotation angle and of
   // the body orientations, and a NaN there renders nothing at all — a group
   // carrying a NaN quaternion disappears.
-  await open(page, `sats=nan:${SAT_A}&centre=0&frame=localOrbital&epoch=${EPOCH}`);
+  await open(page, `sats=nan:${SAT_A}&centre=0&frame=localOrbital&epoch=${EPOCH}&arrows=sun,nadir`);
   const arrows = await arrowsAt(page, 0, ["nadir", "sun"]);
   for (const arrow of arrows) {
     expect(
@@ -188,4 +188,36 @@ test("a central-body view is drawn at the scene's time, not a satellite's", asyn
   const sceneLater = await earthQuat();
   const same = [0, 1, 2, 3].every((i) => Math.abs(sceneLater[i] - sceneAtZero[i]) < 1e-6);
   expect(same, "ninety days of rotation should not leave the body where it was").toBe(false);
+});
+
+test("an embedder who says nothing about the arrows gets none", async ({ page }) => {
+  // `directionVectors` is opt-in: the prop is omitted here, which is what every
+  // embedder written before it existed passes. The centred satellite is the one
+  // case that *would* draw them, so this is where the default has to hold.
+  // The attitude is here to make the spacecraft register its own hook, which is
+  // the only way to know the subtree mounted before reading an absence.
+  await open(page, `sats=0:${SAT_A}&centre=0&frame=localOrbital&epoch=${EPOCH}&att=1,0,0,0`);
+
+  // The scene has to be up before absence means anything: the spacecraft's own
+  // hook says so, and it is registered by the same subtree that would carry the
+  // arrows.
+  await expect
+    .poll(
+      () => page.evaluate((id) => window.__debug_get_sat_world_quat?.(id) != null, "fixture-sat-0"),
+      { timeout: 15000 },
+    )
+    .toBe(true);
+
+  const drawn = await page.evaluate(
+    (satId) =>
+      (
+        window as unknown as {
+          __debug_get_direction_vectors?: (id: string) => unknown[] | null;
+        }
+      ).__debug_get_direction_vectors?.(satId) ?? null,
+    "fixture-sat-0",
+  );
+  // Null rather than an empty list: with nothing to draw the component is not
+  // mounted, so it registers no hook at all.
+  expect(drawn, "no arrows are registered when the prop is left out").toBeNull();
 });

--- a/viewer/tests/orbit-viewer-public.spec.ts
+++ b/viewer/tests/orbit-viewer-public.spec.ts
@@ -31,9 +31,16 @@ type Drawn = { kind: string; direction: [number, number, number]; distance: numb
 async function open(page: Page, query: string) {
   await page.goto(`/fixtures/orbit-viewer.html?${query}`, { waitUntil: "load" });
   await expect(page.locator("canvas")).toBeVisible();
-  await expect
-    .poll(() => page.evaluate(() => window.__fixture_arika_ready?.() ?? false), { timeout: 15000 })
-    .toBe(true);
+  // Only where there is an epoch: the scene loads the arika WASM to evaluate one,
+  // and a scene without an epoch never asks for it — so waiting for readiness
+  // there waits for something that is not coming.
+  if (query.includes("epoch=")) {
+    await expect
+      .poll(() => page.evaluate(() => window.__fixture_arika_ready?.() ?? false), {
+        timeout: 15000,
+      })
+      .toBe(true);
+  }
 }
 
 /** The arrows drawn at satellite `index`, once the named kinds are all there. */
@@ -220,4 +227,29 @@ test("an embedder who says nothing about the arrows gets none", async ({ page })
   // Null rather than an empty list: with nothing to draw the component is not
   // mounted, so it registers no hook at all.
   expect(drawn, "no arrows are registered when the prop is left out").toBeNull();
+});
+
+test("the Sun arrow is left out where the direction would be a guess", async ({ page }) => {
+  // `sun_direction_from_body` answers +X — the vernal equinox — for a body it
+  // cannot place, and with no epoch there is nothing to evaluate at all. The
+  // lighting keeps that fallback so a 3D model is not left black; the *arrow*
+  // has to be dropped, or the picture shows a guess as a measurement.
+  //
+  // Nadir is the control: it needs only a position, so its presence says the
+  // arrows reached this scene and the Sun's absence is a decision.
+  await open(page, `sats=0:${SAT_A}&centre=0&frame=localOrbital&arrows=sun,nadir`);
+  await arrowsAt(page, 0, ["nadir"]);
+
+  // Uranus has no elements in arika, so the Sun cannot be placed relative to it
+  // even with an epoch. Its radius is given because the scene has none to look up.
+  await open(
+    page,
+    `sats=0:${SAT_A}&centre=0&frame=localOrbital&epoch=${EPOCH}&body=uranus&radius=25559&arrows=sun,nadir`,
+  );
+  await arrowsAt(page, 0, ["nadir"]);
+
+  // And Earth with the same epoch does draw it, so the two above are not passing
+  // for want of a Sun arrow anywhere.
+  await open(page, `sats=0:${SAT_A}&centre=0&frame=localOrbital&epoch=${EPOCH}&arrows=sun,nadir`);
+  await arrowsAt(page, 0, ["nadir", "sun"]);
 });


### PR DESCRIPTION
viewer の軌道表示は衛星の位置と軌跡を描くが、太陽がどちらにあるかは画面のどこにも出ていない。ADCS の検証では機体の向きと一緒に「太陽はどこか、下はどこか」を読むので、両方が絵にある必要がある。

そこで、衛星中心表示（その機体が原点に来る表示）で太陽方向と nadir 方向を矢印として描けるようにした。矢印は姿勢ビュー（#403）と同じ部品である。

![軌道ビューで衛星中心にしたときの太陽/nadir 矢印](https://gist.githubusercontent.com/sksat/7ad541c299d46606db2a336df3461716/raw/orbit-view-satellite-arrows.png)

## 使い方

```tsx
<OrbitViewer
  centralBody={{ id: "earth", radiusKm: 6378.137 }}
  satellites={[{ id: "sat-1", position: [7000, 0, 1500], velocity: [0, 7.5, 0] }]}
  referenceFrame={{ center: { satelliteId: "sat-1" }, orientation: "localOrbital" }}
  epochJd={2460000.5}
  directionVectors={{ sun: true, nadir: true }}
/>
```

`directionVectors` は向きごとの opt-in。省略すると 1 本も描かないので、既存の embedder の見た目は変わらない。

矢印を描く対象は**中心機体だけ**である。多数の衛星に 2 本ずつ出すと画面が埋まり、中心天体中心の表示では中心天体そのものが見えているので nadir は絵の繰り返しになる。中心以外を対象にしたくなった場合は scene 側に対象を指定する形にする（どの向きを描くかは scene の表示方針で、機体の状態ではない）。

## 直したバグ

太陽方向は照明（`useSunLighting`）が計算しており、矢印はその値を共有する。そのため、時刻の選び方に元からあった誤りが矢印として見えるようになった。下記はいずれも矢印を足す前から照明と天体の回転に効いていたものである。

| 症状 | 原因 |
|---|---|
| 中心機体に描かれる太陽が別の衛星の時刻のものになる | 時刻を position の Map が最初に返した衛星から取っていた |
| 中心天体表示の照明と天体回転が任意の衛星の時刻で決まる | 公開 prop の `OrbitSceneDataProps.time` が `OrbitSceneContents` に渡っていなかった |
| `NaN` の時刻が WASM に届き、フレーム・照明・矢印に広がる | `??` は null と undefined でしか落ちない（scene 全体と各機体の計 4 経路） |
| 時刻が使えない機体だけが inertial に座り、他は body-fixed になる | 時刻を落とすと回転も落ちていた（公開仕様どおり scene の時刻に落とす） |
| 位置が使えない中心機体の隣に太陽矢印だけが原点に出る | nadir は位置を必要とするが太陽は必要としない |
| 単位ノルムでない姿勢が歪んだマーカーになり、ゼロ姿勢が identity として提示される | 軌道表示が `unitAttitude` を通していなかった（姿勢ビューは #403 以降通している） |
| 却下された姿勢の衛星に、向きを示す cube・3D モデル・そのモデル基準の縮尺が残る | 形状は `hasAttitude` だけを見ており、モデルと scene amplification は衛星 id から解決していた |
| `NaN` の epoch で arika WASM を読み込み、使えない値をそのまま各呼び出しに渡す | 公開 prop の epoch を `finiteOrNull` に通していなかった（姿勢 scene は #403 から通している）。描画は変わらない——角度を受ける側がいずれも `NaN` を拒むため |
| 成分の欠けた quaternion（`{qw: 0.5}` など）が identity として描かれる | `sampleAttitude` が `qw` だけを要求し残りを 0 で埋めていた（`orbit.ts` の `hasQuaternion` は 4 成分を要求している） |
| 姿勢を失った 3D モデルが直前の回転を保つ | ref が `quaternion` のある間だけ付いており、quaternion を落とす commit で外れるので reset の effect が group を見つけられない |

## 検証

`fixtures/orbit-viewer.html` が公開 `OrbitViewer` を URL から与えた衛星で mount する。機体ごとの `time`・姿勢・中心天体を指定できるので、`orts serve` では作れない状態（時刻の食い違い、`NaN`、ephemeris の無い天体）を決定的に置ける。

`tests/orbit-viewer-public.spec.ts` が 10 件、`tests/orbit-direction-vectors.spec.ts` が app 経由で 2 件。押さえているのは:

- 中心機体の時刻で太陽が描かれる（90 日離れた 2 機で判別）
- 中心天体表示は scene の時刻で描かれる（中心天体の rendered 回転で判別）
- 時刻が使えない機体も scene と同じフレームに座る
- 矢印を要求しない embedder には 1 本も出ない
- epoch 無し・ephemeris の無い天体では太陽矢印を描かない
- 位置が使えない中心機体には 1 本も出ない
- 単位ノルムでない姿勢は「姿勢なし」として扱われる
- 衛星中心 local-orbital で nadir が scene −Z、矢印の先端が 2.266 span
- 姿勢を却下した衛星は cube を名指しで要求しても sphere になる
- 姿勢を却下した衛星の周囲は、モデル基準でなくマーカー基準の縮尺で描かれる（登録済み ISS で中心天体の半径 1965.9 → 3189.1）

矢印はピクセルでなく `window.__debug_get_direction_vectors(id)` が返す「原点から先端まで」のベクトルで測る。解決済みの入力値を返す作りでは、geometry の軸・回転・先端の配置が壊れていても通ってしまう。

各修正は個別の commit で、そこに再現条件と mutation で測った値を書いてある。

その他: `tsc --noEmit` clean、viewer unit test 577 件 pass、`pnpm lint` / `format:check` error 0、registry と consumer のコピー（`viewer/examples/orbit-viewer/`）再生成済み。

## 後続

矢印の on/off トグルと凡例は #406。中心機体の body 軸長は既存の式のまま — 機体の見かけの大きさから決めると 3D モデルの軸は伸び、マーカー機体の軸は縮むので、矢印とは別の変更として切る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)




