### PR TITLE
feat(orts,utsuroi): let a system report when its right-hand side switches

### DIFF
--- a/orts/src/attitude/augmented.rs
+++ b/orts/src/attitude/augmented.rs
@@ -165,9 +165,17 @@ impl DynamicalSystem for AugmentedAttitudeSystem {
     /// never see it.
     fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
         let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
-        self.models
+        let from_models = self
+            .models
             .iter()
-            .filter_map(|m| m.next_discontinuity_after(t, epoch.as_ref()))
+            .filter_map(|m| m.next_discontinuity_after(t, epoch.as_ref()));
+        let from_effectors = self
+            .effectors
+            .iter()
+            .filter_map(|e| e.next_discontinuity_after(t, epoch.as_ref()));
+        from_models
+            .chain(from_effectors)
+            .filter(|next| *next > t && next.is_finite())
             .min_by(f64::total_cmp)
     }
 

--- a/orts/src/attitude/augmented.rs
+++ b/orts/src/attitude/augmented.rs
@@ -158,11 +158,16 @@ impl AugmentedAttitudeSystem {
 impl DynamicalSystem for AugmentedAttitudeSystem {
     type State = AugmentedState<AttitudeState>;
 
-    /// The earliest boundary any model reports.
+    /// The earliest boundary any model or effector reports.
     ///
-    /// A model that switches on a schedule reports when; a system holding one
-    /// has to pass that on, or a propagation loop stepping the system would
-    /// never see it.
+    /// A model or effector that switches on a schedule reports when; a system
+    /// holding one has to pass that on, or a propagation loop stepping the
+    /// system would never see it.
+    ///
+    /// `orbit_fn` and `mass_fn` are the caller's own functions, so their
+    /// breakpoints are not reported here — a caller who passes a piecewise one
+    /// holds its schedule already, and hands it to the propagation loop the same
+    /// way it hands over the span.
     fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
         let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
         let from_models = self

--- a/orts/src/attitude/augmented.rs
+++ b/orts/src/attitude/augmented.rs
@@ -158,6 +158,19 @@ impl AugmentedAttitudeSystem {
 impl DynamicalSystem for AugmentedAttitudeSystem {
     type State = AugmentedState<AttitudeState>;
 
+    /// The earliest boundary any model reports.
+    ///
+    /// A model that switches on a schedule reports when; a system holding one
+    /// has to pass that on, or a propagation loop stepping the system would
+    /// never see it.
+    fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
+        let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
+        self.models
+            .iter()
+            .filter_map(|m| m.next_discontinuity_after(t, epoch.as_ref()))
+            .min_by(f64::total_cmp)
+    }
+
     fn derivatives(
         &self,
         t: f64,

--- a/orts/src/attitude/decoupled.rs
+++ b/orts/src/attitude/decoupled.rs
@@ -123,6 +123,19 @@ impl DecoupledAttitudeSystem {
 impl DynamicalSystem for DecoupledAttitudeSystem {
     type State = AttitudeState;
 
+    /// The earliest boundary any model reports.
+    ///
+    /// A model that switches on a schedule reports when; a system holding one
+    /// has to pass that on, or a propagation loop stepping the system would
+    /// never see it.
+    fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
+        let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
+        self.models
+            .iter()
+            .filter_map(|m| m.next_discontinuity_after(t, epoch.as_ref()))
+            .min_by(f64::total_cmp)
+    }
+
     fn derivatives(&self, t: f64, state: &AttitudeState) -> AttitudeState {
         let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
 

--- a/orts/src/attitude/decoupled.rs
+++ b/orts/src/attitude/decoupled.rs
@@ -128,6 +128,11 @@ impl DynamicalSystem for DecoupledAttitudeSystem {
     /// A model that switches on a schedule reports when; a system holding one
     /// has to pass that on, or a propagation loop stepping the system would
     /// never see it.
+    ///
+    /// `orbit_fn` and `mass_fn` are the caller's own functions, so their
+    /// breakpoints are not reported here — a caller who passes a piecewise one
+    /// holds its schedule already, and hands it to the propagation loop the same
+    /// way it hands over the span.
     fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
         let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
         self.models

--- a/orts/src/attitude/system.rs
+++ b/orts/src/attitude/system.rs
@@ -63,6 +63,19 @@ impl AttitudeSystem {
 impl DynamicalSystem for AttitudeSystem {
     type State = AttitudeState;
 
+    /// The earliest boundary any model reports.
+    ///
+    /// A model that switches on a schedule reports when; a system holding one
+    /// has to pass that on, or a propagation loop stepping the system would
+    /// never see it.
+    fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
+        let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
+        self.models
+            .iter()
+            .filter_map(|m| m.next_discontinuity_after(t, epoch.as_ref()))
+            .min_by(f64::total_cmp)
+    }
+
     fn derivatives(&self, t: f64, state: &AttitudeState) -> AttitudeState {
         let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
 

--- a/orts/src/effector.rs
+++ b/orts/src/effector.rs
@@ -36,6 +36,23 @@ pub trait StateEffector<S: HasFrame>: Send + Sync + std::any::Any {
     /// Human-readable name for this effector (e.g., "reaction_wheels").
     fn name(&self) -> &str;
 
+    /// The next time after `t` at which this effector's contribution to the
+    /// right-hand side changes discontinuously, if it knows one in advance.
+    ///
+    /// An effector is part of the right-hand side alongside the models, and
+    /// [`derivatives`](Self::derivatives) receives `t` and `epoch`, so one
+    /// driven by a schedule can switch. The contract is the same as
+    /// [`Model::next_discontinuity_after`](crate::model::Model::next_discontinuity_after):
+    /// integration time, strictly after `t`, finite, and only for switches whose
+    /// time is known without integrating.
+    ///
+    /// A reaction wheel reaching its momentum limit is not one of those — when
+    /// that happens follows from the trajectory. Issue #446 covers those as
+    /// state events.
+    fn next_discontinuity_after(&self, _t: f64, _epoch: Option<&Epoch>) -> Option<f64> {
+        None
+    }
+
     /// Number of scalar state variables this effector contributes.
     fn state_dim(&self) -> usize;
 

--- a/orts/src/group/coupled.rs
+++ b/orts/src/group/coupled.rs
@@ -30,6 +30,19 @@ pub struct PairContext<'a> {
 pub trait InterSatelliteForce: Send + Sync {
     fn name(&self) -> &str;
     fn acceleration_pair(&self, ctx: &PairContext<'_>) -> (Vector3<f64>, Vector3<f64>);
+
+    /// The next time after `t` at which this force changes discontinuously, if
+    /// it knows one in advance.
+    ///
+    /// [`acceleration_pair`](Self::acceleration_pair) receives `PairContext::t`,
+    /// so a force can be driven by a schedule of its own. The contract is the
+    /// same as [`Model::next_discontinuity_after`](crate::model::Model::next_discontinuity_after),
+    /// minus the epoch, which `PairContext` does not carry.
+    ///
+    /// Mutual gravitation and the other continuous forces answer `None`.
+    fn next_discontinuity_after(&self, _t: f64) -> Option<f64> {
+        None
+    }
 }
 
 /// A specific satellite-pair interaction: indices into the group + force model.
@@ -146,14 +159,24 @@ where
 {
     type State = GroupState<D::State>;
 
-    /// The earliest boundary any satellite reports.
+    /// The earliest boundary reported by anything in the right-hand side: the
+    /// satellites' own systems and the interaction forces between them.
     ///
-    /// The inter-satellite forces are continuous in time, so the group switches
-    /// exactly where its satellites do.
+    /// A force reached through [`InteractionPair`] can be driven by a schedule
+    /// of its own, so leaving it out would hide it the same way a composite
+    /// answering `None` hides its children.
     fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
-        self.dynamics
+        let from_children = self
+            .dynamics
             .iter()
-            .filter_map(|d| d.next_discontinuity_after(t))
+            .filter_map(|d| d.next_discontinuity_after(t));
+        let from_interactions = self
+            .interactions
+            .iter()
+            .filter_map(|pair| pair.force.next_discontinuity_after(t));
+        from_children
+            .chain(from_interactions)
+            .filter(|next| *next > t && next.is_finite())
             .min_by(f64::total_cmp)
     }
 

--- a/orts/src/group/coupled.rs
+++ b/orts/src/group/coupled.rs
@@ -146,6 +146,17 @@ where
 {
     type State = GroupState<D::State>;
 
+    /// The earliest boundary any satellite reports.
+    ///
+    /// The inter-satellite forces are continuous in time, so the group switches
+    /// exactly where its satellites do.
+    fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
+        self.dynamics
+            .iter()
+            .filter_map(|d| d.next_discontinuity_after(t))
+            .min_by(f64::total_cmp)
+    }
+
     fn derivatives(&self, t: f64, state: &GroupState<D::State>) -> GroupState<D::State> {
         assert_eq!(
             self.dynamics.len(),

--- a/orts/src/group/dynamics.rs
+++ b/orts/src/group/dynamics.rs
@@ -38,6 +38,20 @@ impl<D: DynamicalSystem> DynamicalSystem for IndependentGroupDynamics<D> {
                 .collect(),
         }
     }
+
+    /// The earliest boundary any satellite reports.
+    ///
+    /// The group's right-hand side switches wherever any of its satellites'
+    /// does, so a propagation loop stepping this system has to end its step at
+    /// the first of them. Without this, a satellite carrying a scheduled burn
+    /// would report its windows and the group would answer `None` over the top
+    /// of them.
+    fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
+        self.dynamics
+            .iter()
+            .filter_map(|d| d.next_discontinuity_after(t))
+            .min_by(f64::total_cmp)
+    }
 }
 
 #[cfg(test)]

--- a/orts/src/model.rs
+++ b/orts/src/model.rs
@@ -188,6 +188,29 @@ pub trait Model<S: HasFrame>: Send + Sync {
     /// `epoch` is the absolute time corresponding to integration time `t`.
     /// It is `None` when no initial epoch was provided.
     fn eval(&self, t: f64, state: &S, epoch: Option<&Epoch>) -> ExternalLoads<S::Frame>;
+
+    /// The next time after `t` at which this model's loads change
+    /// discontinuously, if the model knows one in advance.
+    ///
+    /// A model that switches on a schedule — a thruster with burn windows — can
+    /// report the next edge so a propagation loop can end its step there. A
+    /// solver otherwise samples the loads at stage times of its own choosing,
+    /// and a window that opens and closes between two stages contributes
+    /// nothing at all.
+    ///
+    /// The contract matches
+    /// [`DynamicalSystem::next_discontinuity_after`](utsuroi::DynamicalSystem::next_discontinuity_after):
+    /// a finite time strictly greater than `t`, never `t` itself, and only for
+    /// switches whose time is known without integrating. A load that changes
+    /// when the trajectory reaches some limit is not one of those.
+    ///
+    /// The answer is in integration time, like `t`. `epoch` is the absolute time
+    /// at `t`, as [`eval`](Self::eval) receives it, so that a model whose
+    /// schedule is written in epochs can convert its edges: the system owns
+    /// `epoch_0` and the model does not.
+    fn next_discontinuity_after(&self, _t: f64, _epoch: Option<&Epoch>) -> Option<f64> {
+        None
+    }
 }
 
 // Blanket impl so Box<dyn Model<S>> also satisfies Model<S>.
@@ -199,6 +222,10 @@ impl<S: HasFrame> Model<S> for Box<dyn Model<S>> {
 
     fn eval(&self, t: f64, state: &S, epoch: Option<&Epoch>) -> ExternalLoads<S::Frame> {
         (**self).eval(t, state, epoch)
+    }
+
+    fn next_discontinuity_after(&self, t: f64, epoch: Option<&Epoch>) -> Option<f64> {
+        (**self).next_discontinuity_after(t, epoch)
     }
 }
 

--- a/orts/src/orbital/system.rs
+++ b/orts/src/orbital/system.rs
@@ -78,6 +78,20 @@ impl<F: Eci> OrbitalSystem<F> {
 
 impl<F: Eci> DynamicalSystem for OrbitalSystem<F> {
     type State = OrbitalState<F>;
+
+    /// The earliest boundary any model reports.
+    ///
+    /// `ConstantThrust` is one: its burn is bounded by two epochs, and a
+    /// propagation loop that ends its step at them integrates the burn without
+    /// the caller splitting the span by hand.
+    fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
+        let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
+        self.models
+            .iter()
+            .filter_map(|m| m.next_discontinuity_after(t, epoch.as_ref()))
+            .min_by(f64::total_cmp)
+    }
+
     fn derivatives(&self, t: f64, state: &OrbitalState<F>) -> OrbitalState<F> {
         let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
         let mut accel = self.gravity.acceleration(self.mu, state.position());

--- a/orts/src/orbital/system.rs
+++ b/orts/src/orbital/system.rs
@@ -81,9 +81,11 @@ impl<F: Eci> DynamicalSystem for OrbitalSystem<F> {
 
     /// The earliest boundary any model reports.
     ///
-    /// `ConstantThrust` is one: its burn is bounded by two epochs, and a
-    /// propagation loop that ends its step at them integrates the burn without
-    /// the caller splitting the span by hand.
+    /// `ConstantThrust` is one: its burn is bounded by two epochs, which it
+    /// converts to integration time here. What a propagation loop does with the
+    /// times is its own business — ending a step at one is not by itself enough
+    /// to integrate the burn correctly, since a stage landing exactly on the
+    /// edge still needs a rule for which side it belongs to (#446).
     fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
         let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
         self.models

--- a/orts/src/perturbations/constant_thrust.rs
+++ b/orts/src/perturbations/constant_thrust.rs
@@ -124,6 +124,25 @@ impl<F: Eci> ConstantThrust<F> {
 
 impl<F: Eci> ConstantThrust<F> {
     /// Shared body of [`Model::eval`] for the frames this model supports.
+    /// Integration time of the next edge of the burn after `t`.
+    ///
+    /// The burn is bounded by two epochs while a propagation loop works in
+    /// integration time, so this converts through `epoch_at_t`: the offset from
+    /// there to an edge is the same in both. Without an epoch there is no
+    /// mapping and no edge to report.
+    ///
+    /// `end` is inclusive, so the load drops after it rather than at it. The
+    /// time reported is the instant the thrust stops contributing, which is what
+    /// a loop wants to end its step at.
+    fn next_edge_after(&self, t: f64, epoch_at_t: Option<&Epoch>) -> Option<f64> {
+        let now = epoch_at_t?;
+        [self.start, self.end]
+            .iter()
+            .map(|edge| t + edge.duration_since(now).as_si_seconds())
+            .filter(|edge_t| *edge_t > t && edge_t.is_finite())
+            .min_by(f64::total_cmp)
+    }
+
     fn loads(&self, epoch: Option<&Epoch>) -> ExternalLoads<F> {
         // The stored acceleration is already a `Vec3<F>` and `F` is the state's
         // frame, so it goes into the loads without a re-tag.
@@ -164,6 +183,10 @@ impl<S: HasFrame<Frame = frame::SimpleEci> + HasOrbit> Model<S>
     fn eval(&self, _t: f64, _state: &S, epoch: Option<&Epoch>) -> ExternalLoads<S::Frame> {
         self.loads(epoch)
     }
+
+    fn next_discontinuity_after(&self, t: f64, epoch: Option<&Epoch>) -> Option<f64> {
+        self.next_edge_after(t, epoch)
+    }
 }
 
 impl<S: HasFrame<Frame = frame::Gcrs> + HasOrbit> Model<S> for ConstantThrust<frame::Gcrs> {
@@ -173,6 +196,10 @@ impl<S: HasFrame<Frame = frame::Gcrs> + HasOrbit> Model<S> for ConstantThrust<fr
 
     fn eval(&self, _t: f64, _state: &S, epoch: Option<&Epoch>) -> ExternalLoads<S::Frame> {
         self.loads(epoch)
+    }
+
+    fn next_discontinuity_after(&self, t: f64, epoch: Option<&Epoch>) -> Option<f64> {
+        self.next_edge_after(t, epoch)
     }
 }
 

--- a/orts/src/perturbations/constant_thrust.rs
+++ b/orts/src/perturbations/constant_thrust.rs
@@ -123,7 +123,6 @@ impl<F: Eci> ConstantThrust<F> {
 }
 
 impl<F: Eci> ConstantThrust<F> {
-    /// Shared body of [`Model::eval`] for the frames this model supports.
     /// Integration time of the next edge of the burn after `t`.
     ///
     /// The burn is bounded by two epochs while a propagation loop works in
@@ -131,9 +130,9 @@ impl<F: Eci> ConstantThrust<F> {
     /// there to an edge is the same in both. Without an epoch there is no
     /// mapping and no edge to report.
     ///
-    /// `end` is inclusive, so the load drops after it rather than at it. The
-    /// time reported is the instant the thrust stops contributing, which is what
-    /// a loop wants to end its step at.
+    /// `start` and `end` are where the burn begins and ends. Which one-sided
+    /// value a stage landing exactly on an edge should take is the propagation
+    /// loop's to decide (#446); this reports the times, not that rule.
     fn next_edge_after(&self, t: f64, epoch_at_t: Option<&Epoch>) -> Option<f64> {
         let now = epoch_at_t?;
         [self.start, self.end]
@@ -143,6 +142,7 @@ impl<F: Eci> ConstantThrust<F> {
             .min_by(f64::total_cmp)
     }
 
+    /// Shared body of [`Model::eval`] for the frames this model supports.
     fn loads(&self, epoch: Option<&Epoch>) -> ExternalLoads<F> {
         // The stored acceleration is already a `Vec3<F>` and `F` is the state's
         // frame, so it goes into the loads without a re-tag.

--- a/orts/src/perturbations/constant_thrust.rs
+++ b/orts/src/perturbations/constant_thrust.rs
@@ -85,7 +85,7 @@ impl<F: Eci> ConstantThrust<F> {
     ///   in one inertial frame cannot be reused in another (`SimpleEci` and
     ///   `Gcrs` differ by ~484 arcsec at 2024).
     pub fn new(name: &'static str, start: Epoch, end: Epoch, total_dv_kms: Vec3<F>) -> Self {
-        let duration_s = (end.jd() - start.jd()) * 86_400.0;
+        let duration_s = end.duration_since(&start).as_si_seconds();
         assert!(
             duration_s > 0.0,
             "ConstantThrust {name:?}: end epoch must strictly follow start"
@@ -107,7 +107,7 @@ impl<F: Eci> ConstantThrust<F> {
 
     /// Returns the burn duration in seconds.
     pub fn duration_seconds(&self) -> f64 {
-        (self.end.jd() - self.start.jd()) * 86_400.0
+        self.end.duration_since(&self.start).as_si_seconds()
     }
 
     /// Returns the total Δv that this thrust model integrates to over
@@ -117,8 +117,18 @@ impl<F: Eci> ConstantThrust<F> {
     }
 
     /// Returns `true` if `epoch` falls within `[start, end]` (inclusive).
+    ///
+    /// Measured on the canonical TAI timeline, as [`duration_seconds`] and the
+    /// edges reported by [`next_edge_after`] are. UTC Julian Dates do not
+    /// advance uniformly across a leap second, so comparing them would put the
+    /// switch a second away from the boundary this model reports, and would
+    /// spread the Δv over a duration one second short.
+    ///
+    /// [`duration_seconds`]: Self::duration_seconds
+    /// [`next_edge_after`]: Self::next_edge_after
     fn is_active(&self, epoch: &Epoch) -> bool {
-        epoch.jd() >= self.start.jd() && epoch.jd() <= self.end.jd()
+        epoch.duration_since(&self.start).as_si_seconds() >= 0.0
+            && self.end.duration_since(epoch).as_si_seconds() >= 0.0
     }
 }
 

--- a/orts/src/spacecraft/dynamics.rs
+++ b/orts/src/spacecraft/dynamics.rs
@@ -232,7 +232,7 @@ impl<G: GravityField, F: Eci + 'static> SpacecraftDynamics<G, F> {
 impl<G: GravityField, F: Eci + 'static> DynamicalSystem for SpacecraftDynamics<G, F> {
     type State = AugmentedState<SpacecraftState<F>>;
 
-    /// The earliest boundary any model reports.
+    /// The earliest boundary any model or effector reports.
     ///
     /// Models that report the same time collapse to one, which is what a
     /// propagation loop wants: two thrusters whose windows share an edge, or a

--- a/orts/src/spacecraft/dynamics.rs
+++ b/orts/src/spacecraft/dynamics.rs
@@ -232,6 +232,20 @@ impl<G: GravityField, F: Eci + 'static> SpacecraftDynamics<G, F> {
 impl<G: GravityField, F: Eci + 'static> DynamicalSystem for SpacecraftDynamics<G, F> {
     type State = AugmentedState<SpacecraftState<F>>;
 
+    /// The earliest boundary any model reports.
+    ///
+    /// Models that report the same time collapse to one, which is what a
+    /// propagation loop wants: two thrusters whose windows share an edge, or a
+    /// window whose end abuts the next one's start, are one place to end a step.
+    fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
+        let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
+        self.models
+            .iter()
+            .filter_map(|m| m.next_discontinuity_after(t, epoch.as_ref()))
+            .filter(|next| *next > t && next.is_finite())
+            .min_by(f64::total_cmp)
+    }
+
     fn derivatives(
         &self,
         t: f64,

--- a/orts/src/spacecraft/dynamics.rs
+++ b/orts/src/spacecraft/dynamics.rs
@@ -239,9 +239,16 @@ impl<G: GravityField, F: Eci + 'static> DynamicalSystem for SpacecraftDynamics<G
     /// window whose end abuts the next one's start, are one place to end a step.
     fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
         let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
-        self.models
+        let from_models = self
+            .models
             .iter()
-            .filter_map(|m| m.next_discontinuity_after(t, epoch.as_ref()))
+            .filter_map(|m| m.next_discontinuity_after(t, epoch.as_ref()));
+        let from_effectors = self
+            .effectors
+            .iter()
+            .filter_map(|e| e.next_discontinuity_after(t, epoch.as_ref()));
+        from_models
+            .chain(from_effectors)
             .filter(|next| *next > t && next.is_finite())
             .min_by(f64::total_cmp)
     }

--- a/orts/src/spacecraft/thruster.rs
+++ b/orts/src/spacecraft/thruster.rs
@@ -21,6 +21,19 @@ pub trait ThrustProfile: Send + Sync {
     /// 0.0 = off, 1.0 = full thrust.  Values outside this range are clamped
     /// by the [`Thruster`] actuator.
     fn throttle(&self, t: f64, state: &SpacecraftState, epoch: Option<&Epoch>) -> f64;
+
+    /// The next time after `t` at which this profile's throttle jumps, if the
+    /// profile knows one in advance.
+    ///
+    /// A schedule knows its own edges; a law that reads the state does not know
+    /// when the state will cross anything, and answers `None`. A propagation
+    /// loop ends its step at the times reported here, so that a window is not
+    /// sampled only at whichever stage times happen to fall inside it.
+    ///
+    /// Must be finite and strictly greater than `t`.
+    fn next_throttle_jump_after(&self, _t: f64) -> Option<f64> {
+        None
+    }
 }
 
 // Profile implementations
@@ -69,6 +82,21 @@ impl ThrustProfile for ScheduledBurn {
             }
         }
         0.0
+    }
+
+    /// The earliest window edge after `t`.
+    ///
+    /// Both ends of every window count: the throttle jumps up at `start` and
+    /// back down at `end`. `windows` is public and unordered, so this scans
+    /// rather than keeping an index that a later mutation would invalidate. A
+    /// window that abuts the next one shares an edge, and the two report as one
+    /// time.
+    fn next_throttle_jump_after(&self, t: f64) -> Option<f64> {
+        self.windows
+            .iter()
+            .flat_map(|w| [w.start, w.end])
+            .filter(|edge| *edge > t && edge.is_finite())
+            .min_by(f64::total_cmp)
     }
 }
 
@@ -251,6 +279,12 @@ impl<S: HasFrame<Frame = arika::frame::SimpleEci> + HasAttitude + HasOrbit + Has
             mass: state.mass(),
         };
         self.loads(t, &sc_state, epoch)
+    }
+
+    /// Whatever the profile knows. Propellant exhaustion is left out: its time
+    /// follows from the mass the trajectory reaches, not from the clock.
+    fn next_discontinuity_after(&self, t: f64, _epoch: Option<&Epoch>) -> Option<f64> {
+        self.profile.next_throttle_jump_after(t)
     }
 }
 

--- a/orts/src/spacecraft/thruster.rs
+++ b/orts/src/spacecraft/thruster.rs
@@ -30,8 +30,13 @@ pub trait ThrustProfile: Send + Sync {
     /// loop ends its step at the times reported here, so that a window is not
     /// sampled only at whichever stage times happen to fall inside it.
     ///
+    /// The answer is in integration time, like `t`. `epoch` is the absolute time
+    /// at `t`, as [`throttle`](Self::throttle) receives it, so a profile written
+    /// in epochs can convert its own edges. `ScheduledBurn`, whose windows are
+    /// already integration times, ignores it.
+    ///
     /// Must be finite and strictly greater than `t`.
-    fn next_throttle_jump_after(&self, _t: f64) -> Option<f64> {
+    fn next_throttle_jump_after(&self, _t: f64, _epoch: Option<&Epoch>) -> Option<f64> {
         None
     }
 }
@@ -91,7 +96,7 @@ impl ThrustProfile for ScheduledBurn {
     /// rather than keeping an index that a later mutation would invalidate. A
     /// window that abuts the next one shares an edge, and the two report as one
     /// time.
-    fn next_throttle_jump_after(&self, t: f64) -> Option<f64> {
+    fn next_throttle_jump_after(&self, t: f64, _epoch: Option<&Epoch>) -> Option<f64> {
         self.windows
             .iter()
             .flat_map(|w| [w.start, w.end])
@@ -283,8 +288,8 @@ impl<S: HasFrame<Frame = arika::frame::SimpleEci> + HasAttitude + HasOrbit + Has
 
     /// Whatever the profile knows. Propellant exhaustion is left out: its time
     /// follows from the mass the trajectory reaches, not from the clock.
-    fn next_discontinuity_after(&self, t: f64, _epoch: Option<&Epoch>) -> Option<f64> {
-        self.profile.next_throttle_jump_after(t)
+    fn next_discontinuity_after(&self, t: f64, epoch: Option<&Epoch>) -> Option<f64> {
+        self.profile.next_throttle_jump_after(t, epoch)
     }
 }
 

--- a/orts/tests/burn_window_boundaries.rs
+++ b/orts/tests/burn_window_boundaries.rs
@@ -36,11 +36,11 @@ fn a_window_reports_both_of_its_edges() {
     let burn = ScheduledBurn {
         windows: vec![BurnWindow::full(0.1, 0.2)],
     };
-    assert_eq!(burn.next_throttle_jump_after(0.0), Some(0.1));
-    assert_eq!(burn.next_throttle_jump_after(0.1), Some(0.2));
-    assert_eq!(burn.next_throttle_jump_after(0.15), Some(0.2));
+    assert_eq!(burn.next_throttle_jump_after(0.0, None), Some(0.1));
+    assert_eq!(burn.next_throttle_jump_after(0.1, None), Some(0.2));
+    assert_eq!(burn.next_throttle_jump_after(0.15, None), Some(0.2));
     // Past the last edge there is nothing left to report.
-    assert_eq!(burn.next_throttle_jump_after(0.2), None);
+    assert_eq!(burn.next_throttle_jump_after(0.2, None), None);
 }
 
 /// The edge asked about is never the answer, so a loop that steps to one and
@@ -50,8 +50,8 @@ fn the_time_asked_about_is_not_reported() {
     let burn = ScheduledBurn {
         windows: vec![BurnWindow::full(1.0, 2.0)],
     };
-    assert_eq!(burn.next_throttle_jump_after(1.0), Some(2.0));
-    assert_eq!(burn.next_throttle_jump_after(2.0), None);
+    assert_eq!(burn.next_throttle_jump_after(1.0, None), Some(2.0));
+    assert_eq!(burn.next_throttle_jump_after(2.0, None), None);
 }
 
 /// Windows out of order still report their edges in time order.
@@ -69,7 +69,7 @@ fn unordered_windows_report_their_earliest_edge() {
     };
     let mut t = 0.0;
     let mut edges = Vec::new();
-    while let Some(next) = burn.next_throttle_jump_after(t) {
+    while let Some(next) = burn.next_throttle_jump_after(t, None) {
         edges.push(next);
         t = next;
     }
@@ -92,7 +92,7 @@ fn abutting_windows_share_one_edge() {
     };
     let mut t = -1.0;
     let mut edges = Vec::new();
-    while let Some(next) = burn.next_throttle_jump_after(t) {
+    while let Some(next) = burn.next_throttle_jump_after(t, None) {
         edges.push(next);
         t = next;
     }
@@ -249,12 +249,197 @@ fn an_epoch_scheduled_burn_without_an_epoch_reports_no_time() {
     assert_eq!(system.next_discontinuity_after(0.0), None);
 }
 
+/// A model that reports a fixed set of edges, for the systems whose own models
+/// carry no schedule.
+///
+/// Reports the earliest of `edges` after `t`, so a system holding two of these
+/// has a minimum to take and a caller can walk the sequence.
+struct EdgeStub {
+    name: &'static str,
+    edges: Vec<f64>,
+}
+
+impl EdgeStub {
+    fn new(name: &'static str, edges: Vec<f64>) -> Self {
+        Self { name, edges }
+    }
+}
+
+impl<S: orts::model::HasFrame> Model<S> for EdgeStub {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn eval(
+        &self,
+        _t: f64,
+        _state: &S,
+        _epoch: Option<&arika::epoch::Epoch>,
+    ) -> orts::model::ExternalLoads<S::Frame> {
+        orts::model::ExternalLoads::zeros()
+    }
+
+    fn next_discontinuity_after(
+        &self,
+        t: f64,
+        _epoch: Option<&arika::epoch::Epoch>,
+    ) -> Option<f64> {
+        self.edges
+            .iter()
+            .copied()
+            .filter(|e| *e > t)
+            .min_by(f64::total_cmp)
+    }
+}
+
+/// Walk a system's reported edges from `t0` until it stops reporting.
+fn edges_of<D: DynamicalSystem>(system: &D, t0: f64) -> Vec<f64> {
+    let mut t = t0;
+    let mut edges = Vec::new();
+    while let Some(next) = system.next_discontinuity_after(t) {
+        edges.push(next);
+        t = next;
+    }
+    edges
+}
+
+/// `AttitudeSystem` passes on its models' edges.
+#[test]
+fn the_attitude_system_forwards_its_models_edges() {
+    use orts::attitude::AttitudeSystem;
+
+    let bare = AttitudeSystem::new(Matrix3::identity());
+    assert_eq!(bare.next_discontinuity_after(0.0), None);
+
+    let system = AttitudeSystem::new(Matrix3::identity())
+        .with_model(EdgeStub::new("a", vec![3.0, 7.0]))
+        .with_model(EdgeStub::new("b", vec![1.0, 5.0]));
+    assert_eq!(edges_of(&system, 0.0), vec![1.0, 3.0, 5.0, 7.0]);
+}
+
+/// `DecoupledAttitudeSystem` passes on its models' edges.
+#[test]
+fn the_decoupled_attitude_system_forwards_its_models_edges() {
+    use orts::attitude::DecoupledAttitudeSystem;
+
+    let bare =
+        DecoupledAttitudeSystem::circular_orbit(Matrix3::identity(), 398600.4418, 7000.0, 100.0);
+    assert_eq!(bare.next_discontinuity_after(0.0), None);
+
+    let system =
+        DecoupledAttitudeSystem::circular_orbit(Matrix3::identity(), 398600.4418, 7000.0, 100.0)
+            .with_model(EdgeStub::new("a", vec![2.0, 8.0]))
+            .with_model(EdgeStub::new("b", vec![4.0]));
+    assert_eq!(edges_of(&system, 0.0), vec![2.0, 4.0, 8.0]);
+}
+
+/// `AugmentedAttitudeSystem` passes on its models' edges, independently of any
+/// effector state it also carries.
+#[test]
+fn the_augmented_attitude_system_forwards_its_models_edges() {
+    use orts::attitude::AugmentedAttitudeSystem;
+
+    let bare =
+        AugmentedAttitudeSystem::circular_orbit(Matrix3::identity(), 398600.4418, 7000.0, 100.0);
+    assert_eq!(bare.next_discontinuity_after(0.0), None);
+
+    let system =
+        AugmentedAttitudeSystem::circular_orbit(Matrix3::identity(), 398600.4418, 7000.0, 100.0)
+            .with_model(EdgeStub::new("a", vec![6.0]))
+            .with_model(EdgeStub::new("b", vec![1.5, 9.0]));
+    assert_eq!(edges_of(&system, 0.0), vec![1.5, 6.0, 9.0]);
+}
+
+/// `CoupledGroupDynamics` passes on the earliest edge across its satellites.
+///
+/// The inter-satellite forces are continuous, so the group switches exactly
+/// where its satellites do.
+#[test]
+fn a_coupled_group_forwards_the_boundaries_of_its_satellites() {
+    use orts::group::coupled::CoupledGroupDynamics;
+
+    use orts::orbital::system::OrbitalSystem;
+
+    // `CoupledGroupDynamics` needs a state it can add an interaction
+    // acceleration to, which `OrbitalState` is and `AugmentedState` is not.
+    let orbital = || -> OrbitalSystem { OrbitalSystem::new(398600.4418, Box::new(PointMass)) };
+
+    let bare = CoupledGroupDynamics::new(vec![orbital(), orbital()], vec![]);
+    assert_eq!(bare.next_discontinuity_after(0.0), None);
+
+    let group = CoupledGroupDynamics::new(
+        vec![
+            orbital().with_model(EdgeStub::new("a", vec![5.0, 7.0])),
+            orbital().with_model(EdgeStub::new("b", vec![3.0, 11.0])),
+        ],
+        vec![],
+    );
+    assert_eq!(edges_of(&group, 0.0), vec![3.0, 5.0, 7.0, 11.0]);
+}
+
+/// An epoch-scheduled profile reports its edges through `Thruster`.
+///
+/// `throttle` receives the epoch, so `next_throttle_jump_after` does too —
+/// otherwise a profile that schedules itself in epochs could evaluate correctly
+/// while never reporting an edge.
+#[test]
+fn an_epoch_scheduled_profile_reports_through_the_thruster() {
+    use arika::epoch::Epoch;
+
+    /// Fires for 60 s starting 100 s after its reference epoch.
+    struct EpochBurn {
+        reference: Epoch,
+    }
+    impl ThrustProfile for EpochBurn {
+        fn throttle(&self, _t: f64, _s: &SpacecraftState, epoch: Option<&Epoch>) -> f64 {
+            match epoch {
+                Some(now) => {
+                    let since = now.duration_since(&self.reference).as_si_seconds();
+                    if (100.0..160.0).contains(&since) {
+                        1.0
+                    } else {
+                        0.0
+                    }
+                }
+                None => 0.0,
+            }
+        }
+
+        fn next_throttle_jump_after(&self, t: f64, epoch: Option<&Epoch>) -> Option<f64> {
+            let now = epoch?;
+            let since = now.duration_since(&self.reference).as_si_seconds();
+            [100.0 - since, 160.0 - since]
+                .iter()
+                .map(|offset| t + offset)
+                .filter(|edge| *edge > t)
+                .min_by(f64::total_cmp)
+        }
+    }
+
+    let epoch_0 = Epoch::j2000();
+    let thruster = Thruster::new(10.0, 300.0, Vector3::x())
+        .with_profile(Box::new(EpochBurn { reference: epoch_0 }));
+    let system: SpacecraftDynamics<PointMass> =
+        SpacecraftDynamics::new(1e-30, PointMass, Matrix3::identity())
+            .with_epoch(epoch_0)
+            .with_model(thruster);
+
+    assert_eq!(edges_of(&system, 0.0), vec![100.0, 160.0]);
+    // Without an epoch the profile has no reference to measure from.
+    let no_epoch: SpacecraftDynamics<PointMass> =
+        SpacecraftDynamics::new(1e-30, PointMass, Matrix3::identity()).with_model(
+            Thruster::new(10.0, 300.0, Vector3::x())
+                .with_profile(Box::new(EpochBurn { reference: epoch_0 })),
+        );
+    assert_eq!(no_epoch.next_discontinuity_after(0.0), None);
+}
+
 /// A non-finite edge is left out rather than handed to a loop as a target.
 #[test]
 fn a_non_finite_edge_is_not_reported() {
     let burn = ScheduledBurn {
         windows: vec![BurnWindow::full(1.0, f64::INFINITY)],
     };
-    assert_eq!(burn.next_throttle_jump_after(0.0), Some(1.0));
-    assert_eq!(burn.next_throttle_jump_after(1.0), None);
+    assert_eq!(burn.next_throttle_jump_after(0.0, None), Some(1.0));
+    assert_eq!(burn.next_throttle_jump_after(1.0, None), None);
 }

--- a/orts/tests/burn_window_boundaries.rs
+++ b/orts/tests/burn_window_boundaries.rs
@@ -1,0 +1,260 @@
+//! A system reports the times at which its loads switch.
+//!
+//! `ScheduledBurn` answers a throttle for the instant it is asked about, so a
+//! window that falls between an integrator's stage times contributes nothing:
+//! measured with a 1 s RK4 step, `[0.1, 0.2)` produced exactly zero ΔV. A
+//! propagation loop can end its step at a window edge instead, and these tests
+//! cover what it needs in order to: the times themselves, reported through
+//! `Model` and aggregated by `SpacecraftDynamics`.
+//!
+//! Issue #446 tracks the propagation loops consuming these.
+
+use nalgebra::{Matrix3, Vector3};
+use orts::model::Model;
+use orts::orbital::gravity::PointMass;
+use orts::spacecraft::{
+    BurnWindow, ScheduledBurn, SpacecraftDynamics, SpacecraftState, ThrustProfile, Thruster,
+};
+use utsuroi::DynamicalSystem;
+
+fn thruster_with(windows: Vec<BurnWindow>) -> Thruster {
+    Thruster::new(10.0, 300.0, Vector3::x()).with_profile(Box::new(ScheduledBurn { windows }))
+}
+
+fn dynamics_with(thrusters: Vec<Thruster>) -> SpacecraftDynamics<PointMass> {
+    let mut d = SpacecraftDynamics::new(1e-30, PointMass, Matrix3::identity());
+    for t in thrusters {
+        d = d.with_model(t);
+    }
+    d
+}
+
+/// Both ends of a window are edges: the throttle steps up at `start` and back
+/// down at `end`.
+#[test]
+fn a_window_reports_both_of_its_edges() {
+    let burn = ScheduledBurn {
+        windows: vec![BurnWindow::full(0.1, 0.2)],
+    };
+    assert_eq!(burn.next_throttle_jump_after(0.0), Some(0.1));
+    assert_eq!(burn.next_throttle_jump_after(0.1), Some(0.2));
+    assert_eq!(burn.next_throttle_jump_after(0.15), Some(0.2));
+    // Past the last edge there is nothing left to report.
+    assert_eq!(burn.next_throttle_jump_after(0.2), None);
+}
+
+/// The edge asked about is never the answer, so a loop that steps to one and
+/// asks again from there makes progress instead of stopping on it.
+#[test]
+fn the_time_asked_about_is_not_reported() {
+    let burn = ScheduledBurn {
+        windows: vec![BurnWindow::full(1.0, 2.0)],
+    };
+    assert_eq!(burn.next_throttle_jump_after(1.0), Some(2.0));
+    assert_eq!(burn.next_throttle_jump_after(2.0), None);
+}
+
+/// Windows out of order still report their edges in time order.
+///
+/// `ScheduledBurn.windows` is public, so a caller can append to it after
+/// construction; the answer cannot come from an index fixed at build time.
+#[test]
+fn unordered_windows_report_their_earliest_edge() {
+    let burn = ScheduledBurn {
+        windows: vec![
+            BurnWindow::full(5.0, 6.0),
+            BurnWindow::full(1.0, 2.0),
+            BurnWindow::full(3.0, 4.0),
+        ],
+    };
+    let mut t = 0.0;
+    let mut edges = Vec::new();
+    while let Some(next) = burn.next_throttle_jump_after(t) {
+        edges.push(next);
+        t = next;
+    }
+    assert_eq!(edges, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+}
+
+/// A window abutting the next one shares an edge, and the two report as one
+/// time rather than as a pair a loop would step to twice.
+#[test]
+fn abutting_windows_share_one_edge() {
+    let burn = ScheduledBurn {
+        windows: vec![
+            BurnWindow::full(0.0, 1.0),
+            BurnWindow {
+                start: 1.0,
+                end: 2.0,
+                throttle: 0.5,
+            },
+        ],
+    };
+    let mut t = -1.0;
+    let mut edges = Vec::new();
+    while let Some(next) = burn.next_throttle_jump_after(t) {
+        edges.push(next);
+        t = next;
+    }
+    assert_eq!(edges, vec![0.0, 1.0, 2.0]);
+}
+
+/// A throttle that reads the state reports nothing.
+///
+/// When the throttle jumps is then a property of the trajectory, which no
+/// schedule knows in advance. Issue #446 keeps those as state events.
+#[test]
+fn a_state_dependent_profile_reports_no_time() {
+    struct BurnWhileHeavy;
+    impl ThrustProfile for BurnWhileHeavy {
+        fn throttle(
+            &self,
+            _t: f64,
+            state: &SpacecraftState,
+            _e: Option<&arika::epoch::Epoch>,
+        ) -> f64 {
+            if state.mass > 50.0 { 1.0 } else { 0.0 }
+        }
+    }
+
+    let thruster = Thruster::new(10.0, 300.0, Vector3::x()).with_profile(Box::new(BurnWhileHeavy));
+    assert_eq!(
+        Model::<SpacecraftState>::next_discontinuity_after(&thruster, 0.0, None),
+        None
+    );
+    assert_eq!(
+        dynamics_with(vec![thruster]).next_discontinuity_after(0.0),
+        None
+    );
+}
+
+/// A system whose loads are continuous reports nothing, so a propagation loop
+/// over one steps exactly as it does today.
+#[test]
+fn a_system_without_a_schedule_reports_no_time() {
+    let plain: SpacecraftDynamics<PointMass> =
+        SpacecraftDynamics::new(398600.4418, PointMass, Matrix3::identity());
+    assert_eq!(plain.next_discontinuity_after(0.0), None);
+}
+
+/// The system reports the earliest edge among its models.
+#[test]
+fn the_system_reports_the_earliest_edge_across_its_thrusters() {
+    let d = dynamics_with(vec![
+        thruster_with(vec![BurnWindow::full(3.0, 4.0)]),
+        thruster_with(vec![BurnWindow::full(1.0, 8.0)]),
+    ]);
+    // 1.0 opens the second thruster, 3.0 and 4.0 are the first one's window,
+    // 8.0 closes the second.
+    let mut t = 0.0;
+    let mut edges = Vec::new();
+    while let Some(next) = d.next_discontinuity_after(t) {
+        edges.push(next);
+        t = next;
+    }
+    assert_eq!(edges, vec![1.0, 3.0, 4.0, 8.0]);
+}
+
+/// Two thrusters whose windows share an edge report it once.
+#[test]
+fn thrusters_sharing_an_edge_report_it_once() {
+    let d = dynamics_with(vec![
+        thruster_with(vec![BurnWindow::full(2.0, 5.0)]),
+        thruster_with(vec![BurnWindow::full(2.0, 9.0)]),
+    ]);
+    assert_eq!(d.next_discontinuity_after(0.0), Some(2.0));
+    assert_eq!(d.next_discontinuity_after(2.0), Some(5.0));
+}
+
+/// A group passes on the earliest boundary among its satellites.
+///
+/// The group propagation paths integrate the composite system, not the
+/// satellite's own, so a composite that answered `None` would hide every window
+/// its satellites carry.
+#[test]
+fn a_group_forwards_the_boundaries_of_its_satellites() {
+    use orts::group::dynamics::IndependentGroupDynamics;
+
+    let group = IndependentGroupDynamics::new(vec![
+        dynamics_with(vec![thruster_with(vec![BurnWindow::full(4.0, 6.0)])]),
+        dynamics_with(vec![thruster_with(vec![BurnWindow::full(2.0, 9.0)])]),
+    ]);
+
+    let mut t = 0.0;
+    let mut edges = Vec::new();
+    while let Some(next) = group.next_discontinuity_after(t) {
+        edges.push(next);
+        t = next;
+    }
+    assert_eq!(edges, vec![2.0, 4.0, 6.0, 9.0]);
+}
+
+/// A group of satellites that carry no schedule reports nothing.
+#[test]
+fn a_group_without_schedules_reports_no_time() {
+    use orts::group::dynamics::IndependentGroupDynamics;
+
+    let group = IndependentGroupDynamics::new(vec![dynamics_with(vec![]), dynamics_with(vec![])]);
+    assert_eq!(group.next_discontinuity_after(0.0), None);
+}
+
+/// An epoch-scheduled burn reports its edges in integration time.
+///
+/// `ConstantThrust` bounds its burn with two epochs while a propagation loop
+/// works in integration time. The system owns `epoch_0`, so it passes the epoch
+/// at `t` and the model converts. Its doc used to tell the caller to split the
+/// integration at the boundary by hand.
+#[test]
+fn an_epoch_scheduled_burn_reports_its_edges_in_integration_time() {
+    use arika::epoch::Epoch;
+    use orts::orbital::system::OrbitalSystem;
+    use orts::perturbations::ConstantThrust;
+
+    let epoch_0 = Epoch::j2000();
+    let burn = ConstantThrust::new(
+        "burn",
+        epoch_0.add_si_seconds(100.0),
+        epoch_0.add_si_seconds(160.0),
+        arika::frame::Vec3::from_raw(Vector3::new(1e-6, 0.0, 0.0)),
+    );
+    let system: OrbitalSystem = OrbitalSystem::new(398600.4418, Box::new(PointMass))
+        .with_epoch(epoch_0)
+        .with_model(burn);
+
+    // 100 s and 160 s after t = 0, which is where epoch_0 sits.
+    assert_eq!(system.next_discontinuity_after(0.0), Some(100.0));
+    assert_eq!(system.next_discontinuity_after(100.0), Some(160.0));
+    assert_eq!(system.next_discontinuity_after(160.0), None);
+    // Asked from inside the burn, the answer is its end.
+    assert_eq!(system.next_discontinuity_after(120.0), Some(160.0));
+}
+
+/// Without an epoch there is no mapping from the burn's epochs to integration
+/// time, and nothing is reported.
+#[test]
+fn an_epoch_scheduled_burn_without_an_epoch_reports_no_time() {
+    use arika::epoch::Epoch;
+    use orts::orbital::system::OrbitalSystem;
+    use orts::perturbations::ConstantThrust;
+
+    let epoch_0 = Epoch::j2000();
+    let burn = ConstantThrust::new(
+        "burn",
+        epoch_0.add_si_seconds(100.0),
+        epoch_0.add_si_seconds(160.0),
+        arika::frame::Vec3::from_raw(Vector3::new(1e-6, 0.0, 0.0)),
+    );
+    let system: OrbitalSystem =
+        OrbitalSystem::new(398600.4418, Box::new(PointMass)).with_model(burn);
+    assert_eq!(system.next_discontinuity_after(0.0), None);
+}
+
+/// A non-finite edge is left out rather than handed to a loop as a target.
+#[test]
+fn a_non_finite_edge_is_not_reported() {
+    let burn = ScheduledBurn {
+        windows: vec![BurnWindow::full(1.0, f64::INFINITY)],
+    };
+    assert_eq!(burn.next_throttle_jump_after(0.0), Some(1.0));
+    assert_eq!(burn.next_throttle_jump_after(1.0), None);
+}

--- a/orts/tests/burn_window_boundaries.rs
+++ b/orts/tests/burn_window_boundaries.rs
@@ -434,6 +434,121 @@ fn an_epoch_scheduled_profile_reports_through_the_thruster() {
     assert_eq!(no_epoch.next_discontinuity_after(0.0), None);
 }
 
+/// A scheduled effector reports through the systems that hold it.
+///
+/// Effectors are part of the right-hand side alongside the models, and their
+/// `derivatives` receives `t` and `epoch`, so one driven by a schedule can
+/// switch. Both systems that hold effectors take the minimum over models and
+/// effectors together.
+#[test]
+fn a_scheduled_effector_reports_through_its_system() {
+    use orts::effector::StateEffector;
+
+    struct ScheduledEffector {
+        edges: Vec<f64>,
+    }
+
+    impl<S: orts::model::HasFrame> StateEffector<S> for ScheduledEffector {
+        fn name(&self) -> &str {
+            "scheduled_effector"
+        }
+
+        fn state_dim(&self) -> usize {
+            0
+        }
+
+        fn derivatives(
+            &self,
+            _t: f64,
+            _state: &S,
+            _aux: &[f64],
+            _aux_rates: &mut [f64],
+            _epoch: Option<&arika::epoch::Epoch>,
+        ) -> orts::model::ExternalLoads<S::Frame> {
+            orts::model::ExternalLoads::zeros()
+        }
+
+        fn next_discontinuity_after(
+            &self,
+            t: f64,
+            _epoch: Option<&arika::epoch::Epoch>,
+        ) -> Option<f64> {
+            self.edges
+                .iter()
+                .copied()
+                .filter(|e| *e > t)
+                .min_by(f64::total_cmp)
+        }
+    }
+
+    // A model and an effector on the same system: the minimum comes from
+    // whichever is earlier at each step.
+    let system: SpacecraftDynamics<PointMass> =
+        SpacecraftDynamics::new(1e-30, PointMass, Matrix3::identity())
+            .with_model(EdgeStub::new("model", vec![4.0]))
+            .with_effector(ScheduledEffector {
+                edges: vec![2.0, 6.0],
+            });
+    assert_eq!(edges_of(&system, 0.0), vec![2.0, 4.0, 6.0]);
+
+    use orts::attitude::AugmentedAttitudeSystem;
+    let attitude =
+        AugmentedAttitudeSystem::circular_orbit(Matrix3::identity(), 398600.4418, 7000.0, 100.0)
+            .with_effector(ScheduledEffector {
+                edges: vec![1.0, 8.0],
+            });
+    assert_eq!(edges_of(&attitude, 0.0), vec![1.0, 8.0]);
+}
+
+/// A scheduled inter-satellite force reports through the coupled group.
+///
+/// `acceleration_pair` receives `PairContext::t`, so a force can carry a
+/// schedule; the group's own doc used to claim these were continuous.
+#[test]
+fn a_scheduled_interaction_force_reports_through_the_group() {
+    use orts::group::coupled::{
+        CoupledGroupDynamics, InterSatelliteForce, InteractionPair, PairContext,
+    };
+    use orts::orbital::system::OrbitalSystem;
+    use std::sync::Arc;
+
+    struct ScheduledForce {
+        edges: Vec<f64>,
+    }
+    impl InterSatelliteForce for ScheduledForce {
+        fn name(&self) -> &str {
+            "scheduled_force"
+        }
+        fn acceleration_pair(&self, _ctx: &PairContext<'_>) -> (Vector3<f64>, Vector3<f64>) {
+            (Vector3::zeros(), Vector3::zeros())
+        }
+        fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
+            self.edges
+                .iter()
+                .copied()
+                .filter(|e| *e > t)
+                .min_by(f64::total_cmp)
+        }
+    }
+
+    let orbital = || -> OrbitalSystem { OrbitalSystem::new(398600.4418, Box::new(PointMass)) };
+    let group = CoupledGroupDynamics::new(
+        vec![
+            orbital().with_model(EdgeStub::new("child", vec![5.0])),
+            orbital(),
+        ],
+        vec![InteractionPair {
+            i: 0,
+            j: 1,
+            force: Arc::new(ScheduledForce {
+                edges: vec![2.0, 9.0],
+            }),
+        }],
+    );
+    // 2.0 and 9.0 come from the force, 5.0 from the first satellite's model.
+    assert_eq!(edges_of(&group, 0.0), vec![2.0, 5.0, 9.0]);
+}
+
 /// A non-finite edge is left out rather than handed to a loop as a target.
 #[test]
 fn a_non_finite_edge_is_not_reported() {

--- a/orts/tests/burn_window_boundaries.rs
+++ b/orts/tests/burn_window_boundaries.rs
@@ -352,8 +352,9 @@ fn the_augmented_attitude_system_forwards_its_models_edges() {
 
 /// `CoupledGroupDynamics` passes on the earliest edge across its satellites.
 ///
-/// The inter-satellite forces are continuous, so the group switches exactly
-/// where its satellites do.
+/// The interaction forces are part of the same right-hand side and can carry a
+/// schedule of their own, so the group takes the minimum over both; that half is
+/// covered by `a_scheduled_interaction_force_reports_through_the_group`.
 #[test]
 fn a_coupled_group_forwards_the_boundaries_of_its_satellites() {
     use orts::group::coupled::CoupledGroupDynamics;
@@ -547,6 +548,52 @@ fn a_scheduled_interaction_force_reports_through_the_group() {
     );
     // 2.0 and 9.0 come from the force, 5.0 from the first satellite's model.
     assert_eq!(edges_of(&group, 0.0), vec![2.0, 5.0, 9.0]);
+}
+
+/// The reported edge and the switch itself agree across a leap second.
+///
+/// A burn from 2016-12-31T23:59:59Z to 2017-01-01T00:00:00Z spans two SI
+/// seconds — a leap second sits between those labels. The edge this reports and
+/// the instant `is_active` starts and stops answering true have to be the same
+/// time, or a loop ending its step at the boundary steps to the wrong place, and
+/// the Δv is spread over the wrong duration.
+#[test]
+fn the_reported_edge_agrees_with_the_switch_across_a_leap_second() {
+    use arika::epoch::{Epoch, Utc};
+    use orts::orbital::system::OrbitalSystem;
+    use orts::perturbations::ConstantThrust;
+
+    let start: Epoch<Utc> = Epoch::from_iso8601("2016-12-31T23:59:59Z").expect("parse");
+    let end: Epoch<Utc> = Epoch::from_iso8601("2017-01-01T00:00:00Z").expect("parse");
+
+    // Two SI seconds, not the one the civil-time labels suggest.
+    let burn = ConstantThrust::new(
+        "across the leap",
+        start,
+        end,
+        arika::frame::Vec3::from_raw(Vector3::new(2e-3, 0.0, 0.0)),
+    );
+    let elapsed = end.duration_since(&start).as_si_seconds();
+    assert!(
+        (burn.duration_seconds() - elapsed).abs() < 1e-9,
+        "the burn lasts {} s on the uniform timeline, model says {}",
+        elapsed,
+        burn.duration_seconds()
+    );
+
+    // With epoch_0 at the burn's start, the end sits at integration time
+    // `elapsed` — the same number the model spreads the Δv over.
+    let system: OrbitalSystem = OrbitalSystem::new(398600.4418, Box::new(PointMass))
+        .with_epoch(start)
+        .with_model(burn);
+    let reported = system
+        .next_discontinuity_after(0.0)
+        .expect("the end of the burn is ahead of t = 0");
+    assert!(
+        (reported - elapsed).abs() < 1e-9,
+        "reported edge {reported} s against {elapsed} s of burn"
+    );
+    assert_eq!(system.next_discontinuity_after(reported), None);
 }
 
 /// A non-finite edge is left out rather than handed to a loop as a target.

--- a/orts/tests/burn_window_boundaries.rs
+++ b/orts/tests/burn_window_boundaries.rs
@@ -594,6 +594,26 @@ fn the_reported_edge_agrees_with_the_switch_across_a_leap_second() {
         "reported edge {reported} s against {elapsed} s of burn"
     );
     assert_eq!(system.next_discontinuity_after(reported), None);
+
+    // The load has to switch where the edge says it does. These two offsets
+    // separate the timelines in opposite directions, measured: at +1.5 s the
+    // UTC-JD predicate reads the label 00:00:01Z and calls the burn over while
+    // 0.5 s of it remain, and at +2.0 s it reads 00:00:00Z and calls it running
+    // when it has finished.
+    let acceleration_at = |offset: f64| {
+        let state = orts::OrbitalState::new(Vector3::new(1e12, 0.0, 0.0), Vector3::zeros());
+        system.derivatives(offset, &state).velocity().magnitude()
+    };
+    assert!(
+        acceleration_at(1.5) > 1e-6,
+        "1.5 s in, 0.5 s of the burn remains, got {:.3e} km/s²",
+        acceleration_at(1.5)
+    );
+    assert!(
+        acceleration_at(2.0) < 1e-12,
+        "2.0 s in, the burn has finished, got {:.3e} km/s²",
+        acceleration_at(2.0)
+    );
 }
 
 /// A non-finite edge is left out rather than handed to a loop as a target.

--- a/utsuroi/src/state.rs
+++ b/utsuroi/src/state.rs
@@ -288,4 +288,25 @@ pub trait DynamicalSystem {
     type State: OdeState;
 
     fn derivatives(&self, t: f64, state: &Self::State) -> Self::State;
+
+    /// The next time after `t` at which the right-hand side changes
+    /// discontinuously, if the system knows one in advance.
+    ///
+    /// A solver evaluates the right-hand side at stage times of its own
+    /// choosing, so a term that switches inside a step is sampled at whichever
+    /// stages happen to fall on each side of the switch — and one that switches
+    /// on and off between two stages is not sampled at all. A system that knows
+    /// when it switches can say so here, and a propagation loop can end its
+    /// step there instead.
+    ///
+    /// Implementations must return a finite time strictly greater than `t`, and
+    /// must not report `t` itself. Switches whose time depends on the state
+    /// (a limit the trajectory reaches, a threshold it crosses) are not
+    /// knowable here and are not reported.
+    ///
+    /// The default answers `None`: a system whose right-hand side is continuous
+    /// needs no boundary.
+    fn next_discontinuity_after(&self, _t: f64) -> Option<f64> {
+        None
+    }
 }

--- a/utsuroi/src/state.rs
+++ b/utsuroi/src/state.rs
@@ -304,6 +304,12 @@ pub trait DynamicalSystem {
     /// (a limit the trajectory reaches, a threshold it crosses) are not
     /// knowable here and are not reported.
     ///
+    /// What a system reports is what it knows on its caller's behalf: the
+    /// schedules carried by the parts it holds. A function the caller passed in
+    /// — a prescribed trajectory, a prescribed mass — is the caller's own
+    /// knowledge, and a caller who wrote a piecewise one already holds its
+    /// breakpoints. A propagation loop takes boundaries from both.
+    ///
     /// The default answers `None`: a system whose right-hand side is continuous
     /// needs no boundary.
     fn next_discontinuity_after(&self, _t: f64) -> Option<f64> {


### PR DESCRIPTION
## 概要

`ScheduledBurn` に指定した燃焼が伝播に 1 度も入らず、推進剤の消費も速度変化も 0 になる。
throttle は「その時刻が燃焼区間に入っているか」で決まるので、燃焼区間の中で右辺を 1 度も
評価しなければ燃焼は何も寄与しない。刻みを $h$ とすると隣り合う評価点の最大間隔は
RK4($0, \frac{1}{2}, \frac{1}{2}, 1$)も DP45($0, \frac{1}{5}, \frac{3}{10}, \frac{4}{5},
\frac{8}{9}, 1, 1$)も $h/2$ で、$h/2$ より短い燃焼区間は位置次第でどの評価点も含まない。

![RK4 と DP45 の評価点、およびその間に収まる燃焼区間](https://github.com/user-attachments/assets/ebfadb93-9925-4f5e-9951-a71ab766e9f7)

adaptive でも同じ。評価点が燃焼区間に入らない間、誤差推定は厳密に 0 で、制御器はそのステップを
誤差なしとして受理する。推力 10 N、Isp 300 s、質量 100 kg に `BurnWindow::full(0.1, 0.2)` を
置き、400 km 円軌道を 10 s 伝播した実測(推進剤の期待値 $3.399 \times 10^{-4}$ kg):

| integrator | 受理ステップ | 推進剤 [kg] |
|---|---|---|
| RK4 $h = 1$ | 10 | $0$ |
| DOP853 tol = 1e-6 | 3 | $0$ |
| DOP853 tol = 1e-9 | 17 | $3.394 \times 10^{-4}$ |
| DOP853 tol = 1e-12 | 40 | $3.399 \times 10^{-4}$ |

tolerance を締めた結果は 0 か正しい値のどちらかで、間の値を取らない。

直すには燃焼区間の端でステップを区切る必要がある。端の時刻は model が持っている
(`ScheduledBurn` の `windows`、`ConstantThrust` の 2 つの epoch)。伝播側が端を得る道は 2 つ:
呼び出し元が同じ schedule を二重に持って伝播側に渡すか、伝播側が不連続点を探索する。探索では
誤差推定も内挿も使えず boolean の二分探索になるので、評価回数が増え、1 ステップの中に端が
2 つあると片方を取り落とす。model は端をすでに持っているので、返すだけなら計算が要らない。

伝播ループが手に持っているのは最上位の `DynamicalSystem` 1 つ(`SpacecraftDynamics` か group の
composite)で、その下の model には触れない。**この PR は、その 1 つに問い合わせると右辺全体で
最も早い切り替わり時刻が返る状態にする。**変更は右辺側に閉じていて、#446 で伝播ループが
その時刻を呼び出してステップを終える。`Integrator::step(system, t, state, dt)` は公開なので、
伝播を自分で回している呼び出し元はこの PR の時点で端まで切れる。

影響は orts を library として使う経路に限る。CLI と `orts/src/setup.rs` は `ScheduledBurn` に
到達せず、定義とテストだけが構築する。

## 追加したメソッド

右辺に寄与する 5 trait に、次の切り替わり時刻を返すメソッドを足した。既定は `None` なので、
連続な力を出す既存の実装は変更なしで通る。

```rust
// Model / StateEffector — epoch は eval と同じ形で受ける
fn next_discontinuity_after(&self, t: f64, epoch: Option<&Epoch>) -> Option<f64>;
// ThrustProfile
fn next_throttle_jump_after(&self, t: f64, epoch: Option<&Epoch>) -> Option<f64>;
// DynamicalSystem / InterSatelliteForce — epoch を受け取らない
fn next_discontinuity_after(&self, t: f64) -> Option<f64>;
```

メソッドは integration time を返す。値は `t` より後で finite、`t` 自身は返さない。境界で
ステップを終えたループが、その境界を渡して次を訊いても同じ時刻に留まらない。

`epoch_0` は system が持ち、model は持たない。epoch で schedule を書く model は relative な
`t` だけでは自分の端を integration time に直せないので、eval と同じ形で epoch を受ける。

最上位から model まで問い合わせを転送するのが 5 system と composite 2 つ。5 system は自分が
持つ models と effectors から、composite は子と interaction force から、返ってきた時刻の最小値を
返す。衛星 0 に `windows = [0.1, 0.2)` の `ScheduledBurn` を積んだ 2 機 group なら、`t = 0` の
問い合わせに `ScheduledBurn` が 0.1、衛星 0 の `SpacecraftDynamics` が `min(0.1, None) = 0.1`、
`CoupledGroupDynamics` が `min(0.1, 3.0) = 0.1` を返す(3.0 は interaction force の次の端)。
`CoupledGroupDynamics` が既定の `None` を返すと、`ScheduledBurn` の 0.1 は最上位の答えに
出てこない。

メソッドは、時刻が事前に分かる切り替わりだけを返す。state を読む `ThrustProfile` は `None` を
返し、推進剤の枯渇も `None`(枯渇時刻は到達する質量で決まる)。

## うるう秒をまたぐ burn の加速度が 2 倍だった

`ConstantThrust` は burn の duration を `jd()` ベースで測っていた。
`acceleration = total_dv / duration` なので、duration が 1 秒短く出ると加速度が 2 倍になる。
2016-12-31T23:59:59Z から 2017-01-01T00:00:00Z の実測は `duration_since`(canonical TAI)が
1.999994576 s、`jd()` ベースが 0.999994576 s。このモデル内を canonical TAI に揃えた。
#443 と同型のバグ。

## 検証

テストは返ってくる時刻そのものを assert する。

| 検査 | 内容 |
|---|---|
| 端の列挙 | `[0.1, 0.2)` は 0.1 の次に 0.2、その後は `None`。訊いた時刻自身は返さない |
| 未ソート・隣接区間 | `[5,6)` `[1,2)` `[3,4)` は 1〜6、`[0,1)` と `[1,2)` は 0, 1, 2(1 が 2 回出ない) |
| 最小値を辿る経路 | 2 thruster、group、coupled group、scheduled effector、scheduled interaction force |
| `None` を返すもの | state を読む profile、schedule なしの system、epoch なしの system、非有限の端 |
| epoch schedule | `ConstantThrust` と epoch ベースの `ThrustProfile` が integration time で返す |

各経路に「bare は `None`」と「2 つ載せて最小値を辿る」の 2 本を置いた。うるう秒のテストは、
両判定が逆方向に外れる +1.5 s(燃焼中、JD 判定なら停止)と +2.0 s(停止、JD 判定なら燃焼中)で
load を評価し、`is_active` を JD 版に戻す mutation で落ちる。

## 関連

#446 の一部。境界でステップを終えるだけでは足りない。

![境界で終えたステップの第 4 ステージが区間外に乗り 5/6 しか積分されない](https://github.com/user-attachments/assets/704400de-16a8-4ba2-82ec-f40c417b95ac)

segment mode の設計、RW 飽和と推進剤枯渇を state event として扱う方針も #446 に記録した。
