### PR TITLE
ci: diagnose the E2E run step's 110 s rebuild (not for merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,6 +582,10 @@ jobs:
       - name: Run CLI plugin-backend E2E
         env:
           ORTS_BIN: ${{ github.workspace }}/bin/orts
+          # TEMPORARY (diagnostic branch): make cargo report which fingerprint
+          # went stale, to explain the ~110 s rebuild of orts-cli that follows
+          # a build step which already produced every test executable.
+          CARGO_LOG: cargo::core::compiler::fingerprint=info
         run: |
           # The suites the build step above already compiled, in one
           # invocation. Nine separate ones each re-resolved the workspace


### PR DESCRIPTION
cli-plugin-backend-e2e の run step が、直前の `--no-run` step で 9 本の test executable を作り終えているのに orts-cli を約 110s 再コンパイルしている（旧 run でも 1m54s、以降 8 回は 0.5-0.8s）。

この branch は run step に `CARGO_LOG=cargo::core::compiler::fingerprint=info` を入れて、cargo 自身に「どの fingerprint が stale か」を出させるためのもの。**merge しない。** 原因が分かったら close する。

仮説として実測で否定済み:
- `cargo test --no-run --test X` は bin target もビルドする（小さい crate で clean 後に確認）
- 宣言していない env 変数（`ORTS_BIN`）は fingerprint を変えない（同じ crate で確認）