### PR TITLE
ci: gate on the same lint command a contributor runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,11 @@ jobs:
         run: pnpm format:check
 
       - name: Lint
-        run: pnpm exec biome lint .
+        # `pnpm lint` is `biome check .`, which is what CLAUDE.md tells a
+        # contributor to run before committing. `biome lint` alone skips Biome's
+        # assists (import ordering among them), so the gate here was narrower
+        # than the one locally and let assist-only diagnostics through.
+        run: pnpm lint
 
   # Supply-chain gate for the Rust side. Renovate's `minimumReleaseAge` cooldown
   # keeps a freshly published version out of the lockfile; this job is the

--- a/viewer/src/sources/CSVFileAdapter.ts
+++ b/viewer/src/sources/CSVFileAdapter.ts
@@ -9,9 +9,9 @@
  */
 
 import type { CSVMetadata } from "../orbit.js";
-import type { CSVWorkerMessage } from "./csvParseLogic.js";
 import type { BodyCatalog } from "./bodyCatalog.js";
 import { type CentralBody, describeCentralBodyError, resolveCentralBody } from "./centralBody.js";
+import type { CSVWorkerMessage } from "./csvParseLogic.js";
 import { csvMetadataToSimInfo } from "./normalizeMetadata.js";
 import type { SourceAdapter, SourceEventHandler, SourceId } from "./types.js";
 


### PR DESCRIPTION
CLAUDE.md は commit 前に `pnpm lint` を回すよう指示している。これは `biome check .` だが、CI が回すのは `biome exec biome lint .` で、**Biome の assist（import 並べ替えを含む）を見ない**。結果として assist だけの診断が CI を通り、手元のゲートだけが落ちる状態になっていて、main がまさにその状態だった。

main のツリーで実測:

| コマンド | 結果 |
|---|---|
| `pnpm exec biome lint .`（CI の Lint step） | exit 0（283 warnings, 0 errors） |
| `pnpm format:check`（CI の Format step） | exit 0（1 warning） |
| `pnpm lint` = `biome check .`（CLAUDE.md の指示） | **exit 1** |

落ちていた診断は 1 件だけで、`viewer/src/sources/CSVFileAdapter.ts` の `assist/source/organizeImports`（"Sort these imports."）。dee6ede7 が import を並べ替えずに 1 行足したもの。

## この PR

1. その import を並べ替える（1 行）
2. CI の Lint step を `pnpm lint` にする

2 つを 1 つの PR にしたのは、片方だけ入れると壊れるため。CI を先に広げると main が赤くなり、import だけ直すとゲートのずれは残る。

`Format check` は `biome check` が formatting も見るので冗長になるが、step として残した。log で formatting の失敗と lint の失敗を区別できる方がよい。

## もう一つの選び方

ずれを解消する方向は 2 つある。

- **このPR**: CI を `pnpm lint` に広げる。commit 前ゲートと CI が同じものを見る
- **逆**: CLAUDE.md の指示を `biome lint` に変える。CI を今のまま据え置き、assist は手元でも見ない

assist を「見る」か「見ない」かの方針判断なので、後者を採るならこの PR は close して CLAUDE.md 側を直す形になる。判断を仰ぎたい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
