### PR TITLE
perf(ci): stop re-resolving the workspace once per E2E suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,38 +526,23 @@ jobs:
         run: |
           cd plugin-sdk/examples && cargo component build -p orts-example-plugin-pd-rw-control -p orts-example-plugin-commandable-mode-ff -p orts-example-plugin-stream-framed-commander --release
 
-      # Real kble binary for the stream-bridge E2E. The version stays in a shell
-      # assignment because that is the shape renovate.json's custom manager
-      # matches (crates datasource); the cache key and the install both read it
-      # from here, so they cannot end up on different versions.
-      - name: Resolve kble version
-        id: kble
-        run: |
-          # renovate: datasource=crate depName=kble
-          KBLE_VERSION=0.5.0
-          echo "version=${KBLE_VERSION}" >> "$GITHUB_OUTPUT"
-
-      # cargo-binstall took 50 s per run to fetch and unpack the release
-      # (measured); the binary is one file and its version is pinned.
-      - name: Cache kble
-        id: kble-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/bin/kble
-          key: kble-${{ steps.kble.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
-
+      # Real kble binary for the stream-bridge E2E. Installed via
+      # cargo-binstall with the version resolved against crates.io;
+      # Renovate bumps KBLE_VERSION via the custom regex manager in
+      # renovate.json (crates datasource).
       - name: Install cargo-binstall
-        if: steps.kble-cache.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2.82.8
         with:
           tool: cargo-binstall
       - name: Install kble
-        if: steps.kble-cache.outputs.cache-hit != 'true'
-        run: cargo binstall --no-confirm "kble@${{ steps.kble.outputs.version }}"
+        run: |
+          # renovate: datasource=crate depName=kble
+          KBLE_VERSION=0.5.0
+          cargo binstall --no-confirm "kble@${KBLE_VERSION}"
 
-      # Named explicitly so the kble suites fail if the cache ever restores
-      # nothing: their fallback is a PATH lookup, and a missing binary there
-      # makes them soft-skip, which would hide the breakage.
+      # Named explicitly so the kble suites fail if the install ever puts the
+      # binary somewhere else: their fallback is a PATH lookup, and finding
+      # nothing there makes them soft-skip, which hides the breakage.
       - name: Point the kble suites at the binary
         run: echo "KBLE_BIN=$HOME/.cargo/bin/kble" >> "$GITHUB_ENV"
 
@@ -599,11 +584,11 @@ jobs:
           ORTS_BIN: ${{ github.workspace }}/bin/orts
         run: |
           # The suites the build step above already compiled, in one
-          # invocation. Nine separate ones each re-resolved the workspace and
-          # re-checked freshness before running anything: measured 226 s for
-          # 123 s of tests. Cargo still runs the binaries one after another and
-          # prints `Running tests/<suite>.rs` before each, so a failure still
-          # names its suite.
+          # invocation. Nine separate ones each re-resolved the workspace
+          # first, which measured 0.6 s apiece — small, but so is the reason to
+          # repeat the same command nine times. Cargo still runs the binaries
+          # one after another and prints `Running tests/<suite>.rs` before each,
+          # so a failure still names its suite.
           #
           # `e2e` stays separate because it needs a filter, and a filter in a
           # combined invocation would apply to every target.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,19 +526,40 @@ jobs:
         run: |
           cd plugin-sdk/examples && cargo component build -p orts-example-plugin-pd-rw-control -p orts-example-plugin-commandable-mode-ff -p orts-example-plugin-stream-framed-commander --release
 
-      # Real kble binary for the stream-bridge E2E. Installed via
-      # cargo-binstall with the version resolved against crates.io;
-      # Renovate bumps KBLE_VERSION via the custom regex manager in
-      # renovate.json (crates datasource).
+      # Real kble binary for the stream-bridge E2E. The version stays in a shell
+      # assignment because that is the shape renovate.json's custom manager
+      # matches (crates datasource); the cache key and the install both read it
+      # from here, so they cannot end up on different versions.
+      - name: Resolve kble version
+        id: kble
+        run: |
+          # renovate: datasource=crate depName=kble
+          KBLE_VERSION=0.5.0
+          echo "version=${KBLE_VERSION}" >> "$GITHUB_OUTPUT"
+
+      # cargo-binstall took 50 s per run to fetch and unpack the release
+      # (measured); the binary is one file and its version is pinned.
+      - name: Cache kble
+        id: kble-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cargo/bin/kble
+          key: kble-${{ steps.kble.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
+
       - name: Install cargo-binstall
+        if: steps.kble-cache.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2.82.8
         with:
           tool: cargo-binstall
       - name: Install kble
-        run: |
-          # renovate: datasource=crate depName=kble
-          KBLE_VERSION=0.5.0
-          cargo binstall --no-confirm "kble@${KBLE_VERSION}"
+        if: steps.kble-cache.outputs.cache-hit != 'true'
+        run: cargo binstall --no-confirm "kble@${{ steps.kble.outputs.version }}"
+
+      # Named explicitly so the kble suites fail if the cache ever restores
+      # nothing: their fallback is a PATH lookup, and a missing binary there
+      # makes them soft-skip, which would hide the breakage.
+      - name: Point the kble suites at the binary
+        run: echo "KBLE_BIN=$HOME/.cargo/bin/kble" >> "$GITHUB_ENV"
 
       - name: Download orts binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -577,17 +598,29 @@ jobs:
         env:
           ORTS_BIN: ${{ github.workspace }}/bin/orts
         run: |
-          cargo test --locked -p orts-cli --test plugin_backend_e2e
-          cargo test --locked -p orts-cli --test serve_dynamic_controlled_add_e2e
-          cargo test --locked -p orts-cli --test throughput_mode_speedup_e2e
+          # The suites the build step above already compiled, in one
+          # invocation. Nine separate ones each re-resolved the workspace and
+          # re-checked freshness before running anything: measured 226 s for
+          # 123 s of tests. Cargo still runs the binaries one after another and
+          # prints `Running tests/<suite>.rs` before each, so a failure still
+          # names its suite.
+          #
+          # `e2e` stays separate because it needs a filter, and a filter in a
+          # combined invocation would apply to every target.
+          #
+          # run_mode_e2e's README quick-start and controller-config tests need
+          # the guest WASM; under `rust-test`, which does not build it, they
+          # soft-skip.
+          cargo test --locked -p orts-cli \
+            --test plugin_backend_e2e \
+            --test serve_dynamic_controlled_add_e2e \
+            --test throughput_mode_speedup_e2e \
+            --test plugin_msg_config_command_e2e \
+            --test serve_stream_bridge_e2e \
+            --test serve_kble_e2e \
+            --test serve_kble_stdio_e2e \
+            --test run_mode_e2e
           cargo test --locked -p orts-cli --test e2e test_controlled_simulation_via_config
-          cargo test --locked -p orts-cli --test plugin_msg_config_command_e2e
-          cargo test --locked -p orts-cli --test serve_stream_bridge_e2e
-          cargo test --locked -p orts-cli --test serve_kble_e2e
-          cargo test --locked -p orts-cli --test serve_kble_stdio_e2e
-          # The README quick-start and controller-config tests need the guest
-          # WASM; under `rust-test`, which does not build it, they soft-skip.
-          cargo test --locked -p orts-cli --test run_mode_e2e
 
   # Build CLI with embedded viewer SPA in release profile.
   # Runs on main push (smoke test) AND tag push (release job consumes


### PR DESCRIPTION
#421 の再作成。あちらは base が `ci/skip-disk-cleanup-when-ample`（#413 のブランチ）のままだったため、merge したときに main ではなくそのブランチへ入ってしまった。stack を元の形に戻したので、この PR は #413 の後に main へ入る。内容は #421 と同一（レビューも通っている）。

---

cli-plugin-backend-e2e の `Run CLI plugin-backend E2E` step にある無駄を 1 つ削り、silent skip の穴を 1 つ塞ぐ。base は #413（`ci/skip-disk-cleanup-when-ample`）で、同じ job の隣接行を触るため。

## `cargo test` の呼び出しを 9 回から 2 回に

suite は直前の `--no-run` step で compile 済みなので、9 回の invocation がやっていたのは workspace の解決と freshness check だけ。実測すると 1 回あたり 0.6s で、8 つを 1 invocation にまとめて約 5s。

当初この差を 80s と見積もっていたが、実測した内訳は違った。step 226s のうちテスト実行が 123s、残りの約 100s は **1 回だけ起きる orts-cli の再コンパイル**（`Compiling orts-cli` → `Finished in 1m 50s`）で、invocation の回数とは無関係だった。その 110s は #423 で別途修正済み（build script が watch 対象を自分で新しくしていた）。

`e2e` だけは test 名 filter が必要で、統合すると filter が全 target に適用されるので分離したまま。

### 実行順が変わらないことの確認

cargo は複数の test target を逐次実行する。開始と終了を print する test target 2 つで実測した:

```
ALPHA start 1788342788.528
ALPHA end   1788342791.528
BETA  start 1788342791.531   # ALPHA 終了の 3ms 後
BETA  end   1788342794.531
```

`throughput_mode_speedup_e2e` は速度比を assert するので、他の suite と並走すると結果が変わる。統合後も並走しない。

## kble suite の silent skip を塞ぐ

kble の suite は PATH を走査して binary が無ければ soft-skip する。つまり install が想定外の場所に置いた場合、テストが黙って skip され緑になる。`KBLE_BIN` で path を明示し、binary が無ければ suite が失敗するようにした。

kble の cache は入れて revert した。install を 50s と見積もっていたが、それは 5 run の平均で、個別に測ると 8 run すべてで 1〜4s（cargo-binstall 自身のログは "Done in 853ms"、prebuilt binary 1 個の取得）。cache entry と 3 step を増やして 2 秒は見合わない。

## 検証

- `actionlint` と YAML parse
- 逐次実行の実測（上記）、per-invocation の overhead 0.6s、kble install の 8 run 分の実測
- codex review 2 周（指摘なし）、Copilot 🟢
- #421 として CI 20 チェック pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
