### PR TITLE
fix(arika): take the Moon velocity's finite difference in SI seconds

### DIFF
--- a/arika/src/moon/ephemeris.rs
+++ b/arika/src/moon/ephemeris.rs
@@ -539,11 +539,13 @@ mod tests {
     /// a second of that boundary has its two samples 3 SI seconds apart while
     /// the difference is still divided by 2.
     ///
-    /// The oracle is the Moon's own orbital speed, which stays between 0.96 and
-    /// 1.07 km/s (measured over June 2024, near both apogee and perigee) — a
-    /// bound that does not depend on how the velocity is computed. Measured
-    /// with the UTC-JD step: 1.511 km/s against 1.008 km/s a second either
-    /// side, exactly the 3/2 the mismatched interval predicts.
+    /// The oracle is the Moon's own orbital speed, which does not depend on how
+    /// the velocity is computed. At the four epochs below it is 1.0075 km/s, and
+    /// over June 2024 — spanning apogee and perigee — it ran 0.9675 to 1.0626
+    /// km/s. The bound asserted below, 0.96 to 1.08 km/s, contains that measured
+    /// range with margin and sits far under what the UTC-JD step produced here:
+    /// 1.511 km/s, against 1.008 km/s a second either side, which is exactly the
+    /// 3/2 the mismatched interval predicts.
     #[test]
     fn moon_velocity_is_physical_across_a_leap_second() {
         // 2016-12-31T23:59:60Z was a leap second. Both epochs below sit within
@@ -560,7 +562,7 @@ mod tests {
             assert!(
                 (0.96..1.08).contains(&speed),
                 "{y}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:04.1}Z: the Moon's speed is \
-                 0.96-1.07 km/s, got {speed:.6} km/s"
+                 0.96-1.08 km/s, got {speed:.6} km/s"
             );
         }
     }

--- a/arika/src/moon/ephemeris.rs
+++ b/arika/src/moon/ephemeris.rs
@@ -280,20 +280,26 @@ pub(crate) fn moon_position_mean_of_date(epoch: &Epoch<Tdb>) -> Vec3<frame::Mean
 /// single source of truth.
 ///
 /// The default `velocity_eci` implementation uses a central finite difference
-/// (±1 second) over `position_eci`. Tabulated sources (e.g. Hermite-interpolated
-/// Horizons data) that can provide velocity more accurately should override it.
+/// (±1 SI second) over `position_eci`. Tabulated sources (e.g.
+/// Hermite-interpolated Horizons data) that can provide velocity more
+/// accurately should override it.
 pub trait MoonEphemeris: Send + Sync {
     /// Moon position in ECI [km] at the given epoch.
     fn position_eci(&self, epoch: &Epoch) -> Vec3<frame::Gcrs>;
 
     /// Moon velocity in ECI [km/s] at the given epoch.
     ///
-    /// Default: central finite difference over `position_eci` with a 1-second
-    /// step. Override for sources that can supply analytic velocity.
+    /// Default: central finite difference over `position_eci` with a 1 SI
+    /// second step. Override for sources that can supply analytic velocity.
     fn velocity_eci(&self, epoch: &Epoch) -> Vec3<frame::Gcrs> {
         let dt = 1.0;
-        let r_plus = self.position_eci(&epoch.add_seconds(dt));
-        let r_minus = self.position_eci(&epoch.add_seconds(-dt));
+        // `add_si_seconds` rather than `add_seconds`: the divisor below is the
+        // interval between the two samples, so that interval has to be SI
+        // seconds. UTC labels do not advance uniformly across a leap second, and
+        // the naive UTC-JD step puts the samples 3 s apart there while still
+        // dividing by 2.
+        let r_plus = self.position_eci(&epoch.add_si_seconds(dt));
+        let r_minus = self.position_eci(&epoch.add_si_seconds(-dt));
         (r_plus - r_minus) / (2.0 * dt)
     }
 
@@ -520,6 +526,41 @@ mod tests {
                 dist > 340_000.0 && dist < 420_000.0,
                 "Moon distance at JD {} should be 340k-420k km, got {dist:.0} km",
                 epoch.jd()
+            );
+        }
+    }
+
+    /// The default velocity keeps its physical magnitude across a leap second.
+    ///
+    /// `velocity_eci` is a central difference over `position_eci`, so the
+    /// interval between its two samples has to be 2 SI seconds wherever it is
+    /// evaluated. UTC labels do not advance uniformly across a leap second: at
+    /// the end of 2016-12-31 one extra second was inserted, so an epoch within
+    /// a second of that boundary has its two samples 3 SI seconds apart while
+    /// the difference is still divided by 2.
+    ///
+    /// The oracle is the Moon's own orbital speed, which stays between 0.96 and
+    /// 1.07 km/s (measured over June 2024, near both apogee and perigee) — a
+    /// bound that does not depend on how the velocity is computed. Measured
+    /// with the UTC-JD step: 1.511 km/s against 1.008 km/s a second either
+    /// side, exactly the 3/2 the mismatched interval predicts.
+    #[test]
+    fn moon_velocity_is_physical_across_a_leap_second() {
+        // 2016-12-31T23:59:60Z was a leap second. Both epochs below sit within
+        // one second of it, so the ±1 s samples straddle it.
+        for (y, mo, d, h, mi, s) in [
+            (2016, 12, 31, 23, 59, 59.0),
+            (2017, 1, 1, 0, 0, 0.0),
+            // A second further out, where no sample crosses the boundary.
+            (2016, 12, 31, 23, 58, 0.0),
+            (2017, 1, 1, 0, 1, 0.0),
+        ] {
+            let epoch = Epoch::from_gregorian(y, mo, d, h, mi, s);
+            let speed = MeeusMoonEphemeris.velocity_eci(&epoch).into_inner().norm();
+            assert!(
+                (0.96..1.08).contains(&speed),
+                "{y}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:04.1}Z: the Moon's speed is \
+                 0.96-1.07 km/s, got {speed:.6} km/s"
             );
         }
     }
@@ -783,9 +824,13 @@ $$EOE
             2,
             "default velocity_eci should call position_eci exactly twice"
         );
-        // The offsets must be ±1 second from the base epoch. The tolerance
-        // reflects the ~50 microsecond precision of `Epoch::add_seconds` at
-        // modern JDs (f64 ULP on ~2.46e6 JD ≈ 5e-10 days ≈ 50 µs).
+        // The offsets must be ±1 second from the base epoch, read here off the
+        // UTC JD. The tolerance reflects the ~50 microsecond resolution of that
+        // JD at modern epochs (f64 ULP on ~2.46e6 JD ≈ 5e-10 days ≈ 50 µs).
+        // 2024-03-20 has no leap second within a second of it, so the SI step
+        // `velocity_eci` takes and the UTC label agree to that resolution;
+        // `moon_velocity_is_physical_across_a_leap_second` covers where they
+        // do not.
         let mut offsets = ephem.last_offsets.lock().unwrap().clone();
         offsets.sort_by(|a, b| a.partial_cmp(b).unwrap());
         assert!(


### PR DESCRIPTION
## 概要

`MoonEphemeris::velocity_eci` は `position_eci` を `epoch.add_seconds(±1)` で 2 回サンプルし、
その差を 2 で割る。`add_seconds` は UTC の Julian Date に加算するもので、doc にも leap second を
扱わないと書いてある。UTC のラベルはうるう秒をまたいで一様に進まないので、境界から 1 秒以内の
epoch では 2 サンプルが実時間で 3 秒離れる。除数は 2 のままなので、速度が 3/2 倍になる。

`MeeusMoonEphemeris` で 2016-12-31 のうるう秒の周りを実測した値:

| epoch | \|v\| [km/s] |
|---|---|
| 2016-12-31T23:59:00Z | 1.007511 |
| **2016-12-31T23:59:59Z** | **1.511273** |
| **2017-01-01T00:00:00Z** | **1.511274** |
| 2017-01-01T00:00:01Z | 1.007516 |
| 2017-01-01T00:01:00Z | 1.007521 |

月の軌道速度は 1 か月で 0.9675 から 1.0626 km/s の範囲にある。

## 直した形

`add_si_seconds` に替える。これは canonical TAI の瞬間に加算するので、うるう秒の有無に関わらず
2 サンプルの間隔が 2 SI 秒になる。除数が意味する量と一致する。

repository 内の他の epoch 前進はすべて `add_si_seconds` を使っており(`orts/src/orbital`、
`orts/src/attitude`、`orts/src/spacecraft`、`orts/src/visibility.rs`、`arika/src/sgp4.rs`)、
この 1 箇所だけが `add_seconds` だった。

`HorizonsMoonEphemeris` は Hermite 補間の解析速度で `velocity_eci` を override するので、この
変更の影響を受けない。table の範囲外に落ちたときの fallback は default 実装を通る。

## 検証

テストの oracle は月自身の軌道速度で、速度の計算方法には依存しない。上の実測値 0.9675 から
1.0626 km/s を余裕をつけて囲む 0.96 から 1.08 km/s を assert する。
うるう秒から 1 秒以内の 2 つの epoch と、1 分離れた 2 つの epoch で速度がこの範囲に入ることを
確かめる。

mutation で強度を測った。両サンプルを `add_seconds` に戻す、前方だけ戻す、後方だけ戻す、
除数を `dt` にする — いずれもテストが落ちる。

既存の `default_velocity_eci_calls_position_at_plus_minus_one_second` は counting wrapper で
サンプル位置を UTC JD から読み、±1 秒であることを確かめている。基準の epoch(2024-03-20)から
1 秒以内にうるう秒がないので、SI 秒の step と UTC のラベルはこのテストの許容差(1e-3 秒)の中で
一致する。コメントに `add_seconds` の precision と書いてあった箇所を、UTC JD の分解能と
うるう秒がない前提の記述に直した。

`cargo test -p arika` と `cargo test -p orts --lib` がどちらも pass する。in-tree で
`velocity_eci` を呼ぶのは `orts/src/perturbations/third_body.rs` のテスト 1 行だけで、
simulation の経路からは呼ばれていない。
