### PR TITLE
test(utsuroi): require a trajectory that moved, not just a conserved number

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -552,8 +552,9 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   保存される。symplectic のテストは長時間積分の後半 drift を前半と比べていた
   ため、初手で全エネルギーを失っても「有界」と読めていた。実測: accept した
   状態を毎ステップゼロにすると 6 件が通り、`Rk4::step` を凍結すると RK4 の
-  保存則テスト 2 件が通った。各テストに初期エネルギーで正規化した drift の
-  上限、状態が移動したことの検査、`ln` が読む個体数の正値性を追加した。
+  保存則テスト 2 件が通った。symplectic の 4 件には初期エネルギーで正規化した
+  drift の上限を、RK4 の 2 件には状態が移動したことの検査を、Lotka-Volterra
+  には `ln` が読む個体数の正値性を加えた。
   `tight_tolerance_dop853_fewer_evaluations` も、評価回数を比べる前に両者が
   `t_end` まで完走して正しい解に達したことを要求する。
   ([#TBD](https://github.com/sksat/orts/pull/TBD))

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -547,6 +547,16 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   通知する欠陥はどのテストも検出しなかった。調和振動子の一周期テストはどちらも
   検出できない (一周期後の解が初期状態と同じ)。`test_systems` の共有試験系は
   すべて時刻引数を無視している。([#408](https://github.com/sksat/orts/pull/408))
+- テスト: 保存量のテストが、軌道が実際に動いたことを要求するようになった。
+  エネルギー drift も Lotka-Volterra の不変量も、状態が変化しなければ完全に
+  保存される。symplectic のテストは長時間積分の後半 drift を前半と比べていた
+  ため、初手で全エネルギーを失っても「有界」と読めていた。実測: accept した
+  状態を毎ステップゼロにすると 6 件が通り、`Rk4::step` を凍結すると RK4 の
+  保存則テスト 2 件が通った。各テストに初期エネルギーで正規化した drift の
+  上限、状態が移動したことの検査、`ln` が読む個体数の正値性を追加した。
+  `tight_tolerance_dop853_fewer_evaluations` も、評価回数を比べる前に両者が
+  `t_end` まで完走して正しい解に達したことを要求する。
+  ([#TBD](https://github.com/sksat/orts/pull/TBD))
 
 #### Fixed
 - `Integrator::try_integrate` が、結果が非有限になった最初のステップで

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -557,7 +557,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   には `ln` が読む個体数の正値性を加えた。
   `tight_tolerance_dop853_fewer_evaluations` も、評価回数を比べる前に両者が
   `t_end` まで完走して正しい解に達したことを要求する。
-  ([#TBD](https://github.com/sksat/orts/pull/TBD))
+  ([#409](https://github.com/sksat/orts/pull/409))
 
 #### Fixed
 - `Integrator::try_integrate` が、結果が非有限になった最初のステップで

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -617,9 +617,10 @@ section is subdivided by package.
   of the second half of a long integration against the first, which reads as
   bounded when all the energy is lost at once. Measured: zeroing every
   accepted state passed six tests, and freezing `Rk4::step` passed the two
-  RK4 conservation tests. Each now caps the drift relative to the initial
-  energy, checks the state travelled, and keeps the populations positive
-  where a `ln` reads them. `tight_tolerance_dop853_fewer_evaluations` also
+  RK4 conservation tests. The symplectic tests now cap the drift relative to
+  the initial energy, the two RK4 tests require the state to travel, and the
+  Lotka-Volterra one keeps both populations positive, since a `ln` reads
+  them. `tight_tolerance_dop853_fewer_evaluations` also
   requires both integrations to complete at `t_end` with the right answer
   before comparing what they cost. ([#TBD](https://github.com/sksat/orts/pull/TBD))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -622,7 +622,7 @@ section is subdivided by package.
   Lotka-Volterra one keeps both populations positive, since a `ln` reads
   them. `tight_tolerance_dop853_fewer_evaluations` also
   requires both integrations to complete at `t_end` with the right answer
-  before comparing what they cost. ([#TBD](https://github.com/sksat/orts/pull/TBD))
+  before comparing what they cost. ([#409](https://github.com/sksat/orts/pull/409))
 
 #### Fixed
 - `Integrator::try_integrate` stops with `IntegrationError::NonFiniteState` at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -611,6 +611,17 @@ section is subdivided by package.
   harmonic-oscillator test cannot see either, because after one period the
   answer is the initial state, and the shared systems in `test_systems` all
   ignore their time argument. ([#408](https://github.com/sksat/orts/pull/408))
+- Tests: the conserved-quantity tests now require a trajectory that moved.
+  Energy drift and the Lotka-Volterra invariant are both perfectly conserved
+  by a state that never changes, and the symplectic tests compared the drift
+  of the second half of a long integration against the first, which reads as
+  bounded when all the energy is lost at once. Measured: zeroing every
+  accepted state passed six tests, and freezing `Rk4::step` passed the two
+  RK4 conservation tests. Each now caps the drift relative to the initial
+  energy, checks the state travelled, and keeps the populations positive
+  where a `ln` reads them. `tight_tolerance_dop853_fewer_evaluations` also
+  requires both integrations to complete at `t_end` with the right answer
+  before comparing what they cost. ([#TBD](https://github.com/sksat/orts/pull/TBD))
 
 #### Fixed
 - `Integrator::try_integrate` stops with `IntegrationError::NonFiniteState` at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -619,8 +619,8 @@ section is subdivided by package.
   accepted state passed six tests, and freezing `Rk4::step` passed the two
   RK4 conservation tests. The symplectic tests now cap the drift relative to
   the initial energy, the two RK4 tests require the state to travel, and the
-  Lotka-Volterra one keeps both populations positive, since a `ln` reads
-  them. `tight_tolerance_dop853_fewer_evaluations` also
+  Lotka-Volterra one keeps both populations positive, since its invariant
+  reads `ln x` and `ln y`. `tight_tolerance_dop853_fewer_evaluations` also
   requires both integrations to complete at `t_end` with the right answer
   before comparing what they cost. ([#409](https://github.com/sksat/orts/pull/409))
 

--- a/utsuroi/src/comparison.rs
+++ b/utsuroi/src/comparison.rs
@@ -61,6 +61,10 @@ proptest! {
 // the max |ΔE| in each half. For symplectic methods the ratio ≈ 1.0 (bounded);
 // for non-symplectic the ratio ≈ 2.0 (linear growth).
 
+/// The energy of the oscillator `energy_drift_halves` starts from:
+/// `0.5 (v² + x²)` at `x = (1,0,0)`, `v = 0`.
+const INITIAL_ENERGY: f64 = 0.5;
+
 /// Measure max energy deviation in the first and second halves of an integration.
 fn energy_drift_halves<F>(integrator: F, t_end: f64, dt: f64) -> (f64, f64)
 where
@@ -75,7 +79,7 @@ where
 {
     let system = HarmonicOscillator;
     let initial = State::<3, 2>::new(vector![1.0, 0.0, 0.0], vector![0.0, 0.0, 0.0]);
-    let initial_energy = 0.5;
+    let initial_energy = INITIAL_ENERGY;
     let t_mid = t_end / 2.0;
 
     let mut first_half: f64 = 0.0;
@@ -100,7 +104,6 @@ where
 
 #[test]
 fn verlet_no_secular_energy_drift() {
-    // Symplectic: max |ΔE| in the second half ≈ first half (ratio ≈ 1.0).
     let dt = 0.05;
     let t_end = 1000.0 * 2.0 * std::f64::consts::PI; // 1000 periods
 
@@ -110,6 +113,19 @@ fn verlet_no_secular_energy_drift() {
         dt,
     );
 
+    // The drift has to be small, and only then does comparing the halves say
+    // anything. A solver that zeroed the state would drift by the whole
+    // initial energy in both halves, so the ratio alone reads as 1.0 —
+    // measured, that passed a `.scale(0.0)` mutation of every accepted state.
+    let relative = first.max(second) / INITIAL_ENERGY;
+    assert!(
+        relative < VERLET_RELATIVE_DRIFT_CAP,
+        "Verlet drifts by {relative:e} of the initial energy, over the cap \
+         {VERLET_RELATIVE_DRIFT_CAP:e} (first={first:.2e}, second={second:.2e})"
+    );
+    // Bounded rather than growing: for a symplectic method the second half's
+    // peak matches the first, while a non-symplectic one grows into it (see
+    // `rk4_has_secular_energy_drift`, which measures 2.0 here).
     let ratio = second / first;
     assert!(
         ratio < 1.2,
@@ -117,6 +133,10 @@ fn verlet_no_secular_energy_drift() {
          (first={first:.2e}, second={second:.2e})"
     );
 }
+
+/// Ten times the drift measured at `dt = 0.05` over 1000 periods (6.2e-4).
+/// Second order, so this scales as `dt²` and is not a bound to derive.
+const VERLET_RELATIVE_DRIFT_CAP: f64 = 6e-3;
 
 #[test]
 fn rk4_has_secular_energy_drift() {

--- a/utsuroi/src/comparison.rs
+++ b/utsuroi/src/comparison.rs
@@ -134,8 +134,9 @@ fn verlet_no_secular_energy_drift() {
     );
 }
 
-/// Ten times the drift measured at `dt = 0.05` over 1000 periods (6.2e-4).
-/// Second order, so this scales as `dt²` and is not a bound to derive.
+/// An order of magnitude above the drift measured at `dt = 0.05` over 1000
+/// periods (6.2e-4). Second order, so it scales as `dt²`, and the constant
+/// belongs to the problem rather than to anything derivable here.
 const VERLET_RELATIVE_DRIFT_CAP: f64 = 6e-3;
 
 #[test]

--- a/utsuroi/src/solver/dop853/mod.rs
+++ b/utsuroi/src/solver/dop853/mod.rs
@@ -1027,23 +1027,27 @@ mod tests {
         };
 
         let mut dop853_steps = 0u64;
-        let _: IntegrationOutcome<State<3, 2>, ()> = Dop853.integrate_adaptive_with_events(
-            &system,
-            initial.clone(),
-            0.0,
-            t_end,
-            1.0,
-            &tol,
-            |_t, _state| {
-                dop853_steps += 1;
-            },
-            |_t, _state| ControlFlow::Continue(()),
-        );
+        let mut dop853_last_t = 0.0;
+        let dop853_outcome: IntegrationOutcome<State<3, 2>, ()> = Dop853
+            .integrate_adaptive_with_events(
+                &system,
+                initial.clone(),
+                0.0,
+                t_end,
+                1.0,
+                &tol,
+                |t, _state| {
+                    dop853_steps += 1;
+                    dop853_last_t = t;
+                },
+                |_t, _state| ControlFlow::Continue(()),
+            );
         let dop853_evals = system.count();
 
         let system = crate::projection::Counting::new(&HarmonicOscillator);
         let mut dp45_steps = 0u64;
-        let _: IntegrationOutcome<State<3, 2>, ()> = crate::DormandPrince
+        let mut dp45_last_t = 0.0;
+        let dp45_outcome: IntegrationOutcome<State<3, 2>, ()> = crate::DormandPrince
             .integrate_adaptive_with_events(
                 &system,
                 initial,
@@ -1051,12 +1055,37 @@ mod tests {
                 t_end,
                 1.0,
                 &tol,
-                |_t, _state| {
+                |t, _state| {
                     dp45_steps += 1;
+                    dp45_last_t = t;
                 },
                 |_t, _state| ControlFlow::Continue(()),
             );
         let dp45_evals = system.count();
+
+        // Cheaper only counts if both got there. With the outcomes dropped,
+        // an integration that gave up early was the cheapest of all.
+        let IntegrationOutcome::Completed(dop853_final) = dop853_outcome else {
+            panic!("DOP853 must complete the span, got {dop853_outcome:?}");
+        };
+        let IntegrationOutcome::Completed(dp45_final) = dp45_outcome else {
+            panic!("DP45 must complete the span, got {dp45_outcome:?}");
+        };
+        for (label, last_t) in [("DOP853", dop853_last_t), ("DP45", dp45_last_t)] {
+            assert!(
+                (last_t - t_end).abs() < 1e-9,
+                "{label} must report its last state at t_end: {last_t} vs {t_end}"
+            );
+        }
+        // Ten whole periods, so the oscillator is back where it started.
+        for (label, final_state) in [("DOP853", &dop853_final), ("DP45", &dp45_final)] {
+            let error = (final_state.y() - vector![1.0, 0.0, 0.0]).norm();
+            assert!(
+                error < 1e-9,
+                "{label} ends a whole number of periods back at x = (1,0,0), \
+                 off by {error:e}"
+            );
+        }
 
         // Pin the stage structure: DOP853 spends 11 evaluations per trial plus
         // one first-stage evaluation per accepted step; DP45 spends 6 per

--- a/utsuroi/src/solver/dop853/mod.rs
+++ b/utsuroi/src/solver/dop853/mod.rs
@@ -1077,13 +1077,22 @@ mod tests {
                 "{label} must report its last state at t_end: {last_t} vs {t_end}"
             );
         }
-        // Ten whole periods, so the oscillator is back where it started.
+        // Ten whole periods, so the oscillator is back where it started, at
+        // rest. Velocity too: a phase error shows up linearly there and only
+        // quadratically in position, so a position-only check at a period
+        // boundary would admit a phase error of about 4e-5.
         for (label, final_state) in [("DOP853", &dop853_final), ("DP45", &dp45_final)] {
-            let error = (final_state.y() - vector![1.0, 0.0, 0.0]).norm();
+            let position_error = (final_state.y() - vector![1.0, 0.0, 0.0]).norm();
+            let velocity_error = final_state.dy().norm();
             assert!(
-                error < 1e-9,
+                position_error < 1e-9,
                 "{label} ends a whole number of periods back at x = (1,0,0), \
-                 off by {error:e}"
+                 off by {position_error:e}"
+            );
+            assert!(
+                velocity_error < 1e-9,
+                "{label} ends a whole number of periods back at rest, off by \
+                 {velocity_error:e}"
             );
         }
 

--- a/utsuroi/src/solver/rk4.rs
+++ b/utsuroi/src/solver/rk4.rs
@@ -224,20 +224,32 @@ mod tests {
         let initial_energy = 0.5 * (initial.dy().norm_squared() + initial.y().norm_squared());
 
         let mut max_energy_drift: f64 = 0.0;
+        // A state that never moves conserves energy exactly, so the drift
+        // alone says nothing: measured, freezing `Rk4::step` to return its
+        // input passed this test. The oscillator swings from x = 1 to
+        // x = -1, so its furthest excursion from the start is 2.
+        let mut max_excursion: f64 = 0.0;
 
         let t_end = 2.0 * std::f64::consts::PI;
         let dt = 0.01;
+        let start = initial.clone();
 
         Rk4.integrate(&system, initial, 0.0, t_end, dt, |_t, state| {
             let energy = 0.5 * (state.dy().norm_squared() + state.y().norm_squared());
             let drift = (energy - initial_energy).abs();
             max_energy_drift = max_energy_drift.max(drift);
+            max_excursion = max_excursion.max((state.y() - start.y()).norm());
         });
 
         let threshold = 1e-8;
         assert!(
             max_energy_drift < threshold,
             "Energy drift {max_energy_drift:.2e} exceeds threshold {threshold:.2e}"
+        );
+        assert!(
+            max_excursion > 1.9,
+            "the oscillator has to travel: furthest excursion {max_excursion:.3} \
+             of the 2.0 a full swing covers (measured 1.999998)"
         );
     }
 
@@ -472,20 +484,38 @@ mod tests {
         let steps = 10000; // 10 time units
         let mut t = 0.0;
         let mut max_drift: f64 = 0.0;
+        // The invariant holds for a state that never moves too, so it says
+        // nothing on its own: measured, freezing `Rk4::step` to return its
+        // input passed this test. Both populations also have to stay
+        // positive, or `ln` would be reading a state the model cannot reach.
+        let mut max_excursion: f64 = 0.0;
         for _ in 0..steps {
             state = Rk4.step(&system, t, &state, dt);
             t += dt;
             let x = state.components[0][0];
             let y = state.components[0][1];
+            assert!(
+                x > 0.0 && y > 0.0,
+                "populations stay positive: x = {x}, y = {y} at t = {t}"
+            );
             let h = delta * x - gamma * x.ln() + beta * y - alpha * y.ln();
             max_drift = max_drift.max((h - h0).abs());
+            max_excursion = max_excursion.max(((x - x0).powi(2) + (y - y0).powi(2)).sqrt());
         }
 
         assert!(
             max_drift < 1e-6,
             "Lotka-Volterra invariant drift: {max_drift:.2e}"
         );
+        assert!(
+            max_excursion > MIN_LOTKA_VOLTERRA_EXCURSION,
+            "the orbit has to travel: furthest excursion {max_excursion:.3}, \
+             floor {MIN_LOTKA_VOLTERRA_EXCURSION}"
+        );
     }
+
+    /// Half the 0.874 excursion measured over the ten time units above.
+    const MIN_LOTKA_VOLTERRA_EXCURSION: f64 = 0.4;
 
     #[test]
     fn integrate_with_events_callback_fires_on_termination_step() {

--- a/utsuroi/src/solver/rk4.rs
+++ b/utsuroi/src/solver/rk4.rs
@@ -514,7 +514,7 @@ mod tests {
         );
     }
 
-    /// Half the 0.874 excursion measured over the ten time units above.
+    /// Roughly half the 0.874 excursion measured over the ten time units above.
     const MIN_LOTKA_VOLTERRA_EXCURSION: f64 = 0.4;
 
     #[test]

--- a/utsuroi/src/solver/yoshida.rs
+++ b/utsuroi/src/solver/yoshida.rs
@@ -428,8 +428,9 @@ mod tests {
         assert!(first > 0.0, "Should have some energy oscillation");
         // Small first, and only then does the ratio mean anything: a solver
         // that zeroed the state would drift by the whole initial energy in
-        // both halves, which reads as a ratio of 1.0. The cap is ten times
-        // the 4.8e-7 measured at dt = 0.05 over 1000 periods.
+        // both halves, which reads as a ratio of 1.0. The cap is an order of
+        // magnitude above the 4.8e-7 measured at dt = 0.05 over 1000
+        // periods.
         let relative = first.max(second) / INITIAL_ENERGY;
         assert!(
             relative < 5e-6,
@@ -452,8 +453,9 @@ mod tests {
         assert!(first > 0.0);
         // Small first, and only then does the ratio mean anything: a solver
         // that zeroed the state would drift by the whole initial energy in
-        // both halves, which reads as a ratio of 1.0. The cap is ten times
-        // the 4.0e-9 measured at dt = 0.1 over 1000 periods.
+        // both halves, which reads as a ratio of 1.0. The cap is an order of
+        // magnitude above the 4.0e-9 measured at dt = 0.1 over 1000
+        // periods.
         let relative = first.max(second) / INITIAL_ENERGY;
         assert!(
             relative < 4e-8,
@@ -476,8 +478,9 @@ mod tests {
         assert!(first > 0.0);
         // Small first, and only then does the ratio mean anything: a solver
         // that zeroed the state would drift by the whole initial energy in
-        // both halves, which reads as a ratio of 1.0. The cap is ten times
-        // the 3.4e-10 measured at dt = 0.1 over 1000 periods.
+        // both halves, which reads as a ratio of 1.0. The cap is an order of
+        // magnitude above the 3.4e-10 measured at dt = 0.1 over 1000
+        // periods.
         let relative = first.max(second) / INITIAL_ENERGY;
         assert!(
             relative < 4e-9,

--- a/utsuroi/src/solver/yoshida.rs
+++ b/utsuroi/src/solver/yoshida.rs
@@ -386,13 +386,17 @@ mod tests {
 
     // Symplecticity: bounded energy drift
 
+    /// The energy `energy_drift` starts from: `0.5 (v² + x²)` at `x = 1`,
+    /// `v = 0`.
+    const INITIAL_ENERGY: f64 = 0.5;
+
     fn energy_drift<F>(integrator: F, dt: f64, t_end: f64) -> (f64, f64)
     where
         F: Fn(&HarmonicOscillator1D, f64, &State<1, 2>, f64) -> State<1, 2>,
     {
         let system = HarmonicOscillator1D;
         let mut state = State::<1, 2>::new(SVector::from([1.0]), SVector::from([0.0]));
-        let initial_energy = 0.5;
+        let initial_energy = INITIAL_ENERGY;
         let t_mid = t_end / 2.0;
 
         let mut first_half: f64 = 0.0;
@@ -422,6 +426,16 @@ mod tests {
         let (first, second) = energy_drift(|s, t, st, dt| Yoshida4.step(s, t, st, dt), dt, t_end);
 
         assert!(first > 0.0, "Should have some energy oscillation");
+        // Small first, and only then does the ratio mean anything: a solver
+        // that zeroed the state would drift by the whole initial energy in
+        // both halves, which reads as a ratio of 1.0. The cap is ten times
+        // the 4.8e-7 measured at dt = 0.05 over 1000 periods.
+        let relative = first.max(second) / INITIAL_ENERGY;
+        assert!(
+            relative < 5e-6,
+            "Yoshida4 drifts by {relative:e} of the initial energy, over \
+             the cap 5e-6 (first={first:.2e}, second={second:.2e})"
+        );
         let ratio = second / first;
         assert!(
             ratio < 1.5,
@@ -436,6 +450,16 @@ mod tests {
         let (first, second) = energy_drift(|s, t, st, dt| Yoshida6.step(s, t, st, dt), dt, t_end);
 
         assert!(first > 0.0);
+        // Small first, and only then does the ratio mean anything: a solver
+        // that zeroed the state would drift by the whole initial energy in
+        // both halves, which reads as a ratio of 1.0. The cap is ten times
+        // the 4.0e-9 measured at dt = 0.1 over 1000 periods.
+        let relative = first.max(second) / INITIAL_ENERGY;
+        assert!(
+            relative < 4e-8,
+            "Yoshida6 drifts by {relative:e} of the initial energy, over \
+             the cap 4e-8 (first={first:.2e}, second={second:.2e})"
+        );
         let ratio = second / first;
         assert!(
             ratio < 1.5,
@@ -450,6 +474,16 @@ mod tests {
         let (first, second) = energy_drift(|s, t, st, dt| Yoshida8.step(s, t, st, dt), dt, t_end);
 
         assert!(first > 0.0);
+        // Small first, and only then does the ratio mean anything: a solver
+        // that zeroed the state would drift by the whole initial energy in
+        // both halves, which reads as a ratio of 1.0. The cap is ten times
+        // the 3.4e-10 measured at dt = 0.1 over 1000 periods.
+        let relative = first.max(second) / INITIAL_ENERGY;
+        assert!(
+            relative < 4e-9,
+            "Yoshida8 drifts by {relative:e} of the initial energy, over \
+             the cap 4e-9 (first={first:.2e}, second={second:.2e})"
+        );
         let ratio = second / first;
         assert!(
             ratio < 1.5,


### PR DESCRIPTION
## 概要

保存量のテストは、値そのものではなく、値が変化していないかどうかだけを見ていた。
変化しない状態がその条件を満たすので、積分ループを「初手で状態をゼロにする」実装に
変えても、utsuroi のエネルギー・不変量テストは通った。

実装は変えず、その 9 本に「軌道が実際に動いたこと」を足す。1 ステップごとの状態を
解析解と比べる側は #408 で入れた。

## 通ってしまう実装

5 つの積分ループが 1 歩進めて state を確定させる箇所（adaptive なら誤差判定を通った
ところ）で、その state を `.scale(0.0)` に置き換えた。初手で全エネルギーを失う実装に
なる。

通ったのは、Verlet と Yoshida4/6/8 の secular drift テスト、RK4 の
Lotka-Volterra 不変量テスト、DOP853 の評価回数比較。`Rk4::step` を「入力をそのまま返す」に
置き換えた場合は、RK4 のエネルギー保存と Lotka-Volterra 不変量が通る（drift がちょうど
0 になる）。

### 通る理由

**エネルギー誤差の比較が、区間どうしの比だけだった。** symplectic 法ではエネルギー誤差が
増え続けずに振動する。それを検査する 4 件（Verlet と Yoshida4/6/8）は、1000 周期の積分を
時刻 $t_\text{end}/2$ で 2 つの区間に分け、区間ごとの $\max_t |E(t) - E_0|$ を求めて、後の
区間が先の区間の 1.5 倍以内（Verlet は 1.2 倍以内）に収まることを課していた。初手で状態がゼロになると $E(t)$ は
どちらの区間でも 0 のままなので、$\max_t |E(t) - E_0|$ は両区間とも $E_0$ に等しく、比は
1.0 になる。

**保存量は、動かない状態に対して厳密に成立する。** RK4 の 2 件は drift の上限だけを見て
いた。`step` が入力を返すと drift は 0 で、どんな上限も満たす。

**評価回数の比較が outcome を捨てていた。** `tight_tolerance_dop853_fewer_evaluations` は
両方の `IntegrationOutcome` を `_` で束ねていたので、途中で諦めた積分が最も安価と判定され
得た。

## 追加した検査

**symplectic の 4 件**: $\max_t |E(t) - E_0| / E_0$ の固定上限。既存の比の assert は残した。
上限が「drift が小さい」ことを言い、比が「後半も同じ大きさに収まる」ことを言う。

| 手法 | $\Delta t$ | 実測 $\max\|\Delta E\|/E_0$ | 上限 |
|---|---|---|---|
| Verlet | 0.05 | 6.25e-4 | 6e-3 |
| Yoshida4 | 0.05 | 4.76e-7 | 5e-6 |
| Yoshida6 | 0.1 | 3.97e-9 | 4e-8 |
| Yoshida8 | 0.1 | 3.35e-10 | 4e-9 |

いずれも 1000 周期の積分で、上限は実測の 1 桁上（9.6〜11.9 倍）。

**RK4 の 2 件**: 初期状態からの最大距離。調和振動子は 1 往復で 2.0 進むので下限 1.9
（実測 1.999998）、Lotka-Volterra は時間 10 の積分で 0.874 進むので下限 0.4。個体数の
正値性も課した（不変量が $\ln x$ と $\ln y$ を含むため）。

**評価回数の比較**: 両方の outcome を受け取り、`Completed` であること、最後の callback が
$t_\text{end}$ であること、10 周期後に $x = (1,0,0)$ かつ静止に戻ることを、回数を比べる前に
検査する。

位置と速度の両方を見るのは、周期末では位相誤差 $\delta$ が

$$x = \cos\delta \approx 1 - \frac{\delta^2}{2}, \qquad v = -\sin\delta \approx -\delta$$

となり、位置には 2 次でしか現れないため。$\delta = 4\times10^{-5}$ のとき位置誤差は
$8.0\times10^{-10}$ で $10^{-9}$ の上限を通るが、速度誤差は $4.0\times10^{-5}$ になる。

## 検証

同じ mutation を再実行すると、上で通っていたもののうち、mutation を当てたループを通る
ものはすべて検出側に回った（symplectic の 4 件と評価回数比較）。
`test_rk4_lotka_volterra_invariant` は `Rk4.step` を直接回すのでこの mutation を通らず、
`Rk4::step` 凍結の側で検出を確認した。

`cargo clippy -p utsuroi --no-default-features -- -D warnings`（CI の no_std ジョブと同じ）は
警告なし。

## 関連

保存量と移動距離だけでは、エネルギー面上の別の点へ瞬間移動する実装、Lotka-Volterra の同じ不変量曲線上へ跳ぶ実装、
周波数や進行方向が違うまま十分遠くまで動く実装は、保存量と移動距離だけでは通る。これらは
既存の次数・精度テスト（`test_rk4_order_of_accuracy`、`yoshida4_more_accurate_than_verlet`
など）と、#408 が解析解と比較する側で扱う。
