### PR TITLE
docs(utsuroi): say which error estimate DOP853 controls on

### DIFF
--- a/utsuroi/src/solver/dop853/mod.rs
+++ b/utsuroi/src/solver/dop853/mod.rs
@@ -140,7 +140,10 @@ fn dop853_candidate<S: DynamicalSystem>(
         .axpy(dt * B11, &k11)
         .axpy(dt * B12, &k12);
 
-    // Error estimation: combine 5th-order and 3rd-order errors
+    // Error estimation. Both differences are formed here; the one this
+    // returns is `err5`, and `err3` waits on #410 (see the note below the
+    // two).
+    //
     // 5th-order error: dt * (er1*k1 + er6*k6 + ... + er12*k12)
     let err5 = k1
         .scale(ER1)

--- a/utsuroi/src/solver/dop853/mod.rs
+++ b/utsuroi/src/solver/dop853/mod.rs
@@ -175,9 +175,12 @@ fn dop853_candidate<S: DynamicalSystem>(
     //     err = E / sqrt(n (E + 0.01 F))
     //
     // (the published form carries an explicit `|h|` because there the
-    // difference vectors exclude it). `OdeState::error_norm` computes
+    // difference vectors exclude it, and it substitutes 1 for a denominator
+    // that comes out non-positive). `OdeState::error_norm` computes
     // `sqrt(E / n)`, which is the same expression with `F = 0`, so it never
-    // returns less: the ratio is `sqrt(E / (E + 0.01 F)) <= 1`. A larger
+    // returns less: for `E > 0` the ratio is `sqrt(E / (E + 0.01 F)) <= 1`,
+    // and at `E = 0` both are zero — an exact step is accepted either way. A
+    // larger
     // estimate means the controller accepts less, and on one period of a
     // harmonic oscillator that measured as more accuracy than the tolerance
     // asked for — 30x at `tol = 1e-6`, 700x at `1e-10` — over 11 and 41

--- a/utsuroi/src/solver/dop853/mod.rs
+++ b/utsuroi/src/solver/dop853/mod.rs
@@ -14,8 +14,10 @@ use crate::{
 /// Dormand-Prince 8(5,3) adaptive step-size integrator (DOP853).
 ///
 /// Uses a 12-stage embedded Runge-Kutta pair. The 8th-order solution is
-/// propagated (local extrapolation); the 5th and 3rd-order solutions are
-/// used for error estimation. Based on Hairer, Norsett & Wanner (1993).
+/// propagated (local extrapolation), and the step size is controlled on the
+/// 5th-order difference alone. Hairer, Norsett & Wanner (1993) combine that
+/// with a 3rd-order difference; this does not — see
+/// <https://github.com/sksat/orts/issues/410> for what that costs.
 pub struct Dop853;
 
 /// Internal DOP853 candidate computation: stages 2..12 (11 evaluations).
@@ -166,14 +168,21 @@ fn dop853_candidate<S: DynamicalSystem>(
         .scale(dt);
 
     // Hairer's step control divides by a denominator built from both
-    // differences, `err = |h| E / sqrt(n (E + 0.01 F))` with `E` and `F` the
-    // sums of the squared scaled err5 and err3 components. The norm this
-    // returns to is `sqrt(E / n)`, which is that expression with `F = 0`, so
-    // it is never smaller: the ratio is `sqrt(E / (E + 0.01 F)) <= 1`. The
-    // stepper therefore takes smaller steps than DOP853 is designed to, and
-    // returns more accuracy than the caller asked for — measured on one
-    // period of a harmonic oscillator, 30x at `tol = 1e-6` and 700x at
-    // `1e-10`.
+    // differences. Writing `E` and `F` for the sums of the squared
+    // tolerance-scaled components of `err5` and `err3` as they are below —
+    // both already multiplied by `dt` — his estimate is
+    //
+    //     err = E / sqrt(n (E + 0.01 F))
+    //
+    // (the published form carries an explicit `|h|` because there the
+    // difference vectors exclude it). `OdeState::error_norm` computes
+    // `sqrt(E / n)`, which is the same expression with `F = 0`, so it never
+    // returns less: the ratio is `sqrt(E / (E + 0.01 F)) <= 1`. A larger
+    // estimate means the controller accepts less, and on one period of a
+    // harmonic oscillator that measured as more accuracy than the tolerance
+    // asked for — 30x at `tol = 1e-6`, 700x at `1e-10` — over 11 and 41
+    // accepted steps. Whether that holds on a given problem is the
+    // controller's business, not a guarantee of this norm.
     //
     // TODO(#410): implement the composite norm, or drop `err3` and document
     // the estimate as the 5th-order difference. `OdeState::error_norm` takes

--- a/utsuroi/src/solver/dop853/mod.rs
+++ b/utsuroi/src/solver/dop853/mod.rs
@@ -171,28 +171,32 @@ fn dop853_candidate<S: DynamicalSystem>(
         .scale(dt);
 
     // Hairer's step control divides by a denominator built from both
-    // differences. Writing `E` and `F` for the sums of the squared
-    // tolerance-scaled components of `err5` and `err3` as they are below —
-    // both already multiplied by `dt` — his estimate is
+    // differences. Write `E` and `F` for the sums over all `n` state
+    // components of the squared tolerance-scaled components of `err5` and
+    // `err3` — scaled by `sc_i = atol + rtol * max(|y_i|, |y8_i|)`, and both
+    // vectors already multiplied by `dt`. His estimate is
     //
     //     err = E / sqrt(n (E + 0.01 F))
     //
     // (the published form carries an explicit `|h|` because there the
     // difference vectors exclude it, and it substitutes 1 for a denominator
     // that comes out non-positive). `OdeState::error_norm` computes
-    // `sqrt(E / n)`, which is the same expression with `F = 0`, so it never
-    // returns less: for `E > 0` the ratio is `sqrt(E / (E + 0.01 F)) <= 1`,
-    // and at `E = 0` both are zero — an exact step is accepted either way. A
-    // larger
-    // estimate means the controller accepts less, and on one period of a
-    // harmonic oscillator that measured as more accuracy than the tolerance
-    // asked for — 30x at `tol = 1e-6`, 700x at `1e-10` — over 11 and 41
-    // accepted steps. Whether that holds on a given problem is the
-    // controller's business, not a guarantee of this norm.
+    // `sqrt(E / n)`, which is the same expression with `F = 0`, so for the
+    // same candidate and tolerances it never returns less: at `E > 0` the
+    // ratio `err_hairer / err_current` is `sqrt(E / (E + 0.01 F)) <= 1`, and
+    // at `E = 0` both are zero, which the controller accepts either way (that
+    // says the 5th-order difference vanished, not that the step was exact).
+    //
+    // A larger estimate makes the controller accept fewer steps. Measured on
+    // one period of a harmonic oscillator, with the terminal error against
+    // the analytic solution: 3.17e-8 over 11 accepted steps at `tol = 1e-6`,
+    // and 1.45e-13 over 41 steps at `1e-10`. That is this problem, not a
+    // property of the norm.
     //
     // TODO(#410): implement the composite norm, or drop `err3` and document
-    // the estimate as the 5th-order difference. `OdeState::error_norm` takes
-    // one error vector, so the first needs an API for two.
+    // the estimate as the 5th-order difference. The composite needs no new
+    // API: with `a = error_norm(err5)` and `b = error_norm(err3)`, Hairer's
+    // expression is `a * a / (a * a + 0.01 * b * b).sqrt()`.
     let _ = err3;
     let error = err5;
 

--- a/utsuroi/src/solver/dop853/mod.rs
+++ b/utsuroi/src/solver/dop853/mod.rs
@@ -171,38 +171,15 @@ fn dop853_candidate<S: DynamicalSystem>(
         .scale(dt);
 
     // Hairer's step control divides by a denominator built from both
-    // differences. Write `E` and `F` for the sums over all `n` state
-    // components of the squared tolerance-scaled components of `err5` and
-    // `err3` — scaled by `sc_i = atol + rtol * max(|y_i|, |y8_i|)`, and both
-    // vectors already multiplied by `dt`. His estimate is
-    //
-    //     err = E / sqrt(n (E + 0.01 F))
-    //
-    // (the published form carries an explicit `|h|` because there the
-    // difference vectors exclude it, and it substitutes 1 for a denominator
-    // that comes out non-positive). `OdeState::error_norm` computes
-    // `sqrt(E / n)`, which is the same expression with `F = 0`, so for the
-    // same candidate and tolerances it never returns less: at `E > 0` the
-    // ratio `err_hairer / err_current` is `sqrt(E / (E + 0.01 F)) <= 1`, and
-    // at `E = 0` both are zero, which the controller accepts either way (that
-    // says the 5th-order difference vanished, not that the step was exact).
-    //
-    // A larger estimate makes the controller accept fewer steps. Measured on
-    // one period of a harmonic oscillator, with the terminal error against
-    // the analytic solution: 3.17e-8 over 11 accepted steps at `tol = 1e-6`,
-    // and 1.45e-13 over 41 steps at `1e-10`. That is this problem, not a
-    // property of the norm.
+    // differences; this returns `err5` alone, so the controller sees the
+    // 5th-order difference. For a state whose `error_norm` is a flat RMS over
+    // every component, that estimate is never below Hairer's, so the
+    // controller accepts a given candidate no more easily and tends to pick
+    // smaller steps. The derivation, what the other `error_norm`
+    // implementations do instead, and the measured effect are in #410.
     //
     // TODO(#410): implement the composite norm, or drop `err3` and document
-    // the estimate as the 5th-order difference. Implementing it needs a norm
-    // that takes both error vectors at once. Two separate `error_norm` calls
-    // only reconstruct Hairer's expression where the implementation is a flat
-    // RMS over every component — `State<DIM, ORDER>` and `AttitudeState` are,
-    // and there `a = error_norm(err5)`, `b = error_norm(err3)` give
-    // `a * a / (a * a + 0.01 * b * b).sqrt()` because the `n` cancels. But
-    // `SpacecraftState` maxes over orbit, attitude and mass, and `GroupState`
-    // maxes over satellites, so `a` and `b` can come from different
-    // sub-states and their combination is not Hairer's `E` and `F`.
+    // the estimate as the 5th-order difference.
     let _ = err3;
     let error = err5;
 

--- a/utsuroi/src/solver/dop853/mod.rs
+++ b/utsuroi/src/solver/dop853/mod.rs
@@ -22,7 +22,10 @@ pub struct Dop853;
 ///
 /// Returns `(y8, error)` where:
 /// - `y8`: 8th-order solution
-/// - `error`: composite error estimate (combined 5th + 3rd order)
+/// - `error`: the 5th-order difference `y8 - y5`, which is what the stepper
+///   controls on. Hairer combines it with a 3rd-order difference; this does
+///   not, so the estimate behaves as `h⁶` while the controller's exponent
+///   assumes `h⁸` — see <https://github.com/sksat/orts/issues/410>.
 ///
 /// The 13th stage `k13 = f(t + dt, y8)` is *not* computed here. It plays no
 /// part in the error estimate, so a rejected candidate never needs it, and an
@@ -162,17 +165,20 @@ fn dop853_candidate<S: DynamicalSystem>(
         .axpy(B12 - BHH3, &k12)
         .scale(dt);
 
-    // Combined error: sqrt((err5^2 + 0.01 * err3^2) / (1 + 0.01))
-    // We use a weighted combination following Hairer's approach.
-    // For the OdeState interface, we combine err5 and err3 into a single error vector.
-    // The actual norm computation happens in error_norm_dop853.
-    // Store err5 as the primary error; we'll compute the combined norm separately.
-    // Actually, to keep the interface clean, we precompute a combined error.
-    // Hairer uses: err = sqrt( (err5/sc)^2 + 0.01*(err3/sc)^2 ) / sqrt(1.01)
-    // We approximate by returning err5 scaled up slightly when err3 dominates.
-    // For simplicity in the OdeState interface, use err5 as error estimate.
-    // The 5th-order error is the tighter one and drives step control.
-    let _ = err3; // Will be used for combined norm later if needed
+    // Hairer's step control divides by a denominator built from both
+    // differences, `err = |h| E / sqrt(n (E + 0.01 F))` with `E` and `F` the
+    // sums of the squared scaled err5 and err3 components. The norm this
+    // returns to is `sqrt(E / n)`, which is that expression with `F = 0`, so
+    // it is never smaller: the ratio is `sqrt(E / (E + 0.01 F)) <= 1`. The
+    // stepper therefore takes smaller steps than DOP853 is designed to, and
+    // returns more accuracy than the caller asked for — measured on one
+    // period of a harmonic oscillator, 30x at `tol = 1e-6` and 700x at
+    // `1e-10`.
+    //
+    // TODO(#410): implement the composite norm, or drop `err3` and document
+    // the estimate as the 5th-order difference. `OdeState::error_norm` takes
+    // one error vector, so the first needs an API for two.
+    let _ = err3;
     let error = err5;
 
     (y8, error)

--- a/utsuroi/src/solver/dop853/mod.rs
+++ b/utsuroi/src/solver/dop853/mod.rs
@@ -194,9 +194,15 @@ fn dop853_candidate<S: DynamicalSystem>(
     // property of the norm.
     //
     // TODO(#410): implement the composite norm, or drop `err3` and document
-    // the estimate as the 5th-order difference. The composite needs no new
-    // API: with `a = error_norm(err5)` and `b = error_norm(err3)`, Hairer's
-    // expression is `a * a / (a * a + 0.01 * b * b).sqrt()`.
+    // the estimate as the 5th-order difference. Implementing it needs a norm
+    // that takes both error vectors at once. Two separate `error_norm` calls
+    // only reconstruct Hairer's expression where the implementation is a flat
+    // RMS over every component — `State<DIM, ORDER>` and `AttitudeState` are,
+    // and there `a = error_norm(err5)`, `b = error_norm(err3)` give
+    // `a * a / (a * a + 0.01 * b * b).sqrt()` because the `n` cancels. But
+    // `SpacecraftState` maxes over orbit, attitude and mass, and `GroupState`
+    // maxes over satellites, so `a` and `b` can come from different
+    // sub-states and their combination is not Hairer's `E` and `F`.
     let _ = err3;
     let error = err5;
 


### PR DESCRIPTION
## 概要

DOP853 の step 制御は、実装が使っていない誤差推定を使うと書かれていた。rustdoc は返り値を
"composite error estimate (combined 5th + 3rd order)" と呼び、コメントは存在しない関数と
存在しない scaling を説明していたが、実際に見ているのは 5 次差分だけ。

flat RMS の `error_norm` を使う state では、この推定は Hairer の式を下回らない。つまり
candidate の受理が保守的になり、刻みが小さめに選ばれる。導出と実測、他の `error_norm`
実装での事情は #410 にまとめた。

挙動は変えず、記述を実装に合わせ、この差を実測して書き、composite norm を実装するかの
判断を #410 に切り出した。

## 何が食い違っていたか

DOP853 は 8 次解 $y_8$ を伝播しつつ、同じ stage から 5 次解と 3 次解も組める。その差
$y_8 - y_5$（コード上の `err5`）と $y_8 - y_3$（`err3`）が step 幅を決める材料になる。
`dop853_candidate` が返すのは `err5` だけで、`err3` は計算した上で捨てている。

```rust
let _ = err3; // Will be used for combined norm later if needed
let error = err5;
```

同じ関数の中に、存在しない仕組みを説明する記述が 3 つあった。

- "The actual norm computation happens in error_norm_dop853" — `error_norm_dop853` は
  この repo のどこにも定義がない
- "We approximate by returning err5 scaled up slightly when err3 dominates" — scaling は
  行っていない
- 2 つの差分の手前のコメント "Error estimation: combine 5th-order and 3rd-order errors"
  — 組み合わせずに `err5` だけを返す

## 書き直した内容

`dop853_candidate` が返すのは `err5` だけなので、step 制御は 5 次差分を見ている。Hairer の
`dop853.f` は両方の差分から分母を作る式を使っており、現在の norm はその式の $F = 0$ の
場合にあたる（$E$, $F$ は tolerance で割った各成分の 2 乗和）。式の形と成立条件、実測、
`error_norm` の実装ごとの事情は #410 に置いた。

コード側には要点と TODO だけ残す:

```rust
// TODO(#410): implement the composite norm, or drop `err3` and document
// the estimate as the 5th-order difference. `OdeState::error_norm` takes
// one error vector, so the first needs an API for two.
let _ = err3;
let error = err5;
```

`cargo test -p utsuroi` 167 passed、`cargo clippy -p utsuroi --no-default-features -- -D warnings` は警告なし。




