### PR TITLE
perf(ci): stop re-resolving the workspace once per E2E suite, and cache kble

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,38 +526,23 @@ jobs:
         run: |
           cd plugin-sdk/examples && cargo component build -p orts-example-plugin-pd-rw-control -p orts-example-plugin-commandable-mode-ff -p orts-example-plugin-stream-framed-commander --release
 
-      # Real kble binary for the stream-bridge E2E. The version stays in a shell
-      # assignment because that is the shape renovate.json's custom manager
-      # matches (crates datasource); the cache key and the install both read it
-      # from here, so they cannot end up on different versions.
-      - name: Resolve kble version
-        id: kble
-        run: |
-          # renovate: datasource=crate depName=kble
-          KBLE_VERSION=0.5.0
-          echo "version=${KBLE_VERSION}" >> "$GITHUB_OUTPUT"
-
-      # cargo-binstall took 50 s per run to fetch and unpack the release
-      # (measured); the binary is one file and its version is pinned.
-      - name: Cache kble
-        id: kble-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/bin/kble
-          key: kble-${{ steps.kble.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
-
+      # Real kble binary for the stream-bridge E2E. Installed via
+      # cargo-binstall with the version resolved against crates.io;
+      # Renovate bumps KBLE_VERSION via the custom regex manager in
+      # renovate.json (crates datasource).
       - name: Install cargo-binstall
-        if: steps.kble-cache.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2.82.8
         with:
           tool: cargo-binstall
       - name: Install kble
-        if: steps.kble-cache.outputs.cache-hit != 'true'
-        run: cargo binstall --no-confirm "kble@${{ steps.kble.outputs.version }}"
+        run: |
+          # renovate: datasource=crate depName=kble
+          KBLE_VERSION=0.5.0
+          cargo binstall --no-confirm "kble@${KBLE_VERSION}"
 
-      # Named explicitly so the kble suites fail if the cache ever restores
-      # nothing: their fallback is a PATH lookup, and a missing binary there
-      # makes them soft-skip, which would hide the breakage.
+      # Named explicitly so the kble suites fail if the install ever puts the
+      # binary somewhere else: their fallback is a PATH lookup, and finding
+      # nothing there makes them soft-skip, which hides the breakage.
       - name: Point the kble suites at the binary
         run: echo "KBLE_BIN=$HOME/.cargo/bin/kble" >> "$GITHUB_ENV"
 
@@ -599,11 +584,11 @@ jobs:
           ORTS_BIN: ${{ github.workspace }}/bin/orts
         run: |
           # The suites the build step above already compiled, in one
-          # invocation. Nine separate ones each re-resolved the workspace and
-          # re-checked freshness before running anything: measured 226 s for
-          # 123 s of tests. Cargo still runs the binaries one after another and
-          # prints `Running tests/<suite>.rs` before each, so a failure still
-          # names its suite.
+          # invocation. Nine separate ones each re-resolved the workspace
+          # first, which measured 0.6 s apiece — small, but so is the reason to
+          # repeat the same command nine times. Cargo still runs the binaries
+          # one after another and prints `Running tests/<suite>.rs` before each,
+          # so a failure still names its suite.
           #
           # `e2e` stays separate because it needs a filter, and a filter in a
           # combined invocation would apply to every target.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,19 +526,40 @@ jobs:
         run: |
           cd plugin-sdk/examples && cargo component build -p orts-example-plugin-pd-rw-control -p orts-example-plugin-commandable-mode-ff -p orts-example-plugin-stream-framed-commander --release
 
-      # Real kble binary for the stream-bridge E2E. Installed via
-      # cargo-binstall with the version resolved against crates.io;
-      # Renovate bumps KBLE_VERSION via the custom regex manager in
-      # renovate.json (crates datasource).
+      # Real kble binary for the stream-bridge E2E. The version stays in a shell
+      # assignment because that is the shape renovate.json's custom manager
+      # matches (crates datasource); the cache key and the install both read it
+      # from here, so they cannot end up on different versions.
+      - name: Resolve kble version
+        id: kble
+        run: |
+          # renovate: datasource=crate depName=kble
+          KBLE_VERSION=0.5.0
+          echo "version=${KBLE_VERSION}" >> "$GITHUB_OUTPUT"
+
+      # cargo-binstall took 50 s per run to fetch and unpack the release
+      # (measured); the binary is one file and its version is pinned.
+      - name: Cache kble
+        id: kble-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cargo/bin/kble
+          key: kble-${{ steps.kble.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
+
       - name: Install cargo-binstall
+        if: steps.kble-cache.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2.82.8
         with:
           tool: cargo-binstall
       - name: Install kble
-        run: |
-          # renovate: datasource=crate depName=kble
-          KBLE_VERSION=0.5.0
-          cargo binstall --no-confirm "kble@${KBLE_VERSION}"
+        if: steps.kble-cache.outputs.cache-hit != 'true'
+        run: cargo binstall --no-confirm "kble@${{ steps.kble.outputs.version }}"
+
+      # Named explicitly so the kble suites fail if the cache ever restores
+      # nothing: their fallback is a PATH lookup, and a missing binary there
+      # makes them soft-skip, which would hide the breakage.
+      - name: Point the kble suites at the binary
+        run: echo "KBLE_BIN=$HOME/.cargo/bin/kble" >> "$GITHUB_ENV"
 
       - name: Download orts binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -577,17 +598,29 @@ jobs:
         env:
           ORTS_BIN: ${{ github.workspace }}/bin/orts
         run: |
-          cargo test --locked -p orts-cli --test plugin_backend_e2e
-          cargo test --locked -p orts-cli --test serve_dynamic_controlled_add_e2e
-          cargo test --locked -p orts-cli --test throughput_mode_speedup_e2e
+          # The suites the build step above already compiled, in one
+          # invocation. Nine separate ones each re-resolved the workspace and
+          # re-checked freshness before running anything: measured 226 s for
+          # 123 s of tests. Cargo still runs the binaries one after another and
+          # prints `Running tests/<suite>.rs` before each, so a failure still
+          # names its suite.
+          #
+          # `e2e` stays separate because it needs a filter, and a filter in a
+          # combined invocation would apply to every target.
+          #
+          # run_mode_e2e's README quick-start and controller-config tests need
+          # the guest WASM; under `rust-test`, which does not build it, they
+          # soft-skip.
+          cargo test --locked -p orts-cli \
+            --test plugin_backend_e2e \
+            --test serve_dynamic_controlled_add_e2e \
+            --test throughput_mode_speedup_e2e \
+            --test plugin_msg_config_command_e2e \
+            --test serve_stream_bridge_e2e \
+            --test serve_kble_e2e \
+            --test serve_kble_stdio_e2e \
+            --test run_mode_e2e
           cargo test --locked -p orts-cli --test e2e test_controlled_simulation_via_config
-          cargo test --locked -p orts-cli --test plugin_msg_config_command_e2e
-          cargo test --locked -p orts-cli --test serve_stream_bridge_e2e
-          cargo test --locked -p orts-cli --test serve_kble_e2e
-          cargo test --locked -p orts-cli --test serve_kble_stdio_e2e
-          # The README quick-start and controller-config tests need the guest
-          # WASM; under `rust-test`, which does not build it, they soft-skip.
-          cargo test --locked -p orts-cli --test run_mode_e2e
 
   # Build CLI with embedded viewer SPA in release profile.
   # Runs on main push (smoke test) AND tag push (release job consumes


### PR DESCRIPTION
cli-plugin-backend-e2e が PR CI の critical path の後半（mean 648s）で、その中の 2 つの無駄を削る。#413 の上に積んでいる（同じ job の隣接行を触るため）。base は `ci/skip-disk-cleanup-when-ample`。

## E2E の step は 123s のテストに 226s かけている

step の内訳（PR run 5 本平均で 226s）に対して、ログから拾った suite 別の実行時間の合計は 123.1s。

| suite | 実行時間 |
| --- | --- |
| throughput_mode_speedup_e2e | 59.9s |
| run_mode_e2e (12 tests) | 40.0s |
| plugin_backend_e2e | 5.5s |
| e2e (test_controlled_simulation_via_config) | 6.1s |
| serve_dynamic_controlled_add_e2e | 3.0s |
| serve_stream_bridge_e2e / serve_kble_e2e / serve_kble_stdio_e2e | 各 2.4s |
| plugin_msg_config_command_e2e | 1.4s |

差の約 100s は 9 回の `cargo test` invocation。suite は直前の `--no-run` step で既に compile されているので、各 invocation がやっているのは workspace の解決と freshness check だけ。8 つを 1 invocation に統合した（約 80s）。

`e2e` だけは test 名の filter が必要で、統合すると filter が全 target に適用されるので別のままにした。

### 実行順が変わらないことの確認

cargo は複数の test target を逐次実行する。開始と終了を print する test target 2 つで実測した:

```
ALPHA start 1788342788.528
ALPHA end   1788342791.528
BETA  start 1788342791.531   # ALPHA 終了の 3ms 後
BETA  end   1788342794.531
```

`throughput_mode_speedup_e2e` は速度比を assert するので、他の suite と並走すると結果が変わる。統合後も並走しない。

## kble を cache する

`Install kble` は毎 run 50s かけて、version が pin された release を fetch して展開していた。binary は 1 ファイル（tests は PATH 上の `kble` だけを探す）なので、version / OS / arch を key に cache する。

version は renovate.json の customManager が拾う shell assignment の形のまま残し、cache key はそこから読む。Renovate が bump したときに key が古い binary を指す状態にならない。

```yaml
- name: Resolve kble version
  id: kble
  run: |
    # renovate: datasource=crate depName=kble
    KBLE_VERSION=0.5.0
    echo "version=${KBLE_VERSION}" >> "$GITHUB_OUTPUT"
```

### soft-skip を潰さないための措置

kble の suite は PATH を走査して binary が無ければ soft-skip する。cache が何も復元しなかった場合、テストが黙って skip される。`KBLE_BIN` で path を明示し、binary が無ければ suite が失敗するようにした。

## 見込みと検証

step 単位で約 130s（invocation 統合 80s + kble cache 50s）。cli-plugin-backend-e2e 648s → 約 520s。

- `actionlint` と YAML parse
- 逐次実行の実測（上記）
- codex review 1 周（指摘なし）
- この PR の CI で確認すること: E2E step の duration、kble cache の miss → 次 run で hit、9 suite すべてが実行されていること（`Running tests/<suite>.rs` が 9 本、うち 1 本は filter 付き）

run 総時間の比較は event を揃えて 20-30 run 集めてから行う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
