### PR TITLE
feat(docs): put the brand palette on the site

### DIFF
--- a/docs/src/styles/brand.css
+++ b/docs/src/styles/brand.css
@@ -3,9 +3,12 @@
  *
  * The brand is specified in assets/README.md as ink #0E0E10, paper #F5F1E8,
  * blue oklch(0.58 0.12 240) and amber oklch(0.72 0.12 70). Those two accents
- * are what the logo is drawn in, so everything derived from them below moves
- * only L, keeping C and H at the brand values — that is what makes the site's
- * blue and the mark's blue the same blue.
+ * are what the logo is drawn in, so `--sl-color-accent` and `--sl-color-orange`
+ * hold the brand values verbatim wherever contrast allows, and move only L
+ * where it does not — the site's blue and the mark's blue are the same blue.
+ * The `-low` and `-high` steps are a different job: they are backgrounds and
+ * fills that have to sit far from the accent to stay legible against it, so
+ * they take the brand hue and whatever chroma that lightness supports.
  *
  * Layer order: starlight-theme-next declares `@layer starlight, nextjs;`, so
  * restating those names and appending `orts` puts these rules after both. No
@@ -41,11 +44,12 @@
     --sl-color-gray-7: oklch(0.178 0.012 250); /* #0d1216   1.02:1 */
     --sl-color-black: #0e0e10; /* brand ink */
 
-    /* Brand blue at L 0.62 rather than the brand's own 0.58, which reaches
-       only 3.74:1 on ink. The theme's stock accent is chroma 0.208 — nearly
-       twice the brand's — and lands at 3.36:1, under AA for link text. */
+    /* The brand blue itself, unmodified — on ink it clears AA with nothing to
+       spare (4.5:1 required). What it replaces is worth recording: the theme's
+       stock accent is chroma 0.208, nearly twice the brand's, and lands at
+       3.36:1 — under AA for link text. */
     --sl-color-accent-low: oklch(0.28 0.06 240); /* #042c43 */
-    --sl-color-accent: oklch(0.62 0.12 240); /* #338fc7   5.38:1 */
+    --sl-color-accent: oklch(0.58 0.12 240); /* #2382ba   4.57:1 */
     --sl-color-accent-high: oklch(0.8 0.1 240); /* #80c7f8  10.47:1 */
 
     /* Brand amber, unmodified: it already clears AA on ink. Retunes the
@@ -82,8 +86,9 @@
     --sl-color-gray-7: oklch(0.973 0.002 86.8); /* #f7f6f5   1.04:1 */
     --sl-color-black: #f5f1e8; /* brand paper */
 
-    /* L 0.53 is the darkest the brand chroma survives here: 0.50 and below
-       fall outside sRGB at C 0.12. */
+    /* The one place the brand blue has to move: on paper its own L 0.58 is
+       3.74:1, so it has to go darker, and L 0.53 is as far as it can — 0.50
+       and below fall outside sRGB at C 0.12. */
     --sl-color-accent-low: oklch(0.9 0.05 240); /* #c1e3fc */
     --sl-color-accent: oklch(0.53 0.12 240); /* #0573aa   4.61:1 */
     --sl-color-accent-high: oklch(0.4 0.09 240); /* #034d73   8.08:1 */

--- a/docs/src/styles/brand.css
+++ b/docs/src/styles/brand.css
@@ -63,7 +63,16 @@
     --sl-color-text-accent: oklch(0.58 0.12 240); /* #2382ba   4.57:1 */
 
     /* Brand amber, unmodified: it already clears AA on ink. Retunes the
-       `caution` aside and badge, which is the one place amber belongs. */
+       `caution` aside and badge, which is the one place amber belongs.
+
+       Amber and the blue below are what tell a `caution` aside from a `note`
+       one, and for a protanope they do not: simulated, the two borders sit at
+       1.38:1 in dark and 1.01:1 in light. That is not tunable — reaching 3:1
+       would need amber near L 0.85, which is 1.5:1 on paper and so invisible as
+       a border. The distinction survives because Starlight renders an icon and
+       the word "Note" or "Caution" in each aside, which is the redundant channel
+       colour universal design asks for. Amber therefore stays at the brand
+       value rather than being pushed around for a separation it cannot reach. */
     --sl-color-orange-low: oklch(0.3 0.06 70);
     --sl-color-orange: oklch(0.72 0.12 70); /* #d49648   7.61:1 */
     --sl-color-orange-high: oklch(0.86 0.09 70);
@@ -118,6 +127,39 @@
     --sl-color-blue-high: var(--sl-color-accent-high);
 
     --sl-nextjs-header-bg-color: rgb(245 241 232 / 50%);
+  }
+}
+
+@layer orts {
+  /*
+   * Mark the current sidebar item with something other than its colour.
+   *
+   * Starlight fills the current item and bolds it. The theme replaces that with
+   * `background-color: transparent` plus an accent text colour, and Starlight
+   * already renders top-level sidebar items white and 600 — so on a page whose
+   * sidebar entry is top level, the current item ends up distinguished by hue
+   * alone. Measured against its siblings in dark mode: 1.84:1, and 1.72:1 when
+   * simulated for protanopia. Colour universal design's first rule is that
+   * information must not be carried by colour alone, and a ratio that low would
+   * be weak even for a reader who sees the hue.
+   *
+   * A leading bar puts the cue back in geometry instead of chroma: it survives
+   * greyscale, and it holds against the sidebar ground in the worst of the
+   * protanopia, deuteranopia and tritanopia simulations — 4.31:1 in dark
+   * (#2382ba on ink) and 4.21:1 in light (#0573aa on paper).
+   *
+   * A tinted background was the other candidate and is deliberately not here:
+   * `--sl-color-accent-low` reaches only 1.19-1.33:1 against the ground, so it
+   * would not read as an area, and in light mode it drops the item's own text to
+   * 3.88:1.
+   */
+  .sidebar-content a[aria-current="page"] {
+    border-inline-start: 3px solid var(--sl-color-text-accent);
+    /* Absorb the bar into the existing inline padding so the label does not
+       shift when it becomes current. */
+    padding-inline-start: calc(0.75rem - 3px);
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
   }
 }
 

--- a/docs/src/styles/brand.css
+++ b/docs/src/styles/brand.css
@@ -52,6 +52,16 @@
     --sl-color-accent: oklch(0.58 0.12 240); /* #2382ba   4.57:1 */
     --sl-color-accent-high: oklch(0.8 0.1 240); /* #80c7f8  10.47:1 */
 
+    /* Setting `--sl-color-accent` alone would not put the brand blue on screen
+       in dark mode. `--sl-color-text-accent` is what link text resolves to, and
+       Starlight points it at `accent-high` in dark and at `accent` in light
+       (style/props.css) — so in dark mode the blue a reader sees is accent-high,
+       which has to stay pale because it also labels the splash page's primary
+       button. Point link text at the brand blue and leave accent-high to that
+       job. Both themes are declared, because a value set only here would leak
+       into light mode, where 0.58 is 3.74:1 on paper. */
+    --sl-color-text-accent: oklch(0.58 0.12 240); /* #2382ba   4.57:1 */
+
     /* Brand amber, unmodified: it already clears AA on ink. Retunes the
        `caution` aside and badge, which is the one place amber belongs. */
     --sl-color-orange-low: oklch(0.3 0.06 70);
@@ -92,6 +102,10 @@
     --sl-color-accent-low: oklch(0.9 0.05 240); /* #c1e3fc */
     --sl-color-accent: oklch(0.53 0.12 240); /* #0573aa   4.61:1 */
     --sl-color-accent-high: oklch(0.4 0.09 240); /* #034d73   8.08:1 */
+
+    /* Here the accent is already what link text wants, but it has to be said
+       out loud: the dark declaration above would otherwise carry over. */
+    --sl-color-text-accent: var(--sl-color-accent); /* #0573aa   4.61:1 */
 
     /* C 0.11 rather than the brand's 0.12: at the L this needs to reach AA on
        paper, 0.12 falls outside sRGB. The difference is not visible. */

--- a/docs/src/styles/brand.css
+++ b/docs/src/styles/brand.css
@@ -1,3 +1,116 @@
+/*
+ * orts brand palette for the documentation site.
+ *
+ * The brand is specified in assets/README.md as ink #0E0E10, paper #F5F1E8,
+ * blue oklch(0.58 0.12 240) and amber oklch(0.72 0.12 70). Those two accents
+ * are what the logo is drawn in, so everything derived from them below moves
+ * only L, keeping C and H at the brand values — that is what makes the site's
+ * blue and the mark's blue the same blue.
+ *
+ * Layer order: starlight-theme-next declares `@layer starlight, nextjs;`, so
+ * restating those names and appending `orts` puts these rules after both. No
+ * `!important` and no specificity games are needed as a result.
+ *
+ * The grays keep the exact L the theme chose for each step, so its visual
+ * weight is unchanged, and add chroma tapering to near-zero at both ends (a
+ * tinted white reads as a colour cast). Dark uses hue 250: the brand blue is
+ * 240 and the viewer's hairline blue #4488cc measures 250.6, so 250 sits
+ * between the two things the docs have to look related to. Ink itself measures
+ * C=0.004, so its hue is numerical noise and is not used. Light uses paper's
+ * own measured hue, 86.8, which is a real warm cast — a warm light mode is the
+ * most orts-specific thing in this file.
+ *
+ * Every ratio in the comments is computed against that theme's ground with the
+ * WCAG relative-luminance formula, and every value was checked to be inside
+ * sRGB. Two L values deviate from the theme deliberately, both marked below.
+ */
+@layer starlight, nextjs, orts;
+
+@layer orts {
+  /* Dark theme (Starlight's default). Ground is brand ink. */
+  :root {
+    --sl-color-white: #fff; /* 19.28:1 */
+    --sl-color-gray-1: oklch(0.894 0.007 250); /* #d9dde1  14.07:1 */
+    --sl-color-gray-2: oklch(0.732 0.016 250); /* #a1a9b2   8.12:1  body text */
+    /* L raised from the theme's 0.556, which lands at 4.09:1 — this token
+       carries muted body text, so it has to clear 4.5:1. */
+    --sl-color-gray-3: oklch(0.588 0.021 250); /* #737e89   4.66:1  muted */
+    --sl-color-gray-4: oklch(0.409 0.021 250); /* #424b55   2.18:1 */
+    --sl-color-gray-5: oklch(0.305 0.018 250); /* #283038   1.44:1  hairline */
+    --sl-color-gray-6: oklch(0.222 0.014 250); /* #161c22   1.12:1  sidebar */
+    --sl-color-gray-7: oklch(0.178 0.012 250); /* #0d1216   1.02:1 */
+    --sl-color-black: #0e0e10; /* brand ink */
+
+    /* Brand blue at L 0.62 rather than the brand's own 0.58, which reaches
+       only 3.74:1 on ink. The theme's stock accent is chroma 0.208 — nearly
+       twice the brand's — and lands at 3.36:1, under AA for link text. */
+    --sl-color-accent-low: oklch(0.28 0.06 240); /* #042c43 */
+    --sl-color-accent: oklch(0.62 0.12 240); /* #338fc7   5.38:1 */
+    --sl-color-accent-high: oklch(0.8 0.1 240); /* #80c7f8  10.47:1 */
+
+    /* Brand amber, unmodified: it already clears AA on ink. Retunes the
+       `caution` aside and badge, which is the one place amber belongs. */
+    --sl-color-orange-low: oklch(0.3 0.06 70);
+    --sl-color-orange: oklch(0.72 0.12 70); /* #d49648   7.61:1 */
+    --sl-color-orange-high: oklch(0.86 0.09 70);
+
+    /* Keep the informational blue in step with the accent, so a `note` aside
+       does not sit beside a differently-blue link. green, purple and red stay
+       at Starlight's values: they are semantic, rare, and retuning them would
+       be a separate decision. */
+    --sl-color-blue-low: var(--sl-color-accent-low);
+    --sl-color-blue: var(--sl-color-accent);
+    --sl-color-blue-high: var(--sl-color-accent-high);
+
+    /* The theme's translucent header sits on its own copy of the ground
+       colour, so it has to follow ink or the header reads as a different
+       surface than the page. */
+    --sl-nextjs-header-bg-color: rgb(14 14 16 / 60%);
+  }
+
+  /* Light theme. Ground is brand paper. */
+  :root[data-theme="light"] {
+    --sl-color-white: oklch(0.209 0.012 86.8); /* #1a1812  15.75:1 */
+    --sl-color-gray-1: oklch(0.273 0.015 86.8); /* #2a271f  13.25:1 */
+    --sl-color-gray-2: oklch(0.341 0.018 86.8); /* #3c382e  10.40:1  body text */
+    --sl-color-gray-3: oklch(0.46 0.02 86.8); /* #5d584c   6.31:1  muted */
+    /* L lowered from the theme's 0.637, which lands at 3.02:1 — right on the
+       non-text minimum with no margin. */
+    --sl-color-gray-4: oklch(0.63 0.018 86.8); /* #8e897d   3.10:1 */
+    --sl-color-gray-5: oklch(0.814 0.011 86.8); /* #c5c2ba   1.58:1  hairline */
+    --sl-color-gray-6: oklch(0.949 0.003 86.8); /* #efeeec   1.03:1 */
+    --sl-color-gray-7: oklch(0.973 0.002 86.8); /* #f7f6f5   1.04:1 */
+    --sl-color-black: #f5f1e8; /* brand paper */
+
+    /* L 0.53 is the darkest the brand chroma survives here: 0.50 and below
+       fall outside sRGB at C 0.12. */
+    --sl-color-accent-low: oklch(0.9 0.05 240); /* #c1e3fc */
+    --sl-color-accent: oklch(0.53 0.12 240); /* #0573aa   4.61:1 */
+    --sl-color-accent-high: oklch(0.4 0.09 240); /* #034d73   8.08:1 */
+
+    /* C 0.11 rather than the brand's 0.12: at the L this needs to reach AA on
+       paper, 0.12 falls outside sRGB. The difference is not visible. */
+    --sl-color-orange-low: oklch(0.9 0.05 70);
+    --sl-color-orange: oklch(0.54 0.11 70); /* #976213   4.60:1 */
+    --sl-color-orange-high: oklch(0.4 0.09 70);
+
+    --sl-color-blue-low: var(--sl-color-accent-low);
+    --sl-color-blue: var(--sl-color-accent);
+    --sl-color-blue-high: var(--sl-color-accent-high);
+
+    --sl-nextjs-header-bg-color: rgb(245 241 232 / 50%);
+  }
+}
+
+/*
+ * Header sizing for the wordmark, from before the theme. Unlayered, so it
+ * overrides both Starlight and the theme; the nav has to be tall enough for a
+ * 700x400 mark and the mark sits flush to the viewport edge.
+ *
+ * TODO: revisit with the header navigation work. The theme computes
+ * `--sl-nav-pad-x` above 800px to centre the content column, which the flush
+ * rule below overrides on the inline-start side.
+ */
 :root {
   --sl-nav-height: 6rem;
 }
@@ -7,7 +120,6 @@ a.site-title img {
   max-height: none;
 }
 
-/* Pull the brand wordmark flush to the viewport edge */
 header.header {
   padding-inline-start: 0;
 }


### PR DESCRIPTION
orts のブランド色は `assets/README.md` に規定されている（ink `#0E0E10` / paper `#F5F1E8` / blue `oklch(0.58 0.12 240)` / amber `oklch(0.72 0.12 70)`）が、サイトには一つも届いていない。`brand.css` は nav の高さしか設定しておらず、#428 で入れたテーマの accent と gray がそのまま出ている。**サイトの色を logo の色にする。**

#428 の上に積んでいる（base は `worktree-website-theme-black`）。

![palette: theme tokens vs brand tokens, with contrast against each ground](https://github.com/user-attachments/assets/02375f7a-ef6f-4cdd-a76b-e1a7d16dbf04)

## accent は L だけ動かす

blue と amber は logo を描いている値そのものなので、ブランド値をそのまま入れ、contrast が足りないときだけ L を動かす。

| token | 値 | 地色 | contrast |
| --- | --- | --- | --- |
| dark accent / link text | `oklch(0.58 0.12 240)`（ブランド値） | ink | 4.57:1 |
| light accent / link text | `oklch(0.53 0.12 240)` | paper | 4.61:1 |
| dark amber | `oklch(0.72 0.12 70)`（ブランド値） | ink | 7.61:1 |
| light amber | `oklch(0.54 0.11 70)` | paper | 4.60:1 |

light だけ動かすのは、blue の L 0.58 が paper 上で 3.74:1 しかなく、C 0.12 では L 0.50 以下が sRGB 外なので 0.53 が下限だから。light amber の C 0.11 も同じ理由。

**`--sl-color-accent` だけではブランド青が画面に出ない。** リンクの色は `--sl-color-text-accent` で、Starlight はこれを dark では `accent-high`、light では `accent` に解決する（`style/props.css`）。dark で読者が見る青は accent-high の側で、そこはテーマが splash の primary ボタンのラベルにも使うので淡くしておく必要がある。そのためリンクの色は両テーマで明示している。

置き換わる側も測った。**テーマの標準 accent は chroma 0.208 でブランドの 0.12 のほぼ倍、しかも dark 地に対して 3.36:1 でリンクテキストとして AA 未達だった。**

## gray はテーマの L を保って chroma だけ足す

各段の L はテーマが選んだ値をそのまま使うので視覚的な重みは変わらない。chroma は両端でほぼ 0 に減衰させる（白を色づけると neutral ではなく色かぶりに見える）。dark は hue 250（ブランド青 240 と viewer の hairline 青 `#4488cc` 実測 250.6 の間）、light は paper 自身の実測 hue 86.8。

テーマの L から動かしたのは 2 箇所だけ。

| token | テーマ | 変更後 |
| --- | --- | --- |
| dark gray-3（muted な本文） | L 0.556 → 4.09:1 | L 0.588 → **4.66:1** |
| light gray-4（非テキスト） | L 0.637 → 3.02:1 | L 0.630 → **3.10:1** |

## 見た目の変化は light に出る

![light mode: BEFORE theme only, AFTER brand palette](https://github.com/user-attachments/assets/ebaf1ede-615c-4367-b7d2-406d209a5d0c)

dark はほぼ変わらない。地色の移動が `#0e0e0e` → `#0e0e10` の 1 チャンネル 2/255 で、gray の chroma も 0.007–0.022 しか足していないため。docs ページには本文リンクが無く（見出しの anchor アイコンだけ）accent が出る場所もほぼないので、実測でも 2880×1800 のうち 5% 以上変わるピクセルは 278 個だった。

このPRで実際に効くのは、light の地色と暖色の neutral、そして **AA 未達だった 2 つの token（accent 3.36:1、dark gray-3 4.09:1）の修正**。accent が面で出るのはヘッダのナビゲーション・hero・badge が入る後続 PR から。

## サイドバーの現在項目を色だけで示さない

テーマは Starlight の塗り潰しピルを `background-color: transparent` + accent 色に置き換える。Starlight は top-level のサイドバー項目を既に白・600 で描くので、**サイドバーの入口が top-level のページでは現在項目が色だけで示される**ことになる。

兄弟項目との対比を、二色型のシミュレーション（Viénot, Brettel & Mollon 1999 を linear RGB で適用）込みで測った。

| | 正常 | P型 | D型 | T型 |
| --- | --- | --- | --- | --- |
| dark, before | **1.84** | 1.72 | 1.90 | 2.15 |
| light, before | 3.41 | 3.73 | 3.24 | 3.33 |

1.84:1 は色が見えている読者にとっても弱く、カラーユニバーサルデザインの第一の原則は「色だけで情報を伝えない」である。

3px の先頭バーで手がかりを幾何に戻す。グレースケールでも残り、3 つのシミュレーションの最悪値で地色に対して dark 4.31:1 / light 4.21:1 を保つ。バーは項目の既存の inline padding に食い込ませるので、現在項目になってもラベルは動かない。

![sidebar dark: BEFORE colour only, AFTER leading bar](https://github.com/user-attachments/assets/96cb1893-9284-44f6-bc91-f02ab2b61169)

![sidebar light: BEFORE colour only, AFTER leading bar](https://github.com/user-attachments/assets/f09df24d-c348-4c4b-8b1c-4e63995b7bc8)

背景の淡い塗りも検討したが採らなかった。`--sl-color-accent-low` は地色に対して 1.19–1.33:1 しかなく面として読めず、light では現在項目の文字を 3.88:1 に落とす。

## amber と blue は色では分離できない

この 2 色は `caution` の aside と `note` の aside を区別するものだが、P型のシミュレートではボーダー同士が dark 1.38:1 / light 1.01:1 になる。3:1 にするには amber を L 0.85 付近まで上げる必要があり、それは paper 上 1.5:1 でボーダーとして見えない。**調整で解決できる問題ではない。**

区別を担っているのは、Starlight が各 aside に icon と "Note" / "Caution" の語を描いていることで、これがカラーユニバーサルデザインの言う冗長なチャネルにあたる。したがって amber は届かない分離のために動かさず、ブランド値のままにする。この事実は `brand.css` にも書いた。

## その他

- テーマの半透明ヘッダは `--sl-nextjs-header-bg-color` に地色の複製を持つので、ink と paper に追随させる
- green / purple / red は Starlight の値のまま。意味を持つ色で出番も少なく、調整するなら別の判断になる。情報色の blue は accent に固定した
- テーマが `@layer starlight, nextjs;` を宣言しているので、その 2 つを書き直して `orts` を足すと後段に入る。ビルド出力で宣言順が `starlight` → `nextjs` → `orts` であること、無レイヤの規則が `--sl-color-accent*` / `--sl-color-gray*` を設定していないことを確認した

## 検証

contrast は全値について WCAG の相対輝度式でそれぞれの地色に対して計算し、sRGB 内に収まることも確認した。解決後の値はブラウザから読み出して確認している（dark は `oklch(58% .12 240)` on `rgb(14, 14, 16)`、light は `oklch(53% .12 240)` on `rgb(245, 241, 232)`）。

生成 API ページを含むフルビルド 958 ページ。`astro check` 0 errors、`pnpm format:check` と `biome lint .` clean、docs の vitest 67/67。
