### PR TITLE
fix: ask the event predicate about the initial state, before stepping

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -568,7 +568,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   --duration 100` (地球の大気境界は 100 km の Kármán line) は
   「atmospheric entry at 50.0 km」を t = 10 s で報告し、その時刻の sample も
   記録していた。報告している entry から 78 km 進んだ地点である。現在は t = 0 で
-  開始状態のまま停止する。([#TBD](https://github.com/sksat/orts/pull/TBD))
+  開始状態のまま停止する。([#419](https://github.com/sksat/orts/pull/419))
 - `Integrator::try_integrate` が、結果が非有限になった最初のステップで
   `IntegrationError::NonFiniteState` を返して停止するようになった
   (`integrate_with_events` が既に行っていた検査)。従来は `NaN` 状態のまま

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -560,6 +560,15 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   ([#409](https://github.com/sksat/orts/pull/409))
 
 #### Fixed
+- 積分ループが、渡された状態そのものについて event の判定を行うようになった
+  (1 歩進める前)。`utsuroi` の 5 経路と、`IndependentGroup` / `CoupledGroup` が
+  自前で持つ固定刻みループが対象。「地表より下」「この高度より下」のような level-triggered な
+  event は `t0` で既に成立しうるが、従来はまず 1 歩進めていたため、判定関数自身が
+  無効と呼ぶ状態で 1 step 遅れて報告していた。`orts run --sat altitude=50
+  --duration 100` (地球の大気境界は 100 km の Kármán line) は
+  「atmospheric entry at 50.0 km」を t = 10 s で報告し、その時刻の sample も
+  記録していた。報告している entry から 78 km 進んだ地点である。現在は t = 0 で
+  開始状態のまま停止する。([#TBD](https://github.com/sksat/orts/pull/TBD))
 - `Integrator::try_integrate` が、結果が非有限になった最初のステップで
   `IntegrationError::NonFiniteState` を返して停止するようになった
   (`integrate_with_events` が既に行っていた検査)。従来は `NaN` 状態のまま

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -634,7 +634,7 @@ section is subdivided by package.
   boundary is the 100 km Kármán line) reported "atmospheric entry at 50.0 km"
   at t = 10 s and recorded a sample there, 78 km of arc past the entry it was
   reporting; it now terminates at t = 0 with the state it started from.
-  ([#TBD](https://github.com/sksat/orts/pull/TBD))
+  ([#419](https://github.com/sksat/orts/pull/419))
 - `Integrator::try_integrate` stops with `IntegrationError::NonFiniteState` at
   the first step whose result is not finite, the check
   `integrate_with_events` already made. It ran the whole span on a `NaN` state

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -625,6 +625,16 @@ section is subdivided by package.
   before comparing what they cost. ([#409](https://github.com/sksat/orts/pull/409))
 
 #### Fixed
+- Every integrate loop asks its event predicate about the state it was given,
+  before taking a step — the five in `utsuroi` and the fixed-step ones
+  `IndependentGroup` and `CoupledGroup` run themselves. A level-triggered event — "below the surface", "past
+  this altitude" — can already hold at `t0`, and the loops stepped first, so
+  they reported it one step late at a state the predicate itself calls
+  invalid. `orts run --sat altitude=50 --duration 100` (Earth's atmosphere
+  boundary is the 100 km Kármán line) reported "atmospheric entry at 50.0 km"
+  at t = 10 s and recorded a sample there, 78 km of arc past the entry it was
+  reporting; it now terminates at t = 0 with the state it started from.
+  ([#TBD](https://github.com/sksat/orts/pull/TBD))
 - `Integrator::try_integrate` stops with `IntegrationError::NonFiniteState` at
   the first step whose result is not finite, the check
   `integrate_with_events` already made. It ran the whole span on a `NaN` state

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -733,16 +733,20 @@ where
                 "Simulation terminated at t={:.2}s for {}: {}",
                 term.t, term.satellite_id, term.reason
             );
-            // Record final state for terminated satellites
+            // Record final state for terminated satellites, unless that
+            // state is already recorded: an event that holds at t0 terminates
+            // there, where the initial sample sits.
             if let Some(i) = params
                 .satellites
                 .iter()
                 .position(|s| s.id.as_str() == AsRef::<str>::as_ref(&term.satellite_id))
                 && let Some(entry) = group.satellite(&term.satellite_id)
+                && (entry.t - last_output_t[i]) > 1e-9
             {
                 let tp = TimePoint::new().with_sim_time(entry.t).with_step(steps[i]);
                 log_state(&mut rec, &sat_paths[i], &tp, &entry.state);
                 steps[i] += 1;
+                last_output_t[i] = entry.t;
             }
         }
     }

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -735,13 +735,18 @@ where
             );
             // Record final state for terminated satellites, unless that
             // state is already recorded: an event that holds at t0 terminates
-            // there, where the initial sample sits.
+            // there, where the initial sample sits. `last_output_t` carries
+            // the exact time of the last sample written for this satellite,
+            // and a t0 termination carries that same value, so the comparison
+            // is strict — a tolerance here would also drop a termination that
+            // lands a fraction of a nanosecond after a sample, which is a
+            // different state.
             if let Some(i) = params
                 .satellites
                 .iter()
                 .position(|s| s.id.as_str() == AsRef::<str>::as_ref(&term.satellite_id))
                 && let Some(entry) = group.satellite(&term.satellite_id)
-                && (entry.t - last_output_t[i]) > 1e-9
+                && entry.t > last_output_t[i]
             {
                 let tp = TimePoint::new().with_sim_time(entry.t).with_step(steps[i]);
                 log_state(&mut rec, &sat_paths[i], &tp, &entry.state);

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1221,3 +1221,101 @@ fn test_cli_repeated_sat_id_is_rejected() {
         "error should name the repeated id, got: {stderr}"
     );
 }
+
+/// A satellite that starts inside the atmosphere reports entry at t = 0.
+///
+/// Earth's boundary here is the 100 km Karman line, so `altitude=50` is
+/// already past it when the run starts. The event check ran only after a
+/// step, so the run reported "atmospheric entry at 50.0 km" at t = 10 s and
+/// wrote a sample there — 78 km of arc after the entry it was reporting.
+#[test]
+fn a_run_starting_inside_the_atmosphere_terminates_at_t0() {
+    let binary = env!("CARGO_BIN_EXE_orts");
+    let output = Command::new(binary)
+        .args([
+            "run",
+            "--output",
+            "stdout",
+            "--format",
+            "csv",
+            "--sat",
+            "altitude=50",
+            "--duration",
+            "100",
+        ])
+        .output()
+        .expect("failed to execute orts");
+    assert!(
+        output.status.success(),
+        "orts run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("terminated at t=0.00s"),
+        "the entry holds at t0, so that is when it is reported: {stderr}"
+    );
+    assert!(
+        stderr.contains("atmospheric entry"),
+        "the reason is the atmosphere boundary: {stderr}"
+    );
+
+    // One row, the state handed in. The terminated state is the initial one,
+    // so recording it again would double the sample.
+    let csv = String::from_utf8_lossy(&output.stdout);
+    let rows: Vec<&str> = csv
+        .lines()
+        .filter(|l| !l.starts_with('#') && !l.is_empty())
+        .collect();
+    assert_eq!(rows.len(), 1, "one sample at t0: {rows:?}");
+    assert!(
+        rows[0].starts_with("0.000,"),
+        "the sample sits at t0: {}",
+        rows[0]
+    );
+}
+
+/// The same, on the RK4 path.
+///
+/// `IndependentGroup` runs its own fixed-step loop rather than
+/// `Integrator::integrate_with_events`, so `--integrator rk4` needed the
+/// initial check of its own. Measured before that: `t=10.00s` and two rows.
+#[test]
+fn an_rk4_run_starting_inside_the_atmosphere_terminates_at_t0() {
+    let binary = env!("CARGO_BIN_EXE_orts");
+    let output = Command::new(binary)
+        .args([
+            "run",
+            "--output",
+            "stdout",
+            "--format",
+            "csv",
+            "--sat",
+            "altitude=50",
+            "--duration",
+            "100",
+            "--integrator",
+            "rk4",
+        ])
+        .output()
+        .expect("failed to execute orts");
+    assert!(
+        output.status.success(),
+        "orts run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("terminated at t=0.00s") && stderr.contains("atmospheric entry"),
+        "the entry holds at t0, so that is when it is reported: {stderr}"
+    );
+
+    let csv = String::from_utf8_lossy(&output.stdout);
+    let rows: Vec<&str> = csv
+        .lines()
+        .filter(|l| !l.starts_with('#') && !l.is_empty())
+        .collect();
+    assert_eq!(rows.len(), 1, "one sample at t0: {rows:?}");
+}

--- a/orts/src/group/coupled.rs
+++ b/orts/src/group/coupled.rs
@@ -505,6 +505,29 @@ where
                 let mut current_t = self.t;
                 let mut current_state = self.state.clone();
 
+                // The predicate is asked about the state this call starts
+                // from, before any step. A level-triggered event can already
+                // hold there, and stepping first reports it one step late.
+                if let Some(ref checker) = self.event_checker {
+                    for (id, sat_state) in self.ids.iter().zip(&current_state.states) {
+                        if let ControlFlow::Break(reason) = checker(current_t, sat_state) {
+                            self.state = current_state;
+                            self.t = current_t;
+                            self.terminated = true;
+                            self.is_event_termination = true;
+                            let term = SatelliteTermination {
+                                satellite_id: id.clone(),
+                                t: current_t,
+                                reason,
+                            };
+                            self.termination = Some(term.clone());
+                            return Ok(PropGroupOutcome {
+                                terminations: vec![term],
+                            });
+                        }
+                    }
+                }
+
                 while current_t < t_target - 1e-12 {
                     let h = dt.min(t_target - current_t);
                     // `h > 0` after the validate() above, but for large

--- a/orts/src/group/coupled.rs
+++ b/orts/src/group/coupled.rs
@@ -1308,6 +1308,50 @@ mod tests {
         assert!(group.current_t() < 10000.0);
     }
 
+    /// A satellite already below the surface terminates the group at t0.
+    ///
+    /// `CoupledGroup` runs its own fixed-step RK4 loop rather than
+    /// `Integrator::integrate_with_events`, so it needs the initial check of
+    /// its own. The tests above cross the boundary after stepping, which the
+    /// loop caught either way.
+    #[test]
+    fn coupled_group_rk4_event_true_at_t0_terminates_there() {
+        // Inside the Earth: the predicate below holds before any step.
+        let buried_position = Vector3::new(EARTH_RADIUS - 100.0, 0.0, 0.0);
+        let buried = OrbitalState::new(buried_position, Vector3::new(0.0, 7.5, 0.0));
+
+        let mut group: CoupledGroup<TwoBodySystem> = CoupledGroup::rk4(10.0)
+            .with_event_checker(move |_t: f64, state: &OrbitalState| {
+                if state.position().magnitude() < EARTH_RADIUS {
+                    ControlFlow::Break("collision".to_string())
+                } else {
+                    ControlFlow::Continue(())
+                }
+            })
+            .add_satellite("safe", iss_state(), TwoBodySystem { mu: MU_EARTH })
+            .add_satellite("buried", buried, TwoBodySystem { mu: MU_EARTH });
+
+        let outcome = group.propagate_to(1000.0).unwrap();
+
+        assert_eq!(outcome.terminations.len(), 1);
+        assert_eq!(outcome.terminations[0].satellite_id, SatId::from("buried"));
+        assert!(outcome.terminations[0].reason.contains("collision"));
+        assert_eq!(
+            outcome.terminations[0].t, 0.0,
+            "the event holds at t0, so that is where it stops"
+        );
+        assert!(group.is_terminated());
+        assert_eq!(group.current_t(), 0.0, "the group did not step");
+
+        // The terminated state is the one handed in: `current_t` above says
+        // the clock never moved, and the group reports the satellite that
+        // was already inside the body rather than one it integrated into it.
+        assert!(
+            group.snapshot().positions.is_empty(),
+            "a terminated group reports no positions, as it did before"
+        );
+    }
+
     #[test]
     fn coupled_group_multiple_events_first_wins() {
         // Two decaying satellites: first one detected wins

--- a/orts/src/group/independent.rs
+++ b/orts/src/group/independent.rs
@@ -105,7 +105,12 @@ where
         Self::new(IntegratorConfig::Rk4 { dt })
     }
 
-    /// Set an event checker that is called after each integration step.
+    /// Set an event checker, called on the state each `propagate_to` starts
+    /// from and after every accepted step.
+    ///
+    /// The initial call is what catches a level-triggered event that already
+    /// holds — a satellite starting below the surface, say. Terminating there
+    /// leaves the satellite at the time and state it came in with.
     ///
     /// If the checker returns `ControlFlow::Break(reason)`, the satellite is
     /// terminated with that reason string.
@@ -401,7 +406,21 @@ where
                     let mut current_state = entry.state.clone();
 
                     let mut terminated = false;
-                    while current_t < effective_target - 1e-12 {
+                    // The predicate is asked about the state this call starts from,
+                    // before any step. A level-triggered event can already hold there,
+                    // and stepping first reports it one step late.
+                    if let Some(checker) = event_checker
+                        && let ControlFlow::Break(reason) = checker(current_t, &current_state)
+                    {
+                        entry.terminated = true;
+                        terminated = true;
+                        terminations.push(SatelliteTermination {
+                            satellite_id: entry.id.clone(),
+                            t: current_t,
+                            reason,
+                        });
+                    }
+                    while !terminated && current_t < effective_target - 1e-12 {
                         let h = dt.min(effective_target - current_t);
                         // `h > 0` after the validate() above, but for large
                         // `|current_t|` it can still be below the f64 spacing

--- a/orts/src/group/independent.rs
+++ b/orts/src/group/independent.rs
@@ -105,12 +105,16 @@ where
         Self::new(IntegratorConfig::Rk4 { dt })
     }
 
-    /// Set an event checker, called on the state each `propagate_to` starts
-    /// from and after every accepted step.
+    /// Set an event checker, called on the state each *advancing*
+    /// `propagate_to` starts from and after every accepted step.
     ///
     /// The initial call is what catches a level-triggered event that already
     /// holds — a satellite starting below the surface, say. Terminating there
     /// leaves the satellite at the time and state it came in with.
+    ///
+    /// A satellite already at or past the target is skipped entirely, so a
+    /// call that asks it to advance nowhere evaluates nothing. That matches
+    /// the callback: no step, nothing reported.
     ///
     /// If the checker returns `ControlFlow::Break(reason)`, the satellite is
     /// terminated with that reason string.

--- a/utsuroi/src/integrator.rs
+++ b/utsuroi/src/integrator.rs
@@ -99,7 +99,13 @@ pub trait Integrator {
 
     /// Integrate a dynamical system with event detection and NaN/Inf checking.
     ///
-    /// After each step:
+    /// `event_check(t0, &initial)` runs first, before any step: a
+    /// level-triggered event can already hold at `t0`, and reporting it after
+    /// a step would name a state the predicate itself rejects. Terminating
+    /// there returns the initial state at `t0` and calls no callback, since
+    /// the callback reports accepted steps and none was taken.
+    ///
+    /// Then, after each step:
     /// 1. Checks for NaN/Inf in state → returns `IntegrationOutcome::Error`
     /// 2. Calls `callback(t, &state)`
     /// 3. Calls `event_check(t, &state)` → if `Break(reason)`, returns `Terminated`
@@ -125,6 +131,18 @@ pub trait Integrator {
 
         let mut state = initial;
         let mut t = t0;
+
+        // The predicate is asked about the state it was given, before any
+        // step. A level-triggered event — "below the surface", "past this
+        // altitude" — can already hold at `t0`, and stepping first reports it
+        // one step late with a state the caller's own predicate calls invalid.
+        if let ControlFlow::Break(reason) = event_check(t0, &state) {
+            return IntegrationOutcome::Terminated {
+                state,
+                t: t0,
+                reason,
+            };
+        }
 
         while t < t_end {
             let h = dt.min(t_end - t);

--- a/utsuroi/src/integrator.rs
+++ b/utsuroi/src/integrator.rs
@@ -99,11 +99,13 @@ pub trait Integrator {
 
     /// Integrate a dynamical system with event detection and NaN/Inf checking.
     ///
-    /// `event_check(t0, &initial)` runs first, before any step: a
-    /// level-triggered event can already hold at `t0`, and reporting it after
-    /// a step would name a state the predicate itself rejects. Terminating
-    /// there returns the initial state at `t0` and calls no callback, since
-    /// the callback reports accepted steps and none was taken.
+    /// For a span that advances, `event_check(t0, &initial)` runs first,
+    /// before any step: a level-triggered event can already hold at `t0`, and
+    /// reporting it after a step would name a state the predicate itself
+    /// rejects. Terminating there returns the initial state at `t0` and calls
+    /// no callback, since the callback reports accepted steps and none was
+    /// taken. A span with `t0 == t_end` takes no step, so it asks nothing and
+    /// returns the initial state as it came in.
     ///
     /// Then, after each step:
     /// 1. Checks for NaN/Inf in state → returns `IntegrationOutcome::Error`

--- a/utsuroi/src/integrator.rs
+++ b/utsuroi/src/integrator.rs
@@ -136,7 +136,11 @@ pub trait Integrator {
         // step. A level-triggered event — "below the surface", "past this
         // altitude" — can already hold at `t0`, and stepping first reports it
         // one step late with a state the caller's own predicate calls invalid.
-        if let ControlFlow::Break(reason) = event_check(t0, &state) {
+        // Only for a span that advances: an empty span takes no step, so it
+        // reports nothing and asks nothing, and comes back as it went in.
+        if t0 < t_end
+            && let ControlFlow::Break(reason) = event_check(t0, &state)
+        {
             return IntegrationOutcome::Terminated {
                 state,
                 t: t0,

--- a/utsuroi/src/solver/dop853/mod.rs
+++ b/utsuroi/src/solver/dop853/mod.rs
@@ -238,6 +238,19 @@ pub struct AdaptiveStepper853<'a, S: DynamicalSystem> {
 
 impl<'a, S: DynamicalSystem> AdaptiveStepper853<'a, S> {
     /// Advance adaptively to `t_target`.
+    ///
+    /// - `event_check` runs first on the state the stepper currently holds,
+    ///   before any step. A level-triggered event can already hold there, and
+    ///   reporting it after a step would name a state the predicate itself
+    ///   rejects. Terminating there leaves the stepper where it was and calls
+    ///   no callback, since the callback reports accepted steps and none was
+    ///   taken. A later `advance_to` therefore re-evaluates the state it
+    ///   stopped at: for a predicate that only reads the state that is the
+    ///   same answer, but one carrying its own counters sees the endpoint
+    ///   twice.
+    /// - Each accepted step calls `callback(t, &state)`.
+    /// - If `event_check` returns `Break(reason)`, returns `Event { reason }`.
+    /// - On success returns `Reached` with internal state updated to `t_target`.
     pub fn advance_to<F, E, B>(
         &mut self,
         t_target: f64,

--- a/utsuroi/src/solver/dop853/mod.rs
+++ b/utsuroi/src/solver/dop853/mod.rs
@@ -272,7 +272,11 @@ impl<'a, S: DynamicalSystem> AdaptiveStepper853<'a, S> {
         // any step. A level-triggered event — "below the surface", "past this
         // altitude" — can already hold here, and stepping first reports it one
         // step late with a state the caller's own predicate calls invalid.
-        if let ControlFlow::Break(reason) = event_check(self.t, &self.state) {
+        // Only for a target that advances: `advance_to(self.t, ..)` takes no
+        // step, so it reports nothing and asks nothing.
+        if self.t < t_target
+            && let ControlFlow::Break(reason) = event_check(self.t, &self.state)
+        {
             return Ok(AdvanceOutcome853::Event { reason });
         }
 
@@ -1284,5 +1288,36 @@ mod tests {
         assert_eq!(*state.y(), *initial.y(), "the state is the one handed in");
         assert_eq!(*state.dy(), *initial.dy());
         assert_eq!(callbacks, 0, "no step was taken, so nothing to report");
+    }
+
+    /// A target the stepper already reached asks the predicate nothing.
+    ///
+    /// The initial check is for a target that advances. Driven through the
+    /// stepper rather than the wrapper: the wrapper sizes its first step as
+    /// `dt.min(t_end - t0)`, which is zero for an empty span, so it answers
+    /// with the step-size error before reaching this check.
+    #[test]
+    fn a_target_already_reached_does_not_consult_the_event_check() {
+        let system = HarmonicOscillator;
+        let initial = State::<3, 2>::new(vector![7000.0, 0.0, 0.0], vector![0.0, 7.5, 0.0]);
+        let tol = Tolerances::default();
+        let asked = std::cell::Cell::new(0usize);
+        let mut stepper = Dop853.stepper(&system, initial, 5.0, 1.0, tol);
+        let outcome = stepper
+            .advance_to(
+                5.0,
+                |_, _| {},
+                |_, _| {
+                    asked.set(asked.get() + 1);
+                    ControlFlow::Break("would fire")
+                },
+            )
+            .expect("a target already reached is valid");
+        assert!(
+            matches!(outcome, AdvanceOutcome853::Reached),
+            "nothing to advance to, so the stepper reports Reached"
+        );
+        assert_eq!(asked.get(), 0, "no step was taken, so nothing was asked");
+        assert_eq!(stepper.t(), 5.0, "the clock did not move");
     }
 }

--- a/utsuroi/src/solver/dop853/mod.rs
+++ b/utsuroi/src/solver/dop853/mod.rs
@@ -239,15 +239,16 @@ pub struct AdaptiveStepper853<'a, S: DynamicalSystem> {
 impl<'a, S: DynamicalSystem> AdaptiveStepper853<'a, S> {
     /// Advance adaptively to `t_target`.
     ///
-    /// - `event_check` runs first on the state the stepper currently holds,
-    ///   before any step. A level-triggered event can already hold there, and
-    ///   reporting it after a step would name a state the predicate itself
-    ///   rejects. Terminating there leaves the stepper where it was and calls
-    ///   no callback, since the callback reports accepted steps and none was
-    ///   taken. A later `advance_to` therefore re-evaluates the state it
-    ///   stopped at: for a predicate that only reads the state that is the
-    ///   same answer, but one carrying its own counters sees the endpoint
-    ///   twice.
+    /// - For a target that advances, `event_check` runs first on the state the
+    ///   stepper currently holds, before any step. A level-triggered event can
+    ///   already hold there, and reporting it after a step would name a state
+    ///   the predicate itself rejects. Terminating there leaves the stepper
+    ///   where it was and calls no callback, since the callback reports
+    ///   accepted steps and none was taken. A later `advance_to` therefore
+    ///   re-evaluates the state it stopped at: for a predicate that only reads
+    ///   the state that is the same answer, but one carrying its own counters
+    ///   sees the endpoint twice. A target the stepper has already reached
+    ///   takes no step, so it asks nothing and reports `Reached`.
     /// - Each accepted step calls `callback(t, &state)`.
     /// - If `event_check` returns `Break(reason)`, returns `Event { reason }`.
     /// - On success returns `Reached` with internal state updated to `t_target`.

--- a/utsuroi/src/solver/dop853/mod.rs
+++ b/utsuroi/src/solver/dop853/mod.rs
@@ -255,6 +255,14 @@ impl<'a, S: DynamicalSystem> AdaptiveStepper853<'a, S> {
         // while sitting at its old time.
         validate_time_span(self.t, t_target)?;
 
+        // The predicate is asked about the state the stepper holds, before
+        // any step. A level-triggered event — "below the surface", "past this
+        // altitude" — can already hold here, and stepping first reports it one
+        // step late with a state the caller's own predicate calls invalid.
+        if let ControlFlow::Break(reason) = event_check(self.t, &self.state) {
+            return Ok(AdvanceOutcome853::Event { reason });
+        }
+
         while self.t < t_target {
             let h = self.dt.min(t_target - self.t);
             // `h > 0` holds, but for large `|self.t|` it can still be below
@@ -1226,5 +1234,42 @@ mod tests {
     #[test]
     fn advance_to_still_succeeds_for_valid_input() {
         assert!(advance853(nonzero_state(), 0.1, Tolerances::default(), 1.0).is_ok());
+    }
+
+    /// An event that already holds at `t0` stops there, without a step.
+    ///
+    /// A level-triggered predicate — "below the surface", "past this
+    /// altitude" — can be true of the state the caller hands in. This loop
+    /// stepped once before asking, so it reported the event one step late, at
+    /// a state the predicate itself calls invalid. Measured through the CLI
+    /// before the fix: `orts run --sat altitude=50 --duration 100` (Earth's
+    /// atmosphere boundary is the 100 km Karman line) reported "atmospheric
+    /// entry at 50.0 km" at t = 10 s and wrote a sample there, 78 km of arc
+    /// after the entry it was reporting.
+    #[test]
+    fn an_event_true_at_t0_stops_before_stepping() {
+        let system = HarmonicOscillator;
+        let initial = State::<3, 2>::new(vector![7000.0, 0.0, 0.0], vector![0.0, 7.5, 0.0]);
+        let tol = Tolerances::default();
+        let mut callbacks = 0usize;
+        let outcome = Dop853.integrate_adaptive_with_events(
+            &system,
+            initial.clone(),
+            0.0,
+            100.0,
+            1.0,
+            &tol,
+            |_, _| callbacks += 1,
+            // True of anything, so it is true of the initial state.
+            |_, _| ControlFlow::Break("already there"),
+        );
+        let IntegrationOutcome::Terminated { state, t, reason } = outcome else {
+            panic!("an event true at t0 terminates, got {outcome:?}");
+        };
+        assert_eq!(reason, "already there");
+        assert_eq!(t, 0.0, "it stops at t0, not a step later");
+        assert_eq!(*state.y(), *initial.y(), "the state is the one handed in");
+        assert_eq!(*state.dy(), *initial.dy());
+        assert_eq!(callbacks, 0, "no step was taken, so nothing to report");
     }
 }

--- a/utsuroi/src/solver/dp45/mod.rs
+++ b/utsuroi/src/solver/dp45/mod.rs
@@ -132,6 +132,15 @@ pub struct AdaptiveStepper<'a, S: DynamicalSystem> {
 impl<'a, S: DynamicalSystem> AdaptiveStepper<'a, S> {
     /// Advance adaptively to `t_target`.
     ///
+    /// - `event_check` runs first on the state the stepper currently holds,
+    ///   before any step. A level-triggered event can already hold there, and
+    ///   reporting it after a step would name a state the predicate itself
+    ///   rejects. Terminating there leaves the stepper where it was and calls
+    ///   no callback, since the callback reports accepted steps and none was
+    ///   taken. A later `advance_to` therefore re-evaluates the state it
+    ///   stopped at: for a predicate that only reads the state that is the
+    ///   same answer, but one carrying its own counters sees the endpoint
+    ///   twice.
     /// - Each accepted step calls `callback(t, &state)`.
     /// - If `event_check` returns `Break(reason)`, returns `Event { reason }`.
     /// - On success returns `Reached` with internal state updated to `t_target`.

--- a/utsuroi/src/solver/dp45/mod.rs
+++ b/utsuroi/src/solver/dp45/mod.rs
@@ -165,7 +165,11 @@ impl<'a, S: DynamicalSystem> AdaptiveStepper<'a, S> {
         // any step. A level-triggered event — "below the surface", "past this
         // altitude" — can already hold here, and stepping first reports it one
         // step late with a state the caller's own predicate calls invalid.
-        if let ControlFlow::Break(reason) = event_check(self.t, &self.state) {
+        // Only for a target that advances: `advance_to(self.t, ..)` takes no
+        // step, so it reports nothing and asks nothing.
+        if self.t < t_target
+            && let ControlFlow::Break(reason) = event_check(self.t, &self.state)
+        {
             return Ok(AdvanceOutcome::Event { reason });
         }
 
@@ -1147,5 +1151,36 @@ mod tests {
         assert_eq!(*state.y(), *initial.y(), "the state is the one handed in");
         assert_eq!(*state.dy(), *initial.dy());
         assert_eq!(callbacks, 0, "no step was taken, so nothing to report");
+    }
+
+    /// A target the stepper already reached asks the predicate nothing.
+    ///
+    /// The initial check is for a target that advances. Driven through the
+    /// stepper rather than the wrapper: the wrapper sizes its first step as
+    /// `dt.min(t_end - t0)`, which is zero for an empty span, so it answers
+    /// with the step-size error before reaching this check.
+    #[test]
+    fn a_target_already_reached_does_not_consult_the_event_check() {
+        let system = HarmonicOscillator;
+        let initial = State::<3, 2>::new(vector![7000.0, 0.0, 0.0], vector![0.0, 7.5, 0.0]);
+        let tol = Tolerances::default();
+        let asked = std::cell::Cell::new(0usize);
+        let mut stepper = DormandPrince.stepper(&system, initial, 5.0, 1.0, tol);
+        let outcome = stepper
+            .advance_to(
+                5.0,
+                |_, _| {},
+                |_, _| {
+                    asked.set(asked.get() + 1);
+                    ControlFlow::Break("would fire")
+                },
+            )
+            .expect("a target already reached is valid");
+        assert!(
+            matches!(outcome, AdvanceOutcome::Reached),
+            "nothing to advance to, so the stepper reports Reached"
+        );
+        assert_eq!(asked.get(), 0, "no step was taken, so nothing was asked");
+        assert_eq!(stepper.t(), 5.0, "the clock did not move");
     }
 }

--- a/utsuroi/src/solver/dp45/mod.rs
+++ b/utsuroi/src/solver/dp45/mod.rs
@@ -152,6 +152,14 @@ impl<'a, S: DynamicalSystem> AdaptiveStepper<'a, S> {
         // while sitting at its old time.
         validate_time_span(self.t, t_target)?;
 
+        // The predicate is asked about the state the stepper holds, before
+        // any step. A level-triggered event — "below the surface", "past this
+        // altitude" — can already hold here, and stepping first reports it one
+        // step late with a state the caller's own predicate calls invalid.
+        if let ControlFlow::Break(reason) = event_check(self.t, &self.state) {
+            return Ok(AdvanceOutcome::Event { reason });
+        }
+
         while self.t < t_target {
             let h = self.dt.min(t_target - self.t);
             // `h > 0` holds, but for large `|self.t|` it can still be below
@@ -1093,5 +1101,42 @@ mod tests {
     #[test]
     fn advance_to_still_succeeds_for_valid_input() {
         assert!(advance(0.1, Tolerances::default(), 1.0).is_ok());
+    }
+
+    /// An event that already holds at `t0` stops there, without a step.
+    ///
+    /// A level-triggered predicate — "below the surface", "past this
+    /// altitude" — can be true of the state the caller hands in. This loop
+    /// stepped once before asking, so it reported the event one step late, at
+    /// a state the predicate itself calls invalid. Measured through the CLI
+    /// before the fix: `orts run --sat altitude=50 --duration 100` (Earth's
+    /// atmosphere boundary is the 100 km Karman line) reported "atmospheric
+    /// entry at 50.0 km" at t = 10 s and wrote a sample there, 78 km of arc
+    /// after the entry it was reporting.
+    #[test]
+    fn an_event_true_at_t0_stops_before_stepping() {
+        let system = HarmonicOscillator;
+        let initial = State::<3, 2>::new(vector![7000.0, 0.0, 0.0], vector![0.0, 7.5, 0.0]);
+        let tol = Tolerances::default();
+        let mut callbacks = 0usize;
+        let outcome = DormandPrince.integrate_adaptive_with_events(
+            &system,
+            initial.clone(),
+            0.0,
+            100.0,
+            1.0,
+            &tol,
+            |_, _| callbacks += 1,
+            // True of anything, so it is true of the initial state.
+            |_, _| ControlFlow::Break("already there"),
+        );
+        let IntegrationOutcome::Terminated { state, t, reason } = outcome else {
+            panic!("an event true at t0 terminates, got {outcome:?}");
+        };
+        assert_eq!(reason, "already there");
+        assert_eq!(t, 0.0, "it stops at t0, not a step later");
+        assert_eq!(*state.y(), *initial.y(), "the state is the one handed in");
+        assert_eq!(*state.dy(), *initial.dy());
+        assert_eq!(callbacks, 0, "no step was taken, so nothing to report");
     }
 }

--- a/utsuroi/src/solver/dp45/mod.rs
+++ b/utsuroi/src/solver/dp45/mod.rs
@@ -132,15 +132,16 @@ pub struct AdaptiveStepper<'a, S: DynamicalSystem> {
 impl<'a, S: DynamicalSystem> AdaptiveStepper<'a, S> {
     /// Advance adaptively to `t_target`.
     ///
-    /// - `event_check` runs first on the state the stepper currently holds,
-    ///   before any step. A level-triggered event can already hold there, and
-    ///   reporting it after a step would name a state the predicate itself
-    ///   rejects. Terminating there leaves the stepper where it was and calls
-    ///   no callback, since the callback reports accepted steps and none was
-    ///   taken. A later `advance_to` therefore re-evaluates the state it
-    ///   stopped at: for a predicate that only reads the state that is the
-    ///   same answer, but one carrying its own counters sees the endpoint
-    ///   twice.
+    /// - For a target that advances, `event_check` runs first on the state the
+    ///   stepper currently holds, before any step. A level-triggered event can
+    ///   already hold there, and reporting it after a step would name a state
+    ///   the predicate itself rejects. Terminating there leaves the stepper
+    ///   where it was and calls no callback, since the callback reports
+    ///   accepted steps and none was taken. A later `advance_to` therefore
+    ///   re-evaluates the state it stopped at: for a predicate that only reads
+    ///   the state that is the same answer, but one carrying its own counters
+    ///   sees the endpoint twice. A target the stepper has already reached
+    ///   takes no step, so it asks nothing and reports `Reached`.
     /// - Each accepted step calls `callback(t, &state)`.
     /// - If `event_check` returns `Break(reason)`, returns `Event { reason }`.
     /// - On success returns `Reached` with internal state updated to `t_target`.

--- a/utsuroi/src/solver/rk4.rs
+++ b/utsuroi/src/solver/rk4.rs
@@ -579,4 +579,34 @@ mod tests {
         assert_eq!(*state.dy(), *initial.dy());
         assert_eq!(callbacks, 0, "no step was taken, so nothing to report");
     }
+
+    /// An empty span asks the predicate nothing.
+    ///
+    /// The initial check is for a span that advances: reporting an event for a
+    /// call that takes no step would make `propagate_to(t)` at the current
+    /// time terminate a run. No step, no callback, no predicate call — the
+    /// state comes back as it went in.
+    #[test]
+    fn an_empty_span_does_not_consult_the_event_check() {
+        let system = HarmonicOscillator;
+        let initial = State::<3, 2>::new(vector![7000.0, 0.0, 0.0], vector![0.0, 7.5, 0.0]);
+        let asked = std::cell::Cell::new(0usize);
+        let outcome = Rk4.integrate_with_events(
+            &system,
+            initial.clone(),
+            5.0,
+            5.0,
+            1.0,
+            |_, _| {},
+            |_, _| {
+                asked.set(asked.get() + 1);
+                ControlFlow::Break("would fire")
+            },
+        );
+        let IntegrationOutcome::Completed(state) = outcome else {
+            panic!("an empty span completes, got {outcome:?}");
+        };
+        assert_eq!(*state.y(), *initial.y(), "the state is the one handed in");
+        assert_eq!(asked.get(), 0, "no step was taken, so nothing was asked");
+    }
 }

--- a/utsuroi/src/solver/rk4.rs
+++ b/utsuroi/src/solver/rk4.rs
@@ -544,4 +544,39 @@ mod tests {
         assert_eq!(callback_count, 3);
         assert!(matches!(outcome, IntegrationOutcome::Terminated { .. }));
     }
+
+    /// An event that already holds at `t0` stops there, without a step.
+    ///
+    /// A level-triggered predicate — "below the surface", "past this
+    /// altitude" — can be true of the state the caller hands in. This loop
+    /// stepped once before asking, so it reported the event one step late, at
+    /// a state the predicate itself calls invalid. Measured through the CLI
+    /// before the fix: `orts run --sat altitude=50 --duration 100` (Earth's
+    /// atmosphere boundary is the 100 km Karman line) reported "atmospheric
+    /// entry at 50.0 km" at t = 10 s and wrote a sample there, 78 km of arc
+    /// after the entry it was reporting.
+    #[test]
+    fn an_event_true_at_t0_stops_before_stepping() {
+        let system = HarmonicOscillator;
+        let initial = State::<3, 2>::new(vector![7000.0, 0.0, 0.0], vector![0.0, 7.5, 0.0]);
+        let mut callbacks = 0usize;
+        let outcome = Rk4.integrate_with_events(
+            &system,
+            initial.clone(),
+            0.0,
+            100.0,
+            1.0,
+            |_, _| callbacks += 1,
+            // True of anything, so it is true of the initial state.
+            |_, _| ControlFlow::Break("already there"),
+        );
+        let IntegrationOutcome::Terminated { state, t, reason } = outcome else {
+            panic!("an event true at t0 terminates, got {outcome:?}");
+        };
+        assert_eq!(reason, "already there");
+        assert_eq!(t, 0.0, "it stops at t0, not a step later");
+        assert_eq!(*state.y(), *initial.y(), "the state is the one handed in");
+        assert_eq!(*state.dy(), *initial.dy());
+        assert_eq!(callbacks, 0, "no step was taken, so nothing to report");
+    }
 }

--- a/utsuroi/src/solver/verlet.rs
+++ b/utsuroi/src/solver/verlet.rs
@@ -173,7 +173,11 @@ impl StormerVerlet {
         // step. A level-triggered event — "below the surface", "past this
         // altitude" — can already hold at `t0`, and stepping first reports it
         // one step late with a state the caller's own predicate calls invalid.
-        if let ControlFlow::Break(reason) = event_check(t0, &state) {
+        // Only for a span that advances: an empty span takes no step, so it
+        // reports nothing and asks nothing, and comes back as it went in.
+        if t0 < t_end
+            && let ControlFlow::Break(reason) = event_check(t0, &state)
+        {
             return IntegrationOutcome::Terminated {
                 state,
                 t: t0,
@@ -785,5 +789,35 @@ mod tests {
         assert_eq!(*state.y(), *initial.y(), "the state is the one handed in");
         assert_eq!(*state.dy(), *initial.dy());
         assert_eq!(callbacks, 0, "no step was taken, so nothing to report");
+    }
+
+    /// An empty span asks the predicate nothing.
+    ///
+    /// The initial check is for a span that advances: reporting an event for a
+    /// call that takes no step would make `propagate_to(t)` at the current
+    /// time terminate a run. No step, no callback, no predicate call — the
+    /// state comes back as it went in.
+    #[test]
+    fn an_empty_span_does_not_consult_the_event_check() {
+        let system = HarmonicOscillator;
+        let initial = State::<3, 2>::new(vector![7000.0, 0.0, 0.0], vector![0.0, 7.5, 0.0]);
+        let asked = std::cell::Cell::new(0usize);
+        let outcome = StormerVerlet.integrate_with_events(
+            &system,
+            initial.clone(),
+            5.0,
+            5.0,
+            1.0,
+            |_, _| {},
+            |_, _| {
+                asked.set(asked.get() + 1);
+                ControlFlow::Break("would fire")
+            },
+        );
+        let IntegrationOutcome::Completed(state) = outcome else {
+            panic!("an empty span completes, got {outcome:?}");
+        };
+        assert_eq!(*state.y(), *initial.y(), "the state is the one handed in");
+        assert_eq!(asked.get(), 0, "no step was taken, so nothing was asked");
     }
 }

--- a/utsuroi/src/solver/verlet.rs
+++ b/utsuroi/src/solver/verlet.rs
@@ -169,6 +169,17 @@ impl StormerVerlet {
 
         let mut state = initial;
         let mut t = t0;
+        // The predicate is asked about the state it was given, before any
+        // step. A level-triggered event — "below the surface", "past this
+        // altitude" — can already hold at `t0`, and stepping first reports it
+        // one step late with a state the caller's own predicate calls invalid.
+        if let ControlFlow::Break(reason) = event_check(t0, &state) {
+            return IntegrationOutcome::Terminated {
+                state,
+                t: t0,
+                reason,
+            };
+        }
         while t < t_end {
             let h = dt.min(t_end - t);
             if t + h == t {
@@ -739,5 +750,40 @@ mod tests {
             .expect("valid input");
         let b = StormerVerlet.integrate(&system, initial, 0.0, 1.0, 0.01, |_, _| {});
         assert_eq!(a, b);
+    }
+
+    /// An event that already holds at `t0` stops there, without a step.
+    ///
+    /// A level-triggered predicate — "below the surface", "past this
+    /// altitude" — can be true of the state the caller hands in. This loop
+    /// stepped once before asking, so it reported the event one step late, at
+    /// a state the predicate itself calls invalid. Measured through the CLI
+    /// before the fix: `orts run --sat altitude=50 --duration 100` (Earth's
+    /// atmosphere boundary is the 100 km Karman line) reported "atmospheric
+    /// entry at 50.0 km" at t = 10 s and wrote a sample there, 78 km of arc
+    /// after the entry it was reporting.
+    #[test]
+    fn an_event_true_at_t0_stops_before_stepping() {
+        let system = HarmonicOscillator;
+        let initial = State::<3, 2>::new(vector![7000.0, 0.0, 0.0], vector![0.0, 7.5, 0.0]);
+        let mut callbacks = 0usize;
+        let outcome = StormerVerlet.integrate_with_events(
+            &system,
+            initial.clone(),
+            0.0,
+            100.0,
+            1.0,
+            |_, _| callbacks += 1,
+            // True of anything, so it is true of the initial state.
+            |_, _| ControlFlow::Break("already there"),
+        );
+        let IntegrationOutcome::Terminated { state, t, reason } = outcome else {
+            panic!("an event true at t0 terminates, got {outcome:?}");
+        };
+        assert_eq!(reason, "already there");
+        assert_eq!(t, 0.0, "it stops at t0, not a step later");
+        assert_eq!(*state.y(), *initial.y(), "the state is the one handed in");
+        assert_eq!(*state.dy(), *initial.dy());
+        assert_eq!(callbacks, 0, "no step was taken, so nothing to report");
     }
 }

--- a/utsuroi/src/solver/yoshida.rs
+++ b/utsuroi/src/solver/yoshida.rs
@@ -202,7 +202,11 @@ macro_rules! impl_yoshida {
                 // step. A level-triggered event — "below the surface", "past this
                 // altitude" — can already hold at `t0`, and stepping first reports it
                 // one step late with a state the caller's own predicate calls invalid.
-                if let ControlFlow::Break(reason) = event_check(t0, &state) {
+                // Only for a span that advances: an empty span takes no step, so it
+                // reports nothing and asks nothing, and comes back as it went in.
+                if t0 < t_end
+                    && let ControlFlow::Break(reason) = event_check(t0, &state)
+                {
                     return IntegrationOutcome::Terminated {
                         state,
                         t: t0,
@@ -852,5 +856,35 @@ mod tests {
         assert_eq!(*state.y(), *initial.y(), "the state is the one handed in");
         assert_eq!(*state.dy(), *initial.dy());
         assert_eq!(callbacks, 0, "no step was taken, so nothing to report");
+    }
+
+    /// An empty span asks the predicate nothing.
+    ///
+    /// The initial check is for a span that advances: reporting an event for a
+    /// call that takes no step would make `propagate_to(t)` at the current
+    /// time terminate a run. No step, no callback, no predicate call — the
+    /// state comes back as it went in.
+    #[test]
+    fn an_empty_span_does_not_consult_the_event_check() {
+        let system = HarmonicOscillator;
+        let initial = State::<3, 2>::new(vector![7000.0, 0.0, 0.0], vector![0.0, 7.5, 0.0]);
+        let asked = std::cell::Cell::new(0usize);
+        let outcome = Yoshida4.integrate_with_events(
+            &system,
+            initial.clone(),
+            5.0,
+            5.0,
+            1.0,
+            |_, _| {},
+            |_, _| {
+                asked.set(asked.get() + 1);
+                ControlFlow::Break("would fire")
+            },
+        );
+        let IntegrationOutcome::Completed(state) = outcome else {
+            panic!("an empty span completes, got {outcome:?}");
+        };
+        assert_eq!(*state.y(), *initial.y(), "the state is the one handed in");
+        assert_eq!(asked.get(), 0, "no step was taken, so nothing was asked");
     }
 }

--- a/utsuroi/src/solver/yoshida.rs
+++ b/utsuroi/src/solver/yoshida.rs
@@ -198,6 +198,17 @@ macro_rules! impl_yoshida {
 
                 let mut state = initial;
                 let mut t = t0;
+                // The predicate is asked about the state it was given, before any
+                // step. A level-triggered event — "below the surface", "past this
+                // altitude" — can already hold at `t0`, and stepping first reports it
+                // one step late with a state the caller's own predicate calls invalid.
+                if let ControlFlow::Break(reason) = event_check(t0, &state) {
+                    return IntegrationOutcome::Terminated {
+                        state,
+                        t: t0,
+                        reason,
+                    };
+                }
                 while t < t_end {
                     let h = dt.min(t_end - t);
                     if t + h == t {
@@ -806,5 +817,40 @@ mod tests {
             .expect("valid input");
         let b = Yoshida4.integrate(&system, initial, 0.0, 1.0, 0.01, |_, _| {});
         assert_eq!(a, b);
+    }
+
+    /// An event that already holds at `t0` stops there, without a step.
+    ///
+    /// A level-triggered predicate — "below the surface", "past this
+    /// altitude" — can be true of the state the caller hands in. This loop
+    /// stepped once before asking, so it reported the event one step late, at
+    /// a state the predicate itself calls invalid. Measured through the CLI
+    /// before the fix: `orts run --sat altitude=50 --duration 100` (Earth's
+    /// atmosphere boundary is the 100 km Karman line) reported "atmospheric
+    /// entry at 50.0 km" at t = 10 s and wrote a sample there, 78 km of arc
+    /// after the entry it was reporting.
+    #[test]
+    fn an_event_true_at_t0_stops_before_stepping() {
+        let system = HarmonicOscillator;
+        let initial = State::<3, 2>::new(vector![7000.0, 0.0, 0.0], vector![0.0, 7.5, 0.0]);
+        let mut callbacks = 0usize;
+        let outcome = Yoshida4.integrate_with_events(
+            &system,
+            initial.clone(),
+            0.0,
+            100.0,
+            1.0,
+            |_, _| callbacks += 1,
+            // True of anything, so it is true of the initial state.
+            |_, _| ControlFlow::Break("already there"),
+        );
+        let IntegrationOutcome::Terminated { state, t, reason } = outcome else {
+            panic!("an event true at t0 terminates, got {outcome:?}");
+        };
+        assert_eq!(reason, "already there");
+        assert_eq!(t, 0.0, "it stops at t0, not a step later");
+        assert_eq!(*state.y(), *initial.y(), "the state is the one handed in");
+        assert_eq!(*state.dy(), *initial.dy());
+        assert_eq!(callbacks, 0, "no step was taken, so nothing to report");
     }
 }


### PR DESCRIPTION


## 概要

積分ループが event 判定を step の後にしか呼んでいなかった。step の途中で境界を横切る場合は
それで正しい（横切った時刻そのものを出すには root-finding が必要で、utsuroi はしない）。
問題は「この高度より下」のような判定が、呼び出し側が渡した状態で既に成立している場合で、
ループはそれを飛ばして 1 歩伝播し、その先の状態を event 発生時として報告していた。

CLI で見える形: 大気圏の中から始めた run が突入を 1 step 遅れて報告し、その時刻には衛星が
78 km 先まで進んでいる。

判定を step の前に移す。utsuroi の 5 ループと orts の group 2 ループが同じ順序を持って
いた。

## 判定の順序

`t0` と `t_end` はループ 1 回の呼び出しが受け取る区間で、run 全体の期間ではない。
`orts run` は出力間隔ごとに `propagate_to` を呼ぶので、1 回の区間は 1 出力間隔ぶん。

修正前。判定は step の後だけなので、`t0` で成立していても 1 歩進んでから報告する。

```rust
fn integrate_with_events(
    &self,
    system: &S,
    initial: S::State,
    t0: f64,      // 呼び出し側が渡す開始時刻（前回の到達時刻）
    t_end: f64,   // 今回の目標時刻
    dt: f64,
    mut callback: F,
    event_check: E,
) -> IntegrationOutcome<S::State, B> {
    let mut state = initial;
    let mut t = t0;

    while t < t_end {
        let h = dt.min(t_end - t);
        state = self.step(system, t, &state, h);
        t += h;
        callback(t, &state);
        if let ControlFlow::Break(reason) = event_check(t, &state) {
            // t0 で既に成立していた場合も、報告されるのはここ
            return IntegrationOutcome::Terminated { state, t, reason };
        }
    }
    // ...
}
```

修正後。同じ関数の while より前に、渡された状態についての判定を足す。時間が進む呼び出し
（`t0 < t_end`）に限る。step 後の判定はそのまま。

```rust
    let mut state = initial;
    let mut t = t0;

    if t0 < t_end
        && let ControlFlow::Break(reason) = event_check(t0, &state)
    {
        // 1 歩も進めていないので callback は呼ばない
        return IntegrationOutcome::Terminated { state, t: t0, reason };
    }

    while t < t_end {
        // 以下は修正前と同じ
    }
```

`t0` で成立していた場合、渡された状態をそのまま `t = t0` で `Terminated` として返し、callback は呼ばない。callback は accepted step の通知なので、進めていない以上、報告する step がない。

前置き判定をするのは `t0 < t_end` の呼び出しに限る。`t0 == t_end` は 1 歩も進めないので、判定も callback もせず状態をそのまま返す（`propagate_to` を現在時刻に対して呼んでも run が終了しない）。

`advance_to` を複数回呼ぶ場合、2 回目以降は前回終端の状態について再判定することになる。純粋で level-triggered な述語なら自然な挙動で、呼び出し回数に依存する述語には observable な変更なので rustdoc に書いた。

## 同じ順序だったループ

7 つが同じ順序を持っていた。

| 場所 | 経路 |
|---|---|
| `utsuroi/src/integrator.rs` | `Integrator::integrate_with_events`（既定実装） |
| `utsuroi/src/solver/verlet.rs` | Verlet の固有 event ループ |
| `utsuroi/src/solver/yoshida.rs` | Yoshida マクロが生成する event ループ |
| `utsuroi/src/solver/dp45/mod.rs` | `AdaptiveStepper::advance_to` |
| `utsuroi/src/solver/dop853/mod.rs` | `AdaptiveStepper853::advance_to` |
| `orts/src/group/independent.rs` | `IndependentGroup` の固定刻み RK4 ループ |
| `orts/src/group/coupled.rs` | `CoupledGroup` の固定刻み RK4 ループ |

後ろの 2 つは `Integrator::integrate_with_events` を通らない独自ループで、utsuroi 側の 5 つを直しても `--integrator rk4` では症状が残っていた（実測で `t=10.00s`、2 行）。

## CLI の出力

地球の大気境界は 100 km（Kármán line）なので、`altitude=50` は開始時点で圏内。

```
$ orts run --sat altitude=50 --duration 100
Simulation terminated at t=10.00s for sat-0: atmospheric entry at 50.0 km altitude
```

出力にも t=0 と t=10 の 2 行が入る。報告している entry から 78 km 進んだ地点の状態を記録していた。

修正後:

```
$ orts run --sat altitude=50 --duration 100
Simulation terminated at t=0.00s for sat-0: atmospheric entry at 50.0 km altitude
```

行は t=0 の 1 本。

`t0` で終了すると、終了時状態が初期 sample と同じ行になる。`run` 側で、終了時状態の記録を
「既に記録した時刻より後なら」に限定した。

## テスト

各 solver ループに 1 本ずつ。前置き判定を外すと、対応するテストがちょうど落ちる。`t0 == t_end` の側も各ループに 1 本ずつあり、`t0 < t_end` の限定を外すとそれが落ちる。

CLI は adaptive と RK4 の 2 経路で、`t=0.00s` での終了と出力 1 行を assert する。

途中で大気圏に入る通常の run は変わらない（`altitude=120` で `t=2399.86s`、adaptive と RK4 の両方）。

`cargo clippy -p utsuroi --no-default-features -- -D warnings` と `-p orts --lib` は警告なし。
