### PR TITLE
feat(docs): adopt starlight-theme-next as the visual base

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -6,6 +6,7 @@ import rehypeKatex from "rehype-katex";
 import remarkMath from "remark-math";
 import starlightLlmsTxt from "starlight-llms-txt";
 import starlightRustdoc from "starlight-rustdoc";
+import starlightThemeNext from "starlight-theme-next";
 import starlightTypeDoc from "starlight-typedoc";
 import rewriteTypedocLinks from "./src/integrations/rewrite-typedoc-links";
 import remarkRewriteRootMdLinks from "./src/plugins/remark-rewrite-root-md-links";
@@ -138,6 +139,25 @@ export default defineConfig({
       ],
       social: [{ icon: "github", label: "GitHub", href: "https://github.com/sksat/orts" }],
       plugins: [
+        // Visual base for the site, and deliberately a theme that overrides no
+        // Starlight component: it only appends `customCss` and retunes
+        // Expressive Code, so the layout, the mobile sidebar drawer, collapsed
+        // sidebar groups and every translated UI string stay Starlight's own.
+        //
+        // starlight-theme-black was tried first and rejected for the opposite
+        // reason. It replaces eight components and re-lays-out the header and
+        // sidebar for a desktop-only sidebar: its MobileNav walks the sidebar
+        // one level deep and only over group entries, which reached 5 of the
+        // 484 links on `/orts/en/getting-started/`, and it zeroes
+        // `.main-frame`'s inline padding below 64rem. Both are fine for a
+        // shallow hand-written sidebar; ours is one group per package with
+        // generated API trees underneath.
+        //
+        // It brings Geist Sans/Mono as `--sl-font` / `--sl-font-mono`, bundled
+        // in the package rather than fetched at build time, and sets the
+        // accent to the Next.js blues — brand colours land on top of it in a
+        // later change.
+        starlightThemeNext(),
         starlightTypeDoc({
           entryPoints: ["../uneri/src/index.ts"],
           tsconfig: "../uneri/tsconfig.json",

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,6 +26,7 @@
     "remark-math": "^6.0.0",
     "starlight-llms-txt": "^0.10.0",
     "starlight-rustdoc": "workspace:*",
+    "starlight-theme-next": "^0.4.0",
     "starlight-typedoc": "^0.23.0",
     "typedoc": "^0.28.17",
     "typedoc-plugin-markdown": "^4.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       starlight-rustdoc:
         specifier: workspace:*
         version: link:../starlight-rustdoc
+      starlight-theme-next:
+        specifier: ^0.4.0
+        version: 0.4.0(@astrojs/starlight@0.41.7(astro@7.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(tsx@4.22.4)(yaml@2.9.0))(supports-color@7.2.0)(typescript@6.0.3))
       starlight-typedoc:
         specifier: ^0.23.0
         version: 0.23.1(@astrojs/starlight@0.41.7(astro@7.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(tsx@4.22.4)(yaml@2.9.0))(supports-color@7.2.0)(typescript@6.0.3))(astro@7.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(tsx@4.22.4)(yaml@2.9.0))(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -4169,6 +4172,12 @@ packages:
       '@astrojs/starlight': '>=0.38.0'
       astro: ^6.0.0
 
+  starlight-theme-next@0.4.0:
+    resolution: {integrity: sha512-rIHrl9xZSITamEnBSqmTWdHWSp44Tx5zDpME3SBoONuD2diq0HxVKP4f9atq5QB01NIzulpFSkDRUkzl/L3Cow==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@astrojs/starlight': '>=0.38'
+
   starlight-typedoc@0.23.1:
     resolution: {integrity: sha512-H45Mxv4mZ1xUMhUNjTR4CwKDgKKHZboQA5v5+vTVMdjlCX02Xo7veTB7+F/ivmMHPmQ7SV5auF2BTlU/EpQIoQ==}
     engines: {node: '>=22.12.0'}
@@ -4373,9 +4382,6 @@ packages:
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
-
-  unifont@0.7.4:
-    resolution: {integrity: sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==}
 
   unifont@0.7.5:
     resolution: {integrity: sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==}
@@ -7031,7 +7037,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       ultrahtml: 1.7.0
-      unifont: 0.7.4
+      unifont: 0.7.5
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
@@ -9593,6 +9599,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  starlight-theme-next@0.4.0(@astrojs/starlight@0.41.7(astro@7.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(tsx@4.22.4)(yaml@2.9.0))(supports-color@7.2.0)(typescript@6.0.3)):
+    dependencies:
+      '@astrojs/starlight': 0.41.7(astro@7.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(tsx@4.22.4)(yaml@2.9.0))(supports-color@7.2.0)(typescript@6.0.3)
+
   starlight-typedoc@0.23.1(@astrojs/starlight@0.41.7(astro@7.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(tsx@4.22.4)(yaml@2.9.0))(supports-color@7.2.0)(typescript@6.0.3))(astro@7.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(tsx@4.22.4)(yaml@2.9.0))(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3)):
     dependencies:
       '@astrojs/starlight': 0.41.7(astro@7.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(tsx@4.22.4)(yaml@2.9.0))(supports-color@7.2.0)(typescript@6.0.3)
@@ -9790,12 +9800,6 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
-
-  unifont@0.7.4:
-    dependencies:
-      css-tree: 3.2.1
-      ofetch: 1.5.1
-      ohash: 2.0.11
 
   unifont@0.7.5:
     dependencies:


### PR DESCRIPTION
docs サイトは Starlight の素の見た目で公開されている。system フォント、Starlight 既定の青、白いヘッダで、他の Starlight サイトと見分けがつかない。orts の見た目を作り直したい。

その最初の一枚として `starlight-theme-next` を入れる。Next.js のドキュメントを模したテーマで、**Geist Sans / Geist Mono、半透明でぼかしたヘッダ、Starlight 既定より一段小さい見出しスケール**（h1 が 4xl → 3xl、以下同様）、**vitesse の code theme** が入る。

これは土台で、この上に載せるものは別 PR にする — ブランド色（#429）、ブランドの書体、ヘッダのナビゲーション、トップページ。

![dark mode: BEFORE main, AFTER this PR](https://github.com/user-attachments/assets/df80a845-ba36-40d9-a90a-5ede1b85cc0e)

![light mode: BEFORE main, AFTER this PR](https://github.com/user-attachments/assets/571fc2bd-eef2-4715-acb6-0883cbb7905b)

## このテーマを選んだ理由

**Starlight の component を一つも override しない。** `config:setup` は `customCss` への追記と Expressive Code の再設定だけなので、layout・モバイルの sidebar ドロワー・折り畳んだ sidebar group・翻訳済みの UI 文字列がそのまま残る。

orts の sidebar は package ごとの group の下に生成した API ツリーを畳んでいるので、ここが効く。候補のうち `-black` は 8 component、`-nova` と `-celestia` は 15 前後（`PageFrame` を含む）を override して sidebar と header を desktop 前提に組み直す。`-black` を実際に入れて測ったところ、**モバイルから到達できる sidebar リンクが 484 のうち 5 になった**。override が 3 つ（すべて装飾）の `-rapide` が次点。

## 付随するもの

- フォントは package 同梱なので、ビルド時にフォントを取りに行かない
- ただし Geist 2 family の 9 weight すべてが登録されるので、ビルド出力にフォントが 93 ファイル・1.61 MB 出る
- accent が Next.js の青になる。ブランド色は #429 で上に載せる

## 検証

生成 API ページを含むフルビルド 958 ページ。`/orts/en/getting-started/` / `/orts/en/orts/api/overview/` / `/orts/ja/getting-started/` で、モバイルの menu button と menu footer、到達できる sidebar リンク 483–485、折り畳み可能な group 41、日本語ページの翻訳文字列を確認した。

`astro check` 0 errors、`pnpm format:check` と `biome lint .` clean、docs の vitest 67/67。
