### PR TITLE
fix(plugin): answer magnetic-field-eci with the central body's field

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -90,6 +90,18 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   20-40% 改善する。([#359](https://github.com/sksat/orts/pull/359))
 
 #### Fixed
+- WASM host の `magnetic-field-eci` が中心天体の磁場を返すようになった。sync と async の
+  両 backend が host state を `TiltedDipole::earth()` 固定で作り、中心天体を見ていなかった
+  ので、Mars の run でも plugin には Earth の磁場が返っていた。#372 が残した唯一の経路で、
+  guest は config に磁気デバイスを書かなくてもこの import を呼べる。host も中心天体を受け取り、
+  モデルがない天体では `tobari::magnetic::NoField` を使う（CLI のデバイスと同じ規則、
+  `orts::magnetic::field_is_modelled`）。WIT の変更は不要で、戻り値の `vec3` にゼロを載せる。
+
+  **BREAKING**: `WasmController::new`、`AsyncWasmController::new`、それぞれの
+  `new_with_streams`、`WasmPluginCache::build_*_controller*` が `KnownBody` を取る。
+  呼び出し元のなかった legacy alias `WasmPluginCache::build_controller` は削除した
+  （天体を勝手に選ぶ入口を残さない）。([#431](https://github.com/sksat/orts/issues/431))
+
 - `SurfacePanel::at_com` と `SurfacePanel::rectangle` が、magnitude を計算できない
   方向ベクトルを、無限大の normal を持つ panel にせず reject するようになった。
   正規化した後で結果の長さを検査していたので、`[1e-200, 1e-200, 1e-200]` が通って

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,23 @@ section is subdivided by package.
   0.33 m, and the three shorter Harris-Priester oracles by 20-40%. ([#359](https://github.com/sksat/orts/pull/359))
 
 #### Fixed
+- The WASM host's `magnetic-field-eci` answers with the central body's field
+  instead of Earth's. Both backends built their host state with a fixed
+  `TiltedDipole::earth()` and never saw the body, so a plugin on a Mars run got
+  Earth's field — the one path #372 left behind, because a guest can call this
+  import whether or not its config declares a magnetic device. The host now
+  takes the body and uses `tobari::magnetic::NoField` where there is no model,
+  the same rule the CLI's devices follow
+  (`orts::magnetic::field_is_modelled`), so the reading is zero rather than a
+  field measured one body away. No WIT change: the signature already returns a
+  bare `vec3`, and zero is a value it can carry.
+
+  **BREAKING**: `WasmController::new`, `AsyncWasmController::new`, their
+  `new_with_streams` forms and the `WasmPluginCache::build_*_controller*`
+  builders take a `KnownBody`. `WasmPluginCache::build_controller`, a legacy
+  alias with no callers, is removed — an entry point that picks a body for you
+  is what this fixes. ([#431](https://github.com/sksat/orts/issues/431))
+
 - `SurfacePanel::at_com` and `SurfacePanel::rectangle` reject a direction vector
   whose magnitude cannot be computed, instead of building a panel whose normal
   is infinite. They normalised first and then checked the result was long

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -548,6 +548,7 @@ fn build_controller(
                             label,
                             &config_str,
                             streams.to_vec(),
+                            ctx.params.body,
                         )
                         .map_err(|e| format!("WasmController build failed: {e}"))?;
                     Ok(Box::new(ctrl))
@@ -561,6 +562,7 @@ fn build_controller(
                             label,
                             &config_str,
                             streams.to_vec(),
+                            ctx.params.body,
                         )
                         .map_err(|e| format!("AsyncWasmController build failed: {e}"))?;
                     Ok(Box::new(ctrl))
@@ -581,10 +583,10 @@ fn build_controller(
 
 /// Whether `body`'s magnetic field is modelled.
 ///
-/// `Igrf` and `TiltedDipole` are Earth's, and they are the only field models
-/// there are.
+/// The same rule the WASM host uses for `magnetic-field-eci`, so a run's
+/// devices and its plugin agree about what the field is.
 fn body_field_is_modelled(body: arika::body::KnownBody) -> bool {
-    body == arika::body::KnownBody::Earth
+    orts::magnetic::field_is_modelled(body)
 }
 
 /// How many warnings [`warn_no_field_model`] has emitted on this thread.

--- a/orts/benches/fiber_overhead.rs
+++ b/orts/benches/fiber_overhead.rs
@@ -87,7 +87,13 @@ fn bench_sync_update(c: &mut Criterion) {
     let component = Component::new(engine.inner(), &wasm_bytes).expect("Component compile");
     let pre = WasmController::prepare(&engine, &component).expect("prepare");
 
-    let mut ctrl = WasmController::new(&pre, "bench-sync", PD_RW_CONFIG).expect("new");
+    let mut ctrl = WasmController::new(
+        &pre,
+        "bench-sync",
+        PD_RW_CONFIG,
+        arika::body::KnownBody::Earth,
+    )
+    .expect("new");
 
     let spacecraft = dummy_spacecraft();
     let sensors = dummy_sensors();

--- a/orts/benches/fiber_overhead.rs
+++ b/orts/benches/fiber_overhead.rs
@@ -135,7 +135,12 @@ fn bench_async_update(c: &mut Criterion) {
 
     let mut cache = WasmPluginCache::new().expect("cache");
     let mut ctrl = cache
-        .build_async_controller(&path, "bench-async", PD_RW_CONFIG)
+        .build_async_controller(
+            &path,
+            "bench-async",
+            PD_RW_CONFIG,
+            arika::body::KnownBody::Earth,
+        )
         .expect("build_async_controller");
 
     let spacecraft = dummy_spacecraft();

--- a/orts/examples/wasm-bdot/main.rs
+++ b/orts/examples/wasm-bdot/main.rs
@@ -139,7 +139,8 @@ fn run_case<F: MagneticFieldModel + 'static>(
 
     let field_arc: Arc<dyn MagneticFieldModel> = Arc::new(make_field());
 
-    let mut ctrl = WasmController::new(pre, label, &config).expect("WasmController::new failed");
+    let mut ctrl = WasmController::new(pre, label, &config, arika::body::KnownBody::Earth)
+        .expect("WasmController::new failed");
     let mut bundle = ActuatorBundle::new();
 
     let mut sensor_bundle = SensorBundle {

--- a/orts/examples/wasm-pd-rw/main.rs
+++ b/orts/examples/wasm-pd-rw/main.rs
@@ -57,7 +57,8 @@ fn main() {
     let pre = WasmController::prepare(&engine, &component).expect("prepare failed");
 
     let config = format!(r#"{{"kp":{},"kd":{},"sample_period":{}}}"#, KP, KD, DT_CTRL);
-    let mut ctrl = WasmController::new(&pre, "pd-rw", &config).expect("WasmController::new failed");
+    let mut ctrl = WasmController::new(&pre, "pd-rw", &config, arika::body::KnownBody::Earth)
+        .expect("WasmController::new failed");
 
     let mu = MU_EARTH;
     let radius = R_EARTH + ALT_KM;

--- a/orts/src/magnetic.rs
+++ b/orts/src/magnetic.rs
@@ -27,6 +27,23 @@ pub fn field_is_modelled(body: arika::body::KnownBody) -> bool {
     body == arika::body::KnownBody::Earth
 }
 
+/// The field model to serve for `body`.
+///
+/// [`TiltedDipole`](tobari::magnetic::TiltedDipole) on Earth — what the WASM
+/// host's `magnetic-field-eci` has always used — and
+/// [`NoField`](tobari::magnetic::NoField) where [`field_is_modelled`] says
+/// there is none, so the answer is zero rather than Earth's field read at a
+/// position that is not geocentric.
+///
+/// Both WASM backends call this, so the sync and async hosts cannot disagree.
+pub fn field_for_body(body: arika::body::KnownBody) -> std::sync::Arc<dyn MagneticFieldModel> {
+    if field_is_modelled(body) {
+        std::sync::Arc::new(tobari::magnetic::TiltedDipole::earth())
+    } else {
+        std::sync::Arc::new(tobari::magnetic::NoField)
+    }
+}
+
 /// Evaluate a magnetic field model and return the result in the
 /// propagation frame `F`.
 ///
@@ -66,4 +83,46 @@ pub fn field_eci(
         position_eci,
         &EarthOrientation::simple(*epoch),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arika::body::KnownBody;
+    use arika::earth::geodetic::Geodetic;
+
+    /// The model served for a body is that body's, on both WASM backends.
+    ///
+    /// Both host states call [`field_for_body`], so this ties the body to the
+    /// model once for the sync and the async path — an async-only regression
+    /// would have to route around this function.
+    #[test]
+    fn field_for_body_is_zero_where_no_model_exists() {
+        let epoch = Epoch::<Utc>::j2000();
+        let input = MagneticFieldInput {
+            geodetic: Geodetic {
+                latitude: 0.0,
+                longitude: 0.0,
+                altitude: 400.0,
+            },
+            utc: &epoch,
+        };
+
+        for body in [KnownBody::Mars, KnownBody::Moon, KnownBody::Sun] {
+            assert_eq!(
+                field_for_body(body).field_ecef(&input),
+                [0.0, 0.0, 0.0],
+                "{body:?} has no field model, so the host serves zero"
+            );
+        }
+
+        let on_earth = field_for_body(KnownBody::Earth).field_ecef(&input);
+        let magnitude =
+            (on_earth[0] * on_earth[0] + on_earth[1] * on_earth[1] + on_earth[2] * on_earth[2])
+                .sqrt();
+        assert!(
+            (1e-5..1e-4).contains(&magnitude),
+            "Earth's field is modelled, so the host serves 20-60 µT, got {magnitude:.3e} T"
+        );
+    }
 }

--- a/orts/src/magnetic.rs
+++ b/orts/src/magnetic.rs
@@ -16,6 +16,17 @@ use tobari::magnetic::{MagneticFieldInput, MagneticFieldModel};
 
 use arika::earth::{EarthFixedTransform, EarthOrientation};
 
+/// Whether this crate has a magnetic field model for `body`.
+///
+/// [`tobari::magnetic::Igrf`] and [`tobari::magnetic::TiltedDipole`] are
+/// Earth's, and they are the only models there are — which is not the same as
+/// another body having no field. Callers that need a model for a body without
+/// one use [`tobari::magnetic::NoField`], so a magnetometer reads zero and a
+/// magnetorquer's `m × B` is zero instead of both taking Earth's field.
+pub fn field_is_modelled(body: arika::body::KnownBody) -> bool {
+    body == arika::body::KnownBody::Earth
+}
+
 /// Evaluate a magnetic field model and return the result in the
 /// propagation frame `F`.
 ///

--- a/orts/src/plugin/wasm/async_controller.rs
+++ b/orts/src/plugin/wasm/async_controller.rs
@@ -169,8 +169,9 @@ impl AsyncWasmController {
         built: &AsyncPluginPreBuilt,
         label: impl Into<String>,
         config: &str,
+        body: arika::body::KnownBody,
     ) -> Result<Self, PluginError> {
-        Self::new_with_streams(built, label, config, Vec::new())
+        Self::new_with_streams(built, label, config, Vec::new(), body)
     }
 
     /// As [`new`](Self::new) but wired to the given `stream-io` streams
@@ -180,6 +181,7 @@ impl AsyncWasmController {
         label: impl Into<String>,
         config: &str,
         stream_names: Vec<String>,
+        body: arika::body::KnownBody,
     ) -> Result<Self, PluginError> {
         let label = label.into();
         let config = config.to_string();
@@ -200,7 +202,11 @@ impl AsyncWasmController {
         runtime.handle().spawn(async move {
             let host_state = AsyncHostState {
                 label: label_for_task,
-                field: tobari::magnetic::TiltedDipole::earth(),
+                field: if crate::magnetic::field_is_modelled(body) {
+                    std::sync::Arc::new(tobari::magnetic::TiltedDipole::earth())
+                } else {
+                    std::sync::Arc::new(tobari::magnetic::NoField)
+                },
                 wasi: wasmtime_wasi::WasiCtxBuilder::new().build(),
                 table: wasmtime_wasi::ResourceTable::new(),
                 input_rx,

--- a/orts/src/plugin/wasm/async_controller.rs
+++ b/orts/src/plugin/wasm/async_controller.rs
@@ -202,11 +202,7 @@ impl AsyncWasmController {
         runtime.handle().spawn(async move {
             let host_state = AsyncHostState {
                 label: label_for_task,
-                field: if crate::magnetic::field_is_modelled(body) {
-                    std::sync::Arc::new(tobari::magnetic::TiltedDipole::earth())
-                } else {
-                    std::sync::Arc::new(tobari::magnetic::NoField)
-                },
+                field: crate::magnetic::field_for_body(body),
                 wasi: wasmtime_wasi::WasiCtxBuilder::new().build(),
                 table: wasmtime_wasi::ResourceTable::new(),
                 input_rx,

--- a/orts/src/plugin/wasm/async_host_state.rs
+++ b/orts/src/plugin/wasm/async_host_state.rs
@@ -10,7 +10,6 @@
 
 use std::collections::VecDeque;
 
-use tobari::magnetic::TiltedDipole;
 use tokio::sync::mpsc;
 
 use super::async_bindings::orts::plugin::host_env;
@@ -54,7 +53,7 @@ pub(super) enum GuestResponse {
 /// Per-satellite host state for the async backend.
 pub(super) struct AsyncHostState {
     pub(super) label: String,
-    pub(super) field: TiltedDipole,
+    pub(super) field: std::sync::Arc<dyn tobari::magnetic::MagneticFieldModel>,
     pub(super) wasi: wasmtime_wasi::WasiCtx,
     pub(super) table: wasmtime_wasi::ResourceTable,
 
@@ -109,7 +108,7 @@ impl host_env::Host for AsyncHostState {
             position_eci_km.z,
         );
         let ep = arika::epoch::Epoch::from_jd(epoch.julian_date);
-        let b = crate::magnetic::field_eci(&self.field, &pos, &ep);
+        let b = crate::magnetic::field_eci(self.field.as_ref(), &pos, &ep);
         wit::Vec3 {
             x: b.x(),
             y: b.y(),

--- a/orts/src/plugin/wasm/cache.rs
+++ b/orts/src/plugin/wasm/cache.rs
@@ -138,8 +138,9 @@ impl WasmPluginCache {
         path: &Path,
         label: &str,
         config: &str,
+        body: arika::body::KnownBody,
     ) -> Result<WasmController, PluginError> {
-        self.build_sync_controller_with_streams(path, label, config, Vec::new())
+        self.build_sync_controller_with_streams(path, label, config, Vec::new(), body)
     }
 
     /// As [`build_sync_controller`](Self::build_sync_controller) but wired
@@ -150,19 +151,10 @@ impl WasmPluginCache {
         label: &str,
         config: &str,
         stream_names: Vec<String>,
+        body: arika::body::KnownBody,
     ) -> Result<WasmController, PluginError> {
         let pre = self.get_or_load_sync(path)?;
-        WasmController::new_with_streams(pre, label, config, stream_names)
-    }
-
-    /// Legacy alias for [`build_sync_controller`](Self::build_sync_controller).
-    pub fn build_controller(
-        &mut self,
-        path: &Path,
-        label: &str,
-        config: &str,
-    ) -> Result<WasmController, PluginError> {
-        self.build_sync_controller(path, label, config)
+        WasmController::new_with_streams(pre, label, config, stream_names, body)
     }
 
     fn get_or_load_sync(&mut self, path: &Path) -> Result<&PluginPre<HostState>, PluginError> {
@@ -198,8 +190,9 @@ impl WasmPluginCache {
         path: &Path,
         label: &str,
         config: &str,
+        body: arika::body::KnownBody,
     ) -> Result<AsyncWasmController, PluginError> {
-        self.build_async_controller_with_streams(path, label, config, Vec::new())
+        self.build_async_controller_with_streams(path, label, config, Vec::new(), body)
     }
 
     /// As [`build_async_controller`](Self::build_async_controller) but wired
@@ -210,9 +203,10 @@ impl WasmPluginCache {
         label: &str,
         config: &str,
         stream_names: Vec<String>,
+        body: arika::body::KnownBody,
     ) -> Result<AsyncWasmController, PluginError> {
         let built = self.get_or_load_async(path)?;
-        AsyncWasmController::new_with_streams(built, label, config, stream_names)
+        AsyncWasmController::new_with_streams(built, label, config, stream_names, body)
     }
 
     /// Borrow the async engine, creating it if this is the first

--- a/orts/src/plugin/wasm/cache.rs
+++ b/orts/src/plugin/wasm/cache.rs
@@ -22,6 +22,7 @@
 //!         "plugin-sdk/examples/bdot-finite-diff/target/wasm32-wasip1/release/guest.wasm".as_ref(),
 //!         &format!("sat{i}"),
 //!         "",
+//!         arika::body::KnownBody::Earth,
 //!     )?;
 //!     // use ctrl ...
 //! }

--- a/orts/src/plugin/wasm/sync_controller.rs
+++ b/orts/src/plugin/wasm/sync_controller.rs
@@ -27,7 +27,7 @@
 //! WasmEngine::new()           -> Engine (shared, Arc)
 //! Component::new(&engine, ..) -> Component (shared, Arc)
 //! Linker + Plugin::add_to_linker -> PluginPre (shared, Arc)
-//! WasmController::new(pre, label, config):
+//! WasmController::new(pre, label, config, body):
 //!   - spawn worker thread
 //!   - worker: Store::new, instantiate, call metadata() + call run()
 //!   - outer: receive metadata, return

--- a/orts/src/plugin/wasm/sync_controller.rs
+++ b/orts/src/plugin/wasm/sync_controller.rs
@@ -103,8 +103,9 @@ impl WasmController {
         pre: &PluginPre<HostState>,
         label: impl Into<String>,
         config: &str,
+        body: arika::body::KnownBody,
     ) -> Result<Self, PluginError> {
-        Self::new_with_streams(pre, label, config, Vec::new())
+        Self::new_with_streams(pre, label, config, Vec::new(), body)
     }
 
     /// Instantiate a WASM guest controller wired to the given `stream-io`
@@ -119,6 +120,7 @@ impl WasmController {
         label: impl Into<String>,
         config: &str,
         stream_names: Vec<String>,
+        body: arika::body::KnownBody,
     ) -> Result<Self, PluginError> {
         let label = label.into();
         let config = config.to_string();
@@ -149,6 +151,7 @@ impl WasmController {
                     metadata_tx,
                     worker_current_mode,
                     worker_streams,
+                    body,
                 );
             })
             .map_err(|e| PluginError::Init(format!("failed to spawn worker thread: {e}")))?;
@@ -358,6 +361,7 @@ fn worker_main(
     metadata_tx: mpsc::SyncSender<Result<f64, String>>,
     current_mode: Arc<Mutex<Option<String>>>,
     stream_names: Vec<String>,
+    body: arika::body::KnownBody,
 ) {
     let engine = pre.engine();
     let host_state = HostState::new(
@@ -366,6 +370,7 @@ fn worker_main(
         output_tx.clone(),
         current_mode,
         stream_names,
+        body,
     );
     let mut store = Store::new(engine, host_state);
 

--- a/orts/src/plugin/wasm/sync_host_state.rs
+++ b/orts/src/plugin/wasm/sync_host_state.rs
@@ -17,7 +17,6 @@ use std::collections::VecDeque;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
-use tobari::magnetic::TiltedDipole;
 
 use super::stream_state::{
     DEFAULT_STREAM_CAPACITY, ReadOutcome, StreamDelivery, Streams, WriteOutcome,
@@ -140,11 +139,7 @@ impl HostState {
     ) -> Self {
         Self {
             label: label.into(),
-            field: if crate::magnetic::field_is_modelled(body) {
-                std::sync::Arc::new(TiltedDipole::earth())
-            } else {
-                std::sync::Arc::new(tobari::magnetic::NoField)
-            },
+            field: crate::magnetic::field_for_body(body),
             wasi: wasmtime_wasi::WasiCtxBuilder::new().build(),
             table: wasmtime_wasi::ResourceTable::new(),
             input_rx,
@@ -482,9 +477,9 @@ mod tests {
     ///
     /// A guest can call `magnetic-field-eci` whether or not its config
     /// declares a magnetic device, so the host is a third consumer of the
-    /// field alongside the magnetometer and the magnetorquer. Around Mars it
-    /// used to answer with Earth's field, measured 384 400 km and one body
-    /// away.
+    /// field alongside the magnetometer and the magnetorquer. On a Mars run it
+    /// used to read the position as if it were geocentric — 7000 km from Mars
+    /// answered with Earth's field 7000 km from Earth.
     #[test]
     fn magnetic_field_is_zero_where_no_model_exists() {
         let pos = wit::Vec3 {

--- a/orts/src/plugin/wasm/sync_host_state.rs
+++ b/orts/src/plugin/wasm/sync_host_state.rs
@@ -82,9 +82,14 @@ pub(super) enum GuestResponse {
 pub struct HostState {
     /// Human-readable satellite / controller label for log messages.
     pub label: String,
-    /// Geomagnetic field model used by the `magnetic-field-eci` host
-    /// import. Currently fixed to `TiltedDipole::earth()`.
-    field: TiltedDipole,
+    /// Magnetic field model used by the `magnetic-field-eci` host import.
+    ///
+    /// Chosen from the central body: `TiltedDipole::earth()` on Earth, and
+    /// [`tobari::magnetic::NoField`] where this crate has no model
+    /// ([`crate::magnetic::field_is_modelled`]). A guest asking for the field
+    /// around Mars gets zero rather than Earth's field measured somewhere
+    /// else.
+    field: std::sync::Arc<dyn tobari::magnetic::MagneticFieldModel>,
     /// WASI context.
     wasi: wasmtime_wasi::WasiCtx,
     /// Resource table for WASI resources.
@@ -131,10 +136,15 @@ impl HostState {
         output_tx: mpsc::SyncSender<GuestResponse>,
         current_mode: Arc<Mutex<Option<String>>>,
         stream_names: Vec<String>,
+        body: arika::body::KnownBody,
     ) -> Self {
         Self {
             label: label.into(),
-            field: TiltedDipole::earth(),
+            field: if crate::magnetic::field_is_modelled(body) {
+                std::sync::Arc::new(TiltedDipole::earth())
+            } else {
+                std::sync::Arc::new(tobari::magnetic::NoField)
+            },
             wasi: wasmtime_wasi::WasiCtxBuilder::new().build(),
             table: wasmtime_wasi::ResourceTable::new(),
             input_rx,
@@ -182,7 +192,7 @@ impl host_env::Host for HostState {
             position_eci_km.z,
         );
         let epoch = arika::epoch::Epoch::from_jd(epoch.julian_date);
-        let b = crate::magnetic::field_eci(&self.field, &pos, &epoch);
+        let b = crate::magnetic::field_eci(self.field.as_ref(), &pos, &epoch);
         wit::Vec3 {
             x: b.x(),
             y: b.y(),
@@ -314,10 +324,14 @@ mod tests {
     use super::*;
 
     fn make_state() -> HostState {
+        make_state_for(arika::body::KnownBody::Earth)
+    }
+
+    fn make_state_for(body: arika::body::KnownBody) -> HostState {
         let (_, input_rx) = mpsc::channel();
         let (output_tx, _) = mpsc::sync_channel(1);
         let current_mode = Arc::new(Mutex::new(None));
-        HostState::new("test", input_rx, output_tx, current_mode, Vec::new())
+        HostState::new("test", input_rx, output_tx, current_mode, Vec::new(), body)
     }
 
     /// `seq` is encoded into `kind` so tests can assert delivery order /
@@ -378,7 +392,14 @@ mod tests {
         let (input_tx, input_rx) = mpsc::channel::<TickPacket>();
         let (output_tx, _output_rx) = mpsc::sync_channel::<GuestResponse>(4);
         let current_mode = Arc::new(Mutex::new(None));
-        let mut state = HostState::new("test", input_rx, output_tx, current_mode, Vec::new());
+        let mut state = HostState::new(
+            "test",
+            input_rx,
+            output_tx,
+            current_mode,
+            Vec::new(),
+            arika::body::KnownBody::Earth,
+        );
 
         // Tick 0 delivers two messages; the guest drains only one.
         input_tx
@@ -455,6 +476,38 @@ mod tests {
         assert_eq!(state.outbox.len(), 2);
         assert_eq!(state.outbox[0].kind, "test.tlm.v1");
         assert_eq!(state.outbox[1].kind, "test.tlm.v2");
+    }
+
+    /// The host answers zero where this crate has no field model.
+    ///
+    /// A guest can call `magnetic-field-eci` whether or not its config
+    /// declares a magnetic device, so the host is a third consumer of the
+    /// field alongside the magnetometer and the magnetorquer. Around Mars it
+    /// used to answer with Earth's field, measured 384 400 km and one body
+    /// away.
+    #[test]
+    fn magnetic_field_is_zero_where_no_model_exists() {
+        let pos = wit::Vec3 {
+            x: 7000.0,
+            y: 0.0,
+            z: 0.0,
+        };
+        let epoch = wit::Epoch {
+            julian_date: 2451545.0,
+        };
+        for body in [
+            arika::body::KnownBody::Mars,
+            arika::body::KnownBody::Moon,
+            arika::body::KnownBody::Sun,
+        ] {
+            let mut state = make_state_for(body);
+            let b = state.magnetic_field_eci(pos, epoch);
+            assert_eq!(
+                (b.x, b.y, b.z),
+                (0.0, 0.0, 0.0),
+                "{body:?} has no field model, so the host reports zero"
+            );
+        }
     }
 
     #[test]

--- a/orts/src/plugin/wasm/sync_host_state.rs
+++ b/orts/src/plugin/wasm/sync_host_state.rs
@@ -17,7 +17,6 @@ use std::collections::VecDeque;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
-
 use super::stream_state::{
     DEFAULT_STREAM_CAPACITY, ReadOutcome, StreamDelivery, Streams, WriteOutcome,
 };

--- a/orts/tests/oracle_plugin_wasm_bdot.rs
+++ b/orts/tests/oracle_plugin_wasm_bdot.rs
@@ -144,7 +144,8 @@ fn run_wasm(initial: AttitudeState, epoch: Epoch) -> Option<AttitudeState> {
     let engine = Arc::new(WasmEngine::new().expect("WasmEngine must init"));
     let component = Component::new(engine.inner(), &wasm_bytes).expect("Component must compile");
     let pre = WasmController::prepare(&engine, &component).expect("prepare must succeed");
-    let ctrl = WasmController::new(&pre, "oracle-bdot", "").expect("new must succeed");
+    let ctrl = WasmController::new(&pre, "oracle-bdot", "", arika::body::KnownBody::Earth)
+        .expect("new must succeed");
     Some(drive_wasm(Box::new(ctrl), initial, epoch))
 }
 
@@ -161,7 +162,12 @@ fn run_wasm_async(initial: AttitudeState, epoch: Epoch) -> Option<AttitudeState>
     }
     let mut cache = WasmPluginCache::new().expect("cache init");
     let ctrl = cache
-        .build_async_controller(&path, "oracle-bdot-async", "")
+        .build_async_controller(
+            &path,
+            "oracle-bdot-async",
+            "",
+            arika::body::KnownBody::Earth,
+        )
         .expect("build_async_controller");
     Some(drive_wasm(Box::new(ctrl), initial, epoch))
 }

--- a/orts/tests/oracle_plugin_wasm_pd_rw.rs
+++ b/orts/tests/oracle_plugin_wasm_pd_rw.rs
@@ -143,8 +143,13 @@ fn run_wasm(initial: AttitudeState) -> Option<AugmentedState<AttitudeState>> {
     let engine = Arc::new(WasmEngine::new().expect("WasmEngine must init"));
     let component = Component::new(engine.inner(), &wasm_bytes).expect("Component must compile");
     let pre = WasmController::prepare(&engine, &component).expect("prepare must succeed");
-    let ctrl =
-        WasmController::new(&pre, "oracle-pd-rw", &pd_rw_config()).expect("new must succeed");
+    let ctrl = WasmController::new(
+        &pre,
+        "oracle-pd-rw",
+        &pd_rw_config(),
+        arika::body::KnownBody::Earth,
+    )
+    .expect("new must succeed");
     Some(drive_wasm(Box::new(ctrl), initial))
 }
 
@@ -161,7 +166,12 @@ fn run_wasm_async(initial: AttitudeState) -> Option<AugmentedState<AttitudeState
     }
     let mut cache = WasmPluginCache::new().expect("cache init");
     let ctrl = cache
-        .build_async_controller(&path, "oracle-pd-rw-async", &pd_rw_config())
+        .build_async_controller(
+            &path,
+            "oracle-pd-rw-async",
+            &pd_rw_config(),
+            arika::body::KnownBody::Earth,
+        )
         .expect("build_async_controller");
     Some(drive_wasm(Box::new(ctrl), initial))
 }

--- a/orts/tests/plugin_msg_commandable_mode.rs
+++ b/orts/tests/plugin_msg_commandable_mode.rs
@@ -69,7 +69,10 @@ fn load(binary: &str) -> Option<WasmController> {
     let engine = Arc::new(WasmEngine::new().expect("WasmEngine must init"));
     let component = Component::new(engine.inner(), &bytes).expect("Component must compile");
     let pre = WasmController::prepare(&engine, &component).expect("prepare must succeed");
-    Some(WasmController::new(&pre, "msg-test", "").expect("new must succeed"))
+    Some(
+        WasmController::new(&pre, "msg-test", "", arika::body::KnownBody::Earth)
+            .expect("new must succeed"),
+    )
 }
 
 fn spacecraft() -> SpacecraftState {

--- a/orts/tests/plugin_stream_framed.rs
+++ b/orts/tests/plugin_stream_framed.rs
@@ -62,8 +62,14 @@ fn load() -> Option<WasmController> {
     let pre = WasmController::prepare(&engine, &component).expect("prepare must succeed");
     // The FSW is wired to a single "comlink" stream (declared at construction).
     Some(
-        WasmController::new_with_streams(&pre, "stream-test", "", vec![STREAM.to_string()])
-            .expect("new must succeed"),
+        WasmController::new_with_streams(
+            &pre,
+            "stream-test",
+            "",
+            vec![STREAM.to_string()],
+            arika::body::KnownBody::Earth,
+        )
+        .expect("new must succeed"),
     )
 }
 

--- a/orts/tests/wasm_async_backend.rs
+++ b/orts/tests/wasm_async_backend.rs
@@ -89,7 +89,7 @@ fn async_backend_single_satellite() {
 
     let config = r#"{"kp":1.0,"kd":2.0,"sample_period":0.1}"#;
     let mut ctrl = cache
-        .build_async_controller(&path, "sat0", config)
+        .build_async_controller(&path, "sat0", config, arika::body::KnownBody::Earth)
         .expect("build_async_controller must succeed");
 
     assert!(
@@ -137,7 +137,12 @@ fn run_multi_satellite(n_sats: usize, n_ticks: usize) {
         .map(|i| {
             let config = r#"{"kp":1.0,"kd":2.0,"sample_period":0.1}"#;
             cache
-                .build_async_controller(&path, &format!("sat{i}"), config)
+                .build_async_controller(
+                    &path,
+                    &format!("sat{i}"),
+                    config,
+                    arika::body::KnownBody::Earth,
+                )
                 .unwrap_or_else(|e| panic!("spawn sat{i}: {e}"))
         })
         .collect();
@@ -186,7 +191,7 @@ fn async_backend_drop_during_wait() {
 
     let config = r#"{"kp":1.0,"kd":2.0,"sample_period":0.1}"#;
     let ctrl = cache
-        .build_async_controller(&path, "droptest", config)
+        .build_async_controller(&path, "droptest", config, arika::body::KnownBody::Earth)
         .expect("build_async_controller");
     drop(ctrl);
     // If the drop signal did not propagate, the runtime thread would

--- a/orts/wit/v0/orts.wit
+++ b/orts/wit/v0/orts.wit
@@ -400,15 +400,18 @@ interface host-env {
     /// ゲストからログレコードを出力する。
     log: func(level: log-level, message: string);
 
-    /// 指定 ECI 位置・エポックでの地磁気ベクトルを ECI 座標系で返す \[T\]。
+    /// 指定 ECI 位置・エポックでの中心天体の磁場ベクトルを ECI 座標系で返す \[T\]。
+    ///
+    /// 磁場モデルがあるのは Earth だけなので、それ以外の中心天体では
+    /// ゼロベクトルを返す（Earth の磁場を返すことはしない）。
     ///
     /// 宇宙機の現在位置・姿勢での機体座標系磁場が欲しい場合は
     /// `sensors.magnetometer` を使う方がオーバーヘッドがない。
     /// このインポートは任意位置/エポックの磁場が必要な場合
     /// （予測・計画等）の "escape hatch"。
     ///
-    /// Phase P1 では `tobari::magnetic::TiltedDipole` に接続。
-    /// Phase D-5 で IGRF 球面調和モデルへ移行予定。
+    /// Earth では `tobari::magnetic::TiltedDipole` に接続（Phase D-5 で IGRF
+    /// 球面調和モデルへ移行予定）。他の中心天体は `tobari::magnetic::NoField`。
     magnetic-field-eci: func(
         position-eci-km: vec3,
         e: epoch,

--- a/plugin-sdk/examples/bdot-finite-diff/README.md
+++ b/plugin-sdk/examples/bdot-finite-diff/README.md
@@ -91,4 +91,4 @@ The guest accepts a JSON config blob via `init`:
 }
 ```
 
-All fields are optional (defaults are shown above). The host passes this string at `WasmController::new(pre, label, config)`.
+All fields are optional (defaults are shown above). The host passes this string at `WasmController::new(pre, label, config, body)`.

--- a/plugin-sdk/wit/v0/orts.wit
+++ b/plugin-sdk/wit/v0/orts.wit
@@ -400,15 +400,18 @@ interface host-env {
     /// ゲストからログレコードを出力する。
     log: func(level: log-level, message: string);
 
-    /// 指定 ECI 位置・エポックでの地磁気ベクトルを ECI 座標系で返す \[T\]。
+    /// 指定 ECI 位置・エポックでの中心天体の磁場ベクトルを ECI 座標系で返す \[T\]。
+    ///
+    /// 磁場モデルがあるのは Earth だけなので、それ以外の中心天体では
+    /// ゼロベクトルを返す（Earth の磁場を返すことはしない）。
     ///
     /// 宇宙機の現在位置・姿勢での機体座標系磁場が欲しい場合は
     /// `sensors.magnetometer` を使う方がオーバーヘッドがない。
     /// このインポートは任意位置/エポックの磁場が必要な場合
     /// （予測・計画等）の "escape hatch"。
     ///
-    /// Phase P1 では `tobari::magnetic::TiltedDipole` に接続。
-    /// Phase D-5 で IGRF 球面調和モデルへ移行予定。
+    /// Earth では `tobari::magnetic::TiltedDipole` に接続（Phase D-5 で IGRF
+    /// 球面調和モデルへ移行予定）。他の中心天体は `tobari::magnetic::NoField`。
     magnetic-field-eci: func(
         position-eci-km: vec3,
         e: epoch,


### PR DESCRIPTION
## 概要

WASM plugin が `host-env.magnetic-field-eci` を呼ぶと、中心天体が Mars でも Earth の磁場が
返っていた。sync と async の両 backend が host state を `TiltedDipole::earth()` 固定で作り、
中心天体を受け取っていなかったため。

#372 は config に書かれた磁気デバイス（magnetometer・magnetorquer）を対象に直したが、この
import は config に何も書かなくても guest から呼べるので、経路が 1 つ残っていた。

host state も中心天体を受け取り、モデルのない天体では `tobari::magnetic::NoField` を使う。
判定は `orts::magnetic::field_is_modelled` の 1 箇所で、CLI のデバイスと host が同じ規則を
読む。**WIT の変更は不要**で、戻り値の `vec3` にゼロを載せる（#372 の「未モデル化はゼロ」
方針がそのまま効く）。

## 直した形

```rust
// 修正前: 中心天体を見ない
field: TiltedDipole::earth(),

// 修正後: 中心天体から選ぶ
field: if crate::magnetic::field_is_modelled(body) {
    Arc::new(TiltedDipole::earth())
} else {
    Arc::new(tobari::magnetic::NoField)
},
```

中心天体は CLI（`ctx.params.body`）から controller の constructor と cache builder を通って
host state に届く。

WIT の doc も実態に合わせた。「地磁気ベクトル」→「中心天体の磁場ベクトル。モデルがあるのは
Earth だけなので、それ以外ではゼロを返す」。

## 利用者から見える変化

**plugin が受け取る値**: Earth 以外の run で `magnetic-field-eci` がゼロベクトルを返す。従来は
Earth の磁場（Mars の run でも 20〜60 µT 相当）が返っていた。磁場で操舵する制御は、そこにない
磁場で動くのをやめて何もしなくなる。

**BREAKING**: 次の API が `KnownBody` を取る。

- `WasmController::new` / `new_with_streams`
- `AsyncWasmController::new` / `new_with_streams`
- `WasmPluginCache::build_sync_controller` / `build_sync_controller_with_streams`
- `WasmPluginCache::build_async_controller` / `build_async_controller_with_streams`

呼び出し元のなかった legacy alias `WasmPluginCache::build_controller` は削除した。天体を
勝手に選ぶ入口が、このバグそのものの形なので残さない。

## テスト

`magnetic_field_is_zero_where_no_model_exists` が Mars・Moon・Sun でちょうどゼロを、既存の
`magnetic_field_returns_finite_nonzero_for_leo` が Earth で 20〜60 µT を検査する。host state を
`TiltedDipole::earth()` 固定に戻す mutation で、前者だけが落ちる。

`cargo test -p orts --features plugin-wasm` は 966 件 pass（実行前にビルドで落ちないことを含む
— 最初の実装では in-tree の呼び出し 11 箇所が古い arity のままで、レビューで 2 回指摘された）。
`cargo build -p orts --all-features --all-targets` が clean で、これが feature を跨ぐ漏れを
1 コマンドで押さえる確認になる。

`clippy --all-targets` に残る 4 件（async feature 裏の unused import 2 件、wasm-bdot example の
redundant closure、oracle_discrete_bdot の引数数）は main でも出る既存 lint。CI は
`--all-targets` を付けないため露出しない。

Closes #431
