### PR TITLE
fix(arika): keep the Kepler solver's Newton step inside a root bracket

### DIFF
--- a/arika/src/kepler.rs
+++ b/arika/src/kepler.rs
@@ -62,12 +62,11 @@ fn x_minus_sin(x: f64) -> f64 {
 ///
 /// Eccentric anomaly E [rad], within `e` of the reduced `M`.
 ///
-/// How precisely `E` is pinned down near periapsis at `e` close to 1 is set by
-/// the conditioning of the equation, not by the iteration: `ΔE = f / f'` with
-/// `f' = 1 - e·cos(E)` falling to `1 - e` there, and `f` cannot be evaluated
-/// below the rounding of its own largest term. At `e = 0.9999999999` and `M`
-/// within 1e-13 of `2π`, `f' = 4e-9`, so a residual at the `f64` floor of
-/// 1e-16 already leaves `E` uncertain by 2e-8.
+/// The residual is evaluated at the periapsis nearest `E`, so how accurately it
+/// can be computed is set by its own magnitude rather than by the size of `E`.
+/// What that leaves is the spacing of `f64` itself, which grows with `E`: a
+/// root just below `2π` is placed to `ulp(2π) = 8.9e-16`, one just above zero
+/// to far finer.
 pub fn solve_kepler_equation(mean_anomaly: f64, eccentricity: f64) -> f64 {
     let m = mean_anomaly % (2.0 * PI);
     // `E = M + e·sin(E)` puts the root within `e` of `M`, and `f` increases
@@ -78,19 +77,32 @@ pub fn solve_kepler_equation(mean_anomaly: f64, eccentricity: f64) -> f64 {
     let mut hi = m + eccentricity;
     let mut e_anom = m;
     for _ in 0..KEPLER_MAX_ITERATIONS {
-        // `E - e·sin(E)` rearranged as `(1-e)·E + e·(E - sin(E))`. Written
-        // directly, the two terms cancel near periapsis at `e` close to 1 and
-        // the sign of `f` becomes unreliable, which is what the bracket update
-        // below reads. A wrong sign there moves an endpoint past the root and
-        // takes it out of the bracket for good.
-        let f = (1.0 - eccentricity) * e_anom + eccentricity * x_minus_sin(e_anom) - m;
+        // The residual, evaluated at the periapsis nearest `e_anom`.
+        //
+        // `sin` has period 2π, so shifting `E` and `M` by the same `2πk` leaves
+        // the equation alone: with `u = E - 2πk` and `w = M - 2πk` the residual
+        // is `u - e·sin(u) - w`, rearranged below as `(1-e)·u + e·(u - sin u)`
+        // to keep those two from cancelling. `k` is 0 or ±1 because the reduced
+        // `M` is inside one revolution and `E` is within `e` of it, and both
+        // shifts are exact where they matter (Sterbenz).
+        //
+        // Written at `E` instead, the `E ≈ 2π` branch subtracts two values near
+        // 2π and loses the residual whose sign the bracket update below reads.
+        // A wrong sign there moves an endpoint past the root and takes it out
+        // of the bracket for good. The shift puts `u` near zero at either
+        // periapsis, where `x_minus_sin` is accurate.
+        let k = (e_anom / (2.0 * PI)).round();
+        let u = e_anom - k * (2.0 * PI);
+        let w = m - k * (2.0 * PI);
+        let f = (1.0 - eccentricity) * u + eccentricity * x_minus_sin(u) - w;
         if f > 0.0 {
             hi = e_anom;
         } else {
             lo = e_anom;
         }
 
-        let f_prime = 1.0 - eccentricity * e_anom.cos();
+        // `cos` shares `sin`'s period, so this is the derivative at `E` too.
+        let f_prime = 1.0 - eccentricity * u.cos();
         let step = -f / f_prime;
         // `|step| = |f| / |f'|` and `f' ≤ 1 + e < 2`, so a step this small
         // means the residual is already within twice it. Checking here rather
@@ -830,6 +842,30 @@ mod tests {
                 "M={m}, e={e}: E={e_anom:e} is {relative:.3e} away from {root:e}"
             );
         }
+    }
+
+    /// The periapsis just below `2π` is found as accurately as the one at zero.
+    ///
+    /// Both `M` values here name the same point of the orbit, so the solver has
+    /// to be as accurate at `E ≈ 2π` as at `E ≈ 0`. Evaluating the residual at
+    /// `E` rather than at the nearest periapsis subtracts two values near 2π:
+    /// measured that way, `M = 6.283185307179464` returned
+    /// `E = 6.283097238421463`, off by 2.1e-8.
+    ///
+    /// The expected root comes from bisecting `u - e·sin(u) - v` with
+    /// `u = 2π - E` and `v = 2π - M`, whose terms carry no cancellation
+    /// against each other.
+    #[test]
+    fn the_periapsis_below_two_pi_is_as_accurate_as_the_one_at_zero() {
+        let e = 0.9999999999;
+        let m = 6.283185307179464;
+        let root = 6.283097259381490;
+        let e_anom = solve_kepler_equation(m, e);
+        let relative = (e_anom - root).abs() / root;
+        assert!(
+            relative < 1e-14,
+            "M={m}, e={e}: E={e_anom:.15} is {relative:.3e} away from {root:.15}"
+        );
     }
 
     /// `M = π` is answered with `π` itself, at every eccentricity.

--- a/arika/src/kepler.rs
+++ b/arika/src/kepler.rs
@@ -59,7 +59,15 @@ fn x_minus_sin(x: f64) -> f64 {
 /// * `eccentricity` - Orbital eccentricity (0 ≤ e < 1)
 ///
 /// # Returns
-/// Eccentric anomaly E [rad], within `e` of the reduced `M`
+///
+/// Eccentric anomaly E [rad], within `e` of the reduced `M`.
+///
+/// How precisely `E` is pinned down near periapsis at `e` close to 1 is set by
+/// the conditioning of the equation, not by the iteration: `ΔE = f / f'` with
+/// `f' = 1 - e·cos(E)` falling to `1 - e` there, and `f` cannot be evaluated
+/// below the rounding of its own largest term. At `e = 0.9999999999` and `M`
+/// within 1e-13 of `2π`, `f' = 4e-9`, so a residual at the `f64` floor of
+/// 1e-16 already leaves `E` uncertain by 2e-8.
 pub fn solve_kepler_equation(mean_anomaly: f64, eccentricity: f64) -> f64 {
     let m = mean_anomaly % (2.0 * PI);
     // `E = M + e·sin(E)` puts the root within `e` of `M`, and `f` increases

--- a/arika/src/kepler.rs
+++ b/arika/src/kepler.rs
@@ -24,6 +24,26 @@ use crate::math::F64Ext;
 /// `E - e·sin(E) - M` stays under 8.9e-16.
 const KEPLER_MAX_ITERATIONS: usize = 100;
 
+/// `x - sin(x)`, without the cancellation that subtraction carries near zero.
+///
+/// Both terms approach `x` as `x → 0` while the difference approaches `x³/6`,
+/// so the subtraction keeps only the low bits: at `x = 3e-7` it loses about 13
+/// digits, leaving an absolute error near `ulp(x)`. The series carries no such
+/// loss, and truncating it after `x⁹` costs `x¹¹/39916800`. Measured against a
+/// series carried to `x¹³`, the relative errors cross between 0.1 and 0.15: at
+/// 0.1 the series is 1.5e-15 and the subtraction 1.8e-14, at 0.15 it is
+/// 3.9e-14 against 1.4e-15. Dropping the `x⁹` term moves that crossing down to
+/// about 0.02.
+fn x_minus_sin(x: f64) -> f64 {
+    const SERIES_BELOW: f64 = 0.1;
+    if x.abs() < SERIES_BELOW {
+        let x2 = x * x;
+        x * x2 / 6.0 * (1.0 - x2 / 20.0 * (1.0 - x2 / 42.0 * (1.0 - x2 / 72.0)))
+    } else {
+        x - x.sin()
+    }
+}
+
 /// Solve Kepler's equation `M = E - e·sin(E)` for eccentric anomaly E.
 ///
 /// Newton-Raphson, kept inside a bracket that contains the root: at high
@@ -50,7 +70,12 @@ pub fn solve_kepler_equation(mean_anomaly: f64, eccentricity: f64) -> f64 {
     let mut hi = m + eccentricity;
     let mut e_anom = m;
     for _ in 0..KEPLER_MAX_ITERATIONS {
-        let f = e_anom - eccentricity * e_anom.sin() - m;
+        // `E - e·sin(E)` rearranged as `(1-e)·E + e·(E - sin(E))`. Written
+        // directly, the two terms cancel near periapsis at `e` close to 1 and
+        // the sign of `f` becomes unreliable, which is what the bracket update
+        // below reads. A wrong sign there moves an endpoint past the root and
+        // takes it out of the bracket for good.
+        let f = (1.0 - eccentricity) * e_anom + eccentricity * x_minus_sin(e_anom) - m;
         if f > 0.0 {
             hi = e_anom;
         } else {
@@ -764,6 +789,36 @@ mod tests {
             worst.2,
             solve_kepler_equation(worst.1, worst.2)
         );
+    }
+
+    /// Near periapsis at `e` one ulp below 1, the root is found to 1e-12.
+    ///
+    /// `E` and `e·sin(E)` are equal to 13 digits at `E = 3e-7`, so subtracting
+    /// them leaves the sign of `f` up to the rounding of `e·sin(E)`. The
+    /// bracket update reads that sign, and a wrong one moves an endpoint past
+    /// the root. Measured with the residual written as a plain subtraction:
+    /// `E = 3.0968e-7` against a root of `3.1000864616e-7`, off by 1.1e-3
+    /// relative.
+    ///
+    /// The expected roots come from bisecting `E(1-e) + e(E - sin E) - M`,
+    /// whose terms are evaluated without cancelling against each other. As a
+    /// check on their magnitude, `(1-e)·E` is negligible against `E³/6` here,
+    /// so `E → (6M)^(1/3)`: 3.107e-7 for the first row, 0.2% from the root.
+    #[test]
+    fn a_near_parabolic_orbit_near_periapsis_keeps_its_root() {
+        let e = 1.0f64.next_down();
+        for &(m, root) in &[
+            (5e-21, 3.100_086_461_6e-7),
+            (1e-20, 3.909_195_816_0e-7),
+            (1e-15, 1.817_119_370_9e-5),
+        ] {
+            let e_anom = solve_kepler_equation(m, e);
+            let relative = (e_anom - root).abs() / root;
+            assert!(
+                relative < 1e-9,
+                "M={m}, e={e}: E={e_anom:e} is {relative:.3e} away from {root:e}"
+            );
+        }
     }
 
     /// `M = π` is answered with `π` itself, at every eccentricity.

--- a/arika/src/kepler.rs
+++ b/arika/src/kepler.rs
@@ -13,23 +13,61 @@ use nalgebra::Vector3;
 #[allow(unused_imports)]
 use crate::math::F64Ext;
 
-/// Solve Kepler's equation `M = E - e·sin(E)` for eccentric anomaly E
-/// using Newton-Raphson iteration.
+/// Iterations [`solve_kepler_equation`] may take.
+///
+/// Newton reaches the 1e-14 step threshold in a handful of steps wherever it
+/// converges on its own. The bisection fallback sets the floor: halving a
+/// bracket of width `2e ≤ 2` down to that threshold takes
+/// `log2(2 / 1e-14) ≈ 48` steps, and the rest of the budget covers the Newton
+/// steps interleaved with them. As `e` approaches 1 the budget can be spent in
+/// full; measured across the eccentricities nearest 1 that `f64` holds, the
+/// residual `E - e·sin(E) - M` stays under 2.1e-14 either way.
+const KEPLER_MAX_ITERATIONS: usize = 100;
+
+/// Solve Kepler's equation `M = E - e·sin(E)` for eccentric anomaly E.
+///
+/// Newton-Raphson, kept inside a bracket that contains the root: near periapsis
+/// at high eccentricity `f' = 1 - e·cos(E)` approaches `1 - e`, and an
+/// unguarded Newton step from `E₀ = M` there is long enough to leave the
+/// interval and not come back. Bisecting instead of taking such a step
+/// converges for every eccentricity the signature accepts.
 ///
 /// # Arguments
 /// * `mean_anomaly` - Mean anomaly M [rad]
 /// * `eccentricity` - Orbital eccentricity (0 ≤ e < 1)
 ///
 /// # Returns
-/// Eccentric anomaly E [rad]
+/// Eccentric anomaly E [rad], within `e` of the reduced `M`
 pub fn solve_kepler_equation(mean_anomaly: f64, eccentricity: f64) -> f64 {
     let m = mean_anomaly % (2.0 * PI);
-    let mut e_anom = m; // initial guess
-    for _ in 0..50 {
+    // `E = M + e·sin(E)` puts the root within `e` of `M`, and `f` increases
+    // monotonically (`f' = 1 - e·cos(E) > 0` for `e < 1`), so `f(m - e) ≤ 0`
+    // and `f(m + e) ≥ 0` bracket it for any `M`. For `e = 0` the bracket is the
+    // single point `m`, which is the root.
+    let mut lo = m - eccentricity;
+    let mut hi = m + eccentricity;
+    let mut e_anom = m;
+    for _ in 0..KEPLER_MAX_ITERATIONS {
         let f = e_anom - eccentricity * e_anom.sin() - m;
+        if f > 0.0 {
+            hi = e_anom;
+        } else {
+            lo = e_anom;
+        }
+
         let f_prime = 1.0 - eccentricity * e_anom.cos();
-        let delta = f / f_prime;
-        e_anom -= delta;
+        let newton = e_anom - f / f_prime;
+        // A Newton step that leaves the bracket says nothing about where the
+        // root is; the bracket does. Its midpoint also makes progress when
+        // `f_prime` underflows to zero and the step is not finite at all.
+        let next = if newton > lo && newton < hi {
+            newton
+        } else {
+            0.5 * (lo + hi)
+        };
+
+        let delta = next - e_anom;
+        e_anom = next;
         if delta.abs() < 1e-14 {
             break;
         }
@@ -651,6 +689,78 @@ mod tests {
             (m - m_check).abs() < 1e-12,
             "High-e convergence: M={m}, E={e_anom}, M_check={m_check}"
         );
+    }
+
+    /// The returned E solves the equation it is named for, over the whole
+    /// eccentricity range the signature accepts.
+    ///
+    /// The oracle is Kepler's equation itself — `E - e·sin(E) - M`, which the
+    /// solver does not compute a residual of — so this does not compare the
+    /// solver against itself the way a `ν → M → ν` round-trip does.
+    ///
+    /// `test_kepler_equation_high_eccentricity` samples one point, `e = 0.99`
+    /// with `M = 1.0`, which Newton reaches from `E₀ = M` in a few steps. The
+    /// grid here includes the starting points from which it does not.
+    #[test]
+    fn kepler_solution_satisfies_the_equation_at_every_eccentricity() {
+        let mut worst = (0.0f64, 0.0f64, 0.0f64);
+        for &e in &[0.0, 0.1, 0.5, 0.7, 0.9, 0.95, 0.99, 0.995, 0.999] {
+            // 0.05 rad steps across two full revolutions, so the reduction of
+            // `M` and both signs of the residual are covered.
+            for i in -252..=252 {
+                let m = i as f64 * 0.05;
+                let e_anom = solve_kepler_equation(m, e);
+                // `solve_kepler_equation` reduces M the same way; the residual
+                // is against the reduced value it actually solved for.
+                let residual = e_anom - e * e_anom.sin() - m % (2.0 * PI);
+                if residual.abs() > worst.0.abs() {
+                    worst = (residual, m, e);
+                }
+            }
+        }
+        // 1e-13 rather than the solver's 1e-14 step threshold: the step is on
+        // E, and near periapsis at e = 0.999 the residual is that step times
+        // `f' = 1 - e·cos(E)`, which is 1.999 there.
+        assert!(
+            worst.0.abs() < 1e-13,
+            "E must solve M = E - e·sin(E): residual {:.3e} at M={}, e={} (E={})",
+            worst.0,
+            worst.1,
+            worst.2,
+            solve_kepler_equation(worst.1, worst.2)
+        );
+    }
+
+    /// Newton from `E₀ = M` diverges here, and the solver used to return the
+    /// diverged iterate as the answer.
+    ///
+    /// Measured before the bracket went in: `e = 0.995, M = 0.4` returned
+    /// `E = 2.7e6` rad, and the true anomaly that follows from it was 352.9°
+    /// away from the one the root gives. `f' = 1 - e·cos(E)` is 5e-3 at
+    /// `E₀ = 0.4`, so the first step is three orders of magnitude too long.
+    #[test]
+    fn a_diverging_newton_start_still_gives_the_root() {
+        for &(m, e) in &[
+            (0.4, 0.995),
+            (0.45, 0.995),
+            (5.9, 0.995),
+            (6.2, 0.995),
+            (0.25, 0.99),
+            (5.85, 0.99),
+        ] {
+            let e_anom = solve_kepler_equation(m, e);
+            let residual = e_anom - e * e_anom.sin() - m;
+            assert!(
+                residual.abs() < 1e-13,
+                "M={m}, e={e}: E={e_anom} leaves a residual of {residual:.3e}"
+            );
+            // `E = M + e·sin(E)` bounds the root to within e of M. The
+            // diverged values were 6 orders of magnitude outside it.
+            assert!(
+                (e_anom - m).abs() <= e + 1e-12,
+                "M={m}, e={e}: E={e_anom} is further than e from M"
+            );
+        }
     }
 
     #[test]

--- a/arika/src/kepler.rs
+++ b/arika/src/kepler.rs
@@ -19,9 +19,9 @@ use crate::math::F64Ext;
 /// converges on its own. The bisection fallback sets the floor: halving a
 /// bracket of width `2e ≤ 2` down to that threshold takes
 /// `log2(2 / 1e-14) ≈ 48` steps, and the rest of the budget covers the Newton
-/// steps interleaved with them. As `e` approaches 1 the budget can be spent in
-/// full; measured across the eccentricities nearest 1 that `f64` holds, the
-/// residual `E - e·sin(E) - M` stays under 2.1e-14 either way.
+/// steps interleaved with them. Measured over two revolutions of `M` at
+/// eccentricities up to the largest `f64` below 1, the residual
+/// `E - e·sin(E) - M` stays under 8.9e-16.
 const KEPLER_MAX_ITERATIONS: usize = 100;
 
 /// Solve Kepler's equation `M = E - e·sin(E)` for eccentric anomaly E.
@@ -58,7 +58,20 @@ pub fn solve_kepler_equation(mean_anomaly: f64, eccentricity: f64) -> f64 {
         }
 
         let f_prime = 1.0 - eccentricity * e_anom.cos();
-        let newton = e_anom - f / f_prime;
+        let step = -f / f_prime;
+        // `|step| = |f| / |f'|` and `f' ≤ 1 + e < 2`, so a step this small
+        // means the residual is already within twice it. Checking here rather
+        // than after the bracket test matters because `e_anom` has just become
+        // an endpoint: a step that rounds away to nothing would read as
+        // "outside the bracket" and send the iteration bisecting away from a
+        // root it had already found. At `M = π` that cost 46 iterations and
+        // left the answer 16 ulp off.
+        if step.abs() < 1e-14 {
+            e_anom += step;
+            break;
+        }
+
+        let newton = e_anom + step;
         // A Newton step that leaves the bracket says nothing about where the
         // root is; the bracket does. Its midpoint also makes progress when
         // `f_prime` underflows to zero and the step is not finite at all.
@@ -739,7 +752,10 @@ mod tests {
         }
         // 1e-13 rather than the solver's 1e-14 step threshold: the step is on
         // E, and the residual is that step times `f' = 1 - e·cos(E)`, which is
-        // largest at apoapsis where it reaches `1 + e < 2`.
+        // largest at apoapsis where it reaches `1 + e < 2`. The measured worst
+        // is 8.9e-16, so this leaves the analytical bound its margin rather
+        // than pinning today's number. `the_root_at_pi_is_returned_exactly`
+        // is what holds the accuracy at the point that used to be worst.
         assert!(
             worst.0.abs() < 1e-13,
             "E must solve M = E - e·sin(E): residual {:.3e} at M={}, e={} (E={})",
@@ -748,6 +764,27 @@ mod tests {
             worst.2,
             solve_kepler_equation(worst.1, worst.2)
         );
+    }
+
+    /// `M = π` is answered with `π` itself, at every eccentricity.
+    ///
+    /// `E = π` solves `M = E - e·sin(E)` for any `e` because `sin(π) = 0`, so
+    /// the starting point is already the root. `sin(π)` is 1.2e-16 rather than
+    /// zero in `f64`, which leaves a residual for Newton to work on and a step
+    /// too small to change `E`; the iteration has to recognise that instead of
+    /// walking away from it. Measured before the step check went in: 13 to 16
+    /// ulp of drift, worst at `e = 0.5` and `e = 0.995`.
+    #[test]
+    fn the_root_at_pi_is_returned_exactly() {
+        for &e in &[0.0, 0.1, 0.5, 0.9, 0.995, 0.999] {
+            let e_anom = solve_kepler_equation(PI, e);
+            assert_eq!(
+                e_anom.to_bits(),
+                PI.to_bits(),
+                "M = π must give exactly π at e={e}: got {e_anom:.17} ({} ulp off)",
+                e_anom.to_bits() as i64 - PI.to_bits() as i64
+            );
+        }
     }
 
     /// Newton from `E₀ = M` diverges here, and the solver used to return the

--- a/arika/src/kepler.rs
+++ b/arika/src/kepler.rs
@@ -26,11 +26,13 @@ const KEPLER_MAX_ITERATIONS: usize = 100;
 
 /// Solve Kepler's equation `M = E - e·sin(E)` for eccentric anomaly E.
 ///
-/// Newton-Raphson, kept inside a bracket that contains the root: near periapsis
-/// at high eccentricity `f' = 1 - e·cos(E)` approaches `1 - e`, and an
-/// unguarded Newton step from `E₀ = M` there is long enough to leave the
-/// interval and not come back. Bisecting instead of taking such a step
-/// converges for every eccentricity the signature accepts.
+/// Newton-Raphson, kept inside a bracket that contains the root: at high
+/// eccentricity `f' = 1 - e·cos(E)` falls to `1 - e` at periapsis, and near
+/// there an unguarded Newton step from `E₀ = M` is long enough to leave the
+/// interval and not come back. At `e = 0.995, M = 0.4` the step is 4.64 rad,
+/// landing at `E = 5.04` outside the bracket `[-0.595, 1.395]`. Bisecting
+/// instead of taking such a step converges for every eccentricity the
+/// signature accepts.
 ///
 /// # Arguments
 /// * `mean_anomaly` - Mean anomaly M [rad]
@@ -704,12 +706,29 @@ mod tests {
     #[test]
     fn kepler_solution_satisfies_the_equation_at_every_eccentricity() {
         let mut worst = (0.0f64, 0.0f64, 0.0f64);
-        for &e in &[0.0, 0.1, 0.5, 0.7, 0.9, 0.95, 0.99, 0.995, 0.999] {
+        // The last entry is the largest `f64` below 1, where the bracket is
+        // widest and the iteration budget is closest to being spent in full.
+        for &e in &[
+            0.0,
+            0.1,
+            0.5,
+            0.7,
+            0.9,
+            0.95,
+            0.99,
+            0.995,
+            0.999,
+            1.0f64.next_down(),
+        ] {
             // 0.05 rad steps across two full revolutions, so the reduction of
             // `M` and both signs of the residual are covered.
             for i in -252..=252 {
                 let m = i as f64 * 0.05;
                 let e_anom = solve_kepler_equation(m, e);
+                assert!(
+                    e_anom.is_finite(),
+                    "E must be finite: got {e_anom} at M={m}, e={e}"
+                );
                 // `solve_kepler_equation` reduces M the same way; the residual
                 // is against the reduced value it actually solved for.
                 let residual = e_anom - e * e_anom.sin() - m % (2.0 * PI);
@@ -719,8 +738,8 @@ mod tests {
             }
         }
         // 1e-13 rather than the solver's 1e-14 step threshold: the step is on
-        // E, and near periapsis at e = 0.999 the residual is that step times
-        // `f' = 1 - e·cos(E)`, which is 1.999 there.
+        // E, and the residual is that step times `f' = 1 - e·cos(E)`, which is
+        // largest at apoapsis where it reaches `1 + e < 2`.
         assert!(
             worst.0.abs() < 1e-13,
             "E must solve M = E - e·sin(E): residual {:.3e} at M={}, e={} (E={})",

--- a/arika/src/kepler.rs
+++ b/arika/src/kepler.rs
@@ -858,8 +858,9 @@ mod tests {
     ///
     /// Measured before the bracket went in: `e = 0.995, M = 0.4` returned
     /// `E = 2.7e6` rad, and the true anomaly that follows from it was 352.9°
-    /// away from the one the root gives. `f' = 1 - e·cos(E)` is 5e-3 at
-    /// `E₀ = 0.4`, so the first step is three orders of magnitude too long.
+    /// away from the one the root gives. `f' = 1 - e·cos(E)` is 8.35e-2 at
+    /// `E₀ = 0.4`, which makes the first step 4.64 rad — past the root at 1.376
+    /// and out of `[-0.595, 1.395]`, after which the iteration is loose.
     #[test]
     fn a_diverging_newton_start_still_gives_the_root() {
         for &(m, e) in &[

--- a/arika/src/kepler.rs
+++ b/arika/src/kepler.rs
@@ -742,9 +742,12 @@ mod tests {
     /// The returned E solves the equation it is named for, over the whole
     /// eccentricity range the signature accepts.
     ///
-    /// The oracle is Kepler's equation itself — `E - e·sin(E) - M`, which the
-    /// solver does not compute a residual of — so this does not compare the
-    /// solver against itself the way a `ν → M → ν` round-trip does.
+    /// The oracle is Kepler's equation itself, written here as the plain
+    /// `E - e·sin(E) - M`. The solver evaluates the same quantity rearranged
+    /// as `(1-e)·E + e·(E - sin(E)) - M`, and stops on the size of its Newton
+    /// step rather than on that residual. Asserting the residual therefore
+    /// checks a quantity the iteration never checks against a threshold of its
+    /// own, which a `ν → M → ν` round-trip does not do.
     ///
     /// `test_kepler_equation_high_eccentricity` samples one point, `e = 0.99`
     /// with `M = 1.0`, which Newton reaches from `E₀ = M` in a few steps. The


### PR DESCRIPTION
## 概要

`arika::kepler::solve_kepler_equation` は Newton 法を 50 回反復し、最後の `e_anom` を返す。
収束したかを確かめる処理がないので、反復が発散した場合も発散した値が解として返る。

発散するのは離心率が 1 に近いときである。$e = 0.995,\ M = 0.4$ の戻り値は $2.7 \times 10^6$ rad で、
正しい根は $1.376$ rad。真近点角に直すと 352.9° ずれる。$e = 0.999,\ M = -0.3$ の戻り値は
$-3.0 \times 10^{18}$ になる。

影響を受けるのは、arika を library として使うコードである。CLI の `[satellites.orbit]` が取るのは
`circular` / `tle` / `norad` の 3 つで、TLE の伝播は `sgp4` crate が行うので、config からこの関数に
届く設定はない。

## 原因

$f(E) = E - e\sin E - M$ の微分 $f'(E) = 1 - e\cos E$ は近点($E = 0$)で最小値 $1 - e$ を取る。
$e = 0.995$ なら $5 \times 10^{-3}$ である。Newton 法はこの $f'$ で割る。

$$\Delta E = -\frac{f(E_0)}{f'(E_0)}$$

$E_0 = M = 0.4$ での実測値は $f' = 8.35 \times 10^{-2}$、$\Delta E = 4.64$ rad。根までは 0.98 rad
なので $E = 5.04$ に着く。$E = 5.04$ は根が存在しうる範囲の外なので、以降の反復は根と無関係に
進む。

## 直した形

根を含む区間の中だけを動く Newton 法にした。正しさの根拠は、区間が根を含み続けることである。
根が区間から外れる経路は 3 つあり、それぞれ閉じている。

**区間の外へ出るステップを採用しない。** $E = M + e\sin E$ より $|E - M| \le e$ なので、根は
$[M - e,\ M + e]$ にある。$f$ は $e < 1$ で単調増加($f' \ge 1 - e > 0$)なので、両端の符号も決まる。

$$f(M - e) = -e\,(1 + \sin(M - e)) \le 0, \qquad f(M + e) = e\,(1 - \sin(M + e)) \ge 0$$

ステップが区間内に落ちればそのまま進み、外に出るなら区間の中点を取る。区間は反復ごとに狭まるので
$e < 1$ のどこでも収束する。$e = 0$ では区間が $M$ の 1 点に潰れ、$M$ 自身が根である。

**収束したステップを区間の外と読まない。** 反復の先頭で `e_anom` は区間の端になる。ステップが
短くて `e_anom + step` が `e_anom` と同じ値に丸まると、内側判定 `newton > lo && newton < hi` が
偽になり、根に居るのに中点へ移る。$M = \pi$ がその点である。$E = \pi$ はどの $e$ でも根だが、
`f64` の $\sin \pi$ は $1.2 \times 10^{-16}$ なので残差が残り、そのステップは $\mathrm{ulp}(\pi)$
より短い。素朴な内側判定に任せた場合の戻り値は $\pi$ から 16 ulp ずれ、その値に落ち着くまでに
46 反復かかる。区間判定より前にステップを停止条件と比べる。$|\Delta E| = |f| / |f'|$ で $f' < 2$ なので、
ステップが $10^{-14}$ 未満ならその時点の残差は $2 \times 10^{-14}$ 以内である。

**区間の端の更新が読む $f$ の符号を、桁落ちさせない。** 端をどちら側に動かすかは $f$ の符号で
決まるので、符号が狂うと端が根を跨ぎ、根が区間から外れる。$E$ と $e\sin E$ は
$E = 3 \times 10^{-7}$ で 13 桁一致するため、$f$ を差の形で書くと符号が $e\sin E$ の丸めで決まる。
$f$ を $(1-e)E + e(E - \sin E)$ の形にし、$E - \sin E$ は $|E| < 0.1$ で Taylor 級数から求める。
級数と減算の相対誤差は 0.1 と 0.15 の間で交差する(0.1 で $1.5 \times 10^{-15}$ 対
$1.8 \times 10^{-14}$、0.15 で $3.9 \times 10^{-14}$ 対 $1.4 \times 10^{-15}$)。

$e$ を 1 の 1 ulp 下、$M = 5 \times 10^{-21}$ とした実測での根との相対差:

| $f$ の書き方 | 相対差 |
|---|---|
| $E - e\sin E - M$（区間なし、修正前） | $1.7 \times 10^{-5}$ |
| $E - e\sin E - M$（区間あり） | $1.1 \times 10^{-3}$ |
| $(1-e)E + e(E - \sin E) - M$（区間あり） | $1.0 \times 10^{-12}$ |

残差を $E$ の位置で評価すると、この書き換えが効くのは $E$ が 0 付近のときだけである。$M$ を
$[0, 2\pi)$ に落とすので、$2\pi$ のすぐ下の $M$ は $E \approx 2\pi$ の枝に乗り、残差を作る 2 項が
どちらも $2\pi$ 程度になって符号が失われる。$M = 0^+$ と $M = 2\pi^-$ は軌道上の同じ点なので、
精度が枝によって変わるのは筋が通らない。

$\sin$ と $\cos$ の周期は $2\pi$ なので、$E$ と $M$ を同じ $2\pi k$ だけずらしても方程式は変わらない。
$u = E - 2\pi k$、$w = M - 2\pi k$ として残差を $(1-e)u + e(u - \sin u) - w$ で評価する。$k$ は 0 か
$\pm 1$ である($M$ は 1 周内に落ちており、$E$ は $M$ から $e$ 以内)。$u$ はどちらの近点でも 0 付近に
なる。

## 検証

テストの oracle は Kepler 方程式の残差 $E - e\sin E - M$ を、そのままの形で書いたものである。
ソルバは同じ量を $(1-e)E + e(E - \sin E) - M$ に並べ替えて評価し、停止判定にはステップの大きさを
使う。残差を assert することは、反復が自前の閾値と比べていない量を検査することになる。
$\nu \to M \to \nu$ の往復では、これができない。

- $e \in \{0, 0.1, 0.5, 0.7, 0.9, 0.95, 0.99, 0.995, 0.999\}$ と `f64` で表せる 1 未満の最大値に
  ついて、$M$ を 2 周分 0.05 rad 刻みで走査する。$E$ が有限で、残差が $10^{-13}$ 以下。閾値は
  $|f| \le 2 |\Delta E|$ から取った。実測の最悪値は $8.9 \times 10^{-16}$
- $M = \pi$ の戻り値が $\pi$ とビット単位で一致する。走査側の閾値 $10^{-13}$ では 16 ulp のずれが
  通る
- $e$ を 1 の 1 ulp 下、$M \le 10^{-15}$ として、根との相対差が $10^{-9}$ 以下。期待値は
  $E(1-e) + e(E - \sin E) - M$ の二分法から取った
- $e = 0.9999999999$、$M = 6.283185307179464$($2\pi$ の $1.2 \times 10^{-13}$ 下)で、根との
  相対差が $10^{-14}$ 以下。期待値は $u - e\sin u - v$($u = 2\pi - E$、$v = 2\pi - M$)の二分法から
  取った。残差を $E$ の位置で評価した場合の戻り値は $6.283097238421463$ で、根
  $6.283097259381490$ から $2.1 \times 10^{-8}$ 離れる
- 修正前に発散した点で、戻り値が $M$ から $e$ 以内にある

| $e$ | $M$ | 修正前の $E$ | 根 |
|---|---|---|---|
| 0.99 | 0.25 | $-19.04$ | 1.156 |
| 0.995 | 0.40 | $2.71 \times 10^{6}$ | 1.376 |
| 0.995 | 0.45 | $-2.62 \times 10^{7}$ | 1.436 |
| 0.999 | $-0.30$ | $-2.98 \times 10^{18}$ | $-1.247$ |

既存テストがこの発散を通していた理由は、走査した範囲である。高離心率のテストは
$e = 0.99,\ M = 1.0$ の 1 点で、Newton が $E_0 = M$ から数歩で根に着く。往復テストの離心率は
0.9 までである。

mutation で強度を測った。区間判定を外す、区間の更新方向を入れ替える、反復上限を 20 回に削る、
区間の下端から $-e$ を落とす、ステップの収束検査を外す、その検査で `break` せずステップだけ
適用する — いずれもテストが落ちる。二分だけにして Newton を使わない退行は生き残る。どのテストも
assert しているのは戻り値が方程式を満たすことで、戻り値に何手で着いたかは見ていない。

`arika/src/planets/mod.rs` の private な `solve_kepler` も同じ Newton 法である。渡る離心率は惑星の
値(最大は Mercury の 0.21)で、doc にも $e < 0.9$ と範囲がある。
