### PR TITLE
perf(ci): run the disk cleanup only when the runner is short on disk

### DIFF
--- a/.github/actions/free-disk-space-if-low/action.yml
+++ b/.github/actions/free-disk-space-if-low/action.yml
@@ -1,0 +1,49 @@
+name: Free disk space if low
+description: >-
+  Removes preinstalled runtimes, but only when the runner is actually short on
+  disk. The cleanup itself takes 53-113 s per job (measured), so it is worth
+  paying when a build would otherwise run out of space and worth skipping when
+  it would not.
+
+inputs:
+  threshold-gib:
+    description: >-
+      Run the cleanup when the root filesystem has fewer than this many GiB
+      available. The orts workspace builds well under 20 GiB of target and
+      registry data, so this leaves a wide margin. Measured 2026-09-02: x64
+      ubuntu-latest starts with 87 GiB available, and the cleanup reclaimed
+      22 GiB nobody needed.
+    default: "45"
+
+runs:
+  using: composite
+  steps:
+    - name: Measure disk headroom
+      id: headroom
+      shell: bash
+      run: |
+        set -euo pipefail
+        avail=$(df --block-size=1G --output=avail / | tail -1 | tr -d ' ')
+        threshold='${{ inputs.threshold-gib }}'
+        echo "available: ${avail} GiB (cleanup threshold ${threshold} GiB)"
+        if [ "$avail" -lt "$threshold" ]; then
+          echo "low=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "low=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    # large-packages stays off because it would also remove LLVM/clang, which
+    # `.cargo/config.toml` names as the linker driver for wild. tool-cache stays
+    # so setup-rust and setup-node stay hot, and swap stays because the linker
+    # occasionally peaks memory.
+    - name: Free disk space
+      if: steps.headroom.outputs.low == 'true'
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: true
+        swap-storage: false

--- a/.github/actions/free-disk-space-if-low/action.yml
+++ b/.github/actions/free-disk-space-if-low/action.yml
@@ -23,10 +23,13 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        avail=$(df --block-size=1G --output=avail / | tail -1 | tr -d ' ')
-        threshold='${{ inputs.threshold-gib }}'
-        echo "available: ${avail} GiB (cleanup threshold ${threshold} GiB)"
-        if [ "$avail" -lt "$threshold" ]; then
+        # Compared in bytes: `df --block-size=1G` rounds up, so 44.1 GiB
+        # available would report as 45 and skip a cleanup the threshold asks for.
+        avail_bytes=$(df --block-size=1 --output=avail / | tail -1 | tr -d ' ')
+        threshold_bytes=$(( ${{ inputs.threshold-gib }} * 1024 * 1024 * 1024 ))
+        echo "available: $((avail_bytes / 1024 / 1024)) MiB" \
+             "(cleanup threshold ${{ inputs.threshold-gib }} GiB)"
+        if [ "$avail_bytes" -lt "$threshold_bytes" ]; then
           echo "low=true" >> "$GITHUB_OUTPUT"
         else
           echo "low=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,26 +199,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Standard ubuntu-latest runners ship with only ~14 GB of free
-      # disk. The orts workspace (rerun + wasmtime with async feature
-      # + criterion benches + 50+ transitive crates) fills that during
-      # the link phase of `cargo test --workspace --no-run`, so we
-      # reclaim ~17 GB by removing runtimes we don't need (Android,
-      # .NET, Haskell, Docker). Large-packages is intentionally off
-      # because it would also remove LLVM/clang, which our
-      # `.cargo/config.toml` uses as the linker driver for wild.
-      # Tool-cache is kept so setup-rust / setup-node stay hot, and
-      # swap is kept because the linker occasionally peaks memory.
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: false
+      # The cleanup this wraps was added when ubuntu-latest shipped ~14 GB of
+      # free disk, which the link phase of `cargo test --workspace --no-run`
+      # filled. The image now starts with 87 GiB available (measured
+      # 2026-09-02), so the action checks first and skips the 66-113 s cleanup
+      # unless the headroom is actually gone.
+      - name: Free disk space if low
+        uses: ./.github/actions/free-disk-space-if-low
 
       - name: Set up wild linker
         uses: ./.github/actions/setup-wild
@@ -241,6 +228,12 @@ jobs:
       - name: Build workspace
         run: cargo test --locked --workspace --no-run
 
+      # What the cleanup threshold in free-disk-space-if-low is set against:
+      # this is the workspace's heaviest link phase, so the headroom left here
+      # says how much margin that threshold really has.
+      - name: Report disk headroom after the build
+        run: df -h /
+
       - name: Upload CLI binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -258,16 +251,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: false
+      - name: Free disk space if low
+        uses: ./.github/actions/free-disk-space-if-low
 
       - name: Set up wild linker
         uses: ./.github/actions/setup-wild
@@ -310,16 +295,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: false
+      - name: Free disk space if low
+        uses: ./.github/actions/free-disk-space-if-low
 
       - name: Set up wild linker
         uses: ./.github/actions/setup-wild
@@ -353,16 +330,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: false
+      - name: Free disk space if low
+        uses: ./.github/actions/free-disk-space-if-low
 
       - name: Set up wild linker
         uses: ./.github/actions/setup-wild
@@ -398,16 +367,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: false
+      - name: Free disk space if low
+        uses: ./.github/actions/free-disk-space-if-low
 
       - name: Set up wild linker
         uses: ./.github/actions/setup-wild
@@ -534,16 +495,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: false
+      - name: Free disk space if low
+        uses: ./.github/actions/free-disk-space-if-low
 
       - name: Set up wild linker
         uses: ./.github/actions/setup-wild
@@ -615,6 +568,11 @@ jobs:
             --test serve_kble_stdio_e2e \
             --test run_mode_e2e
 
+      # This job carries both the test binaries and the guest WASM, so it is
+      # the other place worth knowing the headroom at (see rust-build).
+      - name: Report disk headroom after the build
+        run: df -h /
+
       - name: Run CLI plugin-backend E2E
         env:
           ORTS_BIN: ${{ github.workspace }}/bin/orts
@@ -654,16 +612,8 @@ jobs:
       - name: Set up wild linker
         uses: ./.github/actions/setup-wild
 
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: false
+      - name: Free disk space if low
+        uses: ./.github/actions/free-disk-space-if-low
 
       - name: Parse rust-toolchain.toml
         id: rust-toolchain
@@ -803,18 +753,11 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-musl'
         uses: ./.github/actions/setup-wild
 
-      # Linux-only action, and only the Linux builds are large enough to need it.
-      - name: Free disk space
+      # Linux-only action. The dist build also holds the `cross` image, so it is
+      # the one job whose headroom is worth cleaning when it runs short.
+      - name: Free disk space if low
         if: runner.os == 'Linux'
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: false
+        uses: ./.github/actions/free-disk-space-if-low
 
       # gnu is built via `cross` so its glibc floor is pinned and
       # host-independent (see Cross.toml); no host wild/clang needed. musl

--- a/.github/workflows/linker-bench.yml
+++ b/.github/workflows/linker-bench.yml
@@ -43,16 +43,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: false
+      - name: Free disk space if low
+        uses: ./.github/actions/free-disk-space-if-low
 
       - name: Show runner size
         run: |


### PR DESCRIPTION
PR CI の critical path は `rust-build`(312s) → `cli-plugin-backend-e2e`(648s) の 960s で、これは直近の PR run 43 本の総時間の中央値 960s と一致する。その 960s のうち **170s** が、テストでもビルドでもない disk cleanup だった。

## 実測した内訳

PR run 5 本の step 平均:

| job | 合計 | うち Free disk space | 主な残り |
| --- | --- | --- | --- |
| rust-build | 312s | **66s** | Build workspace 187s |
| cli-plugin-backend-e2e | 648s | **104s** | E2E 実行 226s / test binaries build 193s / install kble 50s |
| rust-test-orts-integration | 443s | **82s** | integration test 330s |
| rust-test | 408s | **53s** | test 291s |

## cleanup が前提にしている空き容量が変わっている

step のコメントには追加時の前提が書かれていた。「Standard ubuntu-latest runners ship with only ~14 GB of free disk」で、`cargo test --workspace --no-run` の link 段階がそれを使い切る、というもの。

その step 自身のログから取った 2026-09-02 の実測値:

```
before:  /dev/root  145G  58G   87G  41% /
after:   /dev/root  145G  36G  108G  26% /
=> Saved 22GiB, in 112.6 s
```

87 GiB 空いている runner で 22 GiB を回収するために 112.6s 使っている。この workspace の Cargo cache は圧縮後 1.2 GB で、target を展開しても桁が違う。

## 変更

step を消して「image が大きいままである」ことに賭けるのではなく、cleanup を composite action `free-disk-space-if-low` に入れ、root filesystem を測ってから閾値(45 GiB)未満のときだけ実行するようにした。

- 空きが十分な x64 の job は cleanup を skip する
- 空きが足りない環境 — arm64 runner や、将来 image がまた埋まった場合 — では従来どおり実行される
- job ごとの条件を書き分ける必要がない。`rust-dist` だけ `runner.os == 'Linux'` の guard を維持（action が Linux 専用のため）
- cleanup の設定(tool-cache: false, android/dotnet/haskell/docker-images: true, large-packages: false, swap-storage: false)と pinned SHA は変えていない

閾値の根拠を後からデータで見直せるように、critical path の 2 job では重いビルドの直後に `df -h /` を出す。

## 検証

- 3 ファイルの YAML parse、`jlumbroso/free-disk-space` の直接使用が ci.yml から無くなったことの確認
- step 単位の実測は上表（Actions API の job/step duration、PR run 5 本平均）。cleanup 前後の空き容量は step のログから取得
- codex review 1 周（指摘なし。当初案の「無条件削除」に対して、閾値付き条件実行と arm64 の別測定を勧められたので条件実行にした）
- この PR の CI 自体で確認すること: cleanup が skip されること、`df -h /` の残り容量、cleanup step の duration が 0 になること

run 総時間の比較は、event を揃えて 20-30 run 集まってから行う。前回の PR で、6 サンプルの窓を選んだために誤った結論を出した反省による。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
