### PR TITLE
feat(viewer): switch the app between the orbit and attitude views

### DIFF
--- a/.claude/skills/playwright-viewer-testing/SKILL.md
+++ b/.claude/skills/playwright-viewer-testing/SKILL.md
@@ -45,6 +45,33 @@ Key metrics to check:
 - **Max gap**: Maximum consecutive columns without a series' color. Equal gaps for both series = OK (chart padding). Asymmetric gaps = NaN issue
 - **Both columns**: Columns where both colors present — should be majority of data area
 
+### The 3D Scene: Measure the Scene Graph, Not Pixels
+
+The pixel guidance above is for the uPlot **2D** canvases. For the WebGL 3D scene,
+prefer a dev-only debug hook that reads the *rendered* Three.js scene graph:
+
+```javascript
+// window.__debug_get_sat_world_quat(id)      → rendered world quaternion
+// window.__debug_get_direction_vectors(id)   → arrow directions, measured from
+//                                              the arrow's origin to its head
+```
+
+Reasons this beats a pixel test for the 3D view:
+
+- A few triangles on a dark background fail a pixel test for reasons unrelated to
+  the geometry (anti-aliasing, camera framing, the swiftshader software renderer).
+- Frame invariants ("body +X points along scene +Y") are immune to the ±q sign
+  ambiguity, whereas a raw quaternion comparison is not.
+- The hook must measure the scene graph, not report the value that was passed *in*.
+  A hook that echoes its input passes even when the geometry's own axis, the
+  rotation onto it, or a mesh's placement is wrong — the parts a rendering test
+  exists to cover.
+
+Register hooks behind `IS_DEV` and deregister on unmount: an *absent* hook is then
+usable evidence that a subtree was dropped (e.g. the attitude view has no Earth).
+Establish the hook exists before the action whose effect you assert, or its absence
+afterwards proves nothing.
+
 ### Common Pitfalls
 
 1. **Cannot access uPlot data from DOM**: `chart._uplot`, `chart.__uplot` do not exist. uPlot stores instance internally in React ref via `useRef()`.
@@ -60,6 +87,12 @@ Key metrics to check:
    ```
 
 4. **Chart area vs axis area**: ~20% of canvas width is Y-axis labels (left side). Always skip `xStart=30` columns when analyzing data coverage.
+
+5. **`gl.readPixels` on the 3D canvas returns zeros** unless the context was created
+   with `preserveDrawingBuffer: true`: the drawing buffer is cleared at presentation.
+   `page.screenshot()` composites correctly and needs no flag. A bounding-box scan
+   ("does anything touch the viewport edge?") is a cheap way to check
+   framing/clipping without judging the image itself.
 
 ## Multi-Satellite NaN Alignment
 

--- a/.claude/skills/playwright-viewer-testing/SKILL.md
+++ b/.claude/skills/playwright-viewer-testing/SKILL.md
@@ -72,6 +72,26 @@ usable evidence that a subtree was dropped (e.g. the attitude view has no Earth)
 Establish the hook exists before the action whose effect you assert, or its absence
 afterwards proves nothing.
 
+#### Inventorying the whole scene
+
+To count or measure *everything* drawn — is that mesh a cylinder or a line, how
+many sprites are there, what opacity did they get — reach the scene root through
+an existing hook's registry rather than the canvas. `canvas.__r3f` is not a
+documented API and reads back `null`; the registries hold the rendered object
+itself, so walk up its `.parent` chain:
+
+```javascript
+const group = window.__debug_sat_quat_registry?.get(id)?.();   // rendered object
+let root = group; while (root.parent != null) root = root.parent;
+root.traverse((o) => { /* o.isSprite, o.geometry?.type, o.material?.opacity */ });
+```
+
+The registry is keyed by the id the *scene* was given, which in the app is the
+entity path (`/world/sat/<id>`), not the config id — enumerate `registry.keys()`
+instead of assuming. This route is for a one-off probe while developing. What a
+committed test asserts should still go through a named hook, so the assertion
+survives a refactor of the scene's internals.
+
 ### Common Pitfalls
 
 1. **Cannot access uPlot data from DOM**: `chart._uplot`, `chart.__uplot` do not exist. uPlot stores instance internally in React ref via `useRef()`.

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/axisTriad.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/axisTriad.ts
@@ -43,8 +43,10 @@ export function axisLabelScale(length: number): number {
  *
  * The letters sit *past* the tips, so a camera fitted to the axes alone clips
  * them. A sprite is a quad facing the camera, so it reaches half its diagonal in
- * whichever direction the view happens to put that — and a letter's texture is
- * square, which makes the diagonal `sqrt(2)` times its side.
+ * whichever direction the view happens to put that. A letter's texture is
+ * narrower than it is tall — a bold "X" measures about 0.76 of the height, "Z"
+ * about 0.70 — so `sqrt(2)` times the height bounds the diagonal from above,
+ * which is the side a camera fit should err on.
  */
 export function axisLabelExtent(length: number): number {
   return length * TIP_OVERSHOOT + (axisLabelScale(length) * Math.SQRT2) / 2;

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/axisTriad.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/axisTriad.ts
@@ -42,10 +42,12 @@ export function axisLabelScale(length: number): number {
  * Outermost point the labels of a triad reach, from the origin.
  *
  * The letters sit *past* the tips, so a camera fitted to the axes alone clips
- * them.
+ * them. A sprite is a quad facing the camera, so it reaches half its diagonal in
+ * whichever direction the view happens to put that — and a letter's texture is
+ * square, which makes the diagonal `sqrt(2)` times its side.
  */
 export function axisLabelExtent(length: number): number {
-  return length * TIP_OVERSHOOT + axisLabelScale(length) / 2;
+  return length * TIP_OVERSHOOT + (axisLabelScale(length) * Math.SQRT2) / 2;
 }
 
 /** CSS colour for a canvas context, from one of `AXIS_COLORS`. */

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/AxisLabels.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/AxisLabels.tsx
@@ -25,11 +25,10 @@ interface AxisLabelsProps {
 export function AxisLabels({ length, opacity = 1 }: AxisLabelsProps) {
   const labels = useMemo(() => {
     const positions = axisLabelPositions(length);
-    return AXIS_LETTERS.map((letter, i) => ({
-      letter,
-      texture: labelTexture(letter, AXIS_COLORS[i]).texture,
-      position: positions[i],
-    }));
+    return AXIS_LETTERS.map((letter, i) => {
+      const label = labelTexture(letter, AXIS_COLORS[i]);
+      return { letter, label, position: positions[i] };
+    });
   }, [length]);
   const scale = axisLabelScale(length);
 
@@ -39,7 +38,9 @@ export function AxisLabels({ length, opacity = 1 }: AxisLabelsProps) {
         <sprite
           key={label.letter}
           position={label.position}
-          scale={[scale, scale, scale]}
+          // The texture is as wide as the letter needs, so a square sprite would
+          // stretch it: a bold "X" measures narrower than the texture is tall.
+          scale={[scale * label.label.aspect, scale, scale]}
           // Drawn last and without a depth test, so a letter on an axis pointing
           // away from the camera stays readable instead of hiding inside the
           // spacecraft. The axis *arrow* is still depth-tested, so it disappearing
@@ -47,7 +48,7 @@ export function AxisLabels({ length, opacity = 1 }: AxisLabelsProps) {
           renderOrder={LABEL_RENDER_ORDER}
         >
           <spriteMaterial
-            map={label.texture}
+            map={label.label.texture}
             transparent
             opacity={opacity}
             depthTest={false}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/AxisLabels.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/AxisLabels.tsx
@@ -1,59 +1,6 @@
 import { useMemo } from "react";
-import * as THREE from "three";
-import {
-  AXIS_COLORS,
-  AXIS_LETTERS,
-  axisColorCss,
-  axisLabelPositions,
-  axisLabelScale,
-} from "../axisTriad.js";
-
-/**
- * One canvas texture per letter, made on first use and kept.
- *
- * Lazily, not at module scope: the module is imported by tests running without a
- * DOM, and a canvas at import time would throw there.
- */
-const textureCache = new Map<string, THREE.Texture>();
-
-/** Above the scene's meshes, which use the default 0. */
-const LABEL_RENDER_ORDER = 10;
-
-const TEXTURE_SIZE = 128;
-
-function letterTexture(letter: string, color: number): THREE.Texture {
-  const key = `${letter}:${color}`;
-  const cached = textureCache.get(key);
-  if (cached) return cached;
-
-  const canvas = document.createElement("canvas");
-  canvas.width = TEXTURE_SIZE;
-  canvas.height = TEXTURE_SIZE;
-  const ctx = canvas.getContext("2d");
-  if (ctx) {
-    ctx.font = `bold ${TEXTURE_SIZE * 0.76}px ui-sans-serif, system-ui, sans-serif`;
-    ctx.textAlign = "center";
-    ctx.textBaseline = "middle";
-    // Outline first: a letter over a bright 3D model needs its own contrast, and
-    // the scene's background cannot be relied on behind it.
-    ctx.lineWidth = TEXTURE_SIZE * 0.1;
-    // Hex with alpha rather than `rgba(0, 0, 0, 0.85)`: `shadcn add` rewrites
-    // colour functions, and it drops a component from this one, leaving
-    // `rgba(0, 0, 0.85)` in a consumer's copy. Canvas ignores an invalid
-    // `strokeStyle` and keeps the previous one, so the outline the installed
-    // registry item draws would not be the one written here. The registry item
-    // itself carries the source unchanged; the mangling is in the install step.
-    ctx.strokeStyle = "#000000d9";
-    ctx.strokeText(letter, TEXTURE_SIZE / 2, TEXTURE_SIZE * 0.54);
-    ctx.fillStyle = axisColorCss(color);
-    ctx.fillText(letter, TEXTURE_SIZE / 2, TEXTURE_SIZE * 0.54);
-  }
-
-  const texture = new THREE.CanvasTexture(canvas);
-  texture.colorSpace = THREE.SRGBColorSpace;
-  textureCache.set(key, texture);
-  return texture;
-}
+import { AXIS_COLORS, AXIS_LETTERS, axisLabelPositions, axisLabelScale } from "../axisTriad.js";
+import { LABEL_RENDER_ORDER, labelTexture } from "./labelTexture.js";
 
 interface AxisLabelsProps {
   /** Axis length in scene units — the labels sit just past each tip. */
@@ -80,7 +27,7 @@ export function AxisLabels({ length, opacity = 1 }: AxisLabelsProps) {
     const positions = axisLabelPositions(length);
     return AXIS_LETTERS.map((letter, i) => ({
       letter,
-      texture: letterTexture(letter, AXIS_COLORS[i]),
+      texture: labelTexture(letter, AXIS_COLORS[i]).texture,
       position: positions[i],
     }));
   }, [length]);

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/DirectionArrows.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/DirectionArrows.tsx
@@ -1,10 +1,16 @@
 import { useEffect, useMemo, useRef } from "react";
 import type * as THREE from "three";
 import { type DrawnArrow, registerDirectionVectors } from "../debug/directionVectors.js";
-import type { DirectionVector } from "../directionVectors.js";
+import { DIRECTION_VECTOR_LABELS, type DirectionVector } from "../directionVectors.js";
 import type { Vec3 } from "../displayFrame.js";
-import { arrowGeometryForSpan } from "../spacecraftScale.js";
+import {
+  type ArrowGeometry,
+  arrowGeometryForSpan,
+  arrowLabelDistance,
+  arrowLabelHeight,
+} from "../spacecraftScale.js";
 import { Arrow } from "./Arrow.js";
+import { LABEL_RENDER_ORDER, labelTexture } from "./labelTexture.js";
 
 interface DirectionArrowsProps {
   /** Spacecraft position in scene units — where the arrows start. */
@@ -82,6 +88,66 @@ export function DirectionArrows({
           {...geometry}
         />
       ))}
+      <ArrowLabels vectors={vectors} geometry={geometry} span={visualSpan} />
     </group>
+  );
+}
+
+/**
+ * Each arrow's name, at its tip.
+ *
+ * The alternative is a legend in the overlay, which asks the reader to hold a
+ * colour in mind and match it against the picture — and leaves a still image
+ * with nothing to go on. The axis triads name themselves for the same reason,
+ * and these read the same way: a sprite past the tip, coloured like the arrow it
+ * belongs to, drawn last and without a depth test so a name on an arrow pointing
+ * away stays legible.
+ */
+function ArrowLabels({
+  vectors,
+  geometry,
+  span,
+}: {
+  vectors: readonly DirectionVector[];
+  geometry: ArrowGeometry;
+  span: number;
+}) {
+  const labels = useMemo(() => {
+    const distance = arrowLabelDistance(geometry);
+    const height = arrowLabelHeight(span);
+    return vectors.map((v) => {
+      const label = labelTexture(DIRECTION_VECTOR_LABELS[v.kind], v.color);
+      return {
+        kind: v.kind,
+        texture: label.texture,
+        position: [
+          v.direction[0] * distance,
+          v.direction[1] * distance,
+          v.direction[2] * distance,
+        ] as [number, number, number],
+        scale: [height * label.aspect, height, height] as [number, number, number],
+      };
+    });
+  }, [vectors, geometry, span]);
+
+  return (
+    <>
+      {labels.map((label) => (
+        <sprite
+          key={label.kind}
+          position={label.position}
+          scale={label.scale}
+          renderOrder={LABEL_RENDER_ORDER}
+        >
+          <spriteMaterial
+            map={label.texture}
+            transparent
+            depthTest={false}
+            depthWrite={false}
+            toneMapped={false}
+          />
+        </sprite>
+      ))}
+    </>
   );
 }

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/InitialCameraFit.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/InitialCameraFit.tsx
@@ -1,0 +1,62 @@
+import { useThree } from "@react-three/fiber";
+import { useEffect, useRef } from "react";
+import { PerspectiveCamera } from "three";
+import {
+  drawnExtentForSpan,
+  initialCameraDistance,
+  NOMINAL_SPACECRAFT_SPAN,
+} from "../spacecraftScale.js";
+
+/**
+ * Choose the camera's distance once the canvas has a size, pulling it back if the
+ * viewport is narrower than the default framing assumed.
+ *
+ * The `camera` prop is read at mount, before the canvas has a size, so a portrait
+ * embedding would otherwise clip the axes sideways. Applied on the first sizing
+ * only: reframing on every resize would undo a zoom the viewer had chosen, and
+ * this is a starting view, not a constraint.
+ *
+ * `reframe` says whether that distance is ours to choose at all. The depth range
+ * is not this component's: a caller's position of `[200, 0, 0]` with the default
+ * `far` of 100, and a viewer dollying out past it, are the same problem — the
+ * scene at the origin falls behind the far plane and the canvas goes blank — and
+ * `FarPlaneBeyondScene`, in the scene itself, holds that invariant for as long as
+ * the scene is mounted.
+ */
+export function InitialCameraFit({ fov, reframe }: { fov: number; reframe: boolean }) {
+  const camera = useThree((s) => s.camera);
+  const size = useThree((s) => s.size);
+  const applied = useRef(false);
+  useEffect(() => {
+    if (applied.current || size.width === 0 || size.height === 0) return;
+    applied.current = true;
+    // A `zoom` narrows the field of view, so fit the *effective* one — a camera
+    // framed for 50° and zoomed 2× sees half as much and would clip.
+    const effectiveFov = camera instanceof PerspectiveCamera ? camera.getEffectiveFOV() : fov;
+    // A `near` from the camera prop can also sit past the scene, which frames it
+    // correctly and draws none of it, so the distance clears that plane too.
+    const needed = initialCameraDistance(
+      NOMINAL_SPACECRAFT_SPAN,
+      effectiveFov,
+      size.width / size.height,
+      camera instanceof PerspectiveCamera ? camera.near : 0,
+    );
+    const current = camera.position.length();
+    // The distance the fit asks for goes through the same check a caller's
+    // position does, in the same precision: the view matrix carries it to WebGL
+    // as float32, so past 3.4e38 the camera is somewhere the renderer cannot
+    // place it and the canvas is blank. A narrow effective field of view asks for
+    // exactly that — a `zoom` of 1e38 leaves 5.3e-37° and fits from 6.5e38 spans
+    // away. The camera keeps the framing it was built with instead, which is
+    // drawable at any zoom.
+    const placeable = Number.isFinite(Math.fround(needed));
+    if (reframe && placeable && current > 0 && needed > current) {
+      camera.position.multiplyScalar(needed / current);
+    }
+    // The far plane is not settled here. A narrow field of view fits from far
+    // away — 1° needs some 345 spans — and so does a viewer dollying out, so the
+    // scene keeps the plane beyond itself for as long as it is mounted rather
+    // than once at this moment. See `FarPlaneBeyondScene`.
+  }, [camera, size, fov, reframe]);
+  return null;
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/InitialCameraFit.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/InitialCameraFit.tsx
@@ -1,11 +1,7 @@
 import { useThree } from "@react-three/fiber";
 import { useEffect, useRef } from "react";
 import { PerspectiveCamera } from "three";
-import {
-  drawnExtentForSpan,
-  initialCameraDistance,
-  NOMINAL_SPACECRAFT_SPAN,
-} from "../spacecraftScale.js";
+import { initialCameraDistance, NOMINAL_SPACECRAFT_SPAN } from "../spacecraftScale.js";
 
 /**
  * Choose the camera's distance once the canvas has a size, pulling it back if the

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/components/labelTexture.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/components/labelTexture.ts
@@ -1,0 +1,89 @@
+import * as THREE from "three";
+
+/**
+ * Canvas textures for the short labels drawn in the scene: the letters on an
+ * axis triad, and the names at the tips of the direction arrows.
+ *
+ * Sprites rather than 3D text — they face the camera from every angle, need no
+ * font asset, and add no dependency. The texture is as wide as the text needs, so
+ * a caller scales the sprite by {@link SceneLabel.aspect} to keep the glyphs from
+ * stretching.
+ */
+
+/** One texture per text and colour, made on first use and kept. */
+const cache = new Map<string, SceneLabel>();
+
+/** Texture height in pixels. The width follows the text. */
+const TEXTURE_HEIGHT = 128;
+
+/** Outline width, as a fraction of the height. */
+const OUTLINE_RATIO = 0.1;
+
+/** Padding around the text, as a fraction of the height. */
+const PADDING_RATIO = 0.12;
+
+export interface SceneLabel {
+  texture: THREE.Texture;
+  /** Width / height of the texture, for scaling the sprite. */
+  aspect: number;
+}
+
+/** CSS colour for a canvas context, from a Three.js hex colour. */
+export function labelColorCss(color: number): string {
+  return `#${color.toString(16).padStart(6, "0")}`;
+}
+
+/**
+ * A texture with `text` drawn on it in `color`, outlined so it reads over a lit
+ * 3D model as well as over the scene's background.
+ *
+ * Built lazily rather than at module scope: this module is imported by tests
+ * that run without a DOM, where a canvas at import time would throw.
+ */
+export function labelTexture(text: string, color: number): SceneLabel {
+  const key = `${text}:${color}`;
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  const font = `bold ${TEXTURE_HEIGHT * 0.76}px ui-sans-serif, system-ui, sans-serif`;
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+  let aspect = 1;
+  if (ctx) {
+    // Measure with the final font before sizing the canvas: setting the width
+    // resets the context, so the font is applied twice on purpose.
+    ctx.font = font;
+    const width = ctx.measureText(text).width + TEXTURE_HEIGHT * PADDING_RATIO * 2;
+    canvas.width = Math.max(1, Math.ceil(width));
+    canvas.height = TEXTURE_HEIGHT;
+    aspect = canvas.width / canvas.height;
+
+    ctx.font = font;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    // Outline first: the text over a bright 3D model needs its own contrast, and
+    // the scene's background cannot be relied on behind it.
+    ctx.lineWidth = TEXTURE_HEIGHT * OUTLINE_RATIO;
+    // Hex with alpha rather than `rgba(0, 0, 0, 0.85)`: `shadcn add` rewrites
+    // colour functions, and it drops a component from this one, leaving
+    // `rgba(0, 0, 0.85)` in a consumer's copy. Canvas ignores an invalid
+    // `strokeStyle` and keeps the previous one, so the outline the installed
+    // registry item draws would not be the one written here.
+    ctx.strokeStyle = "#000000d9";
+    ctx.strokeText(text, canvas.width / 2, TEXTURE_HEIGHT * 0.54);
+    ctx.fillStyle = labelColorCss(color);
+    ctx.fillText(text, canvas.width / 2, TEXTURE_HEIGHT * 0.54);
+  } else {
+    canvas.width = TEXTURE_HEIGHT;
+    canvas.height = TEXTURE_HEIGHT;
+  }
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  const label = { texture, aspect };
+  cache.set(key, label);
+  return label;
+}
+
+/** Above the scene's meshes, which use the default 0. */
+export const LABEL_RENDER_ORDER = 10;

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/directionVectors.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/directionVectors.ts
@@ -1,10 +1,10 @@
-import { centrePositionIsUsable } from "./frameResolve.js";
 import {
   type DisplayFrame,
   type DisplayRotationFrame,
   displayDirection,
   type Vec3,
 } from "./displayFrame.js";
+import { centrePositionIsUsable } from "./frameResolve.js";
 
 /** Which reference direction an arrow shows. */
 export type DirectionVectorKind = "sun" | "nadir";

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/directionVectors.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/directionVectors.ts
@@ -1,3 +1,4 @@
+import { centrePositionIsUsable } from "./frameResolve.js";
 import {
   type DisplayFrame,
   type DisplayRotationFrame,
@@ -114,26 +115,33 @@ export function resolveDirectionVectors({
 }
 
 /**
- * Whether a scene centred on this spacecraft can place it at all.
+ * Which arrows the orbit view would draw at a spacecraft it is centred on.
  *
- * The orbit view drops every arrow at a centre whose position its frame cannot
- * use, so a control that offers one there offers an arrow the scene then drops.
- * The Sun is the case that needs saying: it has no position of its own, and would
- * otherwise stay on offer beside a spacecraft that is not on screen.
+ * Two conditions in order, because they fail differently. The scene draws nothing
+ * at all at a centre it cannot place, and the Sun is why that has to be said
+ * first: it needs no position of its own, so it would otherwise stay on offer
+ * beside a spacecraft that is not on screen. Placing a centre asks
+ * {@link centrePositionIsUsable} — the renderer's own condition, so this cannot
+ * answer more strictly than the scene draws. A centre at the coordinate origin is
+ * placeable: the spacecraft is drawn there and the Sun with it, and only nadir
+ * drops out, having no bearing to take.
  *
- * Asked of the resolver rather than derived from "a position is present": a
- * position can be there and still yield no direction — zero, or non-finite from a
- * file source. Nadir is the arrow that needs the position, so whether it resolves
- * is the whole question, and this takes no Sun input so the answer cannot come
- * from one. The frame decides where a direction points, not whether it resolves,
- * so the inertial one stands in.
+ * Then the arrows themselves, from the resolver both scenes use, so a control
+ * cannot offer one the scene goes on to drop. The frame decides where a direction
+ * points rather than whether it resolves, so the inertial one stands in.
  */
-export function centreIsPlaceable(positionEci: Vec3 | null | undefined): boolean {
-  return (
-    resolveDirectionVectors({
-      frame: { kind: "inertial", origin: null },
-      positionEci,
-      options: { nadir: true },
-    }).length > 0
-  );
+export function drawableAtCentre(inputs: {
+  positionEci: Vec3 | null | undefined;
+  /** Whether the scene can compute a Sun direction at all — an epoch, and a body arika can place. */
+  sunIsComputable: boolean;
+}): readonly DirectionVectorKind[] {
+  if (!centrePositionIsUsable(inputs.positionEci)) return [];
+  return resolveDirectionVectors({
+    frame: { kind: "inertial", origin: null },
+    // A stand-in: only whether a Sun direction exists changes the answer, never
+    // which way it points.
+    sunDisplay: inputs.sunIsComputable ? [1, 0, 0] : null,
+    positionEci: inputs.positionEci,
+    options: { sun: true, nadir: true },
+  }).map((v) => v.kind);
 }

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/directionVectors.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/directionVectors.ts
@@ -112,3 +112,28 @@ export function resolveDirectionVectors({
 
   return vectors;
 }
+
+/**
+ * Whether a scene centred on this spacecraft can place it at all.
+ *
+ * The orbit view drops every arrow at a centre whose position its frame cannot
+ * use, so a control that offers one there offers an arrow the scene then drops.
+ * The Sun is the case that needs saying: it has no position of its own, and would
+ * otherwise stay on offer beside a spacecraft that is not on screen.
+ *
+ * Asked of the resolver rather than derived from "a position is present": a
+ * position can be there and still yield no direction — zero, or non-finite from a
+ * file source. Nadir is the arrow that needs the position, so whether it resolves
+ * is the whole question, and this takes no Sun input so the answer cannot come
+ * from one. The frame decides where a direction points, not whether it resolves,
+ * so the inertial one stands in.
+ */
+export function centreIsPlaceable(positionEci: Vec3 | null | undefined): boolean {
+  return (
+    resolveDirectionVectors({
+      frame: { kind: "inertial", origin: null },
+      positionEci,
+      options: { nadir: true },
+    }).length > 0
+  );
+}

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/frameResolve.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/frameResolve.ts
@@ -26,6 +26,21 @@ export interface SceneFrameContext {
   cameraTracking: boolean;
 }
 
+/**
+ * Whether a spacecraft's position can centre the scene on it.
+ *
+ * A non-finite component is no position: it would put the origin offset and the
+ * camera's up vector at NaN, which blanks the canvas. Everything finite is
+ * usable, zero included — the centred spacecraft is drawn at the origin whatever
+ * its coordinates, and only the directions that need a *bearing* from it drop
+ * out. The UI asks this so a control cannot be disabled over a scene that draws.
+ */
+export function centrePositionIsUsable(
+  position: readonly number[] | null | undefined,
+): position is readonly number[] {
+  return position != null && position.length === 3 && position.every(Number.isFinite);
+}
+
 export function resolveSceneFrame(
   frame: ReferenceFrame,
   getEntity: FrameEntityLookup,
@@ -44,11 +59,9 @@ export function resolveSceneFrame(
 
   const id = frame.center.id;
   const state = getEntity(id);
-  // A non-finite position is no position: it cannot centre the scene, and passing
-  // it on would put the origin offset and the camera's up vector at NaN, which
-  // blanks the canvas. Treated like a state that has not arrived — the entity is
-  // still the centre, so the camera stays put until a usable sample lands.
-  if (state == null || !state.position.every(Number.isFinite)) {
+  // Treated like a state that has not arrived — the entity is still the centre,
+  // so the camera stays put until a usable sample lands.
+  if (state == null || !centrePositionIsUsable(state.position)) {
     return { ...inert, centeredSatId: id };
   }
 

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/frameResolve.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/frameResolve.ts
@@ -29,16 +29,27 @@ export interface SceneFrameContext {
 /**
  * Whether a spacecraft's position can centre the scene on it.
  *
- * A non-finite component is no position: it would put the origin offset and the
- * camera's up vector at NaN, which blanks the canvas. Everything finite is
- * usable, zero included — the centred spacecraft is drawn at the origin whatever
- * its coordinates, and only the directions that need a *bearing* from it drop
- * out. The UI asks this so a control cannot be disabled over a scene that draws.
+ * Two ways to fail, and both blank the canvas rather than draw something wrong. A
+ * non-finite component puts the origin offset and the camera's up vector at NaN.
+ * And the offset reaches the renderer as float32, where anything past 3.4e38 is
+ * `Infinity`: `[1e100, 0, 0]` is a perfectly good double and no place to put a
+ * spacecraft. What the matrix carries is the distance rather than the components,
+ * so that is what is measured — `[3e38, 3e38, 0]` has both components inside
+ * float32 and a length of 4.24e38 that is not, and a per-component check passes
+ * it. The same test guards the camera in `usablePosition`.
+ *
+ * Zero is usable, which is where this parts company with the camera's version: a
+ * spacecraft at the body's centre is drawn at the origin like any other centre,
+ * and only the directions needing a *bearing* from it drop out. The UI asks this
+ * so a control cannot be disabled over a scene that draws.
  */
 export function centrePositionIsUsable(
   position: readonly number[] | null | undefined,
 ): position is readonly number[] {
-  return position != null && position.length === 3 && position.every(Number.isFinite);
+  if (position == null || position.length !== 3) return false;
+  const [x, y, z] = position;
+  if (!(Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z))) return false;
+  return Number.isFinite(Math.fround(Math.hypot(x, y, z)));
 }
 
 export function resolveSceneFrame(

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/frameResolve.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/frameResolve.ts
@@ -29,14 +29,20 @@ export interface SceneFrameContext {
 /**
  * Whether a spacecraft's position can centre the scene on it.
  *
- * Two ways to fail, and both blank the canvas rather than draw something wrong. A
- * non-finite component puts the origin offset and the camera's up vector at NaN.
- * And the offset reaches the renderer as float32, where anything past 3.4e38 is
- * `Infinity`: `[1e100, 0, 0]` is a perfectly good double and no place to put a
- * spacecraft. What the matrix carries is the distance rather than the components,
- * so that is what is measured — `[3e38, 3e38, 0]` has both components inside
- * float32 and a length of 4.24e38 that is not, and a per-component check passes
- * it. The same test guards the camera in `usablePosition`.
+ * Two ways to fail, and either would blank the canvas if the position were
+ * applied. A non-finite component puts the origin offset and the camera's up
+ * vector at NaN. And the offset reaches the renderer as float32, where anything
+ * past 3.4e38 is `Infinity`: `[1e100, 0, 0]` is a perfectly good double and no
+ * place to put a spacecraft. What the matrix carries is the distance rather than
+ * the components, so that is what is measured — `[3e38, 3e38, 0]` has both
+ * components inside float32 and a length of 4.24e38 that is not, and a
+ * per-component check passes it. The same test guards the camera in
+ * `usablePosition`.
+ *
+ * Answering false is how the blanking is avoided rather than a report of it:
+ * `resolveSceneFrame` then keeps the entity as the centre with no origin, which
+ * is how it holds a state that has not arrived, and the camera stays where it is
+ * until a usable sample lands.
  *
  * Zero is usable, which is where this parts company with the camera's version: a
  * spacecraft at the body's centre is drawn at the origin like any other centre,

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/frameResolve.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/frameResolve.ts
@@ -29,33 +29,27 @@ export interface SceneFrameContext {
 /**
  * Whether a spacecraft's position can centre the scene on it.
  *
- * Two ways to fail, and either would blank the canvas if the position were
- * applied. A non-finite component puts the origin offset and the camera's up
- * vector at NaN. And the offset reaches the renderer as float32, where anything
- * past 3.4e38 is `Infinity`: `[1e100, 0, 0]` is a perfectly good double and no
- * place to put a spacecraft. What the matrix carries is the distance rather than
- * the components, so that is what is measured — `[3e38, 3e38, 0]` has both
- * components inside float32 and a length of 4.24e38 that is not, and a
- * per-component check passes it. The same test guards the camera in
- * `usablePosition`.
+ * A non-finite component is no position: it would put the origin offset and the
+ * camera's up vector at NaN. Everything finite is accepted, zero included — a
+ * spacecraft at the body's centre is drawn at the origin like any other centre,
+ * and only the directions needing a *bearing* from it drop out. The UI asks this
+ * so a control cannot be disabled over a scene that draws.
  *
- * Answering false is how the blanking is avoided rather than a report of it:
+ * Answering false is how the NaN is avoided rather than a report of it:
  * `resolveSceneFrame` then keeps the entity as the centre with no origin, which
  * is how it holds a state that has not arrived, and the camera stays where it is
  * until a usable sample lands.
  *
- * Zero is usable, which is where this parts company with the camera's version: a
- * spacecraft at the body's centre is drawn at the origin like any other centre,
- * and only the directions needing a *bearing* from it drop out. The UI asks this
- * so a control cannot be disabled over a scene that draws.
+ * The magnitude a float32 uniform can hold is deliberately not judged here.
+ * Positions reach the renderer divided by the scene's scale radius — itself the
+ * central body's radius over the amplification — so the limit lives in units this
+ * function is not given, and testing the kilometres would reject positions the
+ * renderer draws perfectly well. See #451, where the scale is in scope.
  */
 export function centrePositionIsUsable(
   position: readonly number[] | null | undefined,
 ): position is readonly number[] {
-  if (position == null || position.length !== 3) return false;
-  const [x, y, z] = position;
-  if (!(Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z))) return false;
-  return Number.isFinite(Math.fround(Math.hypot(x, y, z)));
+  return position != null && position.length === 3 && position.every(Number.isFinite);
 }
 
 export function resolveSceneFrame(

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/lib/AttitudeViewer.tsx
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/lib/AttitudeViewer.tsx
@@ -1,15 +1,13 @@
-import { Canvas, useThree } from "@react-three/fiber";
-import { useEffect, useRef } from "react";
-import { PerspectiveCamera } from "three";
+import { Canvas } from "@react-three/fiber";
 import { usableDirection, usablePosition, usableProjection } from "../cameraProps.js";
 import { CameraViewProbe } from "../components/CameraViewProbe.js";
 import { FarPlaneBeyondScene } from "../components/FarPlaneBeyondScene.js";
+import { InitialCameraFit } from "../components/InitialCameraFit.js";
 import { SCENE_UP } from "../sceneFrame.js";
 import {
   cameraDistanceForSpan,
   DEFAULT_CAMERA_FOV_DEGREES,
   drawnExtentForSpan,
-  initialCameraDistance,
   NOMINAL_SPACECRAFT_SPAN,
   usableFovDegrees,
 } from "../spacecraftScale.js";
@@ -32,60 +30,6 @@ const DEFAULT_CAMERA_POSITION: [number, number, number] = (() => {
   const d = cameraDistanceForSpan(NOMINAL_SPACECRAFT_SPAN, DEFAULT_FOV);
   return [CAMERA_DIRECTION[0] * d, CAMERA_DIRECTION[1] * d, CAMERA_DIRECTION[2] * d];
 })();
-
-/**
- * Choose the camera's distance once the canvas has a size, pulling it back if the
- * viewport is narrower than the default framing assumed.
- *
- * The `camera` prop is read at mount, before the canvas has a size, so a portrait
- * embedding would otherwise clip the axes sideways. Applied on the first sizing
- * only: reframing on every resize would undo a zoom the viewer had chosen, and
- * this is a starting view, not a constraint.
- *
- * `reframe` says whether that distance is ours to choose at all. The depth range
- * is not this component's: a caller's position of `[200, 0, 0]` with the default
- * `far` of 100, and a viewer dollying out past it, are the same problem — the
- * scene at the origin falls behind the far plane and the canvas goes blank — and
- * `FarPlaneBeyondScene`, in the scene itself, holds that invariant for as long as
- * the scene is mounted.
- */
-function InitialCameraFit({ fov, reframe }: { fov: number; reframe: boolean }) {
-  const camera = useThree((s) => s.camera);
-  const size = useThree((s) => s.size);
-  const applied = useRef(false);
-  useEffect(() => {
-    if (applied.current || size.width === 0 || size.height === 0) return;
-    applied.current = true;
-    // A `zoom` narrows the field of view, so fit the *effective* one — a camera
-    // framed for 50° and zoomed 2× sees half as much and would clip.
-    const effectiveFov = camera instanceof PerspectiveCamera ? camera.getEffectiveFOV() : fov;
-    // A `near` from the camera prop can also sit past the scene, which frames it
-    // correctly and draws none of it, so the distance clears that plane too.
-    const needed = initialCameraDistance(
-      NOMINAL_SPACECRAFT_SPAN,
-      effectiveFov,
-      size.width / size.height,
-      camera instanceof PerspectiveCamera ? camera.near : 0,
-    );
-    const current = camera.position.length();
-    // The distance the fit asks for goes through the same check a caller's
-    // position does, in the same precision: the view matrix carries it to WebGL
-    // as float32, so past 3.4e38 the camera is somewhere the renderer cannot
-    // place it and the canvas is blank. A narrow effective field of view asks for
-    // exactly that — a `zoom` of 1e38 leaves 5.3e-37° and fits from 6.5e38 spans
-    // away. The camera keeps the framing it was built with instead, which is
-    // drawable at any zoom.
-    const placeable = Number.isFinite(Math.fround(needed));
-    if (reframe && placeable && current > 0 && needed > current) {
-      camera.position.multiplyScalar(needed / current);
-    }
-    // The far plane is not settled here. A narrow field of view fits from far
-    // away — 1° needs some 345 spans — and so does a viewer dollying out, so the
-    // scene keeps the plane beyond itself for as long as it is mounted rather
-    // than once at this moment. See `FarPlaneBeyondScene`.
-  }, [camera, size, fov, reframe]);
-  return null;
-}
 
 /**
  * Embeddable attitude viewer.

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/spacecraftScale.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/spacecraftScale.ts
@@ -231,6 +231,25 @@ export function usableFovDegrees(fovDegrees: number | undefined): number {
 const VIEW_MARGIN = 1.15;
 
 /**
+ * How far past an arrow's tip its name sits, as a fraction of the arrow's length.
+ * On the tip the text overlaps the head it names.
+ */
+const ARROW_LABEL_OVERSHOOT = 0.14;
+
+/** Name height as a fraction of the spacecraft's apparent size. */
+const ARROW_LABEL_SCALE = 0.22;
+
+/** Distance from the arrow's tail group to where its name is drawn. */
+export function arrowLabelDistance(geometry: ArrowGeometry): number {
+  return geometry.startOffset + geometry.length * (1 + ARROW_LABEL_OVERSHOOT);
+}
+
+/** Name height in scene units for a spacecraft of this apparent size. */
+export function arrowLabelHeight(span: number): number {
+  return span * ARROW_LABEL_SCALE;
+}
+
+/**
  * Distance from the origin to the furthest thing drawn around the spacecraft:
  * whichever reaches further, the reference-frame triad or a direction arrow's tip.
  *
@@ -240,7 +259,9 @@ const VIEW_MARGIN = 1.15;
 export function drawnExtentForSpan(span: number): number {
   // The widest marker decides, so the framing holds whichever shape is drawn.
   const arrow = arrowGeometryForSpan(span, markerBoundingRadius("axes-cube", span));
-  return Math.max(axisLabelExtent(frameAxisLengthForSpan(span)), arrow.startOffset + arrow.length);
+  // Each arrow's name sits past its tip, as each axis letter sits past its own.
+  const arrowReach = arrowLabelDistance(arrow) + arrowLabelHeight(span) / 2;
+  return Math.max(axisLabelExtent(frameAxisLengthForSpan(span)), arrowReach);
 }
 
 /**

--- a/viewer/examples/orbit-viewer/components/orbit-viewer/spacecraftScale.ts
+++ b/viewer/examples/orbit-viewer/components/orbit-viewer/spacecraftScale.ts
@@ -239,6 +239,18 @@ const ARROW_LABEL_OVERSHOOT = 0.14;
 /** Name height as a fraction of the spacecraft's apparent size. */
 const ARROW_LABEL_SCALE = 0.22;
 
+/**
+ * Widest a name is drawn, as a multiple of its height.
+ *
+ * The texture is as wide as the text needs, so the sprite is not square the way
+ * an axis letter's is: measured in a browser, "Sun" comes out at 1.70 and
+ * "Nadir" at 2.22 times its height. The bound is what the camera fit has to
+ * assume, since the width depends on the font the browser resolves; it is here
+ * rather than in the label module because this file is the pure one, and it is
+ * generous enough for a longer name to be added without clipping.
+ */
+const ARROW_LABEL_MAX_ASPECT = 2.5;
+
 /** Distance from the arrow's tail group to where its name is drawn. */
 export function arrowLabelDistance(geometry: ArrowGeometry): number {
   return geometry.startOffset + geometry.length * (1 + ARROW_LABEL_OVERSHOOT);
@@ -247,6 +259,18 @@ export function arrowLabelDistance(geometry: ArrowGeometry): number {
 /** Name height in scene units for a spacecraft of this apparent size. */
 export function arrowLabelHeight(span: number): number {
   return span * ARROW_LABEL_SCALE;
+}
+
+/**
+ * How far a name reaches from where it is placed.
+ *
+ * Half the sprite's diagonal: it faces the camera, so its width lies across the
+ * view rather than along the arrow, and the framing has to hold it whichever way
+ * the reader has turned the scene.
+ */
+export function arrowLabelReach(span: number): number {
+  const height = arrowLabelHeight(span);
+  return (height * Math.hypot(ARROW_LABEL_MAX_ASPECT, 1)) / 2;
 }
 
 /**
@@ -260,7 +284,7 @@ export function drawnExtentForSpan(span: number): number {
   // The widest marker decides, so the framing holds whichever shape is drawn.
   const arrow = arrowGeometryForSpan(span, markerBoundingRadius("axes-cube", span));
   // Each arrow's name sits past its tip, as each axis letter sits past its own.
-  const arrowReach = arrowLabelDistance(arrow) + arrowLabelHeight(span) / 2;
+  const arrowReach = arrowLabelDistance(arrow) + arrowLabelReach(span);
   return Math.max(axisLabelExtent(frameAxisLengthForSpan(span)), arrowReach);
 }
 

--- a/viewer/registry.json
+++ b/viewer/registry.json
@@ -128,6 +128,11 @@
           "target": "@components/orbit-viewer/components/SunLighting.tsx"
         },
         {
+          "path": "src/components/labelTexture.ts",
+          "type": "registry:lib",
+          "target": "@components/orbit-viewer/components/labelTexture.ts"
+        },
+        {
           "path": "src/components/renderEntries.ts",
           "type": "registry:lib",
           "target": "@components/orbit-viewer/components/renderEntries.ts"

--- a/viewer/registry.json
+++ b/viewer/registry.json
@@ -88,6 +88,11 @@
           "target": "@components/orbit-viewer/components/FarPlaneBeyondScene.tsx"
         },
         {
+          "path": "src/components/InitialCameraFit.tsx",
+          "type": "registry:component",
+          "target": "@components/orbit-viewer/components/InitialCameraFit.tsx"
+        },
+        {
           "path": "src/components/OrbitSceneContents.tsx",
           "type": "registry:component",
           "target": "@components/orbit-viewer/components/OrbitSceneContents.tsx"

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -706,7 +706,7 @@ export function App() {
               localOrbitalUnavailable={
                 attitudeFrameAvailable("localOrbital")
                   ? undefined
-                  : "Requires a position and velocity"
+                  : "Requires a position and velocity that define an orbit plane"
               }
               bodyFixedUnavailable={
                 centralBody !== "earth"
@@ -717,7 +717,7 @@ export function App() {
               }
               sunUnavailable={epoch == null ? "Requires epoch" : undefined}
               nadirUnavailable={
-                attitudeDrawableKinds.includes("nadir") ? undefined : "Requires a position"
+                attitudeDrawableKinds.includes("nadir") ? undefined : "Requires a non-zero position"
               }
               directionVectors={directionVectors}
               onDirectionVectorsChange={setDirectionVectors}

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -443,12 +443,14 @@ export function App() {
   }, [referenceFrame, satellites]);
   const centredSatelliteId = centredSatellite?.id ?? null;
 
-  // Keep the attitude view's subject on a spacecraft that still exists. A
+  // Keep the attitude view's subject on a spacecraft the viewer still has. A
   // satellite-centred orbit view hands over its centre; otherwise the previous
-  // choice stands while it is still valid, and the first spacecraft takes over
-  // when it is not (a terminated satellite drops out of the list). The centre is
-  // only a candidate while it is still in the list — a frame can point at a
-  // satellite the current source never had.
+  // choice stands while it is still in the list, and the first spacecraft takes
+  // over when it is not — which happens when the source changes, not when a
+  // satellite terminates: a terminated one keeps its buffers and its last state,
+  // and its final attitude is worth looking at. The centre is only a candidate
+  // while it is in the list too, since a frame can name a satellite the current
+  // source never had.
   useEffect(() => {
     if (selectedSatelliteId != null && satellites.some((s) => s.id === selectedSatelliteId)) return;
     const fallback = centredSatelliteId ?? satellites[0]?.id ?? null;

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -64,7 +64,10 @@ const VITE_TEXTURE_BASE_URL = import.meta.env.VITE_TEXTURE_BASE_URL;
  */
 const LEGEND_FRAME: DisplayFrame = { kind: "inertial", origin: null };
 
-/** Stands in for "the scene will have a Sun direction", which it computes itself. */
+/**
+ * Stands in for "the scene will have a Sun direction", which the scene computes
+ * itself, from the lighting. Any direction answers the question.
+ */
 const SUN_PRESENT: DisplayVec3 = [1, 0, 0];
 
 /** Both reference-direction arrows on, the starting state for either view. */
@@ -558,7 +561,7 @@ export function App() {
     ): readonly DirectionVectorKind[] =>
       resolveDirectionVectors({
         frame: LEGEND_FRAME,
-        sunEci: sunIsComputable ? SUN_PRESENT : null,
+        sunDisplay: sunIsComputable ? SUN_PRESENT : null,
         positionEci: position ?? null,
         options,
       }).map((v) => v.kind),

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -6,17 +6,29 @@ import { initArika } from "./wasm/arikaInit.js";
 const arikaReady = initArika();
 
 import type { TimeRange } from "@sksat/uneri";
+import appStyles from "./App.module.css";
+import { AttitudeOverlay } from "./components/AttitudeOverlay.js";
+import { DIRECTION_VECTOR_KINDS } from "./components/DirectionVectorControls.js";
 import { GraphPanel } from "./components/GraphPanel.js";
+import { InitialCameraFit } from "./components/InitialCameraFit.js";
+import { OrbitOverlay } from "./components/OrbitOverlay.js";
 import { PlaybackBar } from "./components/PlaybackBar.js";
-import { SceneOverlay } from "./components/SceneOverlay.js";
 import { SimConfigModal } from "./components/SimConfigModal.js";
 import { StatusBar } from "./components/StatusBar.js";
+import { type ViewMode, ViewSelector } from "./components/ViewSelector.js";
 import { toViewerReferenceFrame } from "./frameToViewer.js";
 import { CSV_SOURCE_ID, RRD_SOURCE_ID, useFileSource } from "./hooks/useFileSource.js";
 import { useRealtimePlayback } from "./hooks/useRealtimePlayback.js";
 import { useSimInfoDerived } from "./hooks/useSimInfoDerived.js";
 import { useSimulationData } from "./hooks/useSimulationData.js";
-import { type DirectionVectorOptions, OrbitScene, type SatelliteState } from "./lib/index.js";
+import {
+  type AttitudeBodyState,
+  type AttitudeFrame,
+  AttitudeScene,
+  type DirectionVectorOptions,
+  OrbitScene,
+  type SatelliteState,
+} from "./lib/index.js";
 import type { ClientMessage } from "./protocol/generated/ClientMessage.js";
 import { DEFAULT_FRAME, type ReferenceFrame } from "./referenceFrame.js";
 import { type MarkerShape, readSatShapeParam, writeSatShapeParam } from "./satelliteShapes.js";
@@ -26,7 +38,12 @@ import { useWebSocketSource, WS_SOURCE_ID } from "./sources/useWebSocketSource.j
 import { resolveTextureBaseUrl } from "./textureBaseUrl.js";
 import { resolveDefaultWsUrl } from "./utils/defaultWsUrl.js";
 import { planInitialRangeQuery } from "./utils/initialRangeQuery.js";
-import { readTimeRangeParam, writeTimeRangeParam } from "./utils/urlParams.js";
+import {
+  readTimeRangeParam,
+  readViewParam,
+  writeTimeRangeParam,
+  writeViewParam,
+} from "./utils/urlParams.js";
 
 const DEFAULT_WS_URL: string = resolveDefaultWsUrl({
   explicitWsUrl: import.meta.env.VITE_WS_URL,
@@ -38,12 +55,15 @@ const DEFAULT_WS_URL: string = resolveDefaultWsUrl({
 // Build-time texture base URL — present when VITE_TEXTURE_BASE_URL is set at Vite startup.
 const VITE_TEXTURE_BASE_URL = import.meta.env.VITE_TEXTURE_BASE_URL;
 
+/** Both reference-direction arrows on, the starting state for either view. */
+const DEFAULT_DIRECTION_VECTORS: DirectionVectorOptions = { sun: true, nadir: true };
+
 /**
- * Reference-direction arrows the app asks for. The scene draws them only at a
- * centred satellite, so a central-body view is unaffected. Module-level so the
- * prop keeps one identity across renders.
+ * Camera framing for the attitude view, whose scene unit is the spacecraft.
+ * `InitialCameraFit` pulls it further back on a viewport narrower than square.
  */
-const DIRECTION_VECTORS: DirectionVectorOptions = { sun: true, nadir: true };
+const ATTITUDE_FOV = 50;
+const ATTITUDE_CAMERA_POSITION: [number, number, number] = [4.3, 0, 2.15];
 
 export function App() {
   // WASM initialization (must complete before rendering ECEF transforms)
@@ -53,6 +73,19 @@ export function App() {
   }, []);
 
   const [referenceFrame, setReferenceFrame] = useState<ReferenceFrame>(DEFAULT_FRAME);
+
+  // Which presentation is showing, persisted to the URL. Each view keeps its own
+  // display state: the orbit view's frame pairs a centre with an orientation, the
+  // attitude view has only an orientation, and mapping one onto the other on every
+  // switch would quietly change what the reader is looking at.
+  const [view, setView] = useState<ViewMode>(() => readViewParam());
+  const [attitudeFrame, setAttitudeFrame] = useState<AttitudeFrame>("inertial");
+  const [selectedSatelliteId, setSelectedSatelliteId] = useState<string | null>(null);
+  const [directionVectors, setDirectionVectors] =
+    useState<DirectionVectorOptions>(DEFAULT_DIRECTION_VECTORS);
+  useEffect(() => {
+    writeViewParam(view);
+  }, [view]);
 
   // Chart time range
   const [timeRange, setTimeRange] = useState<TimeRange>(() => readTimeRangeParam());
@@ -402,6 +435,93 @@ export function App() {
     timeRange,
   ]);
 
+  /** The orbit view's centred satellite, when it is one the viewer still has. */
+  const centredSatellite = useMemo(() => {
+    if (referenceFrame.center.type !== "satellite") return null;
+    const id = referenceFrame.center.id;
+    return satellites.find((s) => s.id === id) ?? null;
+  }, [referenceFrame, satellites]);
+  const centredSatelliteId = centredSatellite?.id ?? null;
+
+  // Keep the attitude view's subject on a spacecraft that still exists. A
+  // satellite-centred orbit view hands over its centre; otherwise the previous
+  // choice stands while it is still valid, and the first spacecraft takes over
+  // when it is not (a terminated satellite drops out of the list). The centre is
+  // only a candidate while it is still in the list — a frame can point at a
+  // satellite the current source never had.
+  useEffect(() => {
+    if (selectedSatelliteId != null && satellites.some((s) => s.id === selectedSatelliteId)) return;
+    const fallback = centredSatelliteId ?? satellites[0]?.id ?? null;
+    if (fallback !== selectedSatelliteId) setSelectedSatelliteId(fallback);
+  }, [satellites, centredSatelliteId, selectedSatelliteId]);
+
+  const handleViewChange = useCallback(
+    (next: ViewMode) => {
+      // Switching from a satellite-centred orbit view carries that satellite over:
+      // it is the one the reader was already looking at.
+      if (next === "attitude" && centredSatelliteId != null) {
+        setSelectedSatelliteId(centredSatelliteId);
+      }
+      setView(next);
+    },
+    [centredSatelliteId],
+  );
+
+  /**
+   * The attitude view's subject. Null when the chosen spacecraft has no attitude:
+   * this view has nothing to show then, and inventing an identity quaternion would
+   * present "no data" as "pointing at the reference frame".
+   */
+  const attitudeBody = useMemo<AttitudeBodyState | null>(() => {
+    const sat = satellites.find((s) => s.id === selectedSatelliteId);
+    if (sat?.attitude == null) return null;
+    return {
+      id: sat.id,
+      attitude: sat.attitude,
+      position: sat.position,
+      velocity: sat.velocity,
+      time: sat.time,
+      name: sat.name,
+      color: sat.color,
+      markerShape: sat.markerShape,
+    };
+  }, [satellites, selectedSatelliteId]);
+
+  // Which arrows the attitude view can actually draw, for its legend.
+  const attitudeVectorKinds = useMemo(
+    () =>
+      attitudeBody == null
+        ? []
+        : DIRECTION_VECTOR_KINDS.filter((kind) => {
+            if (directionVectors[kind] === false) return false;
+            if (kind === "sun") return epochJd != null;
+            return attitudeBody.position != null;
+          }),
+    [directionVectors, epochJd, attitudeBody],
+  );
+
+  /**
+   * The display orientation the attitude view actually renders in.
+   *
+   * A request whose inputs are absent falls back to inertial in the scene, so the
+   * selection is normalised here rather than left showing "LVLH" over inertial
+   * axes — the data behind a choice can disappear after it was made (a satellite
+   * terminates, a source without velocities takes over).
+   */
+  const attitudeFrameAvailable = useCallback(
+    (frame: AttitudeFrame) => {
+      if (frame === "localOrbital") {
+        return attitudeBody?.position != null && attitudeBody?.velocity != null;
+      }
+      if (frame === "bodyFixed") return epochJd != null && centralBody === "earth";
+      return true;
+    },
+    [attitudeBody, epochJd, centralBody],
+  );
+  useEffect(() => {
+    if (!attitudeFrameAvailable(attitudeFrame)) setAttitudeFrame("inertial");
+  }, [attitudeFrame, attitudeFrameAvailable]);
+
   // Total points across all satellite buffers.
   // chartBufferVersion bumps on data ingest AND on resetBuffers (clear),
   // so this recalculates when data arrives or buffers are cleared.
@@ -432,7 +552,9 @@ export function App() {
 
   if (!wasmReady) return null;
 
-  const showGraph = simData.dbReady;
+  // The charts are orbital, so the attitude view hides them — and the layout
+  // collapses to a single column with them.
+  const showGraph = simData.dbReady && view === "orbit";
 
   return (
     <div
@@ -464,52 +586,108 @@ export function App() {
 
       {/* 3D Scene (row 2, column 1) */}
       <div className="scene-container">
-        <SceneOverlay
-          referenceFrame={referenceFrame}
-          onReferenceFrameChange={setReferenceFrame}
-          satellites={simInfo?.satellites}
-          centralBody={centralBody}
-          epochJd={epochJd}
-          orbitInfo={fileSource.orbitInfo}
-          simInfo={simInfo}
-          totalPoints={totalPoints}
-          activePerturbations={activePerturbations}
-          defaultMarkerShape={defaultMarkerShape}
-          onDefaultMarkerShapeChange={setDefaultMarkerShape}
-          markerShapeOverrides={markerShapeOverrides}
-          onMarkerShapeOverride={handleMarkerShapeOverride}
-        />
+        {/* The app owns the overlay area: the view switch has to outlive both
+            views, and each view contributes only its own controls. */}
+        <div className={appStyles.sceneOverlay}>
+          <ViewSelector view={view} onChange={handleViewChange} />
+          {view === "orbit" ? (
+            <OrbitOverlay
+              referenceFrame={referenceFrame}
+              onReferenceFrameChange={setReferenceFrame}
+              satellites={simInfo?.satellites}
+              centralBody={centralBody}
+              epochJd={epochJd}
+              orbitInfo={fileSource.orbitInfo}
+              simInfo={simInfo}
+              totalPoints={totalPoints}
+              activePerturbations={activePerturbations}
+              defaultMarkerShape={defaultMarkerShape}
+              onDefaultMarkerShapeChange={setDefaultMarkerShape}
+              markerShapeOverrides={markerShapeOverrides}
+              onMarkerShapeOverride={handleMarkerShapeOverride}
+              directionVectors={directionVectors}
+              onDirectionVectorsChange={setDirectionVectors}
+              centredSatelliteId={centredSatelliteId}
+              hasCentredPosition={centredSatellite?.position != null}
+            />
+          ) : (
+            <AttitudeOverlay
+              satellites={simInfo?.satellites}
+              selectedSatelliteId={selectedSatelliteId}
+              onSelectedSatelliteChange={setSelectedSatelliteId}
+              orientation={attitudeFrame}
+              onOrientationChange={setAttitudeFrame}
+              hasEpoch={epochJd != null}
+              hasPosition={attitudeBody?.position != null}
+              hasVelocity={attitudeBody?.velocity != null}
+              supportsBodyFixed={centralBody === "earth"}
+              directionVectors={directionVectors}
+              onDirectionVectorsChange={setDirectionVectors}
+              drawnVectorKinds={attitudeVectorKinds}
+              hasBody={attitudeBody != null}
+            />
+          )}
+        </div>
 
-        {/* The orts app dogfoods the public <OrbitScene> API: it owns the Canvas
+        {/* The orts app dogfoods the public scene APIs: it owns the Canvas
             (camera up = SCENE_UP, no global THREE.Object3D.DEFAULT_UP mutation)
-            and feeds the scene the public SatelliteState[]. */}
+            and feeds the scene the public state types. Keyed on the view so the
+            camera props — read only at mount — apply to the view being shown;
+            keyed on nothing else, or a frame change would rebuild the WebGL
+            context and re-fetch every GLTF. */}
         <Canvas
+          key={view}
           camera={{
-            position: DEFAULT_CAMERA_POSITION,
+            position: view === "attitude" ? ATTITUDE_CAMERA_POSITION : DEFAULT_CAMERA_POSITION,
             up: SCENE_UP,
-            fov: 60,
+            fov: view === "attitude" ? ATTITUDE_FOV : 60,
             near: 0.01,
-            far: 1000,
+            far: view === "attitude" ? 100 : 1000,
           }}
-          gl={{ logarithmicDepthBuffer: true }}
+          gl={{ logarithmicDepthBuffer: view !== "attitude" }}
           style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%" }}
         >
-          <OrbitScene
-            centralBody={{ id: centralBody, radiusKm: centralBodyRadius }}
-            satellites={satellites}
-            referenceFrame={viewerFrame}
-            epochJd={epochJd ?? undefined}
-            time={snapshot.currentTime}
-            defaultMarkerShape={defaultMarkerShape}
-            directionVectors={DIRECTION_VECTORS}
-            atmosphereScale="visual"
-            textureVersion={textureRevision}
-            textureBaseUrl={textureBaseUrl}
-          />
+          {/* The app asks for the viewer's framing: the constant above is the
+              viewing direction and a starting distance, and the fit settles the
+              distance and the far plane once the canvas has a size. */}
+          {view === "attitude" && <InitialCameraFit fov={ATTITUDE_FOV} reframe />}
+          {view === "orbit" ? (
+            <OrbitScene
+              centralBody={{ id: centralBody, radiusKm: centralBodyRadius }}
+              satellites={satellites}
+              referenceFrame={viewerFrame}
+              epochJd={epochJd ?? undefined}
+              time={snapshot.currentTime}
+              defaultMarkerShape={defaultMarkerShape}
+              directionVectors={directionVectors}
+              atmosphereScale="visual"
+              textureVersion={textureRevision}
+              textureBaseUrl={textureBaseUrl}
+            />
+          ) : (
+            attitudeBody != null && (
+              <AttitudeScene
+                centralBody={{ id: centralBody }}
+                body={attitudeBody}
+                orientation={attitudeFrame}
+                epochJd={epochJd ?? undefined}
+                time={snapshot.currentTime}
+                defaultMarkerShape={defaultMarkerShape}
+                directionVectors={directionVectors}
+              />
+            )
+          )}
         </Canvas>
+
+        {view === "attitude" && attitudeBody == null && (
+          <div className="scene-placeholder" data-testid="attitude-no-data">
+            No attitude data for this spacecraft.
+          </div>
+        )}
       </div>
 
-      {/* Graph panel (row 2, column 2) */}
+      {/* Graph panel (row 2, column 2). The charts are orbital; the attitude view
+          has no use for altitude or energy. */}
       {showGraph && (
         <GraphPanel
           chartData={simData.isMultiSatellite ? undefined : simData.visibleChartData}

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -8,7 +8,6 @@ const arikaReady = initArika();
 import type { TimeRange } from "@sksat/uneri";
 import appStyles from "./App.module.css";
 import { AttitudeOverlay } from "./components/AttitudeOverlay.js";
-import { DIRECTION_VECTOR_KINDS } from "./components/DirectionVectorControls.js";
 import { GraphPanel } from "./components/GraphPanel.js";
 import { InitialCameraFit } from "./components/InitialCameraFit.js";
 import { OrbitOverlay } from "./components/OrbitOverlay.js";
@@ -16,6 +15,8 @@ import { PlaybackBar } from "./components/PlaybackBar.js";
 import { SimConfigModal } from "./components/SimConfigModal.js";
 import { StatusBar } from "./components/StatusBar.js";
 import { type ViewMode, ViewSelector } from "./components/ViewSelector.js";
+import { type DirectionVectorKind, resolveDirectionVectors } from "./directionVectors.js";
+import type { DisplayFrame, Vec3 as DisplayVec3 } from "./displayFrame.js";
 import { toViewerReferenceFrame } from "./frameToViewer.js";
 import { CSV_SOURCE_ID, RRD_SOURCE_ID, useFileSource } from "./hooks/useFileSource.js";
 import { useRealtimePlayback } from "./hooks/useRealtimePlayback.js";
@@ -32,7 +33,7 @@ import {
 import type { ClientMessage } from "./protocol/generated/ClientMessage.js";
 import { DEFAULT_FRAME, type ReferenceFrame } from "./referenceFrame.js";
 import { type MarkerShape, readSatShapeParam, writeSatShapeParam } from "./satelliteShapes.js";
-import { DEFAULT_CAMERA_POSITION, SCENE_UP } from "./sceneFrame.js";
+import { computeLvlhAxes, DEFAULT_CAMERA_POSITION, SCENE_UP } from "./sceneFrame.js";
 import { useSourceRuntime } from "./sources/useSourceRuntime.js";
 import { useWebSocketSource, WS_SOURCE_ID } from "./sources/useWebSocketSource.js";
 import { resolveTextureBaseUrl } from "./textureBaseUrl.js";
@@ -54,6 +55,15 @@ const DEFAULT_WS_URL: string = resolveDefaultWsUrl({
 
 // Build-time texture base URL — present when VITE_TEXTURE_BASE_URL is set at Vite startup.
 const VITE_TEXTURE_BASE_URL = import.meta.env.VITE_TEXTURE_BASE_URL;
+
+/**
+ * Frame the legend asks the resolver with. Which arrows resolve depends on their
+ * inputs, not on the frame, so any frame answers the question.
+ */
+const LEGEND_FRAME: DisplayFrame = { kind: "inertial", origin: null };
+
+/** Stands in for "the scene will have a Sun direction", which it computes itself. */
+const SUN_PRESENT: DisplayVec3 = [1, 0, 0];
 
 /** Both reference-direction arrows on, the starting state for either view. */
 const DEFAULT_DIRECTION_VECTORS: DirectionVectorOptions = { sun: true, nadir: true };
@@ -501,18 +511,25 @@ export function App() {
     };
   }, [satellites, selectedSatelliteId]);
 
-  // Which arrows the attitude view can actually draw, for its legend.
-  const attitudeVectorKinds = useMemo(
-    () =>
-      attitudeBody == null
-        ? []
-        : DIRECTION_VECTOR_KINDS.filter((kind) => {
-            if (directionVectors[kind] === false) return false;
-            if (kind === "sun") return epochJd != null;
-            return attitudeBody.position != null;
-          }),
-    [directionVectors, epochJd, attitudeBody],
-  );
+  /**
+   * Which arrows the attitude view will actually draw — asked of the resolver the
+   * scene uses, not re-derived from "is the input present". A position can be
+   * there and still not yield a direction (zero, or non-finite from a file
+   * source), and a control that offers an arrow the scene then drops is lying.
+   *
+   * The kinds a resolver returns do not depend on the display frame, so the
+   * inertial one stands in; the Sun's own direction is computed inside the scene,
+   * so an epoch is all the app can know about it.
+   */
+  const attitudeVectorKinds = useMemo<readonly DirectionVectorKind[]>(() => {
+    if (attitudeBody == null) return [];
+    return resolveDirectionVectors({
+      frame: LEGEND_FRAME,
+      sunEci: epochJd != null ? SUN_PRESENT : null,
+      positionEci: attitudeBody.position ?? null,
+      options: directionVectors,
+    }).map((v) => v.kind);
+  }, [directionVectors, epochJd, attitudeBody]);
 
   /**
    * The display orientation the attitude view actually renders in.
@@ -521,11 +538,17 @@ export function App() {
    * selection is normalised here rather than left showing "LVLH" over inertial
    * axes — the data behind a choice can disappear after it was made (a satellite
    * terminates, a source without velocities takes over).
+   *
+   * Local-orbital asks `computeLvlhAxes`, the same function the scene resolves
+   * with: a position and a velocity can both be present and still not span an
+   * orbit frame (parallel, zero, non-finite).
    */
   const attitudeFrameAvailable = useCallback(
     (frame: AttitudeFrame) => {
       if (frame === "localOrbital") {
-        return attitudeBody?.position != null && attitudeBody?.velocity != null;
+        return (
+          computeLvlhAxes(attitudeBody?.position ?? null, attitudeBody?.velocity ?? null) != null
+        );
       }
       if (frame === "bodyFixed") return epochJd != null && centralBody === "earth";
       return true;
@@ -631,10 +654,24 @@ export function App() {
               onSelectedSatelliteChange={setSelectedSatelliteId}
               orientation={attitudeFrame}
               onOrientationChange={setAttitudeFrame}
-              hasEpoch={epochJd != null}
-              hasPosition={attitudeBody?.position != null}
-              hasVelocity={attitudeBody?.velocity != null}
-              supportsBodyFixed={centralBody === "earth"}
+              localOrbitalUnavailable={
+                attitudeFrameAvailable("localOrbital")
+                  ? undefined
+                  : "Requires a position and velocity"
+              }
+              bodyFixedUnavailable={
+                centralBody !== "earth"
+                  ? "The viewer models only Earth's rotation"
+                  : epochJd == null
+                    ? "Requires epoch"
+                    : undefined
+              }
+              sunUnavailable={epochJd == null ? "Requires epoch" : undefined}
+              nadirUnavailable={
+                attitudeVectorKinds.includes("nadir") || directionVectors.nadir === false
+                  ? undefined
+                  : "Requires a position"
+              }
               directionVectors={directionVectors}
               onDirectionVectorsChange={setDirectionVectors}
               drawnVectorKinds={attitudeVectorKinds}

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -470,6 +470,18 @@ export function App() {
   );
 
   /**
+   * The spacecraft the attitude view can offer: the ones being rendered, which is
+   * the same list the selection is validated against. The simulation's declared
+   * list arrives with the `info` message, before any state does, and offering a
+   * spacecraft from it would leave the select with no matching option until the
+   * first sample landed.
+   */
+  const attitudeSubjects = useMemo(
+    () => satellites.map((s) => ({ id: s.id, name: s.name })),
+    [satellites],
+  );
+
+  /**
    * The attitude view's subject. Null when the chosen spacecraft has no attitude:
    * this view has nothing to show then, and inventing an identity quaternion would
    * present "no data" as "pointing at the reference frame".
@@ -614,7 +626,7 @@ export function App() {
             />
           ) : (
             <AttitudeOverlay
-              satellites={simInfo?.satellites}
+              satellites={attitudeSubjects}
               selectedSatelliteId={selectedSatelliteId}
               onSelectedSatelliteChange={setSelectedSatelliteId}
               orientation={attitudeFrame}

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -730,7 +730,9 @@ export function App() {
               }
               sunUnavailable={sunUnavailableReason}
               nadirUnavailable={
-                attitudeDrawableKinds.includes("nadir") ? undefined : "Requires a non-zero position"
+                attitudeDrawableKinds.includes("nadir")
+                  ? undefined
+                  : "Requires a finite, non-zero position"
               }
               directionVectors={directionVectors}
               onDirectionVectorsChange={setDirectionVectors}

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -18,10 +18,11 @@ import { SimConfigModal } from "./components/SimConfigModal.js";
 import { StatusBar } from "./components/StatusBar.js";
 import { type ViewMode, ViewSelector } from "./components/ViewSelector.js";
 import {
-  centreIsPlaceable,
   type DirectionVectorKind,
+  drawableAtCentre,
   resolveDirectionVectors,
 } from "./directionVectors.js";
+import { centrePositionIsUsable } from "./frameResolve.js";
 import type { DisplayFrame, Vec3 as DisplayVec3 } from "./displayFrame.js";
 import { toViewerReferenceFrame } from "./frameToViewer.js";
 import { CSV_SOURCE_ID, RRD_SOURCE_ID, useFileSource } from "./hooks/useFileSource.js";
@@ -587,13 +588,13 @@ export function App() {
     [resolvedVectorKinds, attitudeBody],
   );
 
-  const orbitDrawableKinds = useMemo<readonly DirectionVectorKind[]>(() => {
-    if (centredSatellite == null) return [];
-    // Nothing is on offer at a centre the scene cannot place, the Sun included.
-    return centreIsPlaceable(centredSatellite.position)
-      ? resolvedVectorKinds(centredSatellite.position, DEFAULT_DIRECTION_VECTORS)
-      : [];
-  }, [resolvedVectorKinds, centredSatellite]);
+  const orbitDrawableKinds = useMemo<readonly DirectionVectorKind[]>(
+    () =>
+      centredSatellite == null
+        ? []
+        : drawableAtCentre({ positionEci: centredSatellite.position, sunIsComputable }),
+    [centredSatellite, sunIsComputable],
+  );
 
   /**
    * The display orientation the attitude view actually renders in.
@@ -721,6 +722,9 @@ export function App() {
               centredSatelliteId={centredSatelliteId}
               drawableVectorKinds={orbitDrawableKinds}
               sunUnavailable={sunUnavailableReason}
+              centreIsPlaceable={
+                centredSatellite != null && centrePositionIsUsable(centredSatellite.position)
+              }
             />
           ) : (
             <AttitudeOverlay

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -571,13 +571,6 @@ export function App() {
     [sunIsComputable],
   );
 
-  /** What the attitude view draws right now — the legend names exactly these. */
-  const attitudeVectorKinds = useMemo<readonly DirectionVectorKind[]>(
-    () =>
-      attitudeBody == null ? [] : resolvedVectorKinds(attitudeBody.position, directionVectors),
-    [resolvedVectorKinds, attitudeBody, directionVectors],
-  );
-
   /**
    * What each view *could* draw, which is the separate question a disabled
    * control answers: a direction switched off is not an unavailable one.
@@ -752,7 +745,6 @@ export function App() {
               }
               directionVectors={directionVectors}
               onDirectionVectorsChange={setDirectionVectors}
-              drawnVectorKinds={attitudeVectorKinds}
               hasBody={attitudeBody != null}
             />
           )}

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -22,8 +22,8 @@ import {
   drawableAtCentre,
   resolveDirectionVectors,
 } from "./directionVectors.js";
-import { centrePositionIsUsable } from "./frameResolve.js";
 import type { DisplayFrame, Vec3 as DisplayVec3 } from "./displayFrame.js";
+import { centrePositionIsUsable } from "./frameResolve.js";
 import { toViewerReferenceFrame } from "./frameToViewer.js";
 import { CSV_SOURCE_ID, RRD_SOURCE_ID, useFileSource } from "./hooks/useFileSource.js";
 import { useRealtimePlayback } from "./hooks/useRealtimePlayback.js";

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -813,11 +813,22 @@ export function App() {
           )}
         </Canvas>
 
-        {view === "attitude" && attitudeBody == null && (
-          <div className="scene-placeholder" data-testid="attitude-no-data">
-            No attitude data for this spacecraft.
-          </div>
-        )}
+        {/* Two states reach an empty attitude view, and they call for different
+            words: no spacecraft has arrived to look at, or the one being looked
+            at carries no attitude. Naming the second for the first would tell a
+            reader watching a stream connect that their spacecraft has no
+            attitude. */}
+        {view === "attitude" &&
+          attitudeBody == null &&
+          (attitudeSubjectId == null ? (
+            <div className="scene-placeholder" data-testid="attitude-no-spacecraft">
+              Waiting for spacecraft data.
+            </div>
+          ) : (
+            <div className="scene-placeholder" data-testid="attitude-no-data">
+              No attitude data for this spacecraft.
+            </div>
+          ))}
       </div>
 
       {/* Graph panel (row 2, column 2). The charts are orbital; the attitude view

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -17,7 +17,11 @@ import { PlaybackBar } from "./components/PlaybackBar.js";
 import { SimConfigModal } from "./components/SimConfigModal.js";
 import { StatusBar } from "./components/StatusBar.js";
 import { type ViewMode, ViewSelector } from "./components/ViewSelector.js";
-import { type DirectionVectorKind, resolveDirectionVectors } from "./directionVectors.js";
+import {
+  centreIsPlaceable,
+  type DirectionVectorKind,
+  resolveDirectionVectors,
+} from "./directionVectors.js";
 import type { DisplayFrame, Vec3 as DisplayVec3 } from "./displayFrame.js";
 import { toViewerReferenceFrame } from "./frameToViewer.js";
 import { CSV_SOURCE_ID, RRD_SOURCE_ID, useFileSource } from "./hooks/useFileSource.js";
@@ -585,13 +589,8 @@ export function App() {
 
   const orbitDrawableKinds = useMemo<readonly DirectionVectorKind[]>(() => {
     if (centredSatellite == null) return [];
-    // The orbit view draws nothing at all at a centre its frame cannot place, so
-    // offering the Sun there would offer an arrow the scene then drops — the Sun
-    // needs no position of its own, which is why this has to be asked
-    // separately. A position the frame can place is exactly one nadir resolves
-    // from, so the question goes to the resolver rather than repeating the rule.
-    const placeable = resolvedVectorKinds(centredSatellite.position, { nadir: true }).length > 0;
-    return placeable
+    // Nothing is on offer at a centre the scene cannot place, the Sun included.
+    return centreIsPlaceable(centredSatellite.position)
       ? resolvedVectorKinds(centredSatellite.position, DEFAULT_DIRECTION_VECTORS)
       : [];
   }, [resolvedVectorKinds, centredSatellite]);

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -46,6 +46,7 @@ import {
   writeTimeRangeParam,
   writeViewParam,
 } from "./utils/urlParams.js";
+import { has_sun_ephemeris } from "./wasm/arikaInit.js";
 
 const DEFAULT_WS_URL: string = resolveDefaultWsUrl({
   explicitWsUrl: import.meta.env.VITE_WS_URL,
@@ -390,6 +391,17 @@ export function App() {
   // arrow that nothing draws.
   const epoch = finiteOrNull(epochJd);
 
+  // The scenes draw the Sun only when arika can place this central body: for one
+  // it cannot, `sun_direction_from_body` answers +X — the vernal equinox — and
+  // that guess must not be drawn. Deciding here from the same predicate keeps the
+  // control and the legend agreeing with the picture.
+  const sunIsComputable = epoch != null && has_sun_ephemeris(centralBody);
+  const sunUnavailableReason = sunIsComputable
+    ? undefined
+    : epoch == null
+      ? "Requires epoch"
+      : "No Sun ephemeris for this central body";
+
   // Sim-declared marker shapes (from SatelliteInfo); the viewer can override these.
   const satelliteSimShapes = useMemo(() => {
     if (!simInfo) return undefined;
@@ -546,11 +558,11 @@ export function App() {
     ): readonly DirectionVectorKind[] =>
       resolveDirectionVectors({
         frame: LEGEND_FRAME,
-        sunEci: epoch != null ? SUN_PRESENT : null,
+        sunEci: sunIsComputable ? SUN_PRESENT : null,
         positionEci: position ?? null,
         options,
       }).map((v) => v.kind),
-    [epoch],
+    [sunIsComputable],
   );
 
   /** What the attitude view draws right now — the legend names exactly these. */
@@ -695,6 +707,7 @@ export function App() {
               onDirectionVectorsChange={setDirectionVectors}
               centredSatelliteId={centredSatelliteId}
               drawableVectorKinds={orbitDrawableKinds}
+              sunUnavailable={sunUnavailableReason}
             />
           ) : (
             <AttitudeOverlay
@@ -715,7 +728,7 @@ export function App() {
                     ? "Requires epoch"
                     : undefined
               }
-              sunUnavailable={epoch == null ? "Requires epoch" : undefined}
+              sunUnavailable={sunUnavailableReason}
               nadirUnavailable={
                 attitudeDrawableKinds.includes("nadir") ? undefined : "Requires a non-zero position"
               }

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -9,6 +9,7 @@ import type { TimeRange } from "@sksat/uneri";
 import appStyles from "./App.module.css";
 import { AttitudeOverlay } from "./components/AttitudeOverlay.js";
 import { CameraViewProbe } from "./components/CameraViewProbe.js";
+import { NADIR_NEEDS_LENGTH } from "./components/DirectionVectorControls.js";
 import { FarPlaneBeyondScene } from "./components/FarPlaneBeyondScene.js";
 import { GraphPanel } from "./components/GraphPanel.js";
 import { InitialCameraFit } from "./components/InitialCameraFit.js";
@@ -747,9 +748,7 @@ export function App() {
               }
               sunUnavailable={sunUnavailableReason}
               nadirUnavailable={
-                attitudeDrawableKinds.includes("nadir")
-                  ? undefined
-                  : "Requires a finite, non-zero position"
+                attitudeDrawableKinds.includes("nadir") ? undefined : NADIR_NEEDS_LENGTH
               }
               directionVectors={directionVectors}
               onDirectionVectorsChange={setDirectionVectors}

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -583,13 +583,18 @@ export function App() {
     [resolvedVectorKinds, attitudeBody],
   );
 
-  const orbitDrawableKinds = useMemo<readonly DirectionVectorKind[]>(
-    () =>
-      centredSatellite == null
-        ? []
-        : resolvedVectorKinds(centredSatellite.position, DEFAULT_DIRECTION_VECTORS),
-    [resolvedVectorKinds, centredSatellite],
-  );
+  const orbitDrawableKinds = useMemo<readonly DirectionVectorKind[]>(() => {
+    if (centredSatellite == null) return [];
+    // The orbit view draws nothing at all at a centre its frame cannot place, so
+    // offering the Sun there would offer an arrow the scene then drops — the Sun
+    // needs no position of its own, which is why this has to be asked
+    // separately. A position the frame can place is exactly one nadir resolves
+    // from, so the question goes to the resolver rather than repeating the rule.
+    const placeable = resolvedVectorKinds(centredSatellite.position, { nadir: true }).length > 0;
+    return placeable
+      ? resolvedVectorKinds(centredSatellite.position, DEFAULT_DIRECTION_VECTORS)
+      : [];
+  }, [resolvedVectorKinds, centredSatellite]);
 
   /**
    * The display orientation the attitude view actually renders in.

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -8,6 +8,8 @@ const arikaReady = initArika();
 import type { TimeRange } from "@sksat/uneri";
 import appStyles from "./App.module.css";
 import { AttitudeOverlay } from "./components/AttitudeOverlay.js";
+import { CameraViewProbe } from "./components/CameraViewProbe.js";
+import { FarPlaneBeyondScene } from "./components/FarPlaneBeyondScene.js";
 import { GraphPanel } from "./components/GraphPanel.js";
 import { InitialCameraFit } from "./components/InitialCameraFit.js";
 import { OrbitOverlay } from "./components/OrbitOverlay.js";
@@ -36,6 +38,7 @@ import { type MarkerShape, readSatShapeParam, writeSatShapeParam } from "./satel
 import { computeLvlhAxes, DEFAULT_CAMERA_POSITION, SCENE_UP } from "./sceneFrame.js";
 import { useSourceRuntime } from "./sources/useSourceRuntime.js";
 import { useWebSocketSource, WS_SOURCE_ID } from "./sources/useWebSocketSource.js";
+import { NOMINAL_SPACECRAFT_SPAN } from "./spacecraftScale.js";
 import { resolveTextureBaseUrl } from "./textureBaseUrl.js";
 import { resolveDefaultWsUrl } from "./utils/defaultWsUrl.js";
 import { finiteOrNull } from "./utils/finite.js";
@@ -773,10 +776,19 @@ export function App() {
           gl={{ logarithmicDepthBuffer: view !== "attitude" }}
           style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%" }}
         >
-          {/* The app asks for the viewer's framing: the constant above is the
+          {/* The app asks for the viewer's framing: the constants above are the
               viewing direction and a starting distance, and the fit settles the
-              distance and the far plane once the canvas has a size. */}
-          {view === "attitude" && <InitialCameraFit fov={ATTITUDE_FOV} reframe />}
+              distance once the canvas has a size. The far plane above is the
+              app's own, so keeping it beyond the spacecraft as the reader dollies
+              out is the app's job — `AttitudeViewer` does the same for the plane
+              it chooses, and neither touches a plane an embedder chose. */}
+          {view === "attitude" && (
+            <>
+              <InitialCameraFit fov={ATTITUDE_FOV} reframe />
+              <FarPlaneBeyondScene span={NOMINAL_SPACECRAFT_SPAN} />
+              <CameraViewProbe />
+            </>
+          )}
           {view === "orbit" ? (
             <OrbitScene
               centralBody={{ id: centralBody, radiusKm: centralBodyRadius }}

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -453,18 +453,27 @@ export function App() {
   }, [referenceFrame, satellites]);
   const centredSatelliteId = centredSatellite?.id ?? null;
 
-  // Keep the attitude view's subject on a spacecraft the viewer still has. A
-  // satellite-centred orbit view hands over its centre; otherwise the previous
-  // choice stands while it is still in the list, and the first spacecraft takes
-  // over when it is not — which happens when the source changes, not when a
-  // satellite terminates: a terminated one keeps its buffers and its last state,
-  // and its final attitude is worth looking at. The centre is only a candidate
-  // while it is in the list too, since a frame can name a satellite the current
-  // source never had.
-  useEffect(() => {
-    if (selectedSatelliteId != null && satellites.some((s) => s.id === selectedSatelliteId)) return;
-    const fallback = centredSatelliteId ?? satellites[0]?.id ?? null;
-    if (fallback !== selectedSatelliteId) setSelectedSatelliteId(fallback);
+  // The attitude view's subject: a spacecraft the viewer still has. Derived
+  // rather than kept in sync, so there is no render where the list holds
+  // spacecraft and the subject is still null — the `<select>` would be showing a
+  // value none of its options carry.
+  //
+  // A satellite-centred orbit view hands over its centre; otherwise the reader's
+  // own choice stands while it is still in the list, and the first spacecraft
+  // takes over when it is not — which happens when the source changes, not when
+  // a satellite terminates: a terminated one keeps its buffers and its last
+  // state, and its final attitude is worth looking at. The centre is only a
+  // candidate while it is in the list too, since a frame can name a satellite the
+  // current source never had.
+  //
+  // The chosen id is left alone when its spacecraft goes missing, so a source
+  // that brings it back returns to it rather than stranding the reader on a
+  // fallback they never picked.
+  const attitudeSubjectId = useMemo(() => {
+    if (selectedSatelliteId != null && satellites.some((s) => s.id === selectedSatelliteId)) {
+      return selectedSatelliteId;
+    }
+    return centredSatelliteId ?? satellites[0]?.id ?? null;
   }, [satellites, centredSatelliteId, selectedSatelliteId]);
 
   const handleViewChange = useCallback(
@@ -497,7 +506,7 @@ export function App() {
    * present "no data" as "pointing at the reference frame".
    */
   const attitudeBody = useMemo<AttitudeBodyState | null>(() => {
-    const sat = satellites.find((s) => s.id === selectedSatelliteId);
+    const sat = satellites.find((s) => s.id === attitudeSubjectId);
     if (sat?.attitude == null) return null;
     return {
       id: sat.id,
@@ -509,7 +518,7 @@ export function App() {
       color: sat.color,
       markerShape: sat.markerShape,
     };
-  }, [satellites, selectedSatelliteId]);
+  }, [satellites, attitudeSubjectId]);
 
   /**
    * Which arrows a scene would draw for a spacecraft at this position — asked of
@@ -682,7 +691,7 @@ export function App() {
           ) : (
             <AttitudeOverlay
               satellites={attitudeSubjects}
-              selectedSatelliteId={selectedSatelliteId}
+              selectedSatelliteId={attitudeSubjectId}
               onSelectedSatelliteChange={setSelectedSatelliteId}
               orientation={attitudeFrame}
               onOrientationChange={setAttitudeFrame}

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -619,9 +619,19 @@ export function App() {
     },
     [attitudeBody, epoch, centralBody],
   );
-  useEffect(() => {
-    if (!attitudeFrameAvailable(attitudeFrame)) setAttitudeFrame("inertial");
-  }, [attitudeFrame, attitudeFrameAvailable]);
+  /**
+   * The frame the attitude view is actually drawn in: the request, gated on what
+   * the data supports.
+   *
+   * Derived rather than written back into the state. An effect that corrected the
+   * selection would run after the render it corrects, leaving one frame where the
+   * selector named `localOrbital` while the scene had already fallen back to
+   * inertial — and it would also forget the request, so a momentary gap in the
+   * velocity would drop the reader out of the frame they chose for good.
+   */
+  const drawnAttitudeFrame: AttitudeFrame = attitudeFrameAvailable(attitudeFrame)
+    ? attitudeFrame
+    : "inertial";
 
   // Total points across all satellite buffers.
   // chartBufferVersion bumps on data ingest AND on resetBuffers (clear),
@@ -717,7 +727,7 @@ export function App() {
               satellites={attitudeSubjects}
               selectedSatelliteId={attitudeSubjectId}
               onSelectedSatelliteChange={setSelectedSatelliteId}
-              orientation={attitudeFrame}
+              orientation={drawnAttitudeFrame}
               onOrientationChange={setAttitudeFrame}
               localOrbitalUnavailable={
                 attitudeFrameAvailable("localOrbital")
@@ -785,7 +795,7 @@ export function App() {
               <AttitudeScene
                 centralBody={{ id: centralBody }}
                 body={attitudeBody}
-                orientation={attitudeFrame}
+                orientation={drawnAttitudeFrame}
                 epochJd={epoch ?? undefined}
                 time={snapshot.currentTime}
                 defaultMarkerShape={defaultMarkerShape}

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -512,24 +512,56 @@ export function App() {
   }, [satellites, selectedSatelliteId]);
 
   /**
-   * Which arrows the attitude view will actually draw — asked of the resolver the
-   * scene uses, not re-derived from "is the input present". A position can be
-   * there and still not yield a direction (zero, or non-finite from a file
-   * source), and a control that offers an arrow the scene then drops is lying.
+   * Which arrows a scene would draw for a spacecraft at this position — asked of
+   * the resolver the scenes use, not re-derived from "is the input present". A
+   * position can be there and still not yield a direction (zero, or non-finite
+   * from a file source), and a control that offers an arrow the scene then drops
+   * is lying.
    *
    * The kinds a resolver returns do not depend on the display frame, so the
    * inertial one stands in; the Sun's own direction is computed inside the scene,
    * so an epoch is all the app can know about it.
    */
-  const attitudeVectorKinds = useMemo<readonly DirectionVectorKind[]>(() => {
-    if (attitudeBody == null) return [];
-    return resolveDirectionVectors({
-      frame: LEGEND_FRAME,
-      sunEci: epochJd != null ? SUN_PRESENT : null,
-      positionEci: attitudeBody.position ?? null,
-      options: directionVectors,
-    }).map((v) => v.kind);
-  }, [directionVectors, epochJd, attitudeBody]);
+  const resolvedVectorKinds = useCallback(
+    (
+      position: DisplayVec3 | null | undefined,
+      options: DirectionVectorOptions,
+    ): readonly DirectionVectorKind[] =>
+      resolveDirectionVectors({
+        frame: LEGEND_FRAME,
+        sunEci: epochJd != null ? SUN_PRESENT : null,
+        positionEci: position ?? null,
+        options,
+      }).map((v) => v.kind),
+    [epochJd],
+  );
+
+  /** What the attitude view draws right now — the legend names exactly these. */
+  const attitudeVectorKinds = useMemo<readonly DirectionVectorKind[]>(
+    () =>
+      attitudeBody == null ? [] : resolvedVectorKinds(attitudeBody.position, directionVectors),
+    [resolvedVectorKinds, attitudeBody, directionVectors],
+  );
+
+  /**
+   * What each view *could* draw, which is the separate question a disabled
+   * control answers: a direction switched off is not an unavailable one.
+   */
+  const attitudeDrawableKinds = useMemo<readonly DirectionVectorKind[]>(
+    () =>
+      attitudeBody == null
+        ? []
+        : resolvedVectorKinds(attitudeBody.position, DEFAULT_DIRECTION_VECTORS),
+    [resolvedVectorKinds, attitudeBody],
+  );
+
+  const orbitDrawableKinds = useMemo<readonly DirectionVectorKind[]>(
+    () =>
+      centredSatellite == null
+        ? []
+        : resolvedVectorKinds(centredSatellite.position, DEFAULT_DIRECTION_VECTORS),
+    [resolvedVectorKinds, centredSatellite],
+  );
 
   /**
    * The display orientation the attitude view actually renders in.
@@ -645,7 +677,7 @@ export function App() {
               directionVectors={directionVectors}
               onDirectionVectorsChange={setDirectionVectors}
               centredSatelliteId={centredSatelliteId}
-              hasCentredPosition={centredSatellite?.position != null}
+              drawableVectorKinds={orbitDrawableKinds}
             />
           ) : (
             <AttitudeOverlay
@@ -668,9 +700,7 @@ export function App() {
               }
               sunUnavailable={epochJd == null ? "Requires epoch" : undefined}
               nadirUnavailable={
-                attitudeVectorKinds.includes("nadir") || directionVectors.nadir === false
-                  ? undefined
-                  : "Requires a position"
+                attitudeDrawableKinds.includes("nadir") ? undefined : "Requires a position"
               }
               directionVectors={directionVectors}
               onDirectionVectorsChange={setDirectionVectors}

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -38,6 +38,7 @@ import { useSourceRuntime } from "./sources/useSourceRuntime.js";
 import { useWebSocketSource, WS_SOURCE_ID } from "./sources/useWebSocketSource.js";
 import { resolveTextureBaseUrl } from "./textureBaseUrl.js";
 import { resolveDefaultWsUrl } from "./utils/defaultWsUrl.js";
+import { finiteOrNull } from "./utils/finite.js";
 import { planInitialRangeQuery } from "./utils/initialRangeQuery.js";
 import {
   readTimeRangeParam,
@@ -382,6 +383,13 @@ export function App() {
   const { centralBody, centralBodyRadius, epochJd, satelliteNames, activePerturbations } =
     useSimInfoDerived(simInfo);
 
+  // A source can hand over an epoch that is not a number: the CSV header parser
+  // runs `Number()` over `# epoch_jd` and forwards whatever comes out, so a
+  // malformed header arrives as NaN — non-null, and useless. The scenes reject it
+  // and fall back; the controls below must agree, or they offer a frame and a Sun
+  // arrow that nothing draws.
+  const epoch = finiteOrNull(epochJd);
+
   // Sim-declared marker shapes (from SatelliteInfo); the viewer can override these.
   const satelliteSimShapes = useMemo(() => {
     if (!simInfo) return undefined;
@@ -538,11 +546,11 @@ export function App() {
     ): readonly DirectionVectorKind[] =>
       resolveDirectionVectors({
         frame: LEGEND_FRAME,
-        sunEci: epochJd != null ? SUN_PRESENT : null,
+        sunEci: epoch != null ? SUN_PRESENT : null,
         positionEci: position ?? null,
         options,
       }).map((v) => v.kind),
-    [epochJd],
+    [epoch],
   );
 
   /** What the attitude view draws right now — the legend names exactly these. */
@@ -591,10 +599,10 @@ export function App() {
           computeLvlhAxes(attitudeBody?.position ?? null, attitudeBody?.velocity ?? null) != null
         );
       }
-      if (frame === "bodyFixed") return epochJd != null && centralBody === "earth";
+      if (frame === "bodyFixed") return epoch != null && centralBody === "earth";
       return true;
     },
-    [attitudeBody, epochJd, centralBody],
+    [attitudeBody, epoch, centralBody],
   );
   useEffect(() => {
     if (!attitudeFrameAvailable(attitudeFrame)) setAttitudeFrame("inertial");
@@ -674,7 +682,7 @@ export function App() {
               onReferenceFrameChange={setReferenceFrame}
               satellites={simInfo?.satellites}
               centralBody={centralBody}
-              epochJd={epochJd}
+              epochJd={epoch ?? undefined}
               orbitInfo={fileSource.orbitInfo}
               simInfo={simInfo}
               totalPoints={totalPoints}
@@ -703,11 +711,11 @@ export function App() {
               bodyFixedUnavailable={
                 centralBody !== "earth"
                   ? "The viewer models only Earth's rotation"
-                  : epochJd == null
+                  : epoch == null
                     ? "Requires epoch"
                     : undefined
               }
-              sunUnavailable={epochJd == null ? "Requires epoch" : undefined}
+              sunUnavailable={epoch == null ? "Requires epoch" : undefined}
               nadirUnavailable={
                 attitudeDrawableKinds.includes("nadir") ? undefined : "Requires a position"
               }
@@ -746,7 +754,7 @@ export function App() {
               centralBody={{ id: centralBody, radiusKm: centralBodyRadius }}
               satellites={satellites}
               referenceFrame={viewerFrame}
-              epochJd={epochJd ?? undefined}
+              epochJd={epoch ?? undefined}
               time={snapshot.currentTime}
               defaultMarkerShape={defaultMarkerShape}
               directionVectors={directionVectors}
@@ -760,7 +768,7 @@ export function App() {
                 centralBody={{ id: centralBody }}
                 body={attitudeBody}
                 orientation={attitudeFrame}
-                epochJd={epochJd ?? undefined}
+                epochJd={epoch ?? undefined}
                 time={snapshot.currentTime}
                 defaultMarkerShape={defaultMarkerShape}
                 directionVectors={directionVectors}
@@ -802,7 +810,7 @@ export function App() {
           onSpeedChange={realtimePlayback.setSpeed}
           isLive={realtimePlayback.snapshot.isLive}
           onGoLive={realtimePlayback.goLive}
-          epochJd={epochJd}
+          epochJd={epoch}
         />
       )}
 

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -618,13 +618,21 @@ export function App() {
     [resolvedVectorKinds, attitudeBody],
   );
 
-  const orbitDrawableKinds = useMemo<readonly DirectionVectorKind[]>(
-    () =>
-      centredSatellite == null
-        ? []
-        : drawableAtCentre({ positionEci: centredSatellite.position, sunIsComputable }),
-    [centredSatellite, sunIsComputable],
-  );
+  /**
+   * The arrows the orbit view would draw at its centre.
+   *
+   * A centred celestial body draws none: `OrbitSceneContents` takes the
+   * `CelestialBody` branch for those ids and returns before the arrows, so
+   * computing them from the body's position would offer the Sun and give nadir a
+   * reason about position length — over a scene with no arrows in it at all.
+   * Replayed recordings put those ids in the entity list, so a reader can centre
+   * on one.
+   */
+  const orbitDrawableKinds = useMemo<readonly DirectionVectorKind[]>(() => {
+    if (centredSatellite == null) return [];
+    if (entityPathToBodyId(centredSatellite.id, orbitBodyDefinitions) != null) return [];
+    return drawableAtCentre({ positionEci: centredSatellite.position, sunIsComputable });
+  }, [centredSatellite, sunIsComputable, orbitBodyDefinitions]);
 
   /**
    * The display orientation the attitude view actually renders in.
@@ -824,6 +832,10 @@ export function App() {
               centredSatelliteId={centredSatelliteId}
               drawnOrientation={drawnOrbitOrientation}
               lvlhUnavailable={orbitLvlhUnavailable}
+              centreIsSpacecraft={
+                centredSatellite == null ||
+                entityPathToBodyId(centredSatellite.id, orbitBodyDefinitions) == null
+              }
               drawableVectorKinds={orbitDrawableKinds}
               sunUnavailable={sunUnavailableReason}
               centreIsPlaceable={

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -7,6 +7,7 @@ const arikaReady = initArika();
 
 import type { TimeRange } from "@sksat/uneri";
 import appStyles from "./App.module.css";
+import { entityPathToBodyId, resolveBodyDefinitions } from "./bodies.js";
 import { AttitudeOverlay } from "./components/AttitudeOverlay.js";
 import { CameraViewProbe } from "./components/CameraViewProbe.js";
 import { NADIR_NEEDS_LENGTH } from "./components/DirectionVectorControls.js";
@@ -25,7 +26,7 @@ import {
 } from "./directionVectors.js";
 import type { DisplayFrame, Vec3 as DisplayVec3 } from "./displayFrame.js";
 import { unitAttitude } from "./displayFrame.js";
-import { centrePositionIsUsable } from "./frameResolve.js";
+import { centrePositionIsUsable, resolveSceneFrame } from "./frameResolve.js";
 import { toViewerReferenceFrame } from "./frameToViewer.js";
 import { CSV_SOURCE_ID, RRD_SOURCE_ID, useFileSource } from "./hooks/useFileSource.js";
 import { useRealtimePlayback } from "./hooks/useRealtimePlayback.js";
@@ -89,6 +90,12 @@ const DEFAULT_DIRECTION_VECTORS: DirectionVectorOptions = { sun: true, nadir: tr
  */
 const ATTITUDE_FOV = 50;
 const ATTITUDE_CAMERA_POSITION: [number, number, number] = [4.3, 0, 2.15];
+
+/**
+ * Why a local-orbital frame cannot be drawn, which both views state the same way:
+ * the axes come from a position and a velocity, and the two have to span a plane.
+ */
+const ORBIT_PLANE_NEEDED = "Requires a position and velocity that define an orbit plane";
 
 export function App() {
   // WASM initialization (must complete before rendering ECEF transforms)
@@ -433,6 +440,10 @@ export function App() {
   // decoupled from React re-renders — no per-render point materialization.
   const snapshot = realtimePlayback.snapshot;
   // biome-ignore lint/correctness/useExhaustiveDependencies: trailBuffersMap is a stable ref-held Map mutated in place; `snapshot` triggers rebuilds on position/playback changes, and `chartBufferVersion` (bumped on ingest AND on resetBuffers) triggers rebuilds when the map is cleared — without it a reset would leave stale satellites referencing detached buffers, since an empty-buffer reset publishes no new snapshot.
+  // What `OrbitScene` resolves with when the app names no bodies of its own, so
+  // the frame question below is asked against the same set the scene draws.
+  const orbitBodyDefinitions = useMemo(() => resolveBodyDefinitions(), []);
+
   const satellites = useMemo<SatelliteState[]>(() => {
     const list: SatelliteState[] = [];
     for (const [id, buf] of trailBuffersMap) {
@@ -639,15 +650,59 @@ export function App() {
   /**
    * The orientation the orbit view is drawn in, which the selector reports.
    *
-   * `OrbitScene` needs an Earth rotation angle for a body-fixed frame and falls
-   * back to inertial without one, so choosing it and then loading a source with
-   * no epoch leaves the toggle pressed over an inertial picture. The same
-   * condition the attitude view asks about its own body-fixed frame answers this.
+   * Asked of `resolveSceneFrame`, the kernel the scene resolves with, rather than
+   * re-tested here: the request falls back to inertial in more ways than one, and
+   * a second description of them drifts. Local-orbital needs a position and a
+   * velocity that span an orbit plane, and a centred *body* keeps its IAU
+   * orientation whatever is requested — both answered by `lvlhActive`.
+   *
+   * Body-fixed asks for the epoch alone, which is the scene's own condition
+   * (`isLegacyEcef(frame) && epochJd != null`). It is not gated on Earth: the
+   * scene applies the Earth rotation angle to whatever central body it was given,
+   * so reporting inertial for another body would describe a picture nobody draws.
+   *
+   * The request stays in `referenceFrame`, which a centre change is computed
+   * from, so a momentary gap in the velocity does not discard it.
    */
+  const drawnOrbitFrame = useMemo(
+    () =>
+      resolveSceneFrame(
+        referenceFrame,
+        (id) => {
+          const sat = satellites.find((s) => s.id === id);
+          return sat ? { position: sat.position, velocity: sat.velocity ?? null } : null;
+        },
+        (id) => entityPathToBodyId(id, orbitBodyDefinitions) != null,
+      ),
+    [referenceFrame, satellites, orbitBodyDefinitions],
+  );
+  /**
+   * Why the orbit view cannot draw its LVLH frame for the current centre.
+   *
+   * Asked hypothetically, so it cannot come from `drawnOrbitFrame`: that resolves
+   * the *current* request, and while the reader sits in inertial it says nothing
+   * about whether the orbit frame would work. `computeLvlhAxes` is the function
+   * the scene resolves with, and a centred body keeps its IAU orientation
+   * whatever is asked.
+   */
+  const orbitLvlhUnavailable: string | undefined = (() => {
+    if (centredSatellite == null) return undefined;
+    if (entityPathToBodyId(centredSatellite.id, orbitBodyDefinitions) != null) {
+      return "A body keeps its own orientation";
+    }
+    return computeLvlhAxes(centredSatellite.position, centredSatellite.velocity ?? null) != null
+      ? undefined
+      : ORBIT_PLANE_NEEDED;
+  })();
+
   const drawnOrbitOrientation: FrameOrientation =
-    referenceFrame.orientation === "body_fixed" && !attitudeFrameAvailable("bodyFixed")
-      ? "inertial"
-      : referenceFrame.orientation;
+    referenceFrame.orientation === "local_orbital"
+      ? drawnOrbitFrame.lvlhActive
+        ? "local_orbital"
+        : "inertial"
+      : referenceFrame.orientation === "body_fixed" && epoch == null
+        ? "inertial"
+        : referenceFrame.orientation;
 
   /**
    * Whether the attitude view draws the body axes.
@@ -746,6 +801,7 @@ export function App() {
               onDirectionVectorsChange={setDirectionVectors}
               centredSatelliteId={centredSatelliteId}
               drawnOrientation={drawnOrbitOrientation}
+              lvlhUnavailable={orbitLvlhUnavailable}
               drawableVectorKinds={orbitDrawableKinds}
               sunUnavailable={sunUnavailableReason}
               centreIsPlaceable={
@@ -760,9 +816,7 @@ export function App() {
               orientation={drawnAttitudeFrame}
               onOrientationChange={setAttitudeFrame}
               localOrbitalUnavailable={
-                attitudeFrameAvailable("localOrbital")
-                  ? undefined
-                  : "Requires a position and velocity that define an orbit plane"
+                attitudeFrameAvailable("localOrbital") ? undefined : ORBIT_PLANE_NEEDED
               }
               bodyFixedUnavailable={
                 centralBody !== "earth"

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -513,12 +513,29 @@ export function App() {
   // The chosen id is left alone when its spacecraft goes missing, so a source
   // that brings it back returns to it rather than stranding the reader on a
   // fallback they never picked.
+  /**
+   * The spacecraft among the entities, which is what the attitude view is about.
+   *
+   * A replayed `.rrd` carries a trail for every entity it logged, the Moon and the
+   * Sun included (`rrdMetadataToSimInfo` maps them all, and the orbit scene draws
+   * those ids as bodies). They reach this list the same way a satellite does, so
+   * without this the attitude selector offers the Moon as a subject — and picks it
+   * when it sorts first.
+   */
+  const spacecraft = useMemo(
+    () => satellites.filter((s) => entityPathToBodyId(s.id, orbitBodyDefinitions) == null),
+    [satellites, orbitBodyDefinitions],
+  );
+
   const attitudeSubjectId = useMemo(() => {
-    if (selectedSatelliteId != null && satellites.some((s) => s.id === selectedSatelliteId)) {
+    if (selectedSatelliteId != null && spacecraft.some((s) => s.id === selectedSatelliteId)) {
       return selectedSatelliteId;
     }
-    return centredSatelliteId ?? satellites[0]?.id ?? null;
-  }, [satellites, centredSatelliteId, selectedSatelliteId]);
+    // A centred body is no subject either, so it is taken only when it is one of
+    // the spacecraft.
+    const centred = spacecraft.some((s) => s.id === centredSatelliteId) ? centredSatelliteId : null;
+    return centred ?? spacecraft[0]?.id ?? null;
+  }, [spacecraft, centredSatelliteId, selectedSatelliteId]);
 
   const handleViewChange = useCallback(
     (next: ViewMode) => {
@@ -540,8 +557,8 @@ export function App() {
    * first sample landed.
    */
   const attitudeSubjects = useMemo(
-    () => satellites.map((s) => ({ id: s.id, name: s.name })),
-    [satellites],
+    () => spacecraft.map((s) => ({ id: s.id, name: s.name })),
+    [spacecraft],
   );
 
   /**
@@ -550,7 +567,7 @@ export function App() {
    * present "no data" as "pointing at the reference frame".
    */
   const attitudeBody = useMemo<AttitudeBodyState | null>(() => {
-    const sat = satellites.find((s) => s.id === attitudeSubjectId);
+    const sat = spacecraft.find((s) => s.id === attitudeSubjectId);
     if (sat?.attitude == null) return null;
     return {
       id: sat.id,
@@ -562,7 +579,7 @@ export function App() {
       color: sat.color,
       markerShape: sat.markerShape,
     };
-  }, [satellites, attitudeSubjectId]);
+  }, [spacecraft, attitudeSubjectId]);
 
   /**
    * Which arrows a scene would draw for a spacecraft at this position — asked of
@@ -686,7 +703,12 @@ export function App() {
    * whatever is asked.
    */
   const orbitLvlhUnavailable: string | undefined = (() => {
-    if (centredSatellite == null) return undefined;
+    if (referenceFrame.center.type !== "satellite") return undefined;
+    // The frame names a satellite the viewer holds no sample for — before the
+    // first arrives, or after a source change took it away. The scene draws
+    // inertial until one lands, so the option would sit enabled over a frame it
+    // cannot produce.
+    if (centredSatellite == null) return "Waiting for this spacecraft's data";
     if (entityPathToBodyId(centredSatellite.id, orbitBodyDefinitions) != null) {
       return "A body keeps its own orientation";
     }

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -24,6 +24,7 @@ import {
   resolveDirectionVectors,
 } from "./directionVectors.js";
 import type { DisplayFrame, Vec3 as DisplayVec3 } from "./displayFrame.js";
+import { unitAttitude } from "./displayFrame.js";
 import { centrePositionIsUsable } from "./frameResolve.js";
 import { toViewerReferenceFrame } from "./frameToViewer.js";
 import { CSV_SOURCE_ID, RRD_SOURCE_ID, useFileSource } from "./hooks/useFileSource.js";
@@ -39,7 +40,7 @@ import {
   type SatelliteState,
 } from "./lib/index.js";
 import type { ClientMessage } from "./protocol/generated/ClientMessage.js";
-import { DEFAULT_FRAME, type ReferenceFrame } from "./referenceFrame.js";
+import { DEFAULT_FRAME, type FrameOrientation, type ReferenceFrame } from "./referenceFrame.js";
 import { type MarkerShape, readSatShapeParam, writeSatShapeParam } from "./satelliteShapes.js";
 import { computeLvlhAxes, DEFAULT_CAMERA_POSITION, SCENE_UP } from "./sceneFrame.js";
 import { useSourceRuntime } from "./sources/useSourceRuntime.js";
@@ -635,6 +636,29 @@ export function App() {
     ? attitudeFrame
     : "inertial";
 
+  /**
+   * The orientation the orbit view is drawn in, which the selector reports.
+   *
+   * `OrbitScene` needs an Earth rotation angle for a body-fixed frame and falls
+   * back to inertial without one, so choosing it and then loading a source with
+   * no epoch leaves the toggle pressed over an inertial picture. The same
+   * condition the attitude view asks about its own body-fixed frame answers this.
+   */
+  const drawnOrbitOrientation: FrameOrientation =
+    referenceFrame.orientation === "body_fixed" && !attitudeFrameAvailable("bodyFixed")
+      ? "inertial"
+      : referenceFrame.orientation;
+
+  /**
+   * Whether the attitude view draws the body axes.
+   *
+   * The subject can be on screen without them: this app forwards a zero or
+   * non-finite quaternion, and `AttitudeScene` brings it to unit norm or refuses
+   * it, drawing the marker that shows no orientation. The legend reads this so it
+   * cannot name a triad the reader has no way to see.
+   */
+  const attitudeBodyAxesDrawn = unitAttitude(attitudeBody?.attitude) != null;
+
   // Total points across all satellite buffers.
   // chartBufferVersion bumps on data ingest AND on resetBuffers (clear),
   // so this recalculates when data arrives or buffers are cleared.
@@ -721,6 +745,7 @@ export function App() {
               directionVectors={directionVectors}
               onDirectionVectorsChange={setDirectionVectors}
               centredSatelliteId={centredSatelliteId}
+              drawnOrientation={drawnOrbitOrientation}
               drawableVectorKinds={orbitDrawableKinds}
               sunUnavailable={sunUnavailableReason}
               centreIsPlaceable={
@@ -753,6 +778,7 @@ export function App() {
               directionVectors={directionVectors}
               onDirectionVectorsChange={setDirectionVectors}
               hasBody={attitudeBody != null}
+              bodyAxesDrawn={attitudeBodyAxesDrawn}
             />
           )}
         </div>

--- a/viewer/src/axisTriad.test.ts
+++ b/viewer/src/axisTriad.test.ts
@@ -61,7 +61,13 @@ describe("axis label placement", () => {
   it("reports an extent that covers the sprite, not just its centre", () => {
     for (const length of [0.03, 0.75, 2]) {
       const [x] = axisLabelPositions(length);
-      expect(axisLabelExtent(length)).toBeCloseTo(x[0] + axisLabelScale(length) / 2, 12);
+      // Half the sprite's *diagonal*, not half its height: a sprite faces the
+      // camera, so a square letter reaches `sqrt(2)/2` of its side in whichever
+      // direction the view puts that. Half the height would leave the corners
+      // outside a camera fitted to this number.
+      const halfDiagonal = (axisLabelScale(length) * Math.SQRT2) / 2;
+      expect(axisLabelExtent(length)).toBeCloseTo(x[0] + halfDiagonal, 12);
+      expect(axisLabelExtent(length)).toBeGreaterThan(x[0] + axisLabelScale(length) / 2);
       expect(axisLabelExtent(length)).toBeGreaterThan(length);
     }
   });

--- a/viewer/src/axisTriad.ts
+++ b/viewer/src/axisTriad.ts
@@ -50,10 +50,12 @@ export function axisLabelScale(length: number): number {
  * Outermost point the labels of a triad reach, from the origin.
  *
  * The letters sit *past* the tips, so a camera fitted to the axes alone clips
- * them.
+ * them. A sprite is a quad facing the camera, so it reaches half its diagonal in
+ * whichever direction the view happens to put that — and a letter's texture is
+ * square, which makes the diagonal `sqrt(2)` times its side.
  */
 export function axisLabelExtent(length: number): number {
-  return length * TIP_OVERSHOOT + axisLabelScale(length) / 2;
+  return length * TIP_OVERSHOOT + (axisLabelScale(length) * Math.SQRT2) / 2;
 }
 
 /** CSS colour for a canvas context, from one of `AXIS_COLORS`. */

--- a/viewer/src/axisTriad.ts
+++ b/viewer/src/axisTriad.ts
@@ -51,8 +51,10 @@ export function axisLabelScale(length: number): number {
  *
  * The letters sit *past* the tips, so a camera fitted to the axes alone clips
  * them. A sprite is a quad facing the camera, so it reaches half its diagonal in
- * whichever direction the view happens to put that — and a letter's texture is
- * square, which makes the diagonal `sqrt(2)` times its side.
+ * whichever direction the view happens to put that. A letter's texture is
+ * narrower than it is tall — a bold "X" measures about 0.76 of the height, "Z"
+ * about 0.70 — so `sqrt(2)` times the height bounds the diagonal from above,
+ * which is the side a camera fit should err on.
  */
 export function axisLabelExtent(length: number): number {
   return length * TIP_OVERSHOOT + (axisLabelScale(length) * Math.SQRT2) / 2;

--- a/viewer/src/components/AttitudeOverlay.tsx
+++ b/viewer/src/components/AttitudeOverlay.tsx
@@ -1,0 +1,132 @@
+import styles from "../App.module.css";
+import type { DirectionVectorKind, DirectionVectorOptions } from "../directionVectors.js";
+import type { SatelliteInfo } from "../hooks/useWebSocket.js";
+import type { AttitudeFrame } from "../lib/types.js";
+import { DirectionVectorControls } from "./DirectionVectorControls.js";
+import selectorStyles from "./FrameSelector.module.css";
+import { SceneLegend } from "./SceneLegend.js";
+import { type SegmentedOption, SegmentedToggle } from "./SegmentedToggle.js";
+
+export interface AttitudeOverlayProps {
+  /** Spacecraft available to show (from simInfo or replay metadata). */
+  satellites: SatelliteInfo[] | undefined;
+  selectedSatelliteId: string | null;
+  onSelectedSatelliteChange: (id: string) => void;
+  orientation: AttitudeFrame;
+  onOrientationChange: (orientation: AttitudeFrame) => void;
+  /** True when an epoch is known — the body-fixed frame and the Sun need it. */
+  hasEpoch: boolean;
+  /** True when the shown spacecraft has a position (nadir, local-orbital need it). */
+  hasPosition: boolean;
+  /** True when it also has a velocity (the local-orbital basis needs it). */
+  hasVelocity: boolean;
+  /** True when the central body is the one whose rotation the viewer models. */
+  supportsBodyFixed: boolean;
+  directionVectors: DirectionVectorOptions;
+  onDirectionVectorsChange: (value: DirectionVectorOptions) => void;
+  /** Kinds actually drawn, for the legend. */
+  drawnVectorKinds: readonly DirectionVectorKind[];
+  /**
+   * Whether a spacecraft is being drawn at all. Without one the scene is empty,
+   * so the legend would name lines that are not there.
+   */
+  hasBody: boolean;
+}
+
+/**
+ * The attitude view's overlay controls: which spacecraft, which display
+ * orientation, which reference-direction arrows, and what the colours mean.
+ *
+ * A fragment, like the orbit view's overlay: the app owns the overlay area.
+ *
+ * Every option whose input the current data lacks is disabled with the reason
+ * rather than left selectable — the scene falls back safely, but a control that
+ * says "LVLH" while showing inertial axes would be lying.
+ */
+export function AttitudeOverlay({
+  satellites,
+  selectedSatelliteId,
+  onSelectedSatelliteChange,
+  orientation,
+  onOrientationChange,
+  hasEpoch,
+  hasPosition,
+  hasVelocity,
+  supportsBodyFixed,
+  directionVectors,
+  onDirectionVectorsChange,
+  drawnVectorKinds,
+  hasBody,
+}: AttitudeOverlayProps) {
+  const orientationOptions: SegmentedOption<AttitudeFrame>[] = [
+    { value: "inertial", label: "Inertial", testId: "attitude-orientation-inertial" },
+    {
+      value: "localOrbital",
+      label: "LVLH",
+      testId: "attitude-orientation-lvlh",
+      disabled: !hasPosition || !hasVelocity,
+      title: !hasPosition
+        ? "Requires a position"
+        : !hasVelocity
+          ? "Requires a velocity"
+          : undefined,
+    },
+    {
+      value: "bodyFixed",
+      label: "Body-Fixed",
+      testId: "attitude-orientation-body-fixed",
+      disabled: !hasEpoch || !supportsBodyFixed,
+      title: !supportsBodyFixed
+        ? "The viewer models only Earth's rotation"
+        : !hasEpoch
+          ? "Requires epoch"
+          : undefined,
+    },
+  ];
+
+  return (
+    <>
+      <div className={selectorStyles.frameSelector}>
+        <div className={selectorStyles.row}>
+          <label className={selectorStyles.label} htmlFor="attitude-spacecraft">
+            Spacecraft
+          </label>
+          <select
+            id="attitude-spacecraft"
+            className={selectorStyles.select}
+            data-testid="attitude-spacecraft-select"
+            value={selectedSatelliteId ?? ""}
+            onChange={(e) => onSelectedSatelliteChange(e.target.value)}
+          >
+            {(satellites ?? []).map((sat) => (
+              <option key={sat.id} value={sat.id}>
+                {sat.name ?? sat.id}
+              </option>
+            ))}
+          </select>
+        </div>
+        <SegmentedToggle
+          value={orientation}
+          options={orientationOptions}
+          onChange={onOrientationChange}
+          style={{ marginTop: "4px" }}
+        />
+      </div>
+
+      <DirectionVectorControls
+        value={directionVectors}
+        onChange={onDirectionVectorsChange}
+        unavailable={{
+          ...(hasEpoch ? {} : { sun: "Requires epoch" }),
+          ...(hasPosition ? {} : { nadir: "Requires a position" }),
+        }}
+      />
+
+      {hasBody && <SceneLegend vectorKinds={drawnVectorKinds} />}
+
+      <div className={styles.orbitInfo} data-testid="attitude-info">
+        Attitude view — no central body or trails
+      </div>
+    </>
+  );
+}

--- a/viewer/src/components/AttitudeOverlay.tsx
+++ b/viewer/src/components/AttitudeOverlay.tsx
@@ -1,15 +1,24 @@
 import styles from "../App.module.css";
 import type { DirectionVectorKind, DirectionVectorOptions } from "../directionVectors.js";
-import type { SatelliteInfo } from "../hooks/useWebSocket.js";
 import type { AttitudeFrame } from "../lib/types.js";
 import { DirectionVectorControls } from "./DirectionVectorControls.js";
 import selectorStyles from "./FrameSelector.module.css";
 import { SceneLegend } from "./SceneLegend.js";
 import { type SegmentedOption, SegmentedToggle } from "./SegmentedToggle.js";
 
+/** A spacecraft this view can show. */
+export interface AttitudeSubject {
+  id: string;
+  name?: string;
+}
+
 export interface AttitudeOverlayProps {
-  /** Spacecraft available to show (from simInfo or replay metadata). */
-  satellites: SatelliteInfo[] | undefined;
+  /**
+   * Spacecraft this view can show — the ones actually being rendered, not the
+   * ones the simulation declared. Offering a spacecraft whose state has not
+   * arrived would leave the select with no matching option.
+   */
+  satellites: readonly AttitudeSubject[];
   selectedSatelliteId: string | null;
   onSelectedSatelliteChange: (id: string) => void;
   orientation: AttitudeFrame;
@@ -98,7 +107,7 @@ export function AttitudeOverlay({
             value={selectedSatelliteId ?? ""}
             onChange={(e) => onSelectedSatelliteChange(e.target.value)}
           >
-            {(satellites ?? []).map((sat) => (
+            {satellites.map((sat) => (
               <option key={sat.id} value={sat.id}>
                 {sat.name ?? sat.id}
               </option>

--- a/viewer/src/components/AttitudeOverlay.tsx
+++ b/viewer/src/components/AttitudeOverlay.tsx
@@ -85,6 +85,20 @@ export function AttitudeOverlay({
     },
   ];
 
+  /**
+   * Why no direction can be drawn, when the view is drawing no spacecraft.
+   *
+   * The arrows are drawn at the spacecraft, so an absent one takes both with it,
+   * whatever the epoch says about the Sun. Two states reach here and the
+   * placeholder in the scene names the same two: no spacecraft has arrived, or the
+   * one selected carries no attitude.
+   */
+  const noBody = hasBody
+    ? undefined
+    : satellites.length === 0
+      ? "Waiting for spacecraft data"
+      : "This spacecraft has no attitude";
+
   return (
     <>
       <div className={selectorStyles.frameSelector}>
@@ -117,7 +131,7 @@ export function AttitudeOverlay({
       <DirectionVectorControls
         value={directionVectors}
         onChange={onDirectionVectorsChange}
-        unavailable={{ sun: sunUnavailable, nadir: nadirUnavailable }}
+        unavailable={{ sun: noBody ?? sunUnavailable, nadir: noBody ?? nadirUnavailable }}
       />
 
       {hasBody && <SceneLegend />}

--- a/viewer/src/components/AttitudeOverlay.tsx
+++ b/viewer/src/components/AttitudeOverlay.tsx
@@ -23,14 +23,17 @@ export interface AttitudeOverlayProps {
   onSelectedSatelliteChange: (id: string) => void;
   orientation: AttitudeFrame;
   onOrientationChange: (orientation: AttitudeFrame) => void;
-  /** True when an epoch is known — the body-fixed frame and the Sun need it. */
-  hasEpoch: boolean;
-  /** True when the shown spacecraft has a position (nadir, local-orbital need it). */
-  hasPosition: boolean;
-  /** True when it also has a velocity (the local-orbital basis needs it). */
-  hasVelocity: boolean;
-  /** True when the central body is the one whose rotation the viewer models. */
-  supportsBodyFixed: boolean;
+  /**
+   * Why an option cannot be used right now, or undefined when it can. The reasons
+   * come from the app rather than being re-derived here: whether the scene can
+   * actually build a local-orbital basis, or draw a nadir arrow, is a question for
+   * the same code the scene resolves with — a control that offers what the scene
+   * then drops is lying.
+   */
+  localOrbitalUnavailable?: string;
+  bodyFixedUnavailable?: string;
+  sunUnavailable?: string;
+  nadirUnavailable?: string;
   directionVectors: DirectionVectorOptions;
   onDirectionVectorsChange: (value: DirectionVectorOptions) => void;
   /** Kinds actually drawn, for the legend. */
@@ -58,10 +61,10 @@ export function AttitudeOverlay({
   onSelectedSatelliteChange,
   orientation,
   onOrientationChange,
-  hasEpoch,
-  hasPosition,
-  hasVelocity,
-  supportsBodyFixed,
+  localOrbitalUnavailable,
+  bodyFixedUnavailable,
+  sunUnavailable,
+  nadirUnavailable,
   directionVectors,
   onDirectionVectorsChange,
   drawnVectorKinds,
@@ -73,23 +76,15 @@ export function AttitudeOverlay({
       value: "localOrbital",
       label: "LVLH",
       testId: "attitude-orientation-lvlh",
-      disabled: !hasPosition || !hasVelocity,
-      title: !hasPosition
-        ? "Requires a position"
-        : !hasVelocity
-          ? "Requires a velocity"
-          : undefined,
+      disabled: localOrbitalUnavailable != null,
+      title: localOrbitalUnavailable,
     },
     {
       value: "bodyFixed",
       label: "Body-Fixed",
       testId: "attitude-orientation-body-fixed",
-      disabled: !hasEpoch || !supportsBodyFixed,
-      title: !supportsBodyFixed
-        ? "The viewer models only Earth's rotation"
-        : !hasEpoch
-          ? "Requires epoch"
-          : undefined,
+      disabled: bodyFixedUnavailable != null,
+      title: bodyFixedUnavailable,
     },
   ];
 
@@ -125,10 +120,7 @@ export function AttitudeOverlay({
       <DirectionVectorControls
         value={directionVectors}
         onChange={onDirectionVectorsChange}
-        unavailable={{
-          ...(hasEpoch ? {} : { sun: "Requires epoch" }),
-          ...(hasPosition ? {} : { nadir: "Requires a position" }),
-        }}
+        unavailable={{ sun: sunUnavailable, nadir: nadirUnavailable }}
       />
 
       {hasBody && <SceneLegend vectorKinds={drawnVectorKinds} />}

--- a/viewer/src/components/AttitudeOverlay.tsx
+++ b/viewer/src/components/AttitudeOverlay.tsx
@@ -1,5 +1,5 @@
 import styles from "../App.module.css";
-import type { DirectionVectorKind, DirectionVectorOptions } from "../directionVectors.js";
+import type { DirectionVectorOptions } from "../directionVectors.js";
 import type { AttitudeFrame } from "../lib/types.js";
 import { DirectionVectorControls } from "./DirectionVectorControls.js";
 import selectorStyles from "./FrameSelector.module.css";
@@ -36,8 +36,6 @@ export interface AttitudeOverlayProps {
   nadirUnavailable?: string;
   directionVectors: DirectionVectorOptions;
   onDirectionVectorsChange: (value: DirectionVectorOptions) => void;
-  /** Kinds actually drawn, for the legend. */
-  drawnVectorKinds: readonly DirectionVectorKind[];
   /**
    * Whether a spacecraft is being drawn at all. Without one the scene is empty,
    * so the legend would name lines that are not there.
@@ -67,7 +65,6 @@ export function AttitudeOverlay({
   nadirUnavailable,
   directionVectors,
   onDirectionVectorsChange,
-  drawnVectorKinds,
   hasBody,
 }: AttitudeOverlayProps) {
   const orientationOptions: SegmentedOption<AttitudeFrame>[] = [
@@ -123,7 +120,7 @@ export function AttitudeOverlay({
         unavailable={{ sun: sunUnavailable, nadir: nadirUnavailable }}
       />
 
-      {hasBody && <SceneLegend vectorKinds={drawnVectorKinds} />}
+      {hasBody && <SceneLegend />}
 
       <div className={styles.orbitInfo} data-testid="attitude-info">
         Attitude view — no central body or trails

--- a/viewer/src/components/AttitudeOverlay.tsx
+++ b/viewer/src/components/AttitudeOverlay.tsx
@@ -41,6 +41,12 @@ export interface AttitudeOverlayProps {
    * so the legend would name lines that are not there.
    */
   hasBody: boolean;
+  /**
+   * Whether the scene draws the body axes, which needs an attitude it can use
+   * (default true). A spacecraft whose quaternion names no rotation is drawn
+   * without them.
+   */
+  bodyAxesDrawn?: boolean;
 }
 
 /**
@@ -66,6 +72,7 @@ export function AttitudeOverlay({
   directionVectors,
   onDirectionVectorsChange,
   hasBody,
+  bodyAxesDrawn = true,
 }: AttitudeOverlayProps) {
   const orientationOptions: SegmentedOption<AttitudeFrame>[] = [
     { value: "inertial", label: "Inertial", testId: "attitude-orientation-inertial" },
@@ -134,7 +141,7 @@ export function AttitudeOverlay({
         unavailable={{ sun: noBody ?? sunUnavailable, nadir: noBody ?? nadirUnavailable }}
       />
 
-      {hasBody && <SceneLegend />}
+      {hasBody && <SceneLegend showBodyAxes={bodyAxesDrawn} />}
 
       <div className={styles.orbitInfo} data-testid="attitude-info">
         Attitude view — no central body or trails

--- a/viewer/src/components/AxisLabels.tsx
+++ b/viewer/src/components/AxisLabels.tsx
@@ -25,11 +25,10 @@ interface AxisLabelsProps {
 export function AxisLabels({ length, opacity = 1 }: AxisLabelsProps) {
   const labels = useMemo(() => {
     const positions = axisLabelPositions(length);
-    return AXIS_LETTERS.map((letter, i) => ({
-      letter,
-      texture: labelTexture(letter, AXIS_COLORS[i]).texture,
-      position: positions[i],
-    }));
+    return AXIS_LETTERS.map((letter, i) => {
+      const label = labelTexture(letter, AXIS_COLORS[i]);
+      return { letter, label, position: positions[i] };
+    });
   }, [length]);
   const scale = axisLabelScale(length);
 
@@ -39,7 +38,9 @@ export function AxisLabels({ length, opacity = 1 }: AxisLabelsProps) {
         <sprite
           key={label.letter}
           position={label.position}
-          scale={[scale, scale, scale]}
+          // The texture is as wide as the letter needs, so a square sprite would
+          // stretch it: a bold "X" measures narrower than the texture is tall.
+          scale={[scale * label.label.aspect, scale, scale]}
           // Drawn last and without a depth test, so a letter on an axis pointing
           // away from the camera stays readable instead of hiding inside the
           // spacecraft. The axis *arrow* is still depth-tested, so it disappearing
@@ -47,7 +48,7 @@ export function AxisLabels({ length, opacity = 1 }: AxisLabelsProps) {
           renderOrder={LABEL_RENDER_ORDER}
         >
           <spriteMaterial
-            map={label.texture}
+            map={label.label.texture}
             transparent
             opacity={opacity}
             depthTest={false}

--- a/viewer/src/components/AxisLabels.tsx
+++ b/viewer/src/components/AxisLabels.tsx
@@ -1,59 +1,6 @@
 import { useMemo } from "react";
-import * as THREE from "three";
-import {
-  AXIS_COLORS,
-  AXIS_LETTERS,
-  axisColorCss,
-  axisLabelPositions,
-  axisLabelScale,
-} from "../axisTriad.js";
-
-/**
- * One canvas texture per letter, made on first use and kept.
- *
- * Lazily, not at module scope: the module is imported by tests running without a
- * DOM, and a canvas at import time would throw there.
- */
-const textureCache = new Map<string, THREE.Texture>();
-
-/** Above the scene's meshes, which use the default 0. */
-const LABEL_RENDER_ORDER = 10;
-
-const TEXTURE_SIZE = 128;
-
-function letterTexture(letter: string, color: number): THREE.Texture {
-  const key = `${letter}:${color}`;
-  const cached = textureCache.get(key);
-  if (cached) return cached;
-
-  const canvas = document.createElement("canvas");
-  canvas.width = TEXTURE_SIZE;
-  canvas.height = TEXTURE_SIZE;
-  const ctx = canvas.getContext("2d");
-  if (ctx) {
-    ctx.font = `bold ${TEXTURE_SIZE * 0.76}px ui-sans-serif, system-ui, sans-serif`;
-    ctx.textAlign = "center";
-    ctx.textBaseline = "middle";
-    // Outline first: a letter over a bright 3D model needs its own contrast, and
-    // the scene's background cannot be relied on behind it.
-    ctx.lineWidth = TEXTURE_SIZE * 0.1;
-    // Hex with alpha rather than `rgba(0, 0, 0, 0.85)`: `shadcn add` rewrites
-    // colour functions, and it drops a component from this one, leaving
-    // `rgba(0, 0, 0.85)` in a consumer's copy. Canvas ignores an invalid
-    // `strokeStyle` and keeps the previous one, so the outline the installed
-    // registry item draws would not be the one written here. The registry item
-    // itself carries the source unchanged; the mangling is in the install step.
-    ctx.strokeStyle = "#000000d9";
-    ctx.strokeText(letter, TEXTURE_SIZE / 2, TEXTURE_SIZE * 0.54);
-    ctx.fillStyle = axisColorCss(color);
-    ctx.fillText(letter, TEXTURE_SIZE / 2, TEXTURE_SIZE * 0.54);
-  }
-
-  const texture = new THREE.CanvasTexture(canvas);
-  texture.colorSpace = THREE.SRGBColorSpace;
-  textureCache.set(key, texture);
-  return texture;
-}
+import { AXIS_COLORS, AXIS_LETTERS, axisLabelPositions, axisLabelScale } from "../axisTriad.js";
+import { LABEL_RENDER_ORDER, labelTexture } from "./labelTexture.js";
 
 interface AxisLabelsProps {
   /** Axis length in scene units — the labels sit just past each tip. */
@@ -80,7 +27,7 @@ export function AxisLabels({ length, opacity = 1 }: AxisLabelsProps) {
     const positions = axisLabelPositions(length);
     return AXIS_LETTERS.map((letter, i) => ({
       letter,
-      texture: letterTexture(letter, AXIS_COLORS[i]),
+      texture: labelTexture(letter, AXIS_COLORS[i]).texture,
       position: positions[i],
     }));
   }, [length]);

--- a/viewer/src/components/DirectionArrows.tsx
+++ b/viewer/src/components/DirectionArrows.tsx
@@ -1,10 +1,16 @@
 import { useEffect, useMemo, useRef } from "react";
 import type * as THREE from "three";
 import { type DrawnArrow, registerDirectionVectors } from "../debug/directionVectors.js";
-import type { DirectionVector } from "../directionVectors.js";
+import { DIRECTION_VECTOR_LABELS, type DirectionVector } from "../directionVectors.js";
 import type { Vec3 } from "../displayFrame.js";
-import { arrowGeometryForSpan } from "../spacecraftScale.js";
+import {
+  type ArrowGeometry,
+  arrowGeometryForSpan,
+  arrowLabelDistance,
+  arrowLabelHeight,
+} from "../spacecraftScale.js";
 import { Arrow } from "./Arrow.js";
+import { LABEL_RENDER_ORDER, labelTexture } from "./labelTexture.js";
 
 interface DirectionArrowsProps {
   /** Spacecraft position in scene units — where the arrows start. */
@@ -82,6 +88,66 @@ export function DirectionArrows({
           {...geometry}
         />
       ))}
+      <ArrowLabels vectors={vectors} geometry={geometry} span={visualSpan} />
     </group>
+  );
+}
+
+/**
+ * Each arrow's name, at its tip.
+ *
+ * The alternative is a legend in the overlay, which asks the reader to hold a
+ * colour in mind and match it against the picture — and leaves a still image
+ * with nothing to go on. The axis triads name themselves for the same reason,
+ * and these read the same way: a sprite past the tip, coloured like the arrow it
+ * belongs to, drawn last and without a depth test so a name on an arrow pointing
+ * away stays legible.
+ */
+function ArrowLabels({
+  vectors,
+  geometry,
+  span,
+}: {
+  vectors: readonly DirectionVector[];
+  geometry: ArrowGeometry;
+  span: number;
+}) {
+  const labels = useMemo(() => {
+    const distance = arrowLabelDistance(geometry);
+    const height = arrowLabelHeight(span);
+    return vectors.map((v) => {
+      const label = labelTexture(DIRECTION_VECTOR_LABELS[v.kind], v.color);
+      return {
+        kind: v.kind,
+        texture: label.texture,
+        position: [
+          v.direction[0] * distance,
+          v.direction[1] * distance,
+          v.direction[2] * distance,
+        ] as [number, number, number],
+        scale: [height * label.aspect, height, height] as [number, number, number],
+      };
+    });
+  }, [vectors, geometry, span]);
+
+  return (
+    <>
+      {labels.map((label) => (
+        <sprite
+          key={label.kind}
+          position={label.position}
+          scale={label.scale}
+          renderOrder={LABEL_RENDER_ORDER}
+        >
+          <spriteMaterial
+            map={label.texture}
+            transparent
+            depthTest={false}
+            depthWrite={false}
+            toneMapped={false}
+          />
+        </sprite>
+      ))}
+    </>
   );
 }

--- a/viewer/src/components/DirectionVectorControls.tsx
+++ b/viewer/src/components/DirectionVectorControls.tsx
@@ -56,7 +56,12 @@ export function DirectionVectorControls({
             // announced. The visible label leads it, so speech input still
             // matches what is on screen.
             aria-label={reason == null ? undefined : `${DIRECTION_VECTOR_LABELS[kind]}: ${reason}`}
-            title={reason ?? `Draw the ${DIRECTION_VECTOR_LABELS[kind]} direction`}
+            // What the click will do, which is the opposite of the state the
+            // button is in. A fixed "Draw the …" reads as the current state and
+            // contradicts the arrow already on screen.
+            title={
+              reason ?? `${on ? "Hide" : "Draw"} the ${DIRECTION_VECTOR_LABELS[kind]} direction`
+            }
             onClick={() => {
               if (reason != null) return;
               onChange({ ...value, [kind]: !on });

--- a/viewer/src/components/DirectionVectorControls.tsx
+++ b/viewer/src/components/DirectionVectorControls.tsx
@@ -6,8 +6,8 @@ import {
 } from "../directionVectors.js";
 import controlStyles from "../styles/controls.module.css";
 
-/** Order the arrows appear in, in the controls and in the legend. */
-export const DIRECTION_VECTOR_KINDS: readonly DirectionVectorKind[] = ["sun", "nadir"];
+/** Order the toggles appear in. */
+const DIRECTION_VECTOR_KINDS: readonly DirectionVectorKind[] = ["sun", "nadir"];
 
 interface DirectionVectorControlsProps {
   value: DirectionVectorOptions;

--- a/viewer/src/components/DirectionVectorControls.tsx
+++ b/viewer/src/components/DirectionVectorControls.tsx
@@ -45,9 +45,16 @@ export function DirectionVectorControls({
             // The on/off state is otherwise only in the styling, so a screen
             // reader would announce an identical button either way.
             aria-pressed={on}
-            disabled={reason != null}
+            // `aria-disabled` rather than `disabled`: a disabled button takes no
+            // mouse events, so the reason in its `title` is never shown, and it
+            // leaves the tab order, so a keyboard user cannot reach it either.
+            // The reason is the whole point of the state here.
+            aria-disabled={reason != null}
             title={reason ?? `Draw the ${DIRECTION_VECTOR_LABELS[kind]} direction`}
-            onClick={() => onChange({ ...value, [kind]: !on })}
+            onClick={() => {
+              if (reason != null) return;
+              onChange({ ...value, [kind]: !on });
+            }}
           >
             <span
               aria-hidden="true"

--- a/viewer/src/components/DirectionVectorControls.tsx
+++ b/viewer/src/components/DirectionVectorControls.tsx
@@ -1,0 +1,66 @@
+import {
+  DIRECTION_VECTOR_COLORS,
+  DIRECTION_VECTOR_LABELS,
+  type DirectionVectorKind,
+  type DirectionVectorOptions,
+} from "../directionVectors.js";
+import controlStyles from "../styles/controls.module.css";
+
+/** Order the arrows appear in, in the controls and in the legend. */
+export const DIRECTION_VECTOR_KINDS: readonly DirectionVectorKind[] = ["sun", "nadir"];
+
+interface DirectionVectorControlsProps {
+  value: DirectionVectorOptions;
+  onChange: (value: DirectionVectorOptions) => void;
+  /**
+   * Kinds whose input the current data lacks — greyed out with the reason, rather
+   * than silently drawing nothing. Keeping the choice while disabling it means a
+   * viewer's selection survives a frame change that made it unavailable.
+   */
+  unavailable?: Partial<Record<DirectionVectorKind, string | undefined>>;
+}
+
+/**
+ * Independent on/off toggles for the reference-direction arrows.
+ *
+ * Not a {@link SegmentedToggle}: the arrows are not alternatives, any subset can
+ * be on. Shares the toggle styling so it reads as the same family of control.
+ */
+export function DirectionVectorControls({
+  value,
+  onChange,
+  unavailable,
+}: DirectionVectorControlsProps) {
+  return (
+    <div className={controlStyles.modeToggle}>
+      {DIRECTION_VECTOR_KINDS.map((kind) => {
+        const reason = unavailable?.[kind];
+        const on = value[kind] !== false;
+        return (
+          <button
+            key={kind}
+            type="button"
+            className={`${controlStyles.modeToggleBtn} ${on ? controlStyles.active : ""}`}
+            data-testid={`direction-vector-${kind}`}
+            disabled={reason != null}
+            title={reason ?? `Draw the ${DIRECTION_VECTOR_LABELS[kind]} direction`}
+            onClick={() => onChange({ ...value, [kind]: !on })}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                display: "inline-block",
+                width: "8px",
+                height: "8px",
+                marginRight: "6px",
+                borderRadius: "50%",
+                background: `#${DIRECTION_VECTOR_COLORS[kind].toString(16).padStart(6, "0")}`,
+              }}
+            />
+            {DIRECTION_VECTOR_LABELS[kind]}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/viewer/src/components/DirectionVectorControls.tsx
+++ b/viewer/src/components/DirectionVectorControls.tsx
@@ -9,6 +9,16 @@ import controlStyles from "../styles/controls.module.css";
 /** Order the toggles appear in. */
 const DIRECTION_VECTOR_KINDS: readonly DirectionVectorKind[] = ["sun", "nadir"];
 
+/**
+ * Why nadir cannot be drawn from a spacecraft's own position.
+ *
+ * Its direction is that position reversed, so the resolver needs a length it can
+ * divide by: the coordinate origin has none, and neither does a position whose
+ * components are each finite while their squares overflow. Both views state it the
+ * same way, from here, because it is the same condition in both.
+ */
+export const NADIR_NEEDS_LENGTH = "Requires a position of finite, non-zero length";
+
 interface DirectionVectorControlsProps {
   value: DirectionVectorOptions;
   onChange: (value: DirectionVectorOptions) => void;

--- a/viewer/src/components/DirectionVectorControls.tsx
+++ b/viewer/src/components/DirectionVectorControls.tsx
@@ -50,6 +50,12 @@ export function DirectionVectorControls({
             // leaves the tab order, so a keyboard user cannot reach it either.
             // The reason is the whole point of the state here.
             aria-disabled={reason != null}
+            // `title` renders as a tooltip, which needs a pointer to hover and
+            // which screen readers treat as an optional description. Folding the
+            // reason into the accessible name puts it where a name is always
+            // announced. The visible label leads it, so speech input still
+            // matches what is on screen.
+            aria-label={reason == null ? undefined : `${DIRECTION_VECTOR_LABELS[kind]}: ${reason}`}
             title={reason ?? `Draw the ${DIRECTION_VECTOR_LABELS[kind]} direction`}
             onClick={() => {
               if (reason != null) return;

--- a/viewer/src/components/DirectionVectorControls.tsx
+++ b/viewer/src/components/DirectionVectorControls.tsx
@@ -42,6 +42,9 @@ export function DirectionVectorControls({
             type="button"
             className={`${controlStyles.modeToggleBtn} ${on ? controlStyles.active : ""}`}
             data-testid={`direction-vector-${kind}`}
+            // The on/off state is otherwise only in the styling, so a screen
+            // reader would announce an identical button either way.
+            aria-pressed={on}
             disabled={reason != null}
             title={reason ?? `Draw the ${DIRECTION_VECTOR_LABELS[kind]} direction`}
             onClick={() => onChange({ ...value, [kind]: !on })}

--- a/viewer/src/components/FrameSelector.tsx
+++ b/viewer/src/components/FrameSelector.tsx
@@ -1,7 +1,7 @@
 import type { SatelliteInfo } from "../hooks/useWebSocket.js";
 import type { FrameCenter, FrameOrientation, ReferenceFrame } from "../referenceFrame.js";
 import styles from "./FrameSelector.module.css";
-import { type OrientationOption, OrientationSelector } from "./OrientationSelector.js";
+import { type SegmentedOption, SegmentedToggle } from "./SegmentedToggle.js";
 
 interface FrameSelectorProps {
   referenceFrame: ReferenceFrame;
@@ -71,7 +71,7 @@ export function FrameSelector({
   // Which orientations this centre offers: a satellite centre offers the orbit
   // frame, a central-body centre the body's rotating frame (which needs an
   // epoch to know the rotation angle).
-  const orientationOptions: OrientationOption<FrameOrientation>[] = [
+  const orientationOptions: SegmentedOption<FrameOrientation>[] = [
     { value: "inertial", label: labels.inertial, testId: "frame-orientation-inertial" },
     isSatCentered
       ? { value: "local_orbital", label: "LVLH", testId: "frame-orientation-lvlh" }
@@ -103,7 +103,7 @@ export function FrameSelector({
         </select>
       </div>
 
-      <OrientationSelector
+      <SegmentedToggle
         value={referenceFrame.orientation}
         options={orientationOptions}
         onChange={handleOrientationChange}

--- a/viewer/src/components/FrameSelector.tsx
+++ b/viewer/src/components/FrameSelector.tsx
@@ -10,6 +10,16 @@ interface FrameSelectorProps {
   satellites?: SatelliteInfo[];
   /** Whether epoch is available (needed for body-fixed frame). */
   hasEpoch?: boolean;
+  /**
+   * The orientation the scene is drawing in, when it differs from the request.
+   *
+   * `OrbitScene` falls back to inertial for a body-fixed frame it cannot resolve
+   * a rotation angle for, so without this the toggle reports Body-Fixed as
+   * pressed over an inertial picture — reachable by choosing it and then loading a
+   * source with no epoch. The request stays in `referenceFrame`, which is what a
+   * centre change is computed from, so a momentary gap does not discard it.
+   */
+  drawnOrientation?: FrameOrientation;
   /** Central body identifier (e.g. "earth"). Used for display labels. */
   centralBody?: string;
 }
@@ -41,6 +51,7 @@ export function FrameSelector({
   onChange,
   satellites = [],
   hasEpoch = false,
+  drawnOrientation,
   centralBody,
 }: FrameSelectorProps) {
   const centerKey = encodeCenterKey(referenceFrame.center);
@@ -104,7 +115,7 @@ export function FrameSelector({
       </div>
 
       <SegmentedToggle
-        value={referenceFrame.orientation}
+        value={drawnOrientation ?? referenceFrame.orientation}
         options={orientationOptions}
         onChange={handleOrientationChange}
         style={{ marginTop: "4px" }}

--- a/viewer/src/components/FrameSelector.tsx
+++ b/viewer/src/components/FrameSelector.tsx
@@ -20,6 +20,15 @@ interface FrameSelectorProps {
    * centre change is computed from, so a momentary gap does not discard it.
    */
   drawnOrientation?: FrameOrientation;
+  /**
+   * Why the orbit frame cannot be drawn for this centre, when it cannot.
+   *
+   * The scene needs a position and a velocity that span an orbit plane, and keeps
+   * a centred body in its IAU orientation whatever is asked. Without this the
+   * option stays selectable while {@link drawnOrientation} keeps reporting
+   * inertial, so the click looks lost.
+   */
+  lvlhUnavailable?: string;
   /** Central body identifier (e.g. "earth"). Used for display labels. */
   centralBody?: string;
 }
@@ -52,6 +61,7 @@ export function FrameSelector({
   satellites = [],
   hasEpoch = false,
   drawnOrientation,
+  lvlhUnavailable,
   centralBody,
 }: FrameSelectorProps) {
   const centerKey = encodeCenterKey(referenceFrame.center);
@@ -85,7 +95,13 @@ export function FrameSelector({
   const orientationOptions: SegmentedOption<FrameOrientation>[] = [
     { value: "inertial", label: labels.inertial, testId: "frame-orientation-inertial" },
     isSatCentered
-      ? { value: "local_orbital", label: "LVLH", testId: "frame-orientation-lvlh" }
+      ? {
+          value: "local_orbital",
+          label: "LVLH",
+          testId: "frame-orientation-lvlh",
+          disabled: lvlhUnavailable != null,
+          title: lvlhUnavailable,
+        }
       : {
           value: "body_fixed",
           label: labels.body_fixed,

--- a/viewer/src/components/InitialCameraFit.tsx
+++ b/viewer/src/components/InitialCameraFit.tsx
@@ -1,0 +1,62 @@
+import { useThree } from "@react-three/fiber";
+import { useEffect, useRef } from "react";
+import { PerspectiveCamera } from "three";
+import {
+  drawnExtentForSpan,
+  initialCameraDistance,
+  NOMINAL_SPACECRAFT_SPAN,
+} from "../spacecraftScale.js";
+
+/**
+ * Choose the camera's distance once the canvas has a size, pulling it back if the
+ * viewport is narrower than the default framing assumed.
+ *
+ * The `camera` prop is read at mount, before the canvas has a size, so a portrait
+ * embedding would otherwise clip the axes sideways. Applied on the first sizing
+ * only: reframing on every resize would undo a zoom the viewer had chosen, and
+ * this is a starting view, not a constraint.
+ *
+ * `reframe` says whether that distance is ours to choose at all. The depth range
+ * is not this component's: a caller's position of `[200, 0, 0]` with the default
+ * `far` of 100, and a viewer dollying out past it, are the same problem — the
+ * scene at the origin falls behind the far plane and the canvas goes blank — and
+ * `FarPlaneBeyondScene`, in the scene itself, holds that invariant for as long as
+ * the scene is mounted.
+ */
+export function InitialCameraFit({ fov, reframe }: { fov: number; reframe: boolean }) {
+  const camera = useThree((s) => s.camera);
+  const size = useThree((s) => s.size);
+  const applied = useRef(false);
+  useEffect(() => {
+    if (applied.current || size.width === 0 || size.height === 0) return;
+    applied.current = true;
+    // A `zoom` narrows the field of view, so fit the *effective* one — a camera
+    // framed for 50° and zoomed 2× sees half as much and would clip.
+    const effectiveFov = camera instanceof PerspectiveCamera ? camera.getEffectiveFOV() : fov;
+    // A `near` from the camera prop can also sit past the scene, which frames it
+    // correctly and draws none of it, so the distance clears that plane too.
+    const needed = initialCameraDistance(
+      NOMINAL_SPACECRAFT_SPAN,
+      effectiveFov,
+      size.width / size.height,
+      camera instanceof PerspectiveCamera ? camera.near : 0,
+    );
+    const current = camera.position.length();
+    // The distance the fit asks for goes through the same check a caller's
+    // position does, in the same precision: the view matrix carries it to WebGL
+    // as float32, so past 3.4e38 the camera is somewhere the renderer cannot
+    // place it and the canvas is blank. A narrow effective field of view asks for
+    // exactly that — a `zoom` of 1e38 leaves 5.3e-37° and fits from 6.5e38 spans
+    // away. The camera keeps the framing it was built with instead, which is
+    // drawable at any zoom.
+    const placeable = Number.isFinite(Math.fround(needed));
+    if (reframe && placeable && current > 0 && needed > current) {
+      camera.position.multiplyScalar(needed / current);
+    }
+    // The far plane is not settled here. A narrow field of view fits from far
+    // away — 1° needs some 345 spans — and so does a viewer dollying out, so the
+    // scene keeps the plane beyond itself for as long as it is mounted rather
+    // than once at this moment. See `FarPlaneBeyondScene`.
+  }, [camera, size, fov, reframe]);
+  return null;
+}

--- a/viewer/src/components/InitialCameraFit.tsx
+++ b/viewer/src/components/InitialCameraFit.tsx
@@ -1,11 +1,7 @@
 import { useThree } from "@react-three/fiber";
 import { useEffect, useRef } from "react";
 import { PerspectiveCamera } from "three";
-import {
-  drawnExtentForSpan,
-  initialCameraDistance,
-  NOMINAL_SPACECRAFT_SPAN,
-} from "../spacecraftScale.js";
+import { initialCameraDistance, NOMINAL_SPACECRAFT_SPAN } from "../spacecraftScale.js";
 
 /**
  * Choose the camera's distance once the canvas has a size, pulling it back if the

--- a/viewer/src/components/OrbitOverlay.tsx
+++ b/viewer/src/components/OrbitOverlay.tsx
@@ -80,6 +80,15 @@ export function OrbitOverlay({
   sunUnavailable,
 }: OrbitOverlayProps) {
   const noCentre = centredSatelliteId == null ? "Centre on a satellite to draw it" : undefined;
+  /**
+   * Why nothing can be drawn at the centre, when that is the reason.
+   *
+   * The scene drops every arrow at a centre its frame cannot place, so a
+   * direction that is otherwise available — the Sun needs no position of its own
+   * — still cannot be drawn there. Both toggles give this reason, so neither can
+   * be left enabled over a scene that draws nothing.
+   */
+  const unplaceableCentre = "Requires a finite, non-zero position";
   return (
     <>
       <FrameSelector
@@ -100,12 +109,13 @@ export function OrbitOverlay({
         value={directionVectors}
         onChange={onDirectionVectorsChange}
         unavailable={{
-          sun: noCentre ?? (drawableVectorKinds.includes("sun") ? undefined : sunUnavailable),
-          nadir:
+          sun:
             noCentre ??
-            (drawableVectorKinds.includes("nadir")
+            (drawableVectorKinds.includes("sun")
               ? undefined
-              : "Requires a finite, non-zero position"),
+              : (sunUnavailable ?? unplaceableCentre)),
+          nadir:
+            noCentre ?? (drawableVectorKinds.includes("nadir") ? undefined : unplaceableCentre),
         }}
       />
       {orbitInfo && (

--- a/viewer/src/components/OrbitOverlay.tsx
+++ b/viewer/src/components/OrbitOverlay.tsx
@@ -43,6 +43,12 @@ export interface OrbitOverlayProps {
    * drops is lying.
    */
   drawableVectorKinds: readonly DirectionVectorKind[];
+  /**
+   * Why the Sun is unavailable, when it is. The app owns the wording because it
+   * knows which of the two reasons applies — no epoch, or a central body arika
+   * cannot place.
+   */
+  sunUnavailable?: string;
 }
 
 /**
@@ -71,6 +77,7 @@ export function OrbitOverlay({
   onDirectionVectorsChange,
   centredSatelliteId,
   drawableVectorKinds,
+  sunUnavailable,
 }: OrbitOverlayProps) {
   const noCentre = centredSatelliteId == null ? "Centre on a satellite to draw it" : undefined;
   return (
@@ -93,7 +100,7 @@ export function OrbitOverlay({
         value={directionVectors}
         onChange={onDirectionVectorsChange}
         unavailable={{
-          sun: noCentre ?? (drawableVectorKinds.includes("sun") ? undefined : "Requires epoch"),
+          sun: noCentre ?? (drawableVectorKinds.includes("sun") ? undefined : sunUnavailable),
           nadir:
             noCentre ??
             (drawableVectorKinds.includes("nadir") ? undefined : "Requires a non-zero position"),

--- a/viewer/src/components/OrbitOverlay.tsx
+++ b/viewer/src/components/OrbitOverlay.tsx
@@ -44,6 +44,14 @@ export interface OrbitOverlayProps {
    */
   drawableVectorKinds: readonly DirectionVectorKind[];
   /**
+   * Whether the scene can place the centred spacecraft at all (default true).
+   *
+   * False takes the whole scene with it — no arrow is drawn at an unplaceable
+   * centre, the Sun included — so both toggles then give that one reason. Comes
+   * from the app because only it holds the centred spacecraft's position.
+   */
+  centreIsPlaceable?: boolean;
+  /**
    * Why the Sun is unavailable, when it is. The app owns the wording because it
    * knows which of the two reasons applies — no epoch, or a central body arika
    * cannot place.
@@ -78,17 +86,25 @@ export function OrbitOverlay({
   centredSatelliteId,
   drawableVectorKinds,
   sunUnavailable,
+  centreIsPlaceable = true,
 }: OrbitOverlayProps) {
   const noCentre = centredSatelliteId == null ? "Centre on a satellite to draw it" : undefined;
   /**
    * Why nothing can be drawn at the centre, when that is the reason.
    *
-   * The scene drops every arrow at a centre its frame cannot place, so a
-   * direction that is otherwise available — the Sun needs no position of its own
-   * — still cannot be drawn there. Both toggles give this reason, so neither can
-   * be left enabled over a scene that draws nothing.
+   * A centre the frame cannot place takes the whole scene with it: no arrow is
+   * drawn there, the Sun included, though it needs no position of its own. So
+   * both toggles give this reason and neither is left enabled over a scene that
+   * draws nothing. Asked of the frame's own predicate, which refuses a non-finite
+   * position and accepts every other — the coordinate origin among them.
    */
-  const unplaceableCentre = "Requires a finite, non-zero position";
+  const unplaceableCentre = centreIsPlaceable ? undefined : "Requires a finite position";
+  /**
+   * Nadir's own condition. It is the bearing from the spacecraft to the body,
+   * which a spacecraft at the body's centre does not have — and the scene draws
+   * everything else there, so this reason belongs to nadir alone.
+   */
+  const noBearing = "Requires a non-zero position";
   return (
     <>
       <FrameSelector
@@ -111,11 +127,12 @@ export function OrbitOverlay({
         unavailable={{
           sun:
             noCentre ??
-            (drawableVectorKinds.includes("sun")
-              ? undefined
-              : (sunUnavailable ?? unplaceableCentre)),
+            unplaceableCentre ??
+            (drawableVectorKinds.includes("sun") ? undefined : sunUnavailable),
           nadir:
-            noCentre ?? (drawableVectorKinds.includes("nadir") ? undefined : unplaceableCentre),
+            noCentre ??
+            unplaceableCentre ??
+            (drawableVectorKinds.includes("nadir") ? undefined : noBearing),
         }}
       />
       {orbitInfo && (

--- a/viewer/src/components/OrbitOverlay.tsx
+++ b/viewer/src/components/OrbitOverlay.tsx
@@ -103,7 +103,9 @@ export function OrbitOverlay({
           sun: noCentre ?? (drawableVectorKinds.includes("sun") ? undefined : sunUnavailable),
           nadir:
             noCentre ??
-            (drawableVectorKinds.includes("nadir") ? undefined : "Requires a non-zero position"),
+            (drawableVectorKinds.includes("nadir")
+              ? undefined
+              : "Requires a finite, non-zero position"),
         }}
       />
       {orbitInfo && (

--- a/viewer/src/components/OrbitOverlay.tsx
+++ b/viewer/src/components/OrbitOverlay.tsx
@@ -3,7 +3,7 @@ import type { DirectionVectorKind, DirectionVectorOptions } from "../directionVe
 import type { SatelliteInfo, SimInfo } from "../hooks/useWebSocket.js";
 import type { ReferenceFrame } from "../referenceFrame.js";
 import type { MarkerShape } from "../satelliteShapes.js";
-import { DirectionVectorControls } from "./DirectionVectorControls.js";
+import { DirectionVectorControls, NADIR_NEEDS_LENGTH } from "./DirectionVectorControls.js";
 import { FrameSelector } from "./FrameSelector.js";
 import { MarkerShapeSelector } from "./MarkerShapeSelector.js";
 import { SimInfoBar } from "./SimInfoBar.js";
@@ -104,20 +104,16 @@ export function OrbitOverlay({
    * A centre the frame cannot place takes the whole scene with it: no arrow is
    * drawn there, the Sun included, though it needs no position of its own. So
    * both toggles give this reason and neither is left enabled over a scene that
-   * draws nothing. Asked of the frame's own predicate, which refuses a non-finite
-   * position and accepts every other — the coordinate origin among them.
+   * draws nothing. Asked of the frame's own predicate, which refuses a position it
+   * cannot put in the renderer's float32 origin offset — a non-finite component,
+   * or a length past what that offset holds — and accepts every other, the
+   * coordinate origin among them.
    */
   const unplaceableCentre = centreIsPlaceable ? undefined : "Requires a finite position";
-  /**
-   * Nadir's own condition. It is the bearing from the spacecraft to the body, and
-   * what the resolver needs to compute one is a length it can divide by. Two
-   * positions the frame accepts fail that: the coordinate origin, whose length is
-   * zero, and one whose components are each finite while their squares overflow,
-   * whose length is infinite. The scene draws everything else at both, so this
-   * reason belongs to nadir alone — and it names the length rather than the
-   * position, which is the part that has to work.
-   */
-  const noBearing = "Requires a position of finite, non-zero length";
+  // Nadir's own condition, which the scene draws everything else at: the frame
+  // accepts the coordinate origin and the spacecraft is drawn there, and it is the
+  // bearing alone that cannot be taken.
+  const noBearing = NADIR_NEEDS_LENGTH;
   return (
     <>
       <FrameSelector

--- a/viewer/src/components/OrbitOverlay.tsx
+++ b/viewer/src/components/OrbitOverlay.tsx
@@ -95,7 +95,8 @@ export function OrbitOverlay({
         unavailable={{
           sun: noCentre ?? (drawableVectorKinds.includes("sun") ? undefined : "Requires epoch"),
           nadir:
-            noCentre ?? (drawableVectorKinds.includes("nadir") ? undefined : "Requires a position"),
+            noCentre ??
+            (drawableVectorKinds.includes("nadir") ? undefined : "Requires a non-zero position"),
         }}
       />
       {orbitInfo && (

--- a/viewer/src/components/OrbitOverlay.tsx
+++ b/viewer/src/components/OrbitOverlay.tsx
@@ -88,7 +88,16 @@ export function OrbitOverlay({
   sunUnavailable,
   centreIsPlaceable = true,
 }: OrbitOverlayProps) {
-  const noCentre = centredSatelliteId == null ? "Centre on a satellite to draw it" : undefined;
+  // Three states, all of which draw nothing, and each with its own reason. The
+  // frame may name no satellite at all; it may name one the viewer holds no sample
+  // for, before the first arrives or after a source change took it away; or the
+  // sample it holds may be one the frame cannot use.
+  const noCentre =
+    referenceFrame.center.type === "satellite" ? undefined : "Centre on a satellite to draw it";
+  const awaitingCentre =
+    noCentre == null && centredSatelliteId == null
+      ? "Waiting for this spacecraft's data"
+      : undefined;
   /**
    * Why nothing can be drawn at the centre, when that is the reason.
    *
@@ -127,10 +136,12 @@ export function OrbitOverlay({
         unavailable={{
           sun:
             noCentre ??
+            awaitingCentre ??
             unplaceableCentre ??
             (drawableVectorKinds.includes("sun") ? undefined : sunUnavailable),
           nadir:
             noCentre ??
+            awaitingCentre ??
             unplaceableCentre ??
             (drawableVectorKinds.includes("nadir") ? undefined : noBearing),
         }}

--- a/viewer/src/components/OrbitOverlay.tsx
+++ b/viewer/src/components/OrbitOverlay.tsx
@@ -109,11 +109,15 @@ export function OrbitOverlay({
    */
   const unplaceableCentre = centreIsPlaceable ? undefined : "Requires a finite position";
   /**
-   * Nadir's own condition. It is the bearing from the spacecraft to the body,
-   * which a spacecraft at the body's centre does not have — and the scene draws
-   * everything else there, so this reason belongs to nadir alone.
+   * Nadir's own condition. It is the bearing from the spacecraft to the body, and
+   * what the resolver needs to compute one is a length it can divide by. Two
+   * positions the frame accepts fail that: the coordinate origin, whose length is
+   * zero, and one whose components are each finite while their squares overflow,
+   * whose length is infinite. The scene draws everything else at both, so this
+   * reason belongs to nadir alone — and it names the length rather than the
+   * position, which is the part that has to work.
    */
-  const noBearing = "Requires a non-zero position";
+  const noBearing = "Requires a position of finite, non-zero length";
   return (
     <>
       <FrameSelector

--- a/viewer/src/components/OrbitOverlay.tsx
+++ b/viewer/src/components/OrbitOverlay.tsx
@@ -1,12 +1,14 @@
 import styles from "../App.module.css";
+import type { DirectionVectorOptions } from "../directionVectors.js";
 import type { SatelliteInfo, SimInfo } from "../hooks/useWebSocket.js";
 import type { ReferenceFrame } from "../referenceFrame.js";
 import type { MarkerShape } from "../satelliteShapes.js";
+import { DirectionVectorControls } from "./DirectionVectorControls.js";
 import { FrameSelector } from "./FrameSelector.js";
 import { MarkerShapeSelector } from "./MarkerShapeSelector.js";
 import { SimInfoBar } from "./SimInfoBar.js";
 
-export interface SceneOverlayProps {
+export interface OrbitOverlayProps {
   referenceFrame: ReferenceFrame;
   onReferenceFrameChange: (frame: ReferenceFrame) => void;
   /** Satellites available for the frame selector (from simInfo or replay). */
@@ -25,14 +27,28 @@ export interface SceneOverlayProps {
   /** Per-satellite marker shape overrides. */
   markerShapeOverrides: Map<string, MarkerShape>;
   onMarkerShapeOverride: (satId: string, shape: MarkerShape | null) => void;
+  /**
+   * Reference-direction arrows. The same setting the attitude view uses, offered
+   * here too so a change made in one view is visible in the other rather than
+   * taking effect invisibly.
+   */
+  directionVectors: DirectionVectorOptions;
+  onDirectionVectorsChange: (value: DirectionVectorOptions) => void;
+  /** The centred satellite, or null in a central-body view (no arrows there). */
+  centredSatelliteId: string | null;
+  /** Whether that satellite has a position, which nadir needs. */
+  hasCentredPosition: boolean;
 }
 
 /**
- * Top-left canvas overlay: frame selector, optional file-orbit summary, and the
- * simulation info bar. Grouped out of App so the orchestrator stays focused on
- * data flow rather than canvas chrome layout.
+ * The orbit view's overlay controls: frame selector, marker shapes, the optional
+ * file-orbit summary and the simulation info bar.
+ *
+ * A fragment, not a positioned container: the app owns the overlay area so the
+ * view switch — which must outlive either view — sits alongside this rather than
+ * inside it.
  */
-export function SceneOverlay({
+export function OrbitOverlay({
   referenceFrame,
   onReferenceFrameChange,
   satellites,
@@ -46,9 +62,14 @@ export function SceneOverlay({
   onDefaultMarkerShapeChange,
   markerShapeOverrides,
   onMarkerShapeOverride,
-}: SceneOverlayProps) {
+  directionVectors,
+  onDirectionVectorsChange,
+  centredSatelliteId,
+  hasCentredPosition,
+}: OrbitOverlayProps) {
+  const noCentre = centredSatelliteId == null ? "Centre on a satellite to draw it" : undefined;
   return (
-    <div className={styles.sceneOverlay}>
+    <>
       <FrameSelector
         referenceFrame={referenceFrame}
         onChange={onReferenceFrameChange}
@@ -63,6 +84,14 @@ export function SceneOverlay({
         overrides={markerShapeOverrides}
         onOverrideChange={onMarkerShapeOverride}
       />
+      <DirectionVectorControls
+        value={directionVectors}
+        onChange={onDirectionVectorsChange}
+        unavailable={{
+          sun: noCentre ?? (epochJd == null ? "Requires epoch" : undefined),
+          nadir: noCentre ?? (hasCentredPosition ? undefined : "Requires a position"),
+        }}
+      />
       {orbitInfo && (
         <div className={styles.orbitInfo} data-testid="orbit-info-file">
           {orbitInfo}
@@ -76,6 +105,6 @@ export function SceneOverlay({
           activePerturbations={activePerturbations}
         />
       )}
-    </div>
+    </>
   );
 }

--- a/viewer/src/components/OrbitOverlay.tsx
+++ b/viewer/src/components/OrbitOverlay.tsx
@@ -1,5 +1,5 @@
 import styles from "../App.module.css";
-import type { DirectionVectorOptions } from "../directionVectors.js";
+import type { DirectionVectorKind, DirectionVectorOptions } from "../directionVectors.js";
 import type { SatelliteInfo, SimInfo } from "../hooks/useWebSocket.js";
 import type { ReferenceFrame } from "../referenceFrame.js";
 import type { MarkerShape } from "../satelliteShapes.js";
@@ -36,8 +36,13 @@ export interface OrbitOverlayProps {
   onDirectionVectorsChange: (value: DirectionVectorOptions) => void;
   /** The centred satellite, or null in a central-body view (no arrows there). */
   centredSatelliteId: string | null;
-  /** Whether that satellite has a position, which nadir needs. */
-  hasCentredPosition: boolean;
+  /**
+   * Which arrows the scene could draw for that satellite, as its own resolver
+   * answers. Not "does it have a position": a position that is present but zero
+   * or non-finite yields no nadir, and a control offering an arrow the scene then
+   * drops is lying.
+   */
+  drawableVectorKinds: readonly DirectionVectorKind[];
 }
 
 /**
@@ -65,7 +70,7 @@ export function OrbitOverlay({
   directionVectors,
   onDirectionVectorsChange,
   centredSatelliteId,
-  hasCentredPosition,
+  drawableVectorKinds,
 }: OrbitOverlayProps) {
   const noCentre = centredSatelliteId == null ? "Centre on a satellite to draw it" : undefined;
   return (
@@ -88,8 +93,9 @@ export function OrbitOverlay({
         value={directionVectors}
         onChange={onDirectionVectorsChange}
         unavailable={{
-          sun: noCentre ?? (epochJd == null ? "Requires epoch" : undefined),
-          nadir: noCentre ?? (hasCentredPosition ? undefined : "Requires a position"),
+          sun: noCentre ?? (drawableVectorKinds.includes("sun") ? undefined : "Requires epoch"),
+          nadir:
+            noCentre ?? (drawableVectorKinds.includes("nadir") ? undefined : "Requires a position"),
         }}
       />
       {orbitInfo && (

--- a/viewer/src/components/OrbitOverlay.tsx
+++ b/viewer/src/components/OrbitOverlay.tsx
@@ -1,7 +1,7 @@
 import styles from "../App.module.css";
 import type { DirectionVectorKind, DirectionVectorOptions } from "../directionVectors.js";
 import type { SatelliteInfo, SimInfo } from "../hooks/useWebSocket.js";
-import type { ReferenceFrame } from "../referenceFrame.js";
+import type { FrameOrientation, ReferenceFrame } from "../referenceFrame.js";
 import type { MarkerShape } from "../satelliteShapes.js";
 import { DirectionVectorControls, NADIR_NEEDS_LENGTH } from "./DirectionVectorControls.js";
 import { FrameSelector } from "./FrameSelector.js";
@@ -51,6 +51,8 @@ export interface OrbitOverlayProps {
    * from the app because only it holds the centred spacecraft's position.
    */
   centreIsPlaceable?: boolean;
+  /** The orientation the scene draws in, when it differs from the request. */
+  drawnOrientation?: FrameOrientation;
   /**
    * Why the Sun is unavailable, when it is. The app owns the wording because it
    * knows which of the two reasons applies — no epoch, or a central body arika
@@ -87,6 +89,7 @@ export function OrbitOverlay({
   drawableVectorKinds,
   sunUnavailable,
   centreIsPlaceable = true,
+  drawnOrientation,
 }: OrbitOverlayProps) {
   // Three states, all of which draw nothing, and each with its own reason. The
   // frame may name no satellite at all; it may name one the viewer holds no sample
@@ -121,6 +124,7 @@ export function OrbitOverlay({
         onChange={onReferenceFrameChange}
         satellites={satellites}
         hasEpoch={epochJd != null}
+        drawnOrientation={drawnOrientation}
         centralBody={centralBody}
       />
       <MarkerShapeSelector

--- a/viewer/src/components/OrbitOverlay.tsx
+++ b/viewer/src/components/OrbitOverlay.tsx
@@ -53,6 +53,8 @@ export interface OrbitOverlayProps {
   centreIsPlaceable?: boolean;
   /** The orientation the scene draws in, when it differs from the request. */
   drawnOrientation?: FrameOrientation;
+  /** Why the orbit frame is unavailable for this centre, when it is. */
+  lvlhUnavailable?: string;
   /**
    * Why the Sun is unavailable, when it is. The app owns the wording because it
    * knows which of the two reasons applies — no epoch, or a central body arika
@@ -90,6 +92,7 @@ export function OrbitOverlay({
   sunUnavailable,
   centreIsPlaceable = true,
   drawnOrientation,
+  lvlhUnavailable,
 }: OrbitOverlayProps) {
   // Three states, all of which draw nothing, and each with its own reason. The
   // frame may name no satellite at all; it may name one the viewer holds no sample
@@ -125,6 +128,7 @@ export function OrbitOverlay({
         satellites={satellites}
         hasEpoch={epochJd != null}
         drawnOrientation={drawnOrientation}
+        lvlhUnavailable={lvlhUnavailable}
         centralBody={centralBody}
       />
       <MarkerShapeSelector

--- a/viewer/src/components/OrbitOverlay.tsx
+++ b/viewer/src/components/OrbitOverlay.tsx
@@ -56,6 +56,11 @@ export interface OrbitOverlayProps {
   /** Why the orbit frame is unavailable for this centre, when it is. */
   lvlhUnavailable?: string;
   /**
+   * Whether the centre is a spacecraft rather than a celestial body (default
+   * true). The scene draws no direction arrows at a body.
+   */
+  centreIsSpacecraft?: boolean;
+  /**
    * Why the Sun is unavailable, when it is. The app owns the wording because it
    * knows which of the two reasons applies — no epoch, or a central body arika
    * cannot place.
@@ -93,6 +98,7 @@ export function OrbitOverlay({
   centreIsPlaceable = true,
   drawnOrientation,
   lvlhUnavailable,
+  centreIsSpacecraft = true,
 }: OrbitOverlayProps) {
   // Three states, all of which draw nothing, and each with its own reason. The
   // frame may name no satellite at all; it may name one the viewer holds no sample
@@ -110,16 +116,21 @@ export function OrbitOverlay({
    * A centre the frame cannot place takes the whole scene with it: no arrow is
    * drawn there, the Sun included, though it needs no position of its own. So
    * both toggles give this reason and neither is left enabled over a scene that
-   * draws nothing. Asked of the frame's own predicate, which refuses a position it
-   * cannot put in the renderer's float32 origin offset — a non-finite component,
-   * or a length past what that offset holds — and accepts every other, the
-   * coordinate origin among them.
+   * draws nothing. Asked of the frame's own predicate, which refuses a non-finite
+   * position and accepts every other, the coordinate origin among them.
    */
   const unplaceableCentre = centreIsPlaceable ? undefined : "Requires a finite position";
   // Nadir's own condition, which the scene draws everything else at: the frame
   // accepts the coordinate origin and the spacecraft is drawn there, and it is the
   // bearing alone that cannot be taken.
   const noBearing = NADIR_NEEDS_LENGTH;
+  /**
+   * A centred celestial body draws no arrows at all, so neither toggle has
+   * anything to offer and the reason is about the centre rather than about either
+   * direction. Stated before the per-direction conditions, which would otherwise
+   * describe a position that is perfectly good.
+   */
+  const bodyCentre = centreIsSpacecraft ? undefined : "Arrows are drawn at a spacecraft";
   return (
     <>
       <FrameSelector
@@ -145,11 +156,13 @@ export function OrbitOverlay({
           sun:
             noCentre ??
             awaitingCentre ??
+            bodyCentre ??
             unplaceableCentre ??
             (drawableVectorKinds.includes("sun") ? undefined : sunUnavailable),
           nadir:
             noCentre ??
             awaitingCentre ??
+            bodyCentre ??
             unplaceableCentre ??
             (drawableVectorKinds.includes("nadir") ? undefined : noBearing),
         }}

--- a/viewer/src/components/SceneLegend.module.css
+++ b/viewer/src/components/SceneLegend.module.css
@@ -1,0 +1,38 @@
+.legend {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--orts-space-sm) var(--orts-space-md);
+  background: var(--orts-panel-bg);
+  border: 1px solid var(--orts-panel-border);
+  border-radius: var(--orts-panel-radius);
+  font-size: var(--orts-font-size-sm);
+  color: var(--orts-text-secondary);
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: var(--orts-space-sm);
+  white-space: nowrap;
+}
+
+.group {
+  color: var(--orts-text-primary);
+}
+
+.swatches {
+  display: inline-flex;
+  gap: 3px;
+}
+
+.swatch {
+  display: inline-block;
+  width: 10px;
+  height: 4px;
+  border-radius: 1px;
+}
+
+.dim {
+  opacity: 0.4;
+}

--- a/viewer/src/components/SceneLegend.tsx
+++ b/viewer/src/components/SceneLegend.tsx
@@ -1,34 +1,21 @@
 import { AXIS_COLORS, axisColorCss } from "../axisTriad.js";
-import {
-  DIRECTION_VECTOR_COLORS,
-  DIRECTION_VECTOR_LABELS,
-  type DirectionVectorKind,
-} from "../directionVectors.js";
-import { DIRECTION_VECTOR_KINDS } from "./DirectionVectorControls.js";
 import styles from "./SceneLegend.module.css";
 
-function hex(color: number): string {
-  return `#${color.toString(16).padStart(6, "0")}`;
-}
-
-interface SceneLegendProps {
-  /** Kinds actually drawn right now; the rest are omitted from the legend. */
-  vectorKinds: readonly DirectionVectorKind[];
-  /** Whether the reference-frame triad is drawn (it can be turned off). */
-  showFrameAxes?: boolean;
-}
-
 /**
- * What the coloured lines in the scene mean.
+ * What the coloured axes in the scene mean.
  *
- * The body axes and the reference-frame axes are both RGB triads, so naming
- * "X / Y / Z" once would not tell them apart — the two are listed separately,
- * with the frame's row dimmed to match how it is drawn.
+ * The body axes and the reference-frame axes are both RGB triads and both carry
+ * the same X / Y / Z letters, so the letters alone do not say which triad a
+ * reader is looking at. The two are listed here, with the frame's row dimmed to
+ * match how it is drawn.
  *
- * The swatches read {@link AXIS_COLORS}, the palette the scene draws the axes
- * and their letters with, so the legend cannot drift from the picture.
+ * The direction arrows are not listed: each one carries its own name at its tip,
+ * which a reader can match without holding a colour in mind, and which survives
+ * a screenshot. The swatches read {@link AXIS_COLORS}, the palette the scene
+ * draws the axes and their letters with, so the legend cannot drift from the
+ * picture.
  */
-export function SceneLegend({ vectorKinds, showFrameAxes = true }: SceneLegendProps) {
+export function SceneLegend({ showFrameAxes = true }: { showFrameAxes?: boolean }) {
   return (
     <div className={styles.legend} data-testid="scene-legend">
       <div className={styles.row}>
@@ -49,17 +36,6 @@ export function SceneLegend({ vectorKinds, showFrameAxes = true }: SceneLegendPr
           <span className={styles.group}>Frame X / Y / Z</span>
         </div>
       )}
-      {DIRECTION_VECTOR_KINDS.filter((kind) => vectorKinds.includes(kind)).map((kind) => (
-        <div key={kind} className={styles.row}>
-          <span className={styles.swatches}>
-            <span
-              className={styles.swatch}
-              style={{ background: hex(DIRECTION_VECTOR_COLORS[kind]) }}
-            />
-          </span>
-          <span>{DIRECTION_VECTOR_LABELS[kind]}</span>
-        </div>
-      ))}
     </div>
   );
 }

--- a/viewer/src/components/SceneLegend.tsx
+++ b/viewer/src/components/SceneLegend.tsx
@@ -1,3 +1,4 @@
+import { AXIS_COLORS, axisColorCss } from "../axisTriad.js";
 import {
   DIRECTION_VECTOR_COLORS,
   DIRECTION_VECTOR_LABELS,
@@ -5,9 +6,6 @@ import {
 } from "../directionVectors.js";
 import { DIRECTION_VECTOR_KINDS } from "./DirectionVectorControls.js";
 import styles from "./SceneLegend.module.css";
-
-/** Three.js `AxesHelper` colours, in X, Y, Z order. */
-const AXIS_COLORS = ["#ff0000", "#00ff00", "#0000ff"] as const;
 
 function hex(color: number): string {
   return `#${color.toString(16).padStart(6, "0")}`;
@@ -26,6 +24,9 @@ interface SceneLegendProps {
  * The body axes and the reference-frame axes are both RGB triads, so naming
  * "X / Y / Z" once would not tell them apart — the two are listed separately,
  * with the frame's row dimmed to match how it is drawn.
+ *
+ * The swatches read {@link AXIS_COLORS}, the palette the scene draws the axes
+ * and their letters with, so the legend cannot drift from the picture.
  */
 export function SceneLegend({ vectorKinds, showFrameAxes = true }: SceneLegendProps) {
   return (
@@ -33,7 +34,7 @@ export function SceneLegend({ vectorKinds, showFrameAxes = true }: SceneLegendPr
       <div className={styles.row}>
         <span className={styles.swatches}>
           {AXIS_COLORS.map((c) => (
-            <span key={c} className={styles.swatch} style={{ background: c }} />
+            <span key={c} className={styles.swatch} style={{ background: axisColorCss(c) }} />
           ))}
         </span>
         <span className={styles.group}>Body X / Y / Z</span>
@@ -42,7 +43,7 @@ export function SceneLegend({ vectorKinds, showFrameAxes = true }: SceneLegendPr
         <div className={`${styles.row} ${styles.dim}`}>
           <span className={styles.swatches}>
             {AXIS_COLORS.map((c) => (
-              <span key={c} className={styles.swatch} style={{ background: c }} />
+              <span key={c} className={styles.swatch} style={{ background: axisColorCss(c) }} />
             ))}
           </span>
           <span className={styles.group}>Frame X / Y / Z</span>

--- a/viewer/src/components/SceneLegend.tsx
+++ b/viewer/src/components/SceneLegend.tsx
@@ -1,0 +1,64 @@
+import {
+  DIRECTION_VECTOR_COLORS,
+  DIRECTION_VECTOR_LABELS,
+  type DirectionVectorKind,
+} from "../directionVectors.js";
+import { DIRECTION_VECTOR_KINDS } from "./DirectionVectorControls.js";
+import styles from "./SceneLegend.module.css";
+
+/** Three.js `AxesHelper` colours, in X, Y, Z order. */
+const AXIS_COLORS = ["#ff0000", "#00ff00", "#0000ff"] as const;
+
+function hex(color: number): string {
+  return `#${color.toString(16).padStart(6, "0")}`;
+}
+
+interface SceneLegendProps {
+  /** Kinds actually drawn right now; the rest are omitted from the legend. */
+  vectorKinds: readonly DirectionVectorKind[];
+  /** Whether the reference-frame triad is drawn (it can be turned off). */
+  showFrameAxes?: boolean;
+}
+
+/**
+ * What the coloured lines in the scene mean.
+ *
+ * The body axes and the reference-frame axes are both RGB triads, so naming
+ * "X / Y / Z" once would not tell them apart — the two are listed separately,
+ * with the frame's row dimmed to match how it is drawn.
+ */
+export function SceneLegend({ vectorKinds, showFrameAxes = true }: SceneLegendProps) {
+  return (
+    <div className={styles.legend} data-testid="scene-legend">
+      <div className={styles.row}>
+        <span className={styles.swatches}>
+          {AXIS_COLORS.map((c) => (
+            <span key={c} className={styles.swatch} style={{ background: c }} />
+          ))}
+        </span>
+        <span className={styles.group}>Body X / Y / Z</span>
+      </div>
+      {showFrameAxes && (
+        <div className={`${styles.row} ${styles.dim}`}>
+          <span className={styles.swatches}>
+            {AXIS_COLORS.map((c) => (
+              <span key={c} className={styles.swatch} style={{ background: c }} />
+            ))}
+          </span>
+          <span className={styles.group}>Frame X / Y / Z</span>
+        </div>
+      )}
+      {DIRECTION_VECTOR_KINDS.filter((kind) => vectorKinds.includes(kind)).map((kind) => (
+        <div key={kind} className={styles.row}>
+          <span className={styles.swatches}>
+            <span
+              className={styles.swatch}
+              style={{ background: hex(DIRECTION_VECTOR_COLORS[kind]) }}
+            />
+          </span>
+          <span>{DIRECTION_VECTOR_LABELS[kind]}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/viewer/src/components/SceneLegend.tsx
+++ b/viewer/src/components/SceneLegend.tsx
@@ -9,23 +9,36 @@ import styles from "./SceneLegend.module.css";
  * reader is looking at. The two are listed here, with the frame's row dimmed to
  * match how it is drawn.
  *
+ * Each row appears when the scene draws that triad. The body axes need an
+ * attitude the scene can use, and a spacecraft can be on screen without one — a
+ * zero or non-finite quaternion is drawn as the marker that shows no orientation,
+ * and naming `Body X / Y / Z` beside it would describe axes nobody can see.
+ *
  * The direction arrows are not listed: each one carries its own name at its tip,
  * which a reader can match without holding a colour in mind, and which survives
  * a screenshot. The swatches read {@link AXIS_COLORS}, the palette the scene
  * draws the axes and their letters with, so the legend cannot drift from the
  * picture.
  */
-export function SceneLegend({ showFrameAxes = true }: { showFrameAxes?: boolean }) {
+export function SceneLegend({
+  showBodyAxes = true,
+  showFrameAxes = true,
+}: {
+  showBodyAxes?: boolean;
+  showFrameAxes?: boolean;
+}) {
   return (
     <div className={styles.legend} data-testid="scene-legend">
-      <div className={styles.row}>
-        <span className={styles.swatches}>
-          {AXIS_COLORS.map((c) => (
-            <span key={c} className={styles.swatch} style={{ background: axisColorCss(c) }} />
-          ))}
-        </span>
-        <span className={styles.group}>Body X / Y / Z</span>
-      </div>
+      {showBodyAxes && (
+        <div className={styles.row}>
+          <span className={styles.swatches}>
+            {AXIS_COLORS.map((c) => (
+              <span key={c} className={styles.swatch} style={{ background: axisColorCss(c) }} />
+            ))}
+          </span>
+          <span className={styles.group}>Body X / Y / Z</span>
+        </div>
+      )}
       {showFrameAxes && (
         <div className={`${styles.row} ${styles.dim}`}>
           <span className={styles.swatches}>

--- a/viewer/src/components/SegmentedToggle.tsx
+++ b/viewer/src/components/SegmentedToggle.tsx
@@ -49,6 +49,13 @@ export function SegmentedToggle<T extends string>({
           // and takes no focus, and an unavailable option here carries the reason
           // it is unavailable.
           aria-disabled={option.disabled}
+          // See `DirectionVectorControls`: the reason belongs in the accessible
+          // name, not only in a tooltip. Only when the option is unavailable —
+          // `title` on an available one is an ordinary hint, and repeating it as
+          // the name would announce it on every pass.
+          aria-label={
+            option.disabled && option.title != null ? `${option.label}: ${option.title}` : undefined
+          }
           title={option.title}
           onClick={() => {
             if (option.disabled) return;

--- a/viewer/src/components/SegmentedToggle.tsx
+++ b/viewer/src/components/SegmentedToggle.tsx
@@ -1,11 +1,11 @@
 import type { CSSProperties } from "react";
 import controlStyles from "../styles/controls.module.css";
 
-/** One selectable orientation. */
-export interface OrientationOption<T extends string> {
+/** One selectable segment. */
+export interface SegmentedOption<T extends string> {
   value: T;
   label: string;
-  /** Greyed out and unselectable — the data this orientation needs is missing. */
+  /** Greyed out and unselectable — the data this option needs is missing. */
   disabled?: boolean;
   /** Tooltip, used to say *why* an option is disabled. */
   title?: string;
@@ -13,28 +13,28 @@ export interface OrientationOption<T extends string> {
   testId?: string;
 }
 
-interface OrientationSelectorProps<T extends string> {
+interface SegmentedToggleProps<T extends string> {
   value: T;
-  options: readonly OrientationOption<T>[];
+  options: readonly SegmentedOption<T>[];
   onChange: (value: T) => void;
   style?: CSSProperties;
 }
 
 /**
- * A segmented toggle over the display orientations a view offers.
+ * A one-of-N toggle: the app's segmented control.
  *
- * Generic over the orientation type so the orbit view (whose orientations pair
- * with a frame centre) and the attitude view (whose spacecraft is always at the
- * origin, leaving only an orientation) get the same control without one view's
- * frame type leaking into the other. Which options exist, and which are
- * available for the current data, is the caller's decision.
+ * Generic over the value type so every such choice looks the same without one
+ * caller's domain type leaking into another — the display orientations (whose
+ * meaning differs between the orbit and attitude views) and the view switch
+ * itself both use it. Which options exist, and which are available for the
+ * current data, is the caller's decision.
  */
-export function OrientationSelector<T extends string>({
+export function SegmentedToggle<T extends string>({
   value,
   options,
   onChange,
   style,
-}: OrientationSelectorProps<T>) {
+}: SegmentedToggleProps<T>) {
   return (
     <div className={controlStyles.modeToggle} style={style}>
       {options.map((option) => (

--- a/viewer/src/components/SegmentedToggle.tsx
+++ b/viewer/src/components/SegmentedToggle.tsx
@@ -43,6 +43,8 @@ export function SegmentedToggle<T extends string>({
           type="button"
           className={`${controlStyles.modeToggleBtn} ${value === option.value ? controlStyles.active : ""}`}
           data-testid={option.testId}
+          // Which segment is selected is otherwise only in the styling.
+          aria-pressed={value === option.value}
           onClick={() => onChange(option.value)}
           disabled={option.disabled}
           title={option.title ?? ""}

--- a/viewer/src/components/SegmentedToggle.tsx
+++ b/viewer/src/components/SegmentedToggle.tsx
@@ -45,9 +45,15 @@ export function SegmentedToggle<T extends string>({
           data-testid={option.testId}
           // Which segment is selected is otherwise only in the styling.
           aria-pressed={value === option.value}
-          onClick={() => onChange(option.value)}
-          disabled={option.disabled}
+          // See `DirectionVectorControls`: a `disabled` button shows no tooltip
+          // and takes no focus, and an unavailable option here carries the reason
+          // it is unavailable.
+          aria-disabled={option.disabled}
           title={option.title}
+          onClick={() => {
+            if (option.disabled) return;
+            onChange(option.value);
+          }}
         >
           {option.label}
         </button>

--- a/viewer/src/components/SegmentedToggle.tsx
+++ b/viewer/src/components/SegmentedToggle.tsx
@@ -47,7 +47,7 @@ export function SegmentedToggle<T extends string>({
           aria-pressed={value === option.value}
           onClick={() => onChange(option.value)}
           disabled={option.disabled}
-          title={option.title ?? ""}
+          title={option.title}
         >
           {option.label}
         </button>

--- a/viewer/src/components/ViewSelector.tsx
+++ b/viewer/src/components/ViewSelector.tsx
@@ -1,0 +1,29 @@
+import { type SegmentedOption, SegmentedToggle } from "./SegmentedToggle.js";
+
+/** Which of the app's two presentations is showing. */
+export type ViewMode = "orbit" | "attitude";
+
+const OPTIONS: readonly SegmentedOption<ViewMode>[] = [
+  { value: "orbit", label: "Orbit", testId: "view-orbit" },
+  {
+    value: "attitude",
+    label: "Attitude",
+    testId: "view-attitude",
+    title: "One spacecraft's orientation, without the central body or trails",
+  },
+];
+
+interface ViewSelectorProps {
+  view: ViewMode;
+  onChange: (view: ViewMode) => void;
+}
+
+/**
+ * Switch between the orbit and attitude presentations.
+ *
+ * Rendered by the app rather than by either view's own overlay: switching must
+ * not unmount the control doing the switching.
+ */
+export function ViewSelector({ view, onChange }: ViewSelectorProps) {
+  return <SegmentedToggle value={view} options={OPTIONS} onChange={onChange} />;
+}

--- a/viewer/src/components/labelTexture.ts
+++ b/viewer/src/components/labelTexture.ts
@@ -1,0 +1,89 @@
+import * as THREE from "three";
+
+/**
+ * Canvas textures for the short labels drawn in the scene: the letters on an
+ * axis triad, and the names at the tips of the direction arrows.
+ *
+ * Sprites rather than 3D text — they face the camera from every angle, need no
+ * font asset, and add no dependency. The texture is as wide as the text needs, so
+ * a caller scales the sprite by {@link SceneLabel.aspect} to keep the glyphs from
+ * stretching.
+ */
+
+/** One texture per text and colour, made on first use and kept. */
+const cache = new Map<string, SceneLabel>();
+
+/** Texture height in pixels. The width follows the text. */
+const TEXTURE_HEIGHT = 128;
+
+/** Outline width, as a fraction of the height. */
+const OUTLINE_RATIO = 0.1;
+
+/** Padding around the text, as a fraction of the height. */
+const PADDING_RATIO = 0.12;
+
+export interface SceneLabel {
+  texture: THREE.Texture;
+  /** Width / height of the texture, for scaling the sprite. */
+  aspect: number;
+}
+
+/** CSS colour for a canvas context, from a Three.js hex colour. */
+export function labelColorCss(color: number): string {
+  return `#${color.toString(16).padStart(6, "0")}`;
+}
+
+/**
+ * A texture with `text` drawn on it in `color`, outlined so it reads over a lit
+ * 3D model as well as over the scene's background.
+ *
+ * Built lazily rather than at module scope: this module is imported by tests
+ * that run without a DOM, where a canvas at import time would throw.
+ */
+export function labelTexture(text: string, color: number): SceneLabel {
+  const key = `${text}:${color}`;
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  const font = `bold ${TEXTURE_HEIGHT * 0.76}px ui-sans-serif, system-ui, sans-serif`;
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+  let aspect = 1;
+  if (ctx) {
+    // Measure with the final font before sizing the canvas: setting the width
+    // resets the context, so the font is applied twice on purpose.
+    ctx.font = font;
+    const width = ctx.measureText(text).width + TEXTURE_HEIGHT * PADDING_RATIO * 2;
+    canvas.width = Math.max(1, Math.ceil(width));
+    canvas.height = TEXTURE_HEIGHT;
+    aspect = canvas.width / canvas.height;
+
+    ctx.font = font;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    // Outline first: the text over a bright 3D model needs its own contrast, and
+    // the scene's background cannot be relied on behind it.
+    ctx.lineWidth = TEXTURE_HEIGHT * OUTLINE_RATIO;
+    // Hex with alpha rather than `rgba(0, 0, 0, 0.85)`: `shadcn add` rewrites
+    // colour functions, and it drops a component from this one, leaving
+    // `rgba(0, 0, 0.85)` in a consumer's copy. Canvas ignores an invalid
+    // `strokeStyle` and keeps the previous one, so the outline the installed
+    // registry item draws would not be the one written here.
+    ctx.strokeStyle = "#000000d9";
+    ctx.strokeText(text, canvas.width / 2, TEXTURE_HEIGHT * 0.54);
+    ctx.fillStyle = labelColorCss(color);
+    ctx.fillText(text, canvas.width / 2, TEXTURE_HEIGHT * 0.54);
+  } else {
+    canvas.width = TEXTURE_HEIGHT;
+    canvas.height = TEXTURE_HEIGHT;
+  }
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  const label = { texture, aspect };
+  cache.set(key, label);
+  return label;
+}
+
+/** Above the scene's meshes, which use the default 0. */
+export const LABEL_RENDER_ORDER = 10;

--- a/viewer/src/directionVectors.test.ts
+++ b/viewer/src/directionVectors.test.ts
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 import { describe, expect, it } from "vitest";
 import {
+  centreIsPlaceable,
   DIRECTION_VECTOR_COLORS,
   type DirectionVector,
   type DirectionVectorKind,
@@ -209,5 +210,36 @@ describe("resolveDirectionVectors", () => {
     });
     expect(find(vectors, "sun").color).toBe(DIRECTION_VECTOR_COLORS.sun);
     expect(find(vectors, "nadir").color).toBe(DIRECTION_VECTOR_COLORS.nadir);
+  });
+});
+
+describe("centreIsPlaceable", () => {
+  it("answers for the position, and says no to the ones that carry no direction", () => {
+    expect(centreIsPlaceable([7000, 0, 0])).toBe(true);
+    expect(centreIsPlaceable(null)).toBe(false);
+    expect(centreIsPlaceable(undefined)).toBe(false);
+    expect(centreIsPlaceable([0, 0, 0])).toBe(false);
+    expect(centreIsPlaceable([Number.NaN, 0, 0])).toBe(false);
+    expect(centreIsPlaceable([Number.POSITIVE_INFINITY, 0, 0])).toBe(false);
+    // Each component is finite while the sum of their squares is not, so a length
+    // check that only rejected non-finite components would let this through.
+    expect(centreIsPlaceable([1e200, 1e200, 1e200])).toBe(false);
+  });
+
+  it("cannot be answered by the Sun, which needs no position", () => {
+    // The question the caller asks is whether the *scene* will draw anything at
+    // this centre, and the scene drops every arrow at one it cannot place. Asking
+    // `resolveDirectionVectors` for the drawable set instead answers yes here, on
+    // the strength of an arrow that never needed the position — so a control would
+    // stay on offer over a scene that draws nothing.
+    const unusable: Vec3 = [0, 0, 0];
+    const withSun = resolveDirectionVectors({
+      frame: { kind: "inertial", origin: null },
+      sunDisplay: [1, 0, 0],
+      positionEci: unusable,
+      options: { nadir: true },
+    });
+    expect(withSun.map((v) => v.kind)).toEqual(["sun"]);
+    expect(centreIsPlaceable(unusable)).toBe(false);
   });
 });

--- a/viewer/src/directionVectors.test.ts
+++ b/viewer/src/directionVectors.test.ts
@@ -1,13 +1,14 @@
 import * as THREE from "three";
 import { describe, expect, it } from "vitest";
 import {
-  centreIsPlaceable,
   DIRECTION_VECTOR_COLORS,
   type DirectionVector,
   type DirectionVectorKind,
+  drawableAtCentre,
   resolveDirectionVectors,
 } from "./directionVectors.js";
 import { type DisplayFrame, displayDirection, type Vec3 } from "./displayFrame.js";
+import { centrePositionIsUsable } from "./frameResolve.js";
 import { computeLvlhAxes } from "./sceneFrame.js";
 
 const MU = 398600.4418;
@@ -213,33 +214,56 @@ describe("resolveDirectionVectors", () => {
   });
 });
 
-describe("centreIsPlaceable", () => {
-  it("answers for the position, and says no to the ones that carry no direction", () => {
-    expect(centreIsPlaceable([7000, 0, 0])).toBe(true);
-    expect(centreIsPlaceable(null)).toBe(false);
-    expect(centreIsPlaceable(undefined)).toBe(false);
-    expect(centreIsPlaceable([0, 0, 0])).toBe(false);
-    expect(centreIsPlaceable([Number.NaN, 0, 0])).toBe(false);
-    expect(centreIsPlaceable([Number.POSITIVE_INFINITY, 0, 0])).toBe(false);
-    // Each component is finite while the sum of their squares is not, so a length
-    // check that only rejected non-finite components would let this through.
-    expect(centreIsPlaceable([1e200, 1e200, 1e200])).toBe(false);
+describe("drawableAtCentre", () => {
+  it("offers both arrows at an ordinary centre, and neither without a Sun", () => {
+    expect(drawableAtCentre({ positionEci: [7000, 0, 0], sunIsComputable: true })).toEqual([
+      "sun",
+      "nadir",
+    ]);
+    expect(drawableAtCentre({ positionEci: [7000, 0, 0], sunIsComputable: false })).toEqual([
+      "nadir",
+    ]);
   });
 
-  it("cannot be answered by the Sun, which needs no position", () => {
-    // The question the caller asks is whether the *scene* will draw anything at
-    // this centre, and the scene drops every arrow at one it cannot place. Asking
-    // `resolveDirectionVectors` for the drawable set instead answers yes here, on
-    // the strength of an arrow that never needed the position — so a control would
-    // stay on offer over a scene that draws nothing.
-    const unusable: Vec3 = [0, 0, 0];
-    const withSun = resolveDirectionVectors({
-      frame: { kind: "inertial", origin: null },
-      sunDisplay: [1, 0, 0],
-      positionEci: unusable,
-      options: { nadir: true },
-    });
-    expect(withSun.map((v) => v.kind)).toEqual(["sun"]);
-    expect(centreIsPlaceable(unusable)).toBe(false);
+  it("keeps the Sun at a centre on the coordinate origin, and drops only nadir", () => {
+    // The scene places any finite centre, the origin included: the spacecraft is
+    // drawn there and lit from the Sun's direction, and it is nadir alone that has
+    // no bearing to take. Answering "nothing" here would disable a Sun toggle over
+    // a Sun that is on screen.
+    expect(drawableAtCentre({ positionEci: [0, 0, 0], sunIsComputable: true })).toEqual(["sun"]);
+    // Each component finite while the sum of their squares is not — normalising
+    // divides by an infinite length, so nadir goes the same way as at the origin.
+    expect(drawableAtCentre({ positionEci: [1e200, 1e200, 1e200], sunIsComputable: true })).toEqual(
+      ["sun"],
+    );
+  });
+
+  it("offers nothing at a centre the scene cannot place", () => {
+    // `resolveSceneFrame` refuses a non-finite position, and the scene then draws
+    // no arrow at all — not even the Sun, which needs no position of its own. That
+    // is why the placement question is asked before the resolver.
+    for (const positionEci of [
+      null,
+      undefined,
+      [Number.NaN, 0, 0],
+      [Number.POSITIVE_INFINITY, 0, 0],
+    ] as (Vec3 | null | undefined)[]) {
+      expect(drawableAtCentre({ positionEci, sunIsComputable: true })).toEqual([]);
+    }
+  });
+
+  it("agrees with the frame resolver about which centres are placeable", () => {
+    // The two must not drift: a UI stricter than the frame disables controls over a
+    // scene that draws, and a laxer one offers arrows the scene drops.
+    for (const position of [
+      [7000, 0, 0],
+      [0, 0, 0],
+      [1e200, 1e200, 1e200],
+      [Number.NaN, 0, 0],
+    ] as Vec3[]) {
+      const placeable = centrePositionIsUsable(position);
+      const kinds = drawableAtCentre({ positionEci: position, sunIsComputable: true });
+      expect(kinds.length > 0).toBe(placeable);
+    }
   });
 });

--- a/viewer/src/directionVectors.test.ts
+++ b/viewer/src/directionVectors.test.ts
@@ -226,16 +226,11 @@ describe("drawableAtCentre", () => {
   });
 
   it("keeps the Sun at a centre on the coordinate origin, and drops only nadir", () => {
-    // The scene places any finite centre, the origin included: the spacecraft is
-    // drawn there and lit from the Sun's direction, and it is nadir alone that has
-    // no bearing to take. Answering "nothing" here would disable a Sun toggle over
-    // a Sun that is on screen.
+    // The scene places a centre it can put at the origin, which the coordinate
+    // origin is: the spacecraft is drawn there and lit from the Sun's direction,
+    // and it is nadir alone that has no bearing to take. Answering "nothing" here
+    // would disable a Sun toggle over a Sun that is on screen.
     expect(drawableAtCentre({ positionEci: [0, 0, 0], sunIsComputable: true })).toEqual(["sun"]);
-    // Each component finite while the sum of their squares is not — normalising
-    // divides by an infinite length, so nadir goes the same way as at the origin.
-    expect(drawableAtCentre({ positionEci: [1e200, 1e200, 1e200], sunIsComputable: true })).toEqual(
-      ["sun"],
-    );
   });
 
   it("offers nothing at a centre the scene cannot place", () => {
@@ -247,6 +242,12 @@ describe("drawableAtCentre", () => {
       undefined,
       [Number.NaN, 0, 0],
       [Number.POSITIVE_INFINITY, 0, 0],
+      // Finite as doubles, and past what the renderer's float32 offset can hold —
+      // the scene cannot place the spacecraft, so nothing is drawn beside it.
+      [1e200, 1e200, 1e200],
+      [1e100, 0, 0],
+      // Each component inside float32 while the length is not.
+      [3e38, 3e38, 0],
     ] as (Vec3 | null | undefined)[]) {
       expect(drawableAtCentre({ positionEci, sunIsComputable: true })).toEqual([]);
     }
@@ -259,6 +260,7 @@ describe("drawableAtCentre", () => {
       [7000, 0, 0],
       [0, 0, 0],
       [1e200, 1e200, 1e200],
+      [3e38, 3e38, 0],
       [Number.NaN, 0, 0],
     ] as Vec3[]) {
       const placeable = centrePositionIsUsable(position);

--- a/viewer/src/directionVectors.test.ts
+++ b/viewer/src/directionVectors.test.ts
@@ -215,7 +215,7 @@ describe("resolveDirectionVectors", () => {
 });
 
 describe("drawableAtCentre", () => {
-  it("offers both arrows at an ordinary centre, and neither without a Sun", () => {
+  it("offers both arrows at an ordinary centre, and nadir alone without a Sun", () => {
     expect(drawableAtCentre({ positionEci: [7000, 0, 0], sunIsComputable: true })).toEqual([
       "sun",
       "nadir",

--- a/viewer/src/directionVectors.test.ts
+++ b/viewer/src/directionVectors.test.ts
@@ -231,6 +231,11 @@ describe("drawableAtCentre", () => {
     // and it is nadir alone that has no bearing to take. Answering "nothing" here
     // would disable a Sun toggle over a Sun that is on screen.
     expect(drawableAtCentre({ positionEci: [0, 0, 0], sunIsComputable: true })).toEqual(["sun"]);
+    // Same outcome for a length that overflows: the frame places the spacecraft,
+    // and it is normalising the bearing that fails.
+    expect(drawableAtCentre({ positionEci: [1e200, 1e200, 1e200], sunIsComputable: true })).toEqual(
+      ["sun"],
+    );
   });
 
   it("offers nothing at a centre the scene cannot place", () => {
@@ -242,12 +247,6 @@ describe("drawableAtCentre", () => {
       undefined,
       [Number.NaN, 0, 0],
       [Number.POSITIVE_INFINITY, 0, 0],
-      // Finite as doubles, and past what the renderer's float32 offset can hold —
-      // the scene cannot place the spacecraft, so nothing is drawn beside it.
-      [1e200, 1e200, 1e200],
-      [1e100, 0, 0],
-      // Each component inside float32 while the length is not.
-      [3e38, 3e38, 0],
     ] as (Vec3 | null | undefined)[]) {
       expect(drawableAtCentre({ positionEci, sunIsComputable: true })).toEqual([]);
     }
@@ -260,7 +259,6 @@ describe("drawableAtCentre", () => {
       [7000, 0, 0],
       [0, 0, 0],
       [1e200, 1e200, 1e200],
-      [3e38, 3e38, 0],
       [Number.NaN, 0, 0],
     ] as Vec3[]) {
       const placeable = centrePositionIsUsable(position);

--- a/viewer/src/directionVectors.ts
+++ b/viewer/src/directionVectors.ts
@@ -14,6 +14,7 @@
  * no position means no nadir.
  */
 
+import { centrePositionIsUsable } from "./frameResolve.js";
 import {
   type DisplayFrame,
   type DisplayRotationFrame,
@@ -130,26 +131,33 @@ export function resolveDirectionVectors({
 }
 
 /**
- * Whether a scene centred on this spacecraft can place it at all.
+ * Which arrows the orbit view would draw at a spacecraft it is centred on.
  *
- * The orbit view drops every arrow at a centre whose position its frame cannot
- * use, so a control that offers one there offers an arrow the scene then drops.
- * The Sun is the case that needs saying: it has no position of its own, and would
- * otherwise stay on offer beside a spacecraft that is not on screen.
+ * Two conditions in order, because they fail differently. The scene draws nothing
+ * at all at a centre it cannot place, and the Sun is why that has to be said
+ * first: it needs no position of its own, so it would otherwise stay on offer
+ * beside a spacecraft that is not on screen. Placing a centre asks
+ * {@link centrePositionIsUsable} — the renderer's own condition, so this cannot
+ * answer more strictly than the scene draws. A centre at the coordinate origin is
+ * placeable: the spacecraft is drawn there and the Sun with it, and only nadir
+ * drops out, having no bearing to take.
  *
- * Asked of the resolver rather than derived from "a position is present": a
- * position can be there and still yield no direction — zero, or non-finite from a
- * file source. Nadir is the arrow that needs the position, so whether it resolves
- * is the whole question, and this takes no Sun input so the answer cannot come
- * from one. The frame decides where a direction points, not whether it resolves,
- * so the inertial one stands in.
+ * Then the arrows themselves, from the resolver both scenes use, so a control
+ * cannot offer one the scene goes on to drop. The frame decides where a direction
+ * points rather than whether it resolves, so the inertial one stands in.
  */
-export function centreIsPlaceable(positionEci: Vec3 | null | undefined): boolean {
-  return (
-    resolveDirectionVectors({
-      frame: { kind: "inertial", origin: null },
-      positionEci,
-      options: { nadir: true },
-    }).length > 0
-  );
+export function drawableAtCentre(inputs: {
+  positionEci: Vec3 | null | undefined;
+  /** Whether the scene can compute a Sun direction at all — an epoch, and a body arika can place. */
+  sunIsComputable: boolean;
+}): readonly DirectionVectorKind[] {
+  if (!centrePositionIsUsable(inputs.positionEci)) return [];
+  return resolveDirectionVectors({
+    frame: { kind: "inertial", origin: null },
+    // A stand-in: only whether a Sun direction exists changes the answer, never
+    // which way it points.
+    sunDisplay: inputs.sunIsComputable ? [1, 0, 0] : null,
+    positionEci: inputs.positionEci,
+    options: { sun: true, nadir: true },
+  }).map((v) => v.kind);
 }

--- a/viewer/src/directionVectors.ts
+++ b/viewer/src/directionVectors.ts
@@ -14,13 +14,13 @@
  * no position means no nadir.
  */
 
-import { centrePositionIsUsable } from "./frameResolve.js";
 import {
   type DisplayFrame,
   type DisplayRotationFrame,
   displayDirection,
   type Vec3,
 } from "./displayFrame.js";
+import { centrePositionIsUsable } from "./frameResolve.js";
 
 /** Which reference direction an arrow shows. */
 export type DirectionVectorKind = "sun" | "nadir";

--- a/viewer/src/directionVectors.ts
+++ b/viewer/src/directionVectors.ts
@@ -128,3 +128,28 @@ export function resolveDirectionVectors({
 
   return vectors;
 }
+
+/**
+ * Whether a scene centred on this spacecraft can place it at all.
+ *
+ * The orbit view drops every arrow at a centre whose position its frame cannot
+ * use, so a control that offers one there offers an arrow the scene then drops.
+ * The Sun is the case that needs saying: it has no position of its own, and would
+ * otherwise stay on offer beside a spacecraft that is not on screen.
+ *
+ * Asked of the resolver rather than derived from "a position is present": a
+ * position can be there and still yield no direction — zero, or non-finite from a
+ * file source. Nadir is the arrow that needs the position, so whether it resolves
+ * is the whole question, and this takes no Sun input so the answer cannot come
+ * from one. The frame decides where a direction points, not whether it resolves,
+ * so the inertial one stands in.
+ */
+export function centreIsPlaceable(positionEci: Vec3 | null | undefined): boolean {
+  return (
+    resolveDirectionVectors({
+      frame: { kind: "inertial", origin: null },
+      positionEci,
+      options: { nadir: true },
+    }).length > 0
+  );
+}

--- a/viewer/src/frameResolve.ts
+++ b/viewer/src/frameResolve.ts
@@ -51,16 +51,27 @@ export interface SceneFrameContext {
 /**
  * Whether a spacecraft's position can centre the scene on it.
  *
- * A non-finite component is no position: it would put the origin offset and the
- * camera's up vector at NaN, which blanks the canvas. Everything finite is
- * usable, zero included — the centred spacecraft is drawn at the origin whatever
- * its coordinates, and only the directions that need a *bearing* from it drop
- * out. The UI asks this so a control cannot be disabled over a scene that draws.
+ * Two ways to fail, and both blank the canvas rather than draw something wrong. A
+ * non-finite component puts the origin offset and the camera's up vector at NaN.
+ * And the offset reaches the renderer as float32, where anything past 3.4e38 is
+ * `Infinity`: `[1e100, 0, 0]` is a perfectly good double and no place to put a
+ * spacecraft. What the matrix carries is the distance rather than the components,
+ * so that is what is measured — `[3e38, 3e38, 0]` has both components inside
+ * float32 and a length of 4.24e38 that is not, and a per-component check passes
+ * it. The same test guards the camera in `usablePosition`.
+ *
+ * Zero is usable, which is where this parts company with the camera's version: a
+ * spacecraft at the body's centre is drawn at the origin like any other centre,
+ * and only the directions needing a *bearing* from it drop out. The UI asks this
+ * so a control cannot be disabled over a scene that draws.
  */
 export function centrePositionIsUsable(
   position: readonly number[] | null | undefined,
 ): position is readonly number[] {
-  return position != null && position.length === 3 && position.every(Number.isFinite);
+  if (position == null || position.length !== 3) return false;
+  const [x, y, z] = position;
+  if (!(Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z))) return false;
+  return Number.isFinite(Math.fround(Math.hypot(x, y, z)));
 }
 
 export function resolveSceneFrame(

--- a/viewer/src/frameResolve.ts
+++ b/viewer/src/frameResolve.ts
@@ -48,6 +48,21 @@ export interface SceneFrameContext {
   cameraTracking: boolean;
 }
 
+/**
+ * Whether a spacecraft's position can centre the scene on it.
+ *
+ * A non-finite component is no position: it would put the origin offset and the
+ * camera's up vector at NaN, which blanks the canvas. Everything finite is
+ * usable, zero included — the centred spacecraft is drawn at the origin whatever
+ * its coordinates, and only the directions that need a *bearing* from it drop
+ * out. The UI asks this so a control cannot be disabled over a scene that draws.
+ */
+export function centrePositionIsUsable(
+  position: readonly number[] | null | undefined,
+): position is readonly number[] {
+  return position != null && position.length === 3 && position.every(Number.isFinite);
+}
+
 export function resolveSceneFrame(
   frame: ReferenceFrame,
   getEntity: FrameEntityLookup,
@@ -66,11 +81,9 @@ export function resolveSceneFrame(
 
   const id = frame.center.id;
   const state = getEntity(id);
-  // A non-finite position is no position: it cannot centre the scene, and passing
-  // it on would put the origin offset and the camera's up vector at NaN, which
-  // blanks the canvas. Treated like a state that has not arrived — the entity is
-  // still the centre, so the camera stays put until a usable sample lands.
-  if (state == null || !state.position.every(Number.isFinite)) {
+  // Treated like a state that has not arrived — the entity is still the centre,
+  // so the camera stays put until a usable sample lands.
+  if (state == null || !centrePositionIsUsable(state.position)) {
     return { ...inert, centeredSatId: id };
   }
 

--- a/viewer/src/frameResolve.ts
+++ b/viewer/src/frameResolve.ts
@@ -51,14 +51,20 @@ export interface SceneFrameContext {
 /**
  * Whether a spacecraft's position can centre the scene on it.
  *
- * Two ways to fail, and both blank the canvas rather than draw something wrong. A
- * non-finite component puts the origin offset and the camera's up vector at NaN.
- * And the offset reaches the renderer as float32, where anything past 3.4e38 is
- * `Infinity`: `[1e100, 0, 0]` is a perfectly good double and no place to put a
- * spacecraft. What the matrix carries is the distance rather than the components,
- * so that is what is measured — `[3e38, 3e38, 0]` has both components inside
- * float32 and a length of 4.24e38 that is not, and a per-component check passes
- * it. The same test guards the camera in `usablePosition`.
+ * Two ways to fail, and either would blank the canvas if the position were
+ * applied. A non-finite component puts the origin offset and the camera's up
+ * vector at NaN. And the offset reaches the renderer as float32, where anything
+ * past 3.4e38 is `Infinity`: `[1e100, 0, 0]` is a perfectly good double and no
+ * place to put a spacecraft. What the matrix carries is the distance rather than
+ * the components, so that is what is measured — `[3e38, 3e38, 0]` has both
+ * components inside float32 and a length of 4.24e38 that is not, and a
+ * per-component check passes it. The same test guards the camera in
+ * `usablePosition`.
+ *
+ * Answering false is how the blanking is avoided rather than a report of it:
+ * `resolveSceneFrame` then keeps the entity as the centre with no origin, which
+ * is how it holds a state that has not arrived, and the camera stays where it is
+ * until a usable sample lands.
  *
  * Zero is usable, which is where this parts company with the camera's version: a
  * spacecraft at the body's centre is drawn at the origin like any other centre,

--- a/viewer/src/frameResolve.ts
+++ b/viewer/src/frameResolve.ts
@@ -51,33 +51,27 @@ export interface SceneFrameContext {
 /**
  * Whether a spacecraft's position can centre the scene on it.
  *
- * Two ways to fail, and either would blank the canvas if the position were
- * applied. A non-finite component puts the origin offset and the camera's up
- * vector at NaN. And the offset reaches the renderer as float32, where anything
- * past 3.4e38 is `Infinity`: `[1e100, 0, 0]` is a perfectly good double and no
- * place to put a spacecraft. What the matrix carries is the distance rather than
- * the components, so that is what is measured — `[3e38, 3e38, 0]` has both
- * components inside float32 and a length of 4.24e38 that is not, and a
- * per-component check passes it. The same test guards the camera in
- * `usablePosition`.
+ * A non-finite component is no position: it would put the origin offset and the
+ * camera's up vector at NaN. Everything finite is accepted, zero included — a
+ * spacecraft at the body's centre is drawn at the origin like any other centre,
+ * and only the directions needing a *bearing* from it drop out. The UI asks this
+ * so a control cannot be disabled over a scene that draws.
  *
- * Answering false is how the blanking is avoided rather than a report of it:
+ * Answering false is how the NaN is avoided rather than a report of it:
  * `resolveSceneFrame` then keeps the entity as the centre with no origin, which
  * is how it holds a state that has not arrived, and the camera stays where it is
  * until a usable sample lands.
  *
- * Zero is usable, which is where this parts company with the camera's version: a
- * spacecraft at the body's centre is drawn at the origin like any other centre,
- * and only the directions needing a *bearing* from it drop out. The UI asks this
- * so a control cannot be disabled over a scene that draws.
+ * The magnitude a float32 uniform can hold is deliberately not judged here.
+ * Positions reach the renderer divided by the scene's scale radius — itself the
+ * central body's radius over the amplification — so the limit lives in units this
+ * function is not given, and testing the kilometres would reject positions the
+ * renderer draws perfectly well. See #451, where the scale is in scope.
  */
 export function centrePositionIsUsable(
   position: readonly number[] | null | undefined,
 ): position is readonly number[] {
-  if (position == null || position.length !== 3) return false;
-  const [x, y, z] = position;
-  if (!(Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z))) return false;
-  return Number.isFinite(Math.fround(Math.hypot(x, y, z)));
+  return position != null && position.length === 3 && position.every(Number.isFinite);
 }
 
 export function resolveSceneFrame(

--- a/viewer/src/lib/AttitudeViewer.tsx
+++ b/viewer/src/lib/AttitudeViewer.tsx
@@ -1,15 +1,13 @@
-import { Canvas, useThree } from "@react-three/fiber";
-import { useEffect, useRef } from "react";
-import { PerspectiveCamera } from "three";
+import { Canvas } from "@react-three/fiber";
 import { usableDirection, usablePosition, usableProjection } from "../cameraProps.js";
 import { CameraViewProbe } from "../components/CameraViewProbe.js";
 import { FarPlaneBeyondScene } from "../components/FarPlaneBeyondScene.js";
+import { InitialCameraFit } from "../components/InitialCameraFit.js";
 import { SCENE_UP } from "../sceneFrame.js";
 import {
   cameraDistanceForSpan,
   DEFAULT_CAMERA_FOV_DEGREES,
   drawnExtentForSpan,
-  initialCameraDistance,
   NOMINAL_SPACECRAFT_SPAN,
   usableFovDegrees,
 } from "../spacecraftScale.js";
@@ -32,60 +30,6 @@ const DEFAULT_CAMERA_POSITION: [number, number, number] = (() => {
   const d = cameraDistanceForSpan(NOMINAL_SPACECRAFT_SPAN, DEFAULT_FOV);
   return [CAMERA_DIRECTION[0] * d, CAMERA_DIRECTION[1] * d, CAMERA_DIRECTION[2] * d];
 })();
-
-/**
- * Choose the camera's distance once the canvas has a size, pulling it back if the
- * viewport is narrower than the default framing assumed.
- *
- * The `camera` prop is read at mount, before the canvas has a size, so a portrait
- * embedding would otherwise clip the axes sideways. Applied on the first sizing
- * only: reframing on every resize would undo a zoom the viewer had chosen, and
- * this is a starting view, not a constraint.
- *
- * `reframe` says whether that distance is ours to choose at all. The depth range
- * is not this component's: a caller's position of `[200, 0, 0]` with the default
- * `far` of 100, and a viewer dollying out past it, are the same problem — the
- * scene at the origin falls behind the far plane and the canvas goes blank — and
- * `FarPlaneBeyondScene`, in the scene itself, holds that invariant for as long as
- * the scene is mounted.
- */
-function InitialCameraFit({ fov, reframe }: { fov: number; reframe: boolean }) {
-  const camera = useThree((s) => s.camera);
-  const size = useThree((s) => s.size);
-  const applied = useRef(false);
-  useEffect(() => {
-    if (applied.current || size.width === 0 || size.height === 0) return;
-    applied.current = true;
-    // A `zoom` narrows the field of view, so fit the *effective* one — a camera
-    // framed for 50° and zoomed 2× sees half as much and would clip.
-    const effectiveFov = camera instanceof PerspectiveCamera ? camera.getEffectiveFOV() : fov;
-    // A `near` from the camera prop can also sit past the scene, which frames it
-    // correctly and draws none of it, so the distance clears that plane too.
-    const needed = initialCameraDistance(
-      NOMINAL_SPACECRAFT_SPAN,
-      effectiveFov,
-      size.width / size.height,
-      camera instanceof PerspectiveCamera ? camera.near : 0,
-    );
-    const current = camera.position.length();
-    // The distance the fit asks for goes through the same check a caller's
-    // position does, in the same precision: the view matrix carries it to WebGL
-    // as float32, so past 3.4e38 the camera is somewhere the renderer cannot
-    // place it and the canvas is blank. A narrow effective field of view asks for
-    // exactly that — a `zoom` of 1e38 leaves 5.3e-37° and fits from 6.5e38 spans
-    // away. The camera keeps the framing it was built with instead, which is
-    // drawable at any zoom.
-    const placeable = Number.isFinite(Math.fround(needed));
-    if (reframe && placeable && current > 0 && needed > current) {
-      camera.position.multiplyScalar(needed / current);
-    }
-    // The far plane is not settled here. A narrow field of view fits from far
-    // away — 1° needs some 345 spans — and so does a viewer dollying out, so the
-    // scene keeps the plane beyond itself for as long as it is mounted rather
-    // than once at this moment. See `FarPlaneBeyondScene`.
-  }, [camera, size, fov, reframe]);
-  return null;
-}
 
 /**
  * Embeddable attitude viewer.

--- a/viewer/src/spacecraftScale.ts
+++ b/viewer/src/spacecraftScale.ts
@@ -254,6 +254,18 @@ const ARROW_LABEL_OVERSHOOT = 0.14;
 /** Name height as a fraction of the spacecraft's apparent size. */
 const ARROW_LABEL_SCALE = 0.22;
 
+/**
+ * Widest a name is drawn, as a multiple of its height.
+ *
+ * The texture is as wide as the text needs, so the sprite is not square the way
+ * an axis letter's is: measured in a browser, "Sun" comes out at 1.70 and
+ * "Nadir" at 2.22 times its height. The bound is what the camera fit has to
+ * assume, since the width depends on the font the browser resolves; it is here
+ * rather than in the label module because this file is the pure one, and it is
+ * generous enough for a longer name to be added without clipping.
+ */
+const ARROW_LABEL_MAX_ASPECT = 2.5;
+
 /** Distance from the arrow's tail group to where its name is drawn. */
 export function arrowLabelDistance(geometry: ArrowGeometry): number {
   return geometry.startOffset + geometry.length * (1 + ARROW_LABEL_OVERSHOOT);
@@ -262,6 +274,18 @@ export function arrowLabelDistance(geometry: ArrowGeometry): number {
 /** Name height in scene units for a spacecraft of this apparent size. */
 export function arrowLabelHeight(span: number): number {
   return span * ARROW_LABEL_SCALE;
+}
+
+/**
+ * How far a name reaches from where it is placed.
+ *
+ * Half the sprite's diagonal: it faces the camera, so its width lies across the
+ * view rather than along the arrow, and the framing has to hold it whichever way
+ * the reader has turned the scene.
+ */
+export function arrowLabelReach(span: number): number {
+  const height = arrowLabelHeight(span);
+  return (height * Math.hypot(ARROW_LABEL_MAX_ASPECT, 1)) / 2;
 }
 
 /**
@@ -275,7 +299,7 @@ export function drawnExtentForSpan(span: number): number {
   // The widest marker decides, so the framing holds whichever shape is drawn.
   const arrow = arrowGeometryForSpan(span, markerBoundingRadius("axes-cube", span));
   // Each arrow's name sits past its tip, as each axis letter sits past its own.
-  const arrowReach = arrowLabelDistance(arrow) + arrowLabelHeight(span) / 2;
+  const arrowReach = arrowLabelDistance(arrow) + arrowLabelReach(span);
   return Math.max(axisLabelExtent(frameAxisLengthForSpan(span)), arrowReach);
 }
 

--- a/viewer/src/spacecraftScale.ts
+++ b/viewer/src/spacecraftScale.ts
@@ -246,6 +246,25 @@ export function usableFovDegrees(fovDegrees: number | undefined): number {
 const VIEW_MARGIN = 1.15;
 
 /**
+ * How far past an arrow's tip its name sits, as a fraction of the arrow's length.
+ * On the tip the text overlaps the head it names.
+ */
+const ARROW_LABEL_OVERSHOOT = 0.14;
+
+/** Name height as a fraction of the spacecraft's apparent size. */
+const ARROW_LABEL_SCALE = 0.22;
+
+/** Distance from the arrow's tail group to where its name is drawn. */
+export function arrowLabelDistance(geometry: ArrowGeometry): number {
+  return geometry.startOffset + geometry.length * (1 + ARROW_LABEL_OVERSHOOT);
+}
+
+/** Name height in scene units for a spacecraft of this apparent size. */
+export function arrowLabelHeight(span: number): number {
+  return span * ARROW_LABEL_SCALE;
+}
+
+/**
  * Distance from the origin to the furthest thing drawn around the spacecraft:
  * whichever reaches further, the reference-frame triad or a direction arrow's tip.
  *
@@ -255,7 +274,9 @@ const VIEW_MARGIN = 1.15;
 export function drawnExtentForSpan(span: number): number {
   // The widest marker decides, so the framing holds whichever shape is drawn.
   const arrow = arrowGeometryForSpan(span, markerBoundingRadius("axes-cube", span));
-  return Math.max(axisLabelExtent(frameAxisLengthForSpan(span)), arrow.startOffset + arrow.length);
+  // Each arrow's name sits past its tip, as each axis letter sits past its own.
+  const arrowReach = arrowLabelDistance(arrow) + arrowLabelHeight(span) / 2;
+  return Math.max(axisLabelExtent(frameAxisLengthForSpan(span)), arrowReach);
 }
 
 /**

--- a/viewer/src/styles/base.css
+++ b/viewer/src/styles/base.css
@@ -31,6 +31,18 @@ canvas {
   overflow: hidden;
 }
 
+/* Shown instead of the scene when the chosen view has nothing to draw. */
+.scene-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--orts-text-secondary);
+  font-size: var(--orts-font-size-md);
+  pointer-events: none;
+}
+
 /* === Drop overlay === */
 .drop-overlay {
   position: fixed;

--- a/viewer/src/styles/controls.module.css
+++ b/viewer/src/styles/controls.module.css
@@ -47,12 +47,19 @@
  * direction switched on whose scene cannot draw it, which is the app's default
  * state for the Sun before a satellite is centred — would otherwise read as
  * unselected for as long as the pointer sat on it.
+ *
+ * Both spellings, matching the rule above. `:hover` still applies to a natively
+ * disabled button, so leaving it out would dim such a button and then recolour it
+ * under the pointer. No toggle uses the native attribute today; what this fixes is
+ * the two rules covering different sets.
  */
+.modeToggleBtn:disabled:hover,
 .modeToggleBtn[aria-disabled="true"]:hover {
   background: var(--orts-toggle-inactive-bg);
   color: var(--orts-text-secondary);
 }
 
+.modeToggleBtn.active:disabled:hover,
 .modeToggleBtn.active[aria-disabled="true"]:hover {
   background: var(--orts-toggle-active-bg);
   color: #fff;

--- a/viewer/src/styles/controls.module.css
+++ b/viewer/src/styles/controls.module.css
@@ -40,8 +40,20 @@
   cursor: not-allowed;
 }
 
-/* The hover styling would otherwise suggest the button can be pressed. */
+/*
+ * Hover leaves an unavailable segment looking exactly as it did: the hover
+ * styling would otherwise suggest the button can be pressed. Each state restores
+ * its own resting colours, because a selected-but-unavailable segment — a
+ * direction switched on whose scene cannot draw it, which is the app's default
+ * state for the Sun before a satellite is centred — would otherwise read as
+ * unselected for as long as the pointer sat on it.
+ */
 .modeToggleBtn[aria-disabled="true"]:hover {
   background: var(--orts-toggle-inactive-bg);
   color: var(--orts-text-secondary);
+}
+
+.modeToggleBtn.active[aria-disabled="true"]:hover {
+  background: var(--orts-toggle-active-bg);
+  color: #fff;
 }

--- a/viewer/src/styles/controls.module.css
+++ b/viewer/src/styles/controls.module.css
@@ -29,7 +29,19 @@
   color: #fff;
 }
 
-.modeToggleBtn:disabled {
+/*
+ * Unavailable, by either spelling. `aria-disabled` is what the toggles use, so
+ * that the button still takes hover and focus and can explain itself; `:disabled`
+ * stays for anything that has no explanation to give.
+ */
+.modeToggleBtn:disabled,
+.modeToggleBtn[aria-disabled="true"] {
   opacity: 0.35;
   cursor: not-allowed;
+}
+
+/* The hover styling would otherwise suggest the button can be pressed. */
+.modeToggleBtn[aria-disabled="true"]:hover {
+  background: var(--orts-toggle-inactive-bg);
+  color: var(--orts-text-secondary);
 }

--- a/viewer/src/utils/urlParams.test.ts
+++ b/viewer/src/utils/urlParams.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { readTimeRangeParam, writeTimeRangeParam } from "./urlParams.js";
+import {
+  readTimeRangeParam,
+  readViewParam,
+  writeTimeRangeParam,
+  writeViewParam,
+} from "./urlParams.js";
 
 describe("readTimeRangeParam", () => {
   beforeEach(() => {
@@ -90,5 +95,56 @@ describe("writeTimeRangeParam", () => {
     writeTimeRangeParam(300);
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
+  });
+});
+
+describe("view param", () => {
+  beforeEach(() => {
+    history.replaceState(null, "", "/");
+  });
+
+  it("defaults to the orbit view", () => {
+    expect(readViewParam()).toBe("orbit");
+    history.replaceState(null, "", "/?view=");
+    expect(readViewParam()).toBe("orbit");
+  });
+
+  it("reads the attitude view", () => {
+    history.replaceState(null, "", "/?view=attitude");
+    expect(readViewParam()).toBe("attitude");
+  });
+
+  it("falls back to the orbit view for an unrecognised value", () => {
+    // A hand-edited or stale link must land somewhere, and the orbit view is
+    // what the app opens with.
+    history.replaceState(null, "", "/?view=spin");
+    expect(readViewParam()).toBe("orbit");
+    history.replaceState(null, "", "/?view=ATTITUDE");
+    expect(readViewParam()).toBe("orbit");
+  });
+
+  it("round-trips through the URL", () => {
+    writeViewParam("attitude");
+    expect(window.location.search).toContain("view=attitude");
+    expect(readViewParam()).toBe("attitude");
+    writeViewParam("orbit");
+    expect(window.location.search).not.toContain("view");
+    expect(readViewParam()).toBe("orbit");
+  });
+
+  it("leaves the other view params alone", () => {
+    // Both writers rebuild the query string, so each has to preserve what the
+    // other put there.
+    history.replaceState(null, "", "/?timeRange=300&satShape=axes-cube");
+    writeViewParam("attitude");
+    expect(readTimeRangeParam()).toBe(300);
+    expect(window.location.search).toContain("satShape=axes-cube");
+
+    writeTimeRangeParam(600);
+    expect(readViewParam()).toBe("attitude");
+
+    writeViewParam("orbit");
+    expect(readTimeRangeParam()).toBe(600);
+    expect(window.location.search).toContain("satShape=axes-cube");
   });
 });

--- a/viewer/src/utils/urlParams.ts
+++ b/viewer/src/utils/urlParams.ts
@@ -13,6 +13,29 @@ export function readTimeRangeParam(): TimeRange {
   return n;
 }
 
+/** Read the `view` query parameter. Anything unrecognised means the orbit view. */
+export function readViewParam(): "orbit" | "attitude" {
+  const raw = new URLSearchParams(window.location.search).get("view");
+  return raw === "attitude" ? "attitude" : "orbit";
+}
+
+/**
+ * Write the `view` value into the URL query string, so a link or a reload keeps
+ * the presentation. Uses `history.replaceState`, like the other view params, so
+ * no browser history entry is created.
+ */
+export function writeViewParam(view: "orbit" | "attitude"): void {
+  const params = new URLSearchParams(window.location.search);
+  if (view === "orbit") params.delete("view");
+  else params.set("view", view);
+  const qs = params.toString();
+  history.replaceState(
+    null,
+    "",
+    qs ? `${window.location.pathname}?${qs}` : window.location.pathname,
+  );
+}
+
 /**
  * Write the `timeRange` value into the URL query string.
  * Uses `history.replaceState` so no browser history entry is created.

--- a/viewer/tests/attitude-view.spec.ts
+++ b/viewer/tests/attitude-view.spec.ts
@@ -210,7 +210,9 @@ test("the attitude view drops the central body, the trails and the charts", asyn
   await expect(page.locator('[data-testid="time-series-chart"]')).toHaveCount(0);
 
   // The switch is recorded in the URL, so a reload or a shared link keeps it.
-  expect(page.url()).toContain("view=attitude");
+  // Waited for rather than read: the parameter is written by an effect, which is
+  // not ordered against the effects the scene assertions above waited on.
+  await expect(page).toHaveURL(/view=attitude/);
   await page.reload();
   await expect(page.locator('[data-testid="attitude-info"]')).toBeVisible();
   await connect(page);
@@ -224,7 +226,7 @@ test("the attitude view drops the central body, the trails and the charts", asyn
   await expect(page.locator('[data-testid="time-series-chart"]').first()).toBeVisible({
     timeout: 30000,
   });
-  expect(page.url()).not.toContain("view=attitude");
+  await expect(page).not.toHaveURL(/view=attitude/);
 });
 
 test("switching from a satellite-centred orbit view carries that satellite over", async ({

--- a/viewer/tests/attitude-view.spec.ts
+++ b/viewer/tests/attitude-view.spec.ts
@@ -344,3 +344,47 @@ test("turning an arrow off stops it being drawn", async ({ page }) => {
   await page.locator('[data-testid="direction-vector-sun"]').click();
   await expect.poll(async () => await kinds(), { timeout: 10000 }).toEqual(["nadir"]);
 });
+
+test("the app's own far plane follows the camera out of the attitude view", async ({ page }) => {
+  // The app configures this Canvas, so the far plane is the app's and keeping it
+  // beyond the spacecraft is the app's job — `AttitudeViewer` does it for the
+  // plane it chooses, and neither touches a plane an embedder chose. Without the
+  // mount, dollying out past 100 spans loses the whole scene at once, since the
+  // spacecraft sits at the origin.
+  await page.goto("/?noAutoConnect=1&view=attitude");
+  await connect(page);
+
+  const cameraView = async () =>
+    page.evaluate(() => {
+      const w = window as unknown as {
+        __debug_get_camera_view?: () => {
+          position: [number, number, number];
+          far: number;
+        } | null;
+      };
+      return w.__debug_get_camera_view?.() ?? null;
+    });
+
+  await expect.poll(async () => (await cameraView()) != null, { timeout: 15000 }).toBe(true);
+  const before = await cameraView();
+  if (before == null) throw new Error("no camera hook in the attitude view");
+
+  await page.locator("canvas").hover();
+  const distance = (p: readonly number[]) => Math.sqrt(p[0] ** 2 + p[1] ** 2 + p[2] ** 2);
+  await expect
+    .poll(
+      async () => {
+        for (let i = 0; i < 10; i++) await page.mouse.wheel(0, 240);
+        const view = await cameraView();
+        return view != null && distance(view.position) > before.far;
+      },
+      { timeout: 20000 },
+    )
+    .toBe(true);
+
+  const after = await cameraView();
+  if (after == null) throw new Error("the camera hook went away");
+  expect(after.far, "the far plane is still beyond the spacecraft").toBeGreaterThan(
+    distance(after.position),
+  );
+});

--- a/viewer/tests/attitude-view.spec.ts
+++ b/viewer/tests/attitude-view.spec.ts
@@ -45,25 +45,38 @@ function spawnServer(configFile: string): Promise<{ child: ChildProcess; port: n
   });
   return new Promise((resolve, reject) => {
     const rl = createInterface({ input: child.stderr ?? process.stdin });
+    const onError = (err: Error) => {
+      settle();
+      reject(err);
+    };
+    const onExit = (code: number | null) => {
+      settle();
+      reject(new Error(`orts exited with code ${code} before listening`));
+    };
     const timeout = setTimeout(() => {
-      rl.close();
+      settle();
       reject(new Error("Timed out waiting for orts server to start"));
     }, 30000);
+    /**
+     * Stop watching for the startup line. The readline interface stays attached
+     * on purpose: it is what drains the child's stderr, and a paused pipe fills
+     * up and blocks the server on its next log line.
+     */
+    function settle() {
+      clearTimeout(timeout);
+      rl.removeAllListeners("line");
+      child.off("error", onError);
+      child.off("exit", onExit);
+    }
     rl.on("line", (line) => {
       const match = line.match(/ws:\/\/localhost:(\d+)/);
       if (match) {
-        clearTimeout(timeout);
+        settle();
         resolve({ child, port: parseInt(match[1], 10) });
       }
     });
-    child.on("error", (err) => {
-      clearTimeout(timeout);
-      reject(err);
-    });
-    child.on("exit", (code) => {
-      clearTimeout(timeout);
-      reject(new Error(`orts exited with code ${code} before listening`));
-    });
+    child.on("error", onError);
+    child.on("exit", onExit);
   });
 }
 

--- a/viewer/tests/attitude-view.spec.ts
+++ b/viewer/tests/attitude-view.spec.ts
@@ -390,3 +390,15 @@ test("the app's own far plane follows the camera out of the attitude view", asyn
     distance(after.position),
   );
 });
+
+test("an attitude view with no spacecraft yet says so, rather than blaming one", async ({
+  page,
+}) => {
+  // Nothing is connected on this path, so no spacecraft has arrived at all. That
+  // is a different state from a spacecraft whose sample carries no attitude, and
+  // conflating them tells a reader watching a stream connect that the spacecraft
+  // they are waiting for has no attitude.
+  await page.goto("/?noAutoConnect=1&view=attitude");
+  await expect(page.locator('[data-testid="attitude-no-spacecraft"]')).toBeVisible();
+  await expect(page.locator('[data-testid="attitude-no-data"]')).toHaveCount(0);
+});

--- a/viewer/tests/attitude-view.spec.ts
+++ b/viewer/tests/attitude-view.spec.ts
@@ -55,6 +55,9 @@ function spawnServer(configFile: string): Promise<{ child: ChildProcess; port: n
     };
     const timeout = setTimeout(() => {
       settle();
+      // Nothing else will: `beforeAll` throws before it can record the child, so
+      // `afterAll` has nothing to kill and the server would outlive the run.
+      child.kill("SIGTERM");
       reject(new Error("Timed out waiting for orts server to start"));
     }, 30000);
     /**

--- a/viewer/tests/attitude-view.spec.ts
+++ b/viewer/tests/attitude-view.spec.ts
@@ -1,0 +1,305 @@
+/**
+ * E2E for the app's attitude view: the switch, what the view drops, and the
+ * rendered orientation in each display frame.
+ *
+ * The same reference attitude as `attitude-rendering.spec.ts` — a +90° rotation
+ * about the inertial Z axis on an equatorial circular orbit — so the invariants
+ * are the same ones, asserted in a scene that has no central body:
+ *
+ * - inertial: scene axes coincide with ECI, so the rendered body +X points along
+ *   scene +Y.
+ * - local-orbital: the basis is [in-track, cross-track, radial] = scene [X, Y, Z]
+ *   and the orbit is equatorial, so the cross-track axis is inertial +Z. The
+ *   attitude is a rotation *about* inertial Z, so the body +Z stays on inertial
+ *   +Z: the rendered body +Z points along scene +Y. Nadir is exactly scene -Z.
+ *
+ * Read from the live Three.js scene graph rather than from pixels, and stated as
+ * frame invariants rather than raw quaternions, so the ±q sign ambiguity and the
+ * camera framing cannot affect the result.
+ */
+import { type ChildProcess, spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
+import { expect, type Page, test } from "@playwright/test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const SAT_ID = "att-view";
+/** Entity path the viewer keys the satellite by (`/world/sat/{id}`). */
+const SAT_ENTITY_PATH = `/world/sat/${SAT_ID}`;
+
+/** sin(45°) = cos(45°): components of a +90° rotation quaternion. */
+const SQRT_HALF = Math.SQRT1_2;
+
+let ortsProcess: ChildProcess | undefined;
+let wsUrl: string;
+let configPath: string;
+
+function spawnServer(configFile: string): Promise<{ child: ChildProcess; port: number }> {
+  const binary = process.env.ORTS_BINARY ?? path.resolve(__dirname, "../../target/debug/orts");
+  const child = spawn(binary, ["serve", "--port", "0", "--config", configFile], {
+    env: { ...process.env, ORTS_DISABLE_TEXTURE_DOWNLOAD: "1" },
+  });
+  return new Promise((resolve, reject) => {
+    const rl = createInterface({ input: child.stderr ?? process.stdin });
+    const timeout = setTimeout(() => {
+      rl.close();
+      reject(new Error("Timed out waiting for orts server to start"));
+    }, 30000);
+    rl.on("line", (line) => {
+      const match = line.match(/ws:\/\/localhost:(\d+)/);
+      if (match) {
+        clearTimeout(timeout);
+        resolve({ child, port: parseInt(match[1], 10) });
+      }
+    });
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+    child.on("exit", (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`orts exited with code ${code} before listening`));
+    });
+  });
+}
+
+test.beforeAll(async () => {
+  const config = {
+    body: "earth",
+    dt: 1.0,
+    output_interval: 10,
+    satellites: [
+      {
+        id: SAT_ID,
+        name: "Attitude View Test",
+        orbit: { type: "circular", altitude: 500 },
+        attitude: {
+          mass: 500,
+          inertia_diag: [100, 100, 50],
+          initial_quaternion: [SQRT_HALF, 0, 0, SQRT_HALF],
+          initial_angular_velocity: [0, 0, 0],
+        },
+      },
+    ],
+  };
+  configPath = path.join(os.tmpdir(), `orts-attitude-view-e2e-${Date.now()}.json`);
+  fs.writeFileSync(configPath, JSON.stringify(config));
+
+  const { child, port } = await spawnServer(configPath);
+  ortsProcess = child;
+  wsUrl = `ws://localhost:${port}/ws`;
+  console.log(`orts attitude-view server started at ${wsUrl}`);
+});
+
+test.afterAll(async () => {
+  if (ortsProcess && !ortsProcess.killed) ortsProcess.kill("SIGTERM");
+  if (configPath) {
+    try {
+      fs.unlinkSync(configPath);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+async function connect(page: Page) {
+  await page.locator('[data-testid="ws-url-input"]').fill(wsUrl);
+  await page.locator('[data-testid="ws-connect-btn"]').click();
+  await expect(page.locator('[data-testid="ws-status-text"]')).toContainText("Connected", {
+    timeout: 15000,
+  });
+  await expect(page.locator("canvas").first()).toBeVisible();
+}
+
+/** Rendered world quaternion of the spacecraft, once the scene graph has it. */
+async function worldQuat(page: Page): Promise<[number, number, number, number]> {
+  const quat = await page.evaluate(async (id) => {
+    const w = window as unknown as Record<string, unknown>;
+    // Re-read the hook each pass: it is installed when the first body axes mount,
+    // which can be after the connection is up.
+    for (let i = 0; i < 40; i++) {
+      const get = w.__debug_get_sat_world_quat as
+        | ((id: string) => [number, number, number, number] | null)
+        | undefined;
+      const q = get?.(id) ?? null;
+      if (q) return q;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    return null;
+  }, SAT_ENTITY_PATH);
+  expect(quat, "the rendered world quaternion should be exposed").not.toBeNull();
+  if (quat == null) throw new Error("unreachable");
+  return quat;
+}
+
+/** World direction of a body axis, from the rendered quaternion (x, y, z, w). */
+function bodyAxisInWorld(
+  [qx, qy, qz, qw]: [number, number, number, number],
+  axis: "x" | "z",
+): [number, number, number] {
+  if (axis === "x") {
+    return [1 - 2 * (qy * qy + qz * qz), 2 * (qx * qy + qz * qw), 2 * (qx * qz - qy * qw)];
+  }
+  return [2 * (qx * qz + qy * qw), 2 * (qy * qz - qx * qw), 1 - 2 * (qx * qx + qy * qy)];
+}
+
+test("the attitude view drops the central body, the trails and the charts", async ({ page }) => {
+  await page.goto("/?noAutoConnect=1");
+  await connect(page);
+
+  // The orbit view has all three. Establishing that first is what makes the
+  // absences below evidence of the attitude view dropping them, rather than of a
+  // debug hook that was never installed.
+  await expect(page.locator('[data-testid="time-series-chart"]').first()).toBeVisible({
+    timeout: 30000,
+  });
+  await page.waitForFunction(
+    (id) => {
+      const w = window as Record<string, unknown>;
+      const debug = w.__debug_orbit_viewer as { trail?: (id: string) => unknown } | undefined;
+      return (
+        typeof w.__debug_get_earth_world_quat === "function" &&
+        typeof debug?.trail === "function" &&
+        debug.trail(id) != null
+      );
+    },
+    SAT_ENTITY_PATH,
+    { timeout: 15000 },
+  );
+
+  await page.locator('[data-testid="view-attitude"]').click();
+  await expect(page.locator('[data-testid="attitude-info"]')).toBeVisible();
+
+  // The Earth mesh and the trail buffers deregister their debug hooks on unmount,
+  // so their absence is the scene actually having dropped them.
+  await page.waitForFunction(
+    () => {
+      const w = window as Record<string, unknown>;
+      return w.__debug_get_earth_world_quat === undefined && w.__debug_orbit_viewer === undefined;
+    },
+    { timeout: 15000 },
+  );
+  await expect(page.locator('[data-testid="time-series-chart"]')).toHaveCount(0);
+
+  // The switch is recorded in the URL, so a reload or a shared link keeps it.
+  expect(page.url()).toContain("view=attitude");
+  await page.reload();
+  await expect(page.locator('[data-testid="attitude-info"]')).toBeVisible();
+  await connect(page);
+
+  // Switching back restores the orbit view.
+  await page.locator('[data-testid="view-orbit"]').click();
+  await page.waitForFunction(
+    () => typeof (window as Record<string, unknown>).__debug_get_earth_world_quat === "function",
+    { timeout: 15000 },
+  );
+  await expect(page.locator('[data-testid="time-series-chart"]').first()).toBeVisible({
+    timeout: 30000,
+  });
+  expect(page.url()).not.toContain("view=attitude");
+});
+
+test("switching from a satellite-centred orbit view carries that satellite over", async ({
+  page,
+}) => {
+  await page.goto("/?noAutoConnect=1");
+  await connect(page);
+
+  await page
+    .locator('[data-testid="frame-selector-select"]')
+    .selectOption(`satellite:${SAT_ENTITY_PATH}`);
+  await page.locator('[data-testid="view-attitude"]').click();
+
+  // The spacecraft the reader was already centred on is the one shown.
+  await expect(page.locator('[data-testid="attitude-spacecraft-select"]')).toHaveValue(
+    SAT_ENTITY_PATH,
+  );
+});
+
+test("inertial: the rendered body +X points along scene +Y", async ({ page }) => {
+  await page.goto("/?noAutoConnect=1&view=attitude");
+  await connect(page);
+  await expect(page.locator('[data-testid="attitude-info"]')).toBeVisible();
+  await expect(page.locator('[data-testid="attitude-orientation-inertial"]')).toBeVisible();
+
+  const bodyX = bodyAxisInWorld(await worldQuat(page), "x");
+  expect(
+    bodyX[1],
+    `body +X should point along scene +Y for a +90°-about-Z attitude, got ` +
+      `(${bodyX.map((c) => c.toFixed(3)).join(", ")})`,
+  ).toBeGreaterThan(0.9);
+  expect(Math.abs(bodyX[0]), "body +X should have no scene-X component").toBeLessThan(0.1);
+  expect(Math.abs(bodyX[2]), "body +X should have no scene-Z component").toBeLessThan(0.1);
+});
+
+test("local-orbital: the attitude and the nadir arrow share the basis", async ({ page }) => {
+  await page.goto("/?noAutoConnect=1&view=attitude");
+  await connect(page);
+  await page.locator('[data-testid="attitude-orientation-lvlh"]').click();
+
+  // Poll until the local-orbital basis is in effect: it needs both a position and
+  // a velocity for the spacecraft, which arrive with the stream.
+  const nadir = await page.evaluate(async (id) => {
+    const w = window as unknown as Record<string, unknown>;
+    for (let i = 0; i < 60; i++) {
+      const get = w.__debug_get_direction_vectors as
+        | ((id: string) => { kind: string; direction: [number, number, number] }[] | null)
+        | undefined;
+      const drawn = get?.(id) ?? null;
+      const found = drawn?.find((v) => v.kind === "nadir");
+      // -Z only once the basis is local-orbital; in inertial it points at the
+      // central body in ECI axes instead.
+      if (found && found.direction[2] < -0.99) return found.direction;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    const get = w.__debug_get_direction_vectors as
+      | ((id: string) => { kind: string; direction: [number, number, number] }[] | null)
+      | undefined;
+    return get?.(id)?.find((v) => v.kind === "nadir")?.direction ?? null;
+  }, SAT_ENTITY_PATH);
+
+  expect(nadir, "the nadir arrow should be drawn").not.toBeNull();
+  if (nadir == null) return;
+  expect(nadir[2], "nadir should point along scene -Z in the local-orbital basis").toBeLessThan(
+    -0.99,
+  );
+
+  // Same basis for the spacecraft itself: the attitude rotates about inertial Z,
+  // the equatorial orbit's cross-track axis *is* inertial Z, and cross-track is
+  // scene Y — so the rendered body +Z must point along scene +Y.
+  const bodyZ = bodyAxisInWorld(await worldQuat(page), "z");
+  expect(
+    bodyZ[1],
+    `body +Z should point along scene +Y in the local-orbital basis, got ` +
+      `(${bodyZ.map((c) => c.toFixed(3)).join(", ")}). Scene +Z would mean the attitude was ` +
+      `built in RSW order while the arrows and positions use [in-track, cross-track, radial].`,
+  ).toBeGreaterThan(0.9);
+});
+
+test("turning an arrow off stops it being drawn", async ({ page }) => {
+  await page.goto("/?noAutoConnect=1&view=attitude");
+  await connect(page);
+
+  const kinds = async () =>
+    page.evaluate(async (id) => {
+      const w = window as unknown as Record<string, unknown>;
+      for (let i = 0; i < 40; i++) {
+        const get = w.__debug_get_direction_vectors as
+          | ((id: string) => { kind: string }[] | null)
+          | undefined;
+        const drawn = get?.(id) ?? null;
+        if (drawn != null) return drawn.map((v) => v.kind).sort();
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      return null;
+    }, SAT_ENTITY_PATH);
+
+  expect(await kinds()).toEqual(["nadir", "sun"]);
+
+  await page.locator('[data-testid="direction-vector-sun"]').click();
+  await expect.poll(async () => await kinds(), { timeout: 10000 }).toEqual(["nadir"]);
+});

--- a/viewer/tests/attitude-view.spec.ts
+++ b/viewer/tests/attitude-view.spec.ts
@@ -343,8 +343,14 @@ test("turning an arrow off stops it being drawn", async ({ page }) => {
   // waits on the WASM ephemeris, so reading once could catch nadir alone.
   await expect.poll(async () => await kinds(), { timeout: 15000 }).toEqual(["nadir", "sun"]);
 
-  await page.locator('[data-testid="direction-vector-sun"]').click();
+  // The tooltip names the click's effect, so it reads the other way round from
+  // the state: with the arrow drawn, the button hides it.
+  const sun = page.locator('[data-testid="direction-vector-sun"]');
+  await expect(sun).toHaveAttribute("title", "Hide the Sun direction");
+
+  await sun.click();
   await expect.poll(async () => await kinds(), { timeout: 10000 }).toEqual(["nadir"]);
+  await expect(sun).toHaveAttribute("title", "Draw the Sun direction");
 });
 
 test("the app's own far plane follows the camera out of the attitude view", async ({ page }) => {

--- a/viewer/tests/attitude-view.spec.ts
+++ b/viewer/tests/attitude-view.spec.ts
@@ -233,6 +233,21 @@ test("switching from a satellite-centred orbit view carries that satellite over"
   await page.goto("/?noAutoConnect=1");
   await connect(page);
 
+  // The centred satellite is carried over from the *rendered* list, which is
+  // empty until the first sample arrives. Switching before then would find no
+  // satellite to carry and the assertion would fail on timing.
+  await expect
+    .poll(
+      () =>
+        page.evaluate((id) => {
+          const w = window as unknown as Record<string, unknown>;
+          const get = w.__debug_get_sat_world_quat as ((id: string) => number[] | null) | undefined;
+          return get?.(id) != null;
+        }, SAT_ENTITY_PATH),
+      { timeout: 30000 },
+    )
+    .toBe(true);
+
   await page
     .locator('[data-testid="frame-selector-select"]')
     .selectOption(`satellite:${SAT_ENTITY_PATH}`);
@@ -322,7 +337,9 @@ test("turning an arrow off stops it being drawn", async ({ page }) => {
       return null;
     }, SAT_ENTITY_PATH);
 
-  expect(await kinds()).toEqual(["nadir", "sun"]);
+  // Both arrows, not "some arrow": nadir needs only a position while the Sun
+  // waits on the WASM ephemeris, so reading once could catch nadir alone.
+  await expect.poll(async () => await kinds(), { timeout: 15000 }).toEqual(["nadir", "sun"]);
 
   await page.locator('[data-testid="direction-vector-sun"]').click();
   await expect.poll(async () => await kinds(), { timeout: 10000 }).toEqual(["nadir"]);

--- a/viewer/tests/attitude-view.spec.ts
+++ b/viewer/tests/attitude-view.spec.ts
@@ -41,10 +41,18 @@ let configPath: string;
 function spawnServer(configFile: string): Promise<{ child: ChildProcess; port: number }> {
   const binary = process.env.ORTS_BINARY ?? path.resolve(__dirname, "../../target/debug/orts");
   const child = spawn(binary, ["serve", "--port", "0", "--config", configFile], {
+    // stderr is where the server announces its URL. Named explicitly so the
+    // reader below cannot end up on the runner's own stdin, which never ends.
+    stdio: ["ignore", "ignore", "pipe"],
     env: { ...process.env, ORTS_DISABLE_TEXTURE_DOWNLOAD: "1" },
   });
   return new Promise((resolve, reject) => {
-    const rl = createInterface({ input: child.stderr ?? process.stdin });
+    const serverLog = child.stderr;
+    if (serverLog == null) {
+      reject(new Error("orts serve was spawned without a stderr pipe"));
+      return;
+    }
+    const rl = createInterface({ input: serverLog });
     const onError = (err: Error) => {
       settle();
       reject(err);

--- a/viewer/tests/attitude-viewer-public.spec.ts
+++ b/viewer/tests/attitude-viewer-public.spec.ts
@@ -465,10 +465,13 @@ test("both triads are drawn as meshes with letters, and no GL lines remain", asy
   expect(scene, "the scene graph should be reachable").not.toBeNull();
   if (scene == null) return;
 
-  // Six letters: X, Y and Z on the body triad and on the reference frame's.
-  expect(scene.counts.Sprite, "one letter per axis on each triad").toBe(6);
-  // Each is drawn last and without a depth test, so a letter on an axis pointing
-  // away from the reader stays readable rather than buried in the spacecraft.
+  // Six letters — X, Y and Z on the body triad and on the reference frame's — and
+  // one name per arrow, which is what the scene has instead of a legend entry.
+  const arrows = await drawnArrows(page);
+  expect(scene.counts.Sprite, "a letter per axis and a name per arrow").toBe(6 + arrows.length);
+  // Each is drawn last and without a depth test, so text on an axis or an arrow
+  // pointing away from the reader stays readable rather than buried in the
+  // spacecraft.
   for (const sprite of scene.sprites) {
     expect(sprite.depthTest).toBe(false);
     expect(sprite.renderOrder).toBeGreaterThan(0);

--- a/viewer/tests/direction-vector-availability.spec.ts
+++ b/viewer/tests/direction-vector-availability.spec.ts
@@ -123,6 +123,19 @@ test("a run with no epoch offers no Sun, and says why in the control's name", as
   const sun = page.locator('[data-testid="direction-vector-sun"]');
   await expect(sun).toHaveAttribute("aria-disabled", "true");
   await expect(sun).toHaveAttribute("aria-label", "Sun: Requires epoch");
+
+  // The toggle is switched on and cannot be drawn, which is the app's state for
+  // the Sun on a run with no epoch — so it is selected *and* unavailable. Hovering
+  // has to leave it looking selected: a segment that reads as unselected under the
+  // pointer says the choice changed, and this control keeps its choice while it
+  // waits for the data that would draw it.
+  const background = () => sun.evaluate((el) => getComputedStyle(el).backgroundColor);
+  const atRest = await background();
+  await sun.hover();
+  // Past the colour transition, so this compares resting states rather than a
+  // frame part-way through one.
+  await page.waitForTimeout(400);
+  expect(await background(), "hover should not restyle a selected segment").toBe(atRest);
   await expect(page.locator('[data-testid="direction-vector-nadir"]')).not.toHaveAttribute(
     "aria-disabled",
     "true",

--- a/viewer/tests/direction-vector-availability.spec.ts
+++ b/viewer/tests/direction-vector-availability.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * What the app offers, over the scene it is actually drawing.
+ *
+ * A CSV source is the deterministic way to reach the states that decide this, and
+ * `orts serve` will not produce them: a spacecraft at the coordinate origin, a
+ * run with no epoch, and a spacecraft carrying no attitude at all (the CSV format
+ * has no attitude columns). No server is involved — `?noAutoConnect=1` plus the
+ * file input, as in `csv-file-load.spec.ts`.
+ *
+ * The rule under test is that a control's availability matches what the scene
+ * draws. Two ways to break it, and both have: offering an arrow the scene drops,
+ * and disabling one the scene draws.
+ */
+
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, type Page, test } from "@playwright/test";
+
+/** The single satellite a CSV source yields. */
+const SAT = "default";
+
+type CsvPosition = "orbit" | "origin";
+
+/**
+ * A CSV run of 20 points.
+ *
+ * `orbit` is an ordinary circular one; `origin` puts every sample at [0, 0, 0], a
+ * finite position the frame accepts and one no bearing can be taken from. `epoch`
+ * omits the `# epoch_jd` header, which is what leaves the Sun uncomputable.
+ *
+ * A non-finite position has no variant here: `parseCSVLine` drops any row with a
+ * `NaN` field, so no CSV can put one into app state. That case is a unit test on
+ * `drawableAtCentre`, and a library one in `orbit-viewer-public.spec.ts`.
+ */
+function csvRun(opts: { epoch: boolean; position: CsvPosition }): string {
+  const lines: string[] = [
+    "# orts 2-body orbit propagation",
+    "# mu = 398600.4418 km^3/s^2",
+    ...(opts.epoch ? ["# epoch_jd = 2451545.0"] : []),
+    "# central_body = earth",
+    "# central_body_radius = 6378.137 km",
+  ];
+  const r = 6778;
+  const speed = 7.669;
+  for (let i = 0; i < 20; i++) {
+    const t = i * 10;
+    const angle = (speed / r) * t;
+    const vx = -speed * Math.sin(angle);
+    const vy = speed * Math.cos(angle);
+    const [x, y, z] =
+      opts.position === "origin" ? [0, 0, 0] : [r * Math.cos(angle), r * Math.sin(angle), 0];
+    lines.push(`${t},${x},${y},${z},${vx},${vy},0,${r},0,0.9,0,0,${angle}`);
+  }
+  return lines.join("\n");
+}
+
+async function loadRun(page: Page, opts: { epoch: boolean; position: CsvPosition }) {
+  const path = join(tmpdir(), `orts-availability-${Date.now()}-${Math.random()}.csv`);
+  writeFileSync(path, csvRun(opts));
+  await page.goto("/?noAutoConnect=1");
+  await page.locator('input[type="file"]').setInputFiles(path);
+  await expect(page.locator('[data-testid="orbit-info-file"]')).toContainText("points", {
+    timeout: 15000,
+  });
+}
+
+/** Centre the orbit view on the CSV's satellite, which is what draws the arrows. */
+async function centreOnSatellite(page: Page) {
+  await page.locator('[data-testid="frame-selector-select"]').selectOption(`satellite:${SAT}`);
+}
+
+interface Drawn {
+  kind: string;
+}
+
+/** The arrows the scene has actually put in the graph. */
+async function drawnKinds(page: Page): Promise<string[]> {
+  return await page.evaluate((id) => {
+    const w = window as unknown as {
+      __debug_get_direction_vectors?: (satId: string) => Drawn[] | null;
+    };
+    return (w.__debug_get_direction_vectors?.(id) ?? []).map((v) => v.kind);
+  }, SAT);
+}
+
+test("a spacecraft at the coordinate origin keeps the Sun, and loses only nadir", async ({
+  page,
+}) => {
+  // The frame refuses a non-finite position and accepts every other, so a centre
+  // at the origin is drawn like any other — lit from the Sun's direction, with the
+  // Sun arrow along it. Nadir is the one that cannot be taken: it is the bearing
+  // from the spacecraft to the body, and there is none from the body's centre.
+  await loadRun(page, { epoch: true, position: "origin" });
+  await centreOnSatellite(page);
+
+  await expect.poll(() => drawnKinds(page), { timeout: 20000 }).toEqual(["sun"]);
+
+  const sun = page.locator('[data-testid="direction-vector-sun"]');
+  const nadir = page.locator('[data-testid="direction-vector-nadir"]');
+  await expect(sun, "the Sun is drawn here, so its toggle stays usable").not.toHaveAttribute(
+    "aria-disabled",
+    "true",
+  );
+  await expect(nadir).toHaveAttribute("aria-disabled", "true");
+  // The reason reaches a reader who cannot hover, and names nadir's own condition
+  // rather than the frame's — the position here is finite, and accepted.
+  await expect(nadir).toHaveAttribute("aria-label", "Nadir: Requires a non-zero position");
+});
+
+test("a run with no epoch offers no Sun, and says why in the control's name", async ({ page }) => {
+  // Without an epoch the Sun's direction cannot be computed, and the scene draws
+  // no arrow it would have to guess. This position is an ordinary one, so nadir is
+  // drawn and stays on offer — which is what makes the Sun's absence the subject.
+  await loadRun(page, { epoch: false, position: "orbit" });
+  await centreOnSatellite(page);
+
+  await expect.poll(() => drawnKinds(page), { timeout: 20000 }).toEqual(["nadir"]);
+
+  const sun = page.locator('[data-testid="direction-vector-sun"]');
+  await expect(sun).toHaveAttribute("aria-disabled", "true");
+  await expect(sun).toHaveAttribute("aria-label", "Sun: Requires epoch");
+  await expect(page.locator('[data-testid="direction-vector-nadir"]')).not.toHaveAttribute(
+    "aria-disabled",
+    "true",
+  );
+});
+
+test("a spacecraft with no attitude is named as that, not as one still arriving", async ({
+  page,
+}) => {
+  // The CSV format carries no attitude columns, so this spacecraft has arrived and
+  // has none — the second of the two states that leave the attitude view empty.
+  await loadRun(page, { epoch: true, position: "orbit" });
+  await page.locator('[data-testid="view-attitude"]').click();
+
+  await expect(page.locator('[data-testid="attitude-no-data"]')).toBeVisible();
+  await expect(page.locator('[data-testid="attitude-no-spacecraft"]')).toHaveCount(0);
+});

--- a/viewer/tests/direction-vector-availability.spec.ts
+++ b/viewer/tests/direction-vector-availability.spec.ts
@@ -136,4 +136,19 @@ test("a spacecraft with no attitude is named as that, not as one still arriving"
 
   await expect(page.locator('[data-testid="attitude-no-data"]')).toBeVisible();
   await expect(page.locator('[data-testid="attitude-no-spacecraft"]')).toHaveCount(0);
+
+  // The arrows are drawn at the spacecraft, so an absent one takes both with it —
+  // including the Sun, whose own inputs are all present here (this run has an
+  // epoch). The controls say the same thing the placeholder does.
+  for (const [kind, label] of [
+    ["sun", "Sun"],
+    ["nadir", "Nadir"],
+  ]) {
+    const toggle = page.locator(`[data-testid="direction-vector-${kind}"]`);
+    await expect(toggle, `${kind} is not drawable with no spacecraft drawn`).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+    await expect(toggle).toHaveAttribute("aria-label", `${label}: This spacecraft has no attitude`);
+  }
 });

--- a/viewer/tests/direction-vector-availability.spec.ts
+++ b/viewer/tests/direction-vector-availability.spec.ts
@@ -105,7 +105,10 @@ test("a spacecraft at the coordinate origin keeps the Sun, and loses only nadir"
   await expect(nadir).toHaveAttribute("aria-disabled", "true");
   // The reason reaches a reader who cannot hover, and names nadir's own condition
   // rather than the frame's — the position here is finite, and accepted.
-  await expect(nadir).toHaveAttribute("aria-label", "Nadir: Requires a non-zero position");
+  await expect(nadir).toHaveAttribute(
+    "aria-label",
+    "Nadir: Requires a position of finite, non-zero length",
+  );
 });
 
 test("a run with no epoch offers no Sun, and says why in the control's name", async ({ page }) => {

--- a/viewer/tests/direction-vector-availability.spec.ts
+++ b/viewer/tests/direction-vector-availability.spec.ts
@@ -120,6 +120,16 @@ test("a spacecraft at the coordinate origin keeps the Sun, and loses only nadir"
     "aria-label",
     "Nadir: Requires a position of finite, non-zero length",
   );
+
+  // The orbit frame needs a position and a velocity that span a plane, and this
+  // position gives no radial direction to build one from. The option says so
+  // rather than staying selectable over a frame the scene keeps inertial.
+  const lvlh = page.locator('[data-testid="frame-orientation-lvlh"]');
+  await expect(lvlh).toHaveAttribute("aria-disabled", "true");
+  await expect(lvlh).toHaveAttribute(
+    "title",
+    "Requires a position and velocity that define an orbit plane",
+  );
 });
 
 test("a run with no epoch offers no Sun, and says why in the control's name", async ({ page }) => {

--- a/viewer/tests/direction-vector-availability.spec.ts
+++ b/viewer/tests/direction-vector-availability.spec.ts
@@ -56,9 +56,20 @@ function csvRun(opts: { epoch: boolean; position: CsvPosition }): string {
 }
 
 async function loadRun(page: Page, opts: { epoch: boolean; position: CsvPosition }) {
+  await page.goto("/?noAutoConnect=1");
+  await loadInto(page, opts);
+}
+
+/**
+ * Load a run into the page that is already open.
+ *
+ * Kept apart from {@link loadRun} because navigating resets the app's state: a
+ * test about what survives a source change has to change the source without
+ * reloading, or it measures the reset instead.
+ */
+async function loadInto(page: Page, opts: { epoch: boolean; position: CsvPosition }) {
   const path = join(tmpdir(), `orts-availability-${Date.now()}-${Math.random()}.csv`);
   writeFileSync(path, csvRun(opts));
-  await page.goto("/?noAutoConnect=1");
   await page.locator('input[type="file"]').setInputFiles(path);
   await expect(page.locator('[data-testid="orbit-info-file"]')).toContainText("points", {
     timeout: 15000,
@@ -167,4 +178,34 @@ test("a spacecraft with no attitude is named as that, not as one still arriving"
     );
     await expect(toggle).toHaveAttribute("aria-label", `${label}: This spacecraft has no attitude`);
   }
+});
+
+test("the orientation toggle reports the frame the scene fell back to", async ({ page }) => {
+  // Body-Fixed needs an Earth rotation angle, so `OrbitScene` draws inertial
+  // without an epoch. The request survives in the app's state — a momentary gap
+  // should not discard the reader's choice — so the toggle has to report what is
+  // drawn rather than what was asked for, or it says Body-Fixed over an inertial
+  // picture. Reached by choosing it while an epoch is present and then loading a
+  // run without one.
+  await loadRun(page, { epoch: true, position: "orbit" });
+
+  const bodyFixed = page.locator('[data-testid="frame-orientation-body-fixed"]');
+  const inertial = page.locator('[data-testid="frame-orientation-inertial"]');
+  await expect(bodyFixed).not.toHaveAttribute("aria-disabled", "true");
+  await bodyFixed.click();
+  await expect(bodyFixed).toHaveAttribute("aria-pressed", "true");
+
+  // Without navigating: a reload would put the frame back to its default and the
+  // assertions below would hold whatever the selector reported.
+  await loadInto(page, { epoch: false, position: "orbit" });
+
+  await expect(bodyFixed, "the option is unavailable without an epoch").toHaveAttribute(
+    "aria-disabled",
+    "true",
+  );
+  await expect(bodyFixed, "and is not reported as the frame in use").toHaveAttribute(
+    "aria-pressed",
+    "false",
+  );
+  await expect(inertial, "which is what the scene draws").toHaveAttribute("aria-pressed", "true");
 });


### PR DESCRIPTION
#403 で姿勢ビューを公開コンポーネントとして足したが、app はまだ軌道表示しか描いていない。このPRで app にビュー切替を入れ、2 つの表示が同じ操作 UI を共有する形にする。選択は `?view=` に記録するので、リロードや共有リンクでも同じ表示が開く。

## 見た目

| 軌道ビュー（中心天体） | 軌道ビュー（衛星中心 LVLH） |
|---|---|
| ![軌道ビューの中心天体表示](https://gist.githubusercontent.com/sksat/7ad541c299d46606db2a336df3461716/raw/orbit-view-central-body.png) | ![軌道ビューで衛星中心にしたときの矢印](https://gist.githubusercontent.com/sksat/7ad541c299d46606db2a336df3461716/raw/orbit-view-satellite-arrows.png) |

| 姿勢ビュー（慣性） | 姿勢ビュー（局所軌道） |
|---|---|
| ![姿勢ビュー 慣性フレーム](https://gist.githubusercontent.com/sksat/7ad541c299d46606db2a336df3461716/raw/attitude-view-inertial.png) | ![姿勢ビュー 局所軌道フレーム](https://gist.githubusercontent.com/sksat/7ad541c299d46606db2a336df3461716/raw/attitude-view-lvlh.png) |

左上のオーバーレイに、ビュー切替・機体選択と向き・矢印のトグル・凡例が並ぶ。姿勢ビューではチャートパネルが畳まれて 1 カラムになる。凡例が `Body X/Y/Z` と `Frame X/Y/Z` を分けているのは、どちらも RGB の三つ組で、色だけでは区別できないため。

画像は `orts serve` に接続して撮った。500 km 円軌道 i=51.6°、inertia diag [100, 100, 50] kg·m²、初期姿勢は Z 軸まわり +90°。

## ビューごとに状態を分ける

軌道表示のフレームは center と orientation の組、姿勢表示は orientation だけ。切替のたびに一方をもう一方へ写すと、読み手が見ているものが黙って変わる。`referenceFrame` と `attitudeFrame`、それに機体の選択を別々に持つ。衛星中心の軌道表示から切り替えたときはその衛星を引き継ぐ（読み手が既に見ていた機体だから）。

`<Canvas key={view}>` で切替時に remount する。camera prop は初期値としてしか効かず、`OrbitControls` の内部状態もリセットしたいため。key は `view` だけにする — フレームや機体選択を含めると、そのたびに WebGL context と GLTF が作り直される。

## 共有するもの

`SegmentedToggle`（#402 で `FrameSelector` から抽出）と方向ベクトルのトグル、そして矢印の on/off 状態を両ビューが共有する。設定は見えている方に効く。

凡例は姿勢ビューに置く。軌道表示で RGB の三つ組が出るのは中心機体 1 機のときだけで、姿勢ビューでは常に 2 組が並ぶ。

## control の可否は scene に聞く

無効化するかどうかと、その理由は、scene が描くかどうかを決めるのと同じ述語から取る（`centrePositionIsUsable` / `computeLvlhAxes` / `resolveDirectionVectors`）。position が非 null かどうかで判断すると、scene が落とす入力でトグルを提供してしまう。

条件は 3 つに分かれ、それぞれ別の文言を持つ:

| 条件 | 文言 | 効く相手 |
|---|---|---|
| 中心機体を置ける position か（有限、かつ renderer の float32 origin offset に収まる長さ） | `Requires a finite position` | 太陽・nadir |
| nadir の向きが取れる長さか | `Requires a position of finite, non-zero length` | nadir |
| 太陽方向が計算できるか（epoch と ephemeris） | `Requires epoch` ほか | 太陽 |

原点にいる機体は置ける position を持つ。機体は描かれ、照らされ、太陽矢印も出て、nadir だけが落ちる。逆に置けない position では 1 本も描かれず、太陽まで無効になる — 太陽は自前の position を必要としないので、ここは明示しないと漏れる。

理由は `title` と `aria-label` の両方に載せる。`title` は hover した時だけ出るので、keyboard と screen reader が読むのは `aria-label` の側になる。

epoch は 1 か所で正規化してすべての判定と両 scene に渡す。CSV の壊れた `# epoch_jd` は `Number()` の結果が NaN のまま非 null で届くので、scene が inertial に落として太陽矢印を捨てる一方、UI は Body-Fixed と太陽を提供していた。

姿勢ビューの対象機体は state を同期させるのではなく導出する。effect で同期すると、リストに機体があって対象が未定のレンダーが 1 回入り、その間 `<select>` は option に無い値で制御されて空欄になる。

## E2E

`tests/attitude-view.spec.ts`（新規 7 件）は `orts serve` を spawn し、初期姿勢 Z 軸まわり +90°・ω = 0 で:

- 姿勢ビューに地球・trail・チャートが無い
- 慣性で body +X がシーン +Y を向く
- 局所軌道で姿勢と nadir 矢印が同じ基底に乗る
- トグルを切った矢印がシーンから消える
- far plane がカメラの後退に追従する
- 衛星中心の軌道表示から切り替えた機体が引き継がれる
- 対象機体が未着のときの文言が、姿勢を持たない場合と分かれている

向きは `__debug_get_sat_world_quat` の frame 不変量で読むので、±q の符号両義性に強い。

`tests/direction-vector-availability.spec.ts`（新規 3 件）は control の可否と scene の描画を一緒に読む。CSV source を使うので server が要らず、`orts serve` では作れない状態を決定的に置ける — 原点にいる機体、epoch の無い run、姿勢を持たない機体。

その他: `tsc --noEmit` clean、viewer unit test 593 件 pass、`biome check` error 0、registry と consumer のコピー再生成済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
