### PR TITLE
fix(orts-cli): stop the build script from invalidating itself

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -57,17 +57,19 @@ fn main() {
     // until someone builds the viewer. A `rerun-if-changed` path that cargo
     // cannot stat counts as changed, which re-runs this script — and so
     // recompiles orts-cli, its bin and every integration test — on every
-    // single cargo invocation. Watch them only when they are there, and
-    // create `../viewer/dist/` inside the workspace so that watching it
-    // survives the viewer being built later.
+    // single cargo invocation. So watch them only when they are there.
     if textures_src.is_dir() {
         println!("cargo:rerun-if-changed=../viewer/public/textures/");
     }
-    let viewer_dir = manifest_dir.join("../viewer");
-    if viewer_dir.is_dir() {
-        std::fs::create_dir_all(&source_dist).ok();
-    }
-    if source_dist.is_dir() {
+    // Watched once the viewer has been built, and never created here. Creating
+    // it left the directory's mtime newer than the output file cargo writes for
+    // this script, so the next invocation read the watch as stale and re-ran
+    // the script, recompiling orts-cli, its bin and all nine integration tests.
+    // On a fresh checkout that cost the second invocation 34 s locally and
+    // ~110 s in CI, rebuilding exactly what the first had just built. What this
+    // gives up: a viewer built after a cargo build goes unnoticed until
+    // something else watched here changes.
+    if source_dist.join("index.html").is_file() {
         println!("cargo:rerun-if-changed=../viewer/dist/");
     }
 


### PR DESCRIPTION
build script が自分で自分の watch 対象を新しくしていたため、**build script が走った次の cargo invocation は必ず orts-cli / その bin / integration test 9 本を再ビルドしていた**。CI の cli-plugin-backend-e2e では、直前の step が作り終えたものを run step が作り直しており、648s の job のうち **110s** がこれ。

## 原因

`CARGO_LOG=cargo::core::compiler::fingerprint=info` で cargo に理由を出させた:

```
dirty: FsStatusOutdated(StaleItem(ChangedFile {
  reference: target/debug/build/orts-cli-*/output   mtime …767.440468508
  stale:     cli/../viewer/dist/                     mtime …767.467441382
}))
```

`cli/build.rs` は `../viewer/dist/` を watch しつつ、viewer が未ビルドのときその directory を**自分で作っていた**。結果、watch 対象の mtime が cargo が書く output より 27ms 新しくなり、watch を設定した時点で既に stale になる。fresh checkout から始まる CI の全 job が、2 回目の cargo invocation で 1 回分のフルリビルドを払っていた。

## 変更

directory の作成をやめ、watch は `../viewer/dist/index.html` がある場合だけにした（script が実際に読む入力）。`rust-dist` は cargo 実行前に viewer artifact を `viewer/dist/` へ download するので、release 経路の watch は維持される。

失うもの: 作成していた理由そのもの、つまり「cargo build の後に viewer をビルドした場合、この script が watch している他のものが変わるまで気づかない」。

## 実測

`viewer/dist` が無い状態から、CI の build step のコマンドと run step のコマンドを順に実行:

| | 1 回目 | 2 回目 | 3 回目 |
| --- | --- | --- | --- |
| 修正前 | 167.9s (cold) | **34.2s（再ビルド）** | 0.25s |
| 修正後 | 37.5s（build.rs 変更で 1 度だけ） | **0.32s** | 0.32s |

修正後は script が `viewer/dist` を作らないことも確認した。CI 換算で run step の 110s が消える見込み。

## 検証

- `cargo fmt --check -p orts-cli`、`cargo clippy -p orts-cli -- -D warnings` clean
- `cargo test -p orts-cli --bins`: 335 passed / 0 failed / 2 ignored
- 埋め込み経路は未変更（`source_dist.join("index.html").is_file()` のときに `sync_dist` する分岐はそのまま）
- 仮説として実測で否定したもの: `cargo test --no-run --test X` は bin target もビルドする / 宣言していない env 変数（`ORTS_BIN`）は fingerprint を変えない
- codex review 1 周（指摘なし）

診断に使った `CARGO_LOG` の一時 branch は #422（draft、merge しない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
