### PR TITLE
fix(cli): run the controlled loop on the configured integrator

### DIFF
--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -3,7 +3,7 @@ use std::ops::ControlFlow;
 use arika::body::KnownBody;
 use arika::frame::{SimpleEci, Vec3};
 use orts::OrbitalState;
-use orts::group::{HasPosition, IndependentGroup, IntegratorConfig};
+use orts::group::{HasPosition, IndependentGroup};
 use orts::orbital::kepler::KeplerianElements;
 use orts::record::archetypes::OrbitalState as RecordOrbitalState;
 use orts::record::components::{
@@ -498,21 +498,6 @@ fn report_contact_windows(params: &SimParams, monitors: Vec<VisibilityMonitor<Si
     }
 }
 
-/// Integrator selection for the `run` propagation loop.
-fn integrator_config(params: &SimParams) -> IntegratorConfig {
-    match params.integrator {
-        IntegratorChoice::Rk4 => IntegratorConfig::Rk4 { dt: params.dt },
-        IntegratorChoice::Dp45 => IntegratorConfig::Dp45 {
-            dt: params.dt,
-            tolerances: params.tolerances.clone(),
-        },
-        IntegratorChoice::Dop853 => IntegratorConfig::Dop853 {
-            dt: params.dt,
-            tolerances: params.tolerances.clone(),
-        },
-    }
-}
-
 /// Terminate a satellite on surface impact or atmospheric entry.
 ///
 /// Generic over the state so the orbit-only and spacecraft paths share one
@@ -547,7 +532,7 @@ pub fn run_simulation(params: &SimParams) -> Result<Recording, CmdError> {
     use crate::sim::core::sat_params;
     use orts::setup::{build_orbital_system, default_third_bodies};
 
-    let mut group = IndependentGroup::new(integrator_config(params))
+    let mut group = IndependentGroup::new(params.integrator_config())
         .with_event_checker(body_event_checker::<OrbitalState>(params));
 
     let third_bodies = default_third_bodies(&params.body).map_err(|e| {
@@ -594,7 +579,7 @@ pub fn run_spacecraft_simulation(params: &SimParams) -> Result<Recording, CmdErr
     use orts::spacecraft::SpacecraftState;
 
     let mut group =
-        IndependentGroup::new(integrator_config(params)).with_event_checker(body_event_checker::<
+        IndependentGroup::new(params.integrator_config()).with_event_checker(body_event_checker::<
             orts::effector::AugmentedState<SpacecraftState>,
         >(params));
 
@@ -1224,12 +1209,13 @@ fn run_controlled_simulation(params: &SimParams, sim: &SimArgs) -> Result<Record
         // holds; only the ones whose tick lands there see their controller.
         // A span shorter than a period — the run's last one, or the gap
         // between two rates — therefore integrates without a tick.
+        //
+        // `next_t` is the earliest tick in the fleet, so no tick of this
+        // satellite lies strictly inside the span and `advance_controlled`
+        // reduces to propagate-then-tick here. Sharing it with `serve` is what
+        // keeps one integrator selection across both.
         let step_one = |sat: &mut crate::sim::controlled::ControlledSatellite| {
-            crate::sim::controlled::propagate_controlled(sat, t, next_t, params.dt)?;
-            if sat.tick_due_at(next_t) {
-                crate::sim::controlled::tick_controller(sat, next_t, params.epoch.as_ref())?;
-            }
-            Ok::<(), String>(())
+            crate::sim::controlled::advance_controlled(sat, t, next_t, params)
         };
 
         // `try_for_each` rather than `for_each` + exit: a rayon worker calling

--- a/cli/src/commands/serve/engine.rs
+++ b/cli/src/commands/serve/engine.rs
@@ -22,13 +22,12 @@ use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use orts::OrbitalState;
+use orts::group::IndependentGroup;
 use orts::group::prop_group::{PropGroupOutcome, SatId};
-use orts::group::{IndependentGroup, IntegratorConfig};
 use orts::orbital::OrbitalSystem;
 use orts::orbital::gravity::GravityField;
 use orts::spacecraft::{SpacecraftDynamics, SpacecraftState};
 
-use crate::cli::IntegratorChoice;
 use crate::config::SatelliteConfig;
 use crate::satellite::{SatelliteInfo, SatelliteSpec};
 use crate::sim::controlled::ControlledSatellite;
@@ -119,14 +118,8 @@ impl SimGroup {
             // to call the controller once per span with `dt = span`, so a span
             // shorter than the period ran the controller too often and
             // shortened its hold.
-            crate::sim::controlled::advance_controlled(
-                sat,
-                current_t,
-                target_t,
-                params.dt,
-                params.epoch.as_ref(),
-            )
-            .map_err(|e| format!("controlled simulation error at t={current_t:.3}: {e}"))?;
+            crate::sim::controlled::advance_controlled(sat, current_t, target_t, params)
+                .map_err(|e| format!("controlled simulation error at t={current_t:.3}: {e}"))?;
         }
         Ok(())
     }
@@ -396,17 +389,7 @@ impl ServeEngine {
         params: Arc<SimParams>,
         mut history: HistoryBuffer,
     ) -> Result<EngineInit, String> {
-        let config = match params.integrator {
-            IntegratorChoice::Rk4 => IntegratorConfig::Rk4 { dt: params.dt },
-            IntegratorChoice::Dp45 => IntegratorConfig::Dp45 {
-                dt: params.dt,
-                tolerances: params.tolerances.clone(),
-            },
-            IntegratorChoice::Dop853 => IntegratorConfig::Dop853 {
-                dt: params.dt,
-                tolerances: params.tolerances.clone(),
-            },
-        };
+        let config = params.integrator_config();
 
         let body_radius = params.body.properties().radius;
         let atmosphere_altitude = params.body.properties().atmosphere_altitude;

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -16,13 +16,15 @@ use orts::sensor::{Gyroscope, Magnetometer, SensorBundle, StarTracker};
 use orts::setup::default_third_bodies;
 
 use crate::sim::core::spacecraft_dynamics_for;
+use core::ops::ControlFlow;
 use nalgebra::Vector3;
+use orts::group::IntegratorConfig;
 use orts::spacecraft::{
     MtqAssembly, ReactionWheelAssembly, SpacecraftDynamics, SpacecraftState, ThrusterAssembly,
     ThrusterAssemblyCore, ThrusterSpec,
 };
 use tobari::magnetic::igrf::Igrf;
-use utsuroi::{Integrator, Rk4};
+use utsuroi::{Dop853, DormandPrince, IntegrationError, Integrator, Rk4};
 
 use crate::config::{ControllerConfig, MtqConfig, ReactionWheelConfig, SensorChoice};
 use crate::satellite::SatelliteSpec;
@@ -392,21 +394,29 @@ pub fn next_fleet_event_t(sats: &[ControlledSatellite], horizon: f64) -> f64 {
 /// span is the caller's — `stream_interval` in `serve`, the gap between fleet
 /// events in `run` — and has no reason to be a multiple of the controller's
 /// period, so a span shorter than the period integrates without a tick.
+///
+/// Takes `params` rather than an integrator and an epoch so that both callers
+/// read the same fields: the integrator selection lives in
+/// [`SimParams::integrator_config`] and neither `run` nor `serve` can hand this
+/// loop a different one. That is the shape the fix here needed — the selection
+/// used to be the caller's to make, and the controlled callers made a different
+/// one from the groups.
 pub fn advance_controlled(
     sat: &mut ControlledSatellite,
     from: f64,
     to: f64,
-    params_dt: f64,
-    epoch: Option<&Epoch>,
+    params: &SimParams,
 ) -> Result<(), String> {
+    let integrator = params.integrator_config();
+    let epoch = params.epoch.as_ref();
     let mut t = from;
     while sat.tick_due_at(to) {
         let tick_t = sat.next_tick_t();
-        propagate_controlled(sat, t, tick_t, params_dt)?;
+        propagate_controlled(sat, t, tick_t, &integrator)?;
         tick_controller(sat, tick_t, epoch)?;
         t = tick_t;
     }
-    propagate_controlled(sat, t, to, params_dt)
+    propagate_controlled(sat, t, to, &integrator)
 }
 
 /// Integrate `[t0, t1]` under the command the actuators already hold.
@@ -417,24 +427,64 @@ pub fn advance_controlled(
 /// *fixed* period, so a controller runs on its own schedule via
 /// [`tick_controller`] and nothing else may move it.
 ///
-/// `params_dt` is the requested ODE step; it is capped by the span so a step
-/// cannot reach past `t1`.
+/// `integrator` carries the step the config asked for. For `Rk4` that is the
+/// fixed step, capped by the span so it cannot reach past `t1`; for the adaptive
+/// pair it is the first step the controller tries.
+///
+/// The adaptive steppers are rebuilt for each span rather than carried across
+/// them, which is what `IndependentGroup` does for its own spans. Keeping a
+/// stepper's own `dt` instead would drag the truncated last step of one span
+/// into the next: `advance_to` computes `h = dt.min(t_target - t)` and then
+/// stores `h * factor`, so a span boundary would shrink the step the next span
+/// starts from.
 pub fn propagate_controlled(
     sat: &mut ControlledSatellite,
     t0: f64,
     t1: f64,
-    params_dt: f64,
+    integrator: &IntegratorConfig,
 ) -> Result<(), String> {
     if t1 <= t0 {
         return Ok(());
     }
-    let dt_ode = params_dt.min(t1 - t0);
-    // `try_integrate` rather than `integrate`: the latter panics on a bad step
-    // or a stalled clock, and this returns `Result` so serve can send the
-    // client an Error down its graceful-halt path.
-    sat.state = Rk4
-        .try_integrate(&sat.dynamics, sat.state.clone(), t0, t1, dt_ode, |_, _| {})
-        .map_err(|e| format!("integration failed on [{t0:.3}, {t1:.3}]: {e}"))?;
+    let span = |e: IntegrationError| format!("integration failed on [{t0:.3}, {t1:.3}]: {e}");
+
+    match integrator {
+        IntegratorConfig::Rk4 { dt } => {
+            let dt_ode = dt.min(t1 - t0);
+            // `try_integrate` rather than `integrate`: the latter panics on a
+            // bad step or a stalled clock, and this returns `Result` so serve
+            // can send the client an Error down its graceful-halt path.
+            sat.state = Rk4
+                .try_integrate(&sat.dynamics, sat.state.clone(), t0, t1, dt_ode, |_, _| {})
+                .map_err(span)?;
+        }
+        IntegratorConfig::Dp45 { dt, tolerances } => {
+            let mut stepper = DormandPrince.stepper(
+                &sat.dynamics,
+                sat.state.clone(),
+                t0,
+                *dt,
+                tolerances.clone(),
+            );
+            stepper
+                .advance_to(t1, |_, _| {}, |_, _| ControlFlow::<String>::Continue(()))
+                .map_err(span)?;
+            sat.state = stepper.into_state();
+        }
+        IntegratorConfig::Dop853 { dt, tolerances } => {
+            let mut stepper = Dop853.stepper(
+                &sat.dynamics,
+                sat.state.clone(),
+                t0,
+                *dt,
+                tolerances.clone(),
+            );
+            stepper
+                .advance_to(t1, |_, _| {}, |_, _| ControlFlow::<String>::Continue(()))
+                .map_err(span)?;
+            sat.state = stepper.into_state();
+        }
+    }
     Ok(())
 }
 
@@ -798,10 +848,28 @@ mod tests {
         (sat, ticks)
     }
 
+    /// A `SimParams` carrying just the fields the controlled loop reads.
+    ///
+    /// Built from the CLI defaults so it is the same shape a run gets, then
+    /// overridden field by field.
+    fn params_with(integrator: crate::cli::IntegratorChoice, dt: f64, tol: f64) -> SimParams {
+        use clap::Parser;
+        let args = crate::cli::SimArgs::parse_from(["orts"]);
+        let mut params = SimParams::from_sim_args(&args, false);
+        params.integrator = integrator;
+        params.dt = dt;
+        params.tolerances = utsuroi::Tolerances {
+            atol: tol,
+            rtol: tol,
+        };
+        params
+    }
+
     /// Step one satellite the way a caller does — through the same function
     /// `serve` and `run` call, so an error in that loop fails these tests.
     fn advance(sat: &mut ControlledSatellite, from: f64, to: f64, params_dt: f64) {
-        advance_controlled(sat, from, to, params_dt, None).expect("integrates and ticks");
+        let params = params_with(crate::cli::IntegratorChoice::Rk4, params_dt, 1e-9);
+        advance_controlled(sat, from, to, &params).expect("integrates and ticks");
     }
 
     /// A span shorter than the sample period does not tick the controller.
@@ -979,6 +1047,69 @@ mod tests {
         validate_tick_advances(5.0, 0.1).expect("an ordinary period is fine");
     }
 
+    /// The configured integrator is the one that runs the controlled loop.
+    ///
+    /// Each arm propagates one orbit of the same satellite with a requested step
+    /// of a whole period. For `Rk4` that is the step, and a single step cannot
+    /// follow the orbit; for the adaptive pair it is only the first guess, which
+    /// the error control then subdivides. The reference is the same span under
+    /// `Rk4` at 0.5 s, a step 11,000 times finer.
+    ///
+    /// The propagation runs through `advance_controlled`, the function `run` and
+    /// `serve` both call, so what this measures is the whole path from
+    /// `SimParams` to the integrator — not `propagate_controlled` alone.
+    /// `propagate_controlled` used to take a bare `dt` and hardcode `Rk4`, and
+    /// the selection was the caller's to make: `[integrator]` reached the
+    /// orbit-only and spacecraft groups while the controlled callers passed
+    /// `params.dt` on its own. Every arm then returned the coarse `Rk4` answer.
+    #[test]
+    fn the_configured_integrator_reaches_the_controlled_loop() {
+        use crate::cli::IntegratorChoice;
+
+        let period = 2.0
+            * std::f64::consts::PI
+            * (6778.0f64.powi(3) / arika::body::KnownBody::Earth.properties().mu).sqrt();
+        let after_one_orbit = |choice: IntegratorChoice, dt: f64| {
+            // A controller period past the span, so no tick interrupts it and
+            // the integrator is the only thing under test.
+            let (mut sat, _) = satellite_with(period * 2.0, 0.0);
+            let params = params_with(choice, dt, 1e-10);
+            advance_controlled(&mut sat, 0.0, period, &params).expect("integrates");
+            *sat.state.plant.orbit.position()
+        };
+
+        let reference = after_one_orbit(IntegratorChoice::Rk4, 0.5);
+        let coarse_rk4 = (after_one_orbit(IntegratorChoice::Rk4, period) - reference).norm();
+        let dop853 = (after_one_orbit(IntegratorChoice::Dop853, period) - reference).norm();
+        let dp45 = (after_one_orbit(IntegratorChoice::Dp45, period) - reference).norm();
+
+        // Measured: one RK4 step over the period lands 5.95e4 km from the
+        // reference, while DOP853 lands 2.8e-9 km from it and DP45 4.7e-6 km.
+        // The bound is 1 km, which both sides clear by four orders or more.
+        assert!(
+            coarse_rk4 > 1.0,
+            "one RK4 step over a whole period cannot follow the orbit, \
+             got {coarse_rk4:.3e} km from the reference"
+        );
+        assert!(
+            dop853 < 1.0,
+            "DOP853 subdivides the span, got {dop853:.3e} km from the reference"
+        );
+        assert!(
+            dp45 < 1.0,
+            "DP45 subdivides the span, got {dp45:.3e} km from the reference"
+        );
+        // The two adaptive arms are told apart, so serving one where the config
+        // asked for the other fails here. At the same tolerance the 8th-order
+        // method holds a tighter error than the 5th: measured, 2.8e-9 km
+        // against 4.7e-6 km, a factor of 1700. The bound is 10.
+        assert!(
+            dop853 * 10.0 < dp45,
+            "DOP853 should hold a tighter error than DP45 at the same tolerance: \
+             {dop853:.3e} km against {dp45:.3e} km"
+        );
+    }
+
     /// Two controllers at different rates each run at their own.
     ///
     /// `orts run` used to drive the fleet on the shortest period, so the 1.0 s
@@ -996,7 +1127,8 @@ mod tests {
         while t < 1.0 - 1e-12 {
             let next_t = next_fleet_event_t(&fleet, 1.0);
             for sat in &mut fleet {
-                propagate_controlled(sat, t, next_t, 0.01).expect("integrates");
+                propagate_controlled(sat, t, next_t, &IntegratorConfig::Rk4 { dt: 0.01 })
+                    .expect("integrates");
                 if sat.tick_due_at(next_t) {
                     tick_controller(sat, next_t, None).expect("ticks");
                 }

--- a/cli/src/sim/params.rs
+++ b/cli/src/sim/params.rs
@@ -207,6 +207,27 @@ impl SimParams {
 }
 
 impl SimParams {
+    /// The integrator the config asks for, as the group and the controlled loop
+    /// both take it.
+    ///
+    /// One place so the three propagation paths cannot disagree: `orts run`'s
+    /// orbit-only and spacecraft groups, `orts serve`'s groups, and the
+    /// controlled loop that both of those commands share. `--json` reports
+    /// `integrator` from the same field, so the report follows whatever runs.
+    pub fn integrator_config(&self) -> orts::group::IntegratorConfig {
+        match self.integrator {
+            IntegratorChoice::Rk4 => orts::group::IntegratorConfig::Rk4 { dt: self.dt },
+            IntegratorChoice::Dp45 => orts::group::IntegratorConfig::Dp45 {
+                dt: self.dt,
+                tolerances: self.tolerances.clone(),
+            },
+            IntegratorChoice::Dop853 => orts::group::IntegratorConfig::Dop853 {
+                dt: self.dt,
+                tolerances: self.tolerances.clone(),
+            },
+        }
+    }
+
     /// Build an atmosphere model from the current parameters.
     pub fn build_atmosphere_model(&self) -> Option<Box<dyn tobari::AtmosphereModel>> {
         match self.atmosphere {


### PR DESCRIPTION
## 概要

controlled mode の伝播は `[integrator]` を読まず、常に固定刻み RK4 で回っていた。config に
`type = "dop853"` と `atol` / `rtol` を書いても伝播は変わらず、`orts run --json` は
`simulation.integrator` に config の名前をそのまま報告する。

`orts run` と `orts serve` の両方に当たる。controller を持つ fleet が controlled mode に入る。

## 原因

`propagate_controlled` が `Rk4` を直書きしていた。引数は `params_dt: f64` だけで、
`params.integrator` と `params.tolerances` はこの関数に渡っていない。

```rust
sat.state = Rk4
    .try_integrate(&sat.dynamics, sat.state.clone(), t0, t1, dt_ode, |_, _| {})
```

integrator の選択を組み立てる `match` は 2 箇所にあり、どちらも controlled 経路には渡していな
かった。`run.rs` の `integrator_config(params)` は orbit-only と spacecraft の
`IndependentGroup` に、`serve/engine.rs` の `SimGroup::build` は同じ 2 つのグループに渡す。
`serve` の controlled branch `step_controlled_to` は `advance_controlled` に `params.dt` だけを
渡していた。

`--json` の報告は `params.integrator` を読むので、実際に走った積分器と食い違う。
`unhonored_config_warnings` は controlled mode で即 `Vec::new()` を返すため、警告も出ない。

## 直した形

**選択を `SimParams::integrator_config()` 1 箇所にする。** 2 つの `match` を消し、この関数の呼び出しに置き換えた。`run` の 3 モード、`serve` の 3 モード、`serve` の動的追加が同じ関数を読むので、経路に
よって選択が変わらない。`--json` も同じ `params.integrator` から報告するため、報告と実行が
一致する。

**`propagate_controlled` が `IntegratorConfig` を受ける。** `params_dt: f64` を
`&IntegratorConfig` に替えた。どの variant も `dt` を持つので引数は増えていない。`Rk4` は従来
どおり固定刻み、adaptive の 2 つは `stepper` API で回す。

**選択を呼び出し元から取り上げる。** `advance_controlled` が integrator と epoch を引数で受ける
形だと、`run` と `serve` がそれぞれ別の選択を渡せる。実際にその形で両方が `params.dt` だけを
渡していた。`&SimParams` を受けて中で `integrator_config()` を読むようにしたので、呼び出し元に
選択の余地がない。

`run` の controlled loop も `advance_controlled` を通す。`next_t` は fleet 中で最も早い tick なので、
この衛星の tick が span の内側に来ることはなく、`advance_controlled` は run が書いていた
「propagate してから tick」に一致する。

**adaptive の stepper は span ごとに作り直す。** controlled loop は span 単位に積分し、span の
境界は controller tick・output sample・stream flush・run の終端で決まる。`IndependentGroup` も
`propagate_to` ごとに stepper を作り直して config の `dt` から再開するので、挙動が揃う。

stepper の `dt` を span を越えて持ち越す形は採らない。`advance_to` は

```rust
let h = self.dt.min(t_target - self.t);
// ...
self.dt = h * factor;
```

と書くので、span 終端で切り詰められた短い remainder step が次の span の推奨幅になる。境界が
adaptive の幅を人為的に縮めることになる。持ち越しの得失は #417 と一緒に測る。

## 検証

同じ衛星の 1 周を、要求ステップを 1 周期として 3 通りの integrator で伝播する。`Rk4` にとって
要求ステップは刻み幅そのもので、1 ステップでは軌道を追えない。adaptive の 2 つにとっては初回の推奨値で、
誤差制御が細分する。参照は同じ span を `Rk4` の 0.5 s で回したもので、刻みは 11,000 倍細かい。
伝播は `advance_controlled` を通すので、`SimParams` から integrator に至る経路ごと測っている。

| integrator（要求ステップ = 1 周期 = 5553 s） | 参照からの距離 |
|---|---|
| RK4 | $5.95 \times 10^{4}$ km |
| DP45（atol = rtol = 1e-10） | $4.7 \times 10^{-6}$ km |
| DOP853（atol = rtol = 1e-10） | $2.8 \times 10^{-9}$ km |

閾値は 1 km で、両側から 4 桁以上離れている。テストは `satellite_with` が作る 400 km 円軌道の
衛星を使い、controller の周期を span より長く取って tick が入らないようにしている。

adaptive の 2 つは互いにも区別する。同じ tolerance では 8 次のほうが誤差が小さく、実測で
$2.8 \times 10^{-9}$ km 対 $4.7 \times 10^{-6}$ km、1700 倍の差がある。閾値は 10 倍で、config が
`dop853` と書いているのに DP45 が走る取り違えが落ちる。

mutation で強度を測った。`advance_controlled` が config を読まず `Rk4 { dt: params.dt }` を使う、
`Dp45` の arm で DOP853 を回す、`Dop853` の arm で DP45 を回す、`integrator_config` が
tolerances を捨てる — いずれもテストが落ちる。

測る位置が `advance_controlled` であることが、この 4 つを落とせる条件である。
`propagate_controlled` を直接呼ぶ形だと、`run` と `serve` の呼び出し元で `Rk4` を直書きする退行が
どちらも通ってしまう。呼び出し元が選択を持たない構造にしたので、1 つのテストが両経路を覆う。

`cargo test -p orts-cli` が pass し、`viewer/src/protocol/generated/` に差分は出ない。
`cargo clippy --workspace -- -D warnings` が clean。

## 関連

controlled mode に残る他の差分(`output_interval` が controller tick に丸められる、衝突・大気圏
突入で終了しない、`duration` 省略時の終了時刻が先頭衛星の周期になる)は原因が別なので #442 に
分けてある。

Closes #440
