### PR TITLE
fix(orts,utsuroi): integrate a scheduled burn segment by segment

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -659,11 +659,10 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 ### `utsuroi` (Rust, crates.io)
 
 #### Added
-- `AdaptiveStepper::from_checked_state` と `AdaptiveStepper853::from_checked_state` を追加し、
-  `validate_time_span` を公開した。`advance_to` は開始状態について event 予測子に問い合わせる
-  (level-triggered な event はそこで既に成立しうる)が、前の segment が終えた場所から続く
-  segment では不要で、同じ `(t, state)` を 2 回問い合わせることになる。`validate_time_span` は、
-  span を自分で区切るループが「solver が見ることのない target」を拒否するために要る。([#453](https://github.com/sksat/orts/pull/453))
+- `AdaptiveStepper::from_checked_state` と `AdaptiveStepper853::from_checked_state` を追加。
+  `advance_to` は開始状態について event predicate に問い合わせる (level-triggered な event は
+  そこで既に成立しうる) が、前の segment が終えた場所から続く segment では不要で、同じ
+  `(t, state)` を 2 回問い合わせることになる。([#453](https://github.com/sksat/orts/pull/453))
 - `SegmentContext` / `SegmentSystem` / `DynamicalSystem::derivatives_in_segment`
   (既定は `derivatives` へ転送) を追加。既知の不連続時刻で区切られた区間について右辺を
   評価する。切り替わりで step を終えるだけでは足りない: solver の最後の stage が step の

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -659,6 +659,11 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 ### `utsuroi` (Rust, crates.io)
 
 #### Added
+- `AdaptiveStepper::from_checked_state` と `AdaptiveStepper853::from_checked_state` を追加し、
+  `validate_time_span` を公開した。`advance_to` は開始状態について event 予測子に問い合わせる
+  (level-triggered な event はそこで既に成立しうる)が、前の segment が終えた場所から続く
+  segment では不要で、同じ `(t, state)` を 2 回問い合わせることになる。`validate_time_span` は、
+  span を自分で区切るループが「solver が見ることのない target」を拒否するために要る。([#453](https://github.com/sksat/orts/pull/453))
 - `SegmentContext` / `SegmentSystem` / `DynamicalSystem::derivatives_in_segment`
   (既定は `derivatives` へ転送) を追加。既知の不連続時刻で区切られた区間について右辺を
   評価する。切り替わりでステップを終えるだけでは足りない: solver の最後のステージがステップの

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -669,8 +669,9 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   評価する。切り替わりで step を終えるだけでは足りない: solver の最後の stage が step の
   終端に乗るので、`[a, b)` で on の項が `b` で off と読まれ、RK4 では第 4 stage の重み 1/6 が
   落ちる。`SegmentSystem` で包むと segment が 1 つ束縛され、crate 内の stage ループはどれも
-  変更せずに済む。segment ごとに包み直すことで、adaptive stepper の FSAL derivative が
-  切り替わりを跨がない。([#453](https://github.com/sksat/orts/pull/453))
+  変更せずに済む。segment ごとに包み直すと、DP45 が accept したステップの `k7` を次のステップの
+  `k1` に持ち越すぶんが切り替わりを跨がない。DOP853 は accept 後に `k1` を空にする (reject の
+  再試行のときだけ持つ) ので、そちらで落ちるのは調整済みの step size である。([#453](https://github.com/sksat/orts/pull/453))
 - `IntegrationError` が `core::error::Error` を実装 (手書き、`thiserror` 不使用、
   `no_std` でも動作)。`?` 連鎖や `Box<dyn Error>` に乗るようになった。([#147](https://github.com/sksat/orts/pull/147))
 - テスト: 8 つの積分ループすべてに contract test を追加 (`Integrator` の既定

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -14,7 +14,7 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 - `Model::eval_in_segment` と `ThrustProfile::throttle_in_segment` を追加。引数の
   `EvalSegment` は segment を integration time と開始時刻の絶対時刻の両方で運ぶ (`epoch_0` を
   持つのは system で model ではない)。既定は `eval` / `throttle` への転送で、`ScheduledBurn` は
-  segment 開始時刻の値を返す。これで区間 `[a, b)` は `b` に乗るステージでも on のままになる。
+  segment 開始時刻の値を返す。これで区間 `[a, b)` は `b` に乗る stage でも on のままになる。
   model を評価する 5 つの system と group の composite 2 つが segment を配下に転送する。
   telemetry は `eval` のままなので、`model_breakdown` は区間の終端で区間外を返す。([#453](https://github.com/sksat/orts/pull/453))
 - `StateEffector::derivatives_in_segment` と
@@ -98,17 +98,17 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   20-40% 改善する。([#359](https://github.com/sksat/orts/pull/359))
 
 #### Fixed
-- 積分ステップより短い燃焼も伝播に入るようになった。`IndependentGroup` と `CoupledGroup` は
+- 積分 step より短い燃焼も伝播に入るようになった。`IndependentGroup` と `CoupledGroup` は
   現在時刻から目標時刻まで積分器を 1 回走らせていたので、隣り合う評価点の最大間隔より狭い
   `BurnWindow` が評価点の間に落ちていた。RK4 で `dt = 1` のとき `[0.1, 0.2)` は推進剤
   3.399e-4 kg を 1 つも消さない。tolerance を締めても直らない: 評価点が区間に入らないあいだ
-  誤差推定は厳密に 0 で、制御器はそのステップを受理する。区間がステップ全体を覆う場合も、
-  終端に乗るステージが throttle を off と読むので推進剤が 5/6 になっていた。両方のループが
+  誤差推定は厳密に 0 で、制御器はその step を受理する。区間が step 全体を覆う場合も、
+  終端に乗る stage が throttle を off と読むので推進剤が 5/6 になっていた。両方のループが
   system の報告する境界で span を区切り、segment ごとに束縛した system と新しい stepper で
   積分する。**燃焼を含む軌道と消費推進剤が変わる**。([#453](https://github.com/sksat/orts/pull/453))
 - `ConstantThrust` が Δv を `[start, end]` でなく `[start, end)` に配り、積分中の segment に
   ついて答えるようになった。以前は燃焼区間が両端を数えていたので、その端で span を区切ると、
-  燃焼前の segment の終端ステージと燃焼後の segment の開始ステージが両方とも推力を on と
+  燃焼前の segment の終端 stage と燃焼後の segment の開始 stage が両方とも推力を on と
   読んでいた。0.1 s の燃焼を RK4 `dt = 1` で伝播した実測で、指定 Δv の 4/3 倍を適用していた。
   終端を含めたままにすると segment では stage 単位より悪く、燃焼終了時刻から始まる segment が
   全長にわたって噴射する。**燃焼の最後の瞬間は噴射しなくなり**、燃焼全体の Δv が指定値に
@@ -666,9 +666,9 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   span を自分で区切るループが「solver が見ることのない target」を拒否するために要る。([#453](https://github.com/sksat/orts/pull/453))
 - `SegmentContext` / `SegmentSystem` / `DynamicalSystem::derivatives_in_segment`
   (既定は `derivatives` へ転送) を追加。既知の不連続時刻で区切られた区間について右辺を
-  評価する。切り替わりでステップを終えるだけでは足りない: solver の最後のステージがステップの
-  終端に乗るので、`[a, b)` で on の項が `b` で off と読まれ、RK4 では第 4 ステージの重み 1/6 が
-  落ちる。`SegmentSystem` で包むと segment が 1 つ束縛され、crate 内のステージループはどれも
+  評価する。切り替わりで step を終えるだけでは足りない: solver の最後の stage が step の
+  終端に乗るので、`[a, b)` で on の項が `b` で off と読まれ、RK4 では第 4 stage の重み 1/6 が
+  落ちる。`SegmentSystem` で包むと segment が 1 つ束縛され、crate 内の stage ループはどれも
   変更せずに済む。segment ごとに包み直すことで、adaptive stepper の FSAL derivative が
   切り替わりを跨がない。([#453](https://github.com/sksat/orts/pull/453))
 - `IntegrationError` が `core::error::Error` を実装 (手書き、`thiserror` 不使用、

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -11,6 +11,16 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 ### `orts` (Rust, crates.io)
 
 #### Added
+- `Model::eval_in_segment` と `ThrustProfile::throttle_in_segment` を追加。引数の
+  `EvalSegment` は segment を integration time と開始時刻の絶対時刻の両方で運ぶ (`epoch_0` を
+  持つのは system で model ではない)。既定は `eval` / `throttle` への転送で、`ScheduledBurn` は
+  segment 開始時刻の値を返す。これで区間 `[a, b)` は `b` に乗るステージでも on のままになる。
+  model を評価する 5 つの system と group の composite 2 つが segment を配下に転送する。
+  telemetry は `eval` のままなので、`model_breakdown` は区間の終端で区間外を返す。([#453](https://github.com/sksat/orts/pull/453))
+- `StateEffector::derivatives_in_segment` と
+  `InterSatelliteForce::acceleration_pair_in_segment` を追加 (既定は stage 時刻版への転送)。
+  どちらも境界を報告できるので、segment のあいだ保持すべき schedule を持ちうる。衛星間力の
+  引数が `SegmentContext` なのは、`PairContext` が epoch を運ばないため。([#453](https://github.com/sksat/orts/pull/453))
 - 地上局コンタクトウィンドウ検出 (`visibility` module): `GroundStation`
   (WGS-84 位置 + 仰角マスク)、`ContactWindow` (補間した AOS/LOS、最大仰角、
   span クリップフラグ)、純粋な `PassTracker` ステートマシン、frame-aware な
@@ -88,6 +98,21 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   20-40% 改善する。([#359](https://github.com/sksat/orts/pull/359))
 
 #### Fixed
+- 積分ステップより短い燃焼も伝播に入るようになった。`IndependentGroup` と `CoupledGroup` は
+  現在時刻から目標時刻まで積分器を 1 回走らせていたので、隣り合う評価点の最大間隔より狭い
+  `BurnWindow` が評価点の間に落ちていた。RK4 で `dt = 1` のとき `[0.1, 0.2)` は推進剤
+  3.399e-4 kg を 1 つも消さない。tolerance を締めても直らない: 評価点が区間に入らないあいだ
+  誤差推定は厳密に 0 で、制御器はそのステップを受理する。区間がステップ全体を覆う場合も、
+  終端に乗るステージが throttle を off と読むので推進剤が 5/6 になっていた。両方のループが
+  system の報告する境界で span を区切り、segment ごとに束縛した system と新しい stepper で
+  積分する。**燃焼を含む軌道と消費推進剤が変わる**。([#453](https://github.com/sksat/orts/pull/453))
+- `ConstantThrust` が Δv を `[start, end]` でなく `[start, end)` に配り、積分中の segment に
+  ついて答えるようになった。以前は燃焼区間が両端を数えていたので、その端で span を区切ると、
+  燃焼前の segment の終端ステージと燃焼後の segment の開始ステージが両方とも推力を on と
+  読んでいた。0.1 s の燃焼を RK4 `dt = 1` で伝播した実測で、指定 Δv の 4/3 倍を適用していた。
+  終端を含めたままにすると segment では stage 単位より悪く、燃焼終了時刻から始まる segment が
+  全長にわたって噴射する。**燃焼の最後の瞬間は噴射しなくなり**、燃焼全体の Δv が指定値に
+  一致する。([#453](https://github.com/sksat/orts/pull/453))
 - `PanelSrp` と `PanelDrag` が、一部だけ影に入るパネルに日向のぶんだけの力を、日向の重心で
   与えるようになった。以前はパネルごとに「全部日向」か「全部影」かを答えていたので、半分影に
   入るパネルが面全体ぶんの力を面の中心に出していた。1 m 立方の衛星本体の両側に 2 m x 1 m の
@@ -634,6 +659,13 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 ### `utsuroi` (Rust, crates.io)
 
 #### Added
+- `SegmentContext` / `SegmentSystem` / `DynamicalSystem::derivatives_in_segment`
+  (既定は `derivatives` へ転送) を追加。既知の不連続時刻で区切られた区間について右辺を
+  評価する。切り替わりでステップを終えるだけでは足りない: solver の最後のステージがステップの
+  終端に乗るので、`[a, b)` で on の項が `b` で off と読まれ、RK4 では第 4 ステージの重み 1/6 が
+  落ちる。`SegmentSystem` で包むと segment が 1 つ束縛され、crate 内のステージループはどれも
+  変更せずに済む。segment ごとに包み直すことで、adaptive stepper の FSAL derivative が
+  切り替わりを跨がない。([#453](https://github.com/sksat/orts/pull/453))
 - `IntegrationError` が `core::error::Error` を実装 (手書き、`thiserror` 不使用、
   `no_std` でも動作)。`?` 連鎖や `Box<dyn Error>` に乗るようになった。([#147](https://github.com/sksat/orts/pull/147))
 - テスト: 8 つの積分ループすべてに contract test を追加 (`Integrator` の既定

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -758,13 +758,12 @@ section is subdivided by package.
 
 #### Added
 - `AdaptiveStepper::from_checked_state` and
-  `AdaptiveStepper853::from_checked_state`, and `validate_time_span` is public.
+  `AdaptiveStepper853::from_checked_state`.
   `advance_to` asks the event predicate about the state it starts from, since a
   level-triggered event can already hold there; a stepper built for a segment
   that continues where the previous one ended does not need to, and asking
-  again calls the predicate twice for one `(t, state)`. `validate_time_span`
-  lets a loop that splits its own span reject a target no solver would ever
-  see. ([#453](https://github.com/sksat/orts/pull/453))
+  again calls the predicate twice for one `(t, state)`.
+  ([#453](https://github.com/sksat/orts/pull/453))
 - `SegmentContext`, `SegmentSystem` and `DynamicalSystem::derivatives_in_segment`
   (default forwards to `derivatives`) — evaluating the right-hand side for the
   interval between two known discontinuities. Ending a step at a switch is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -757,6 +757,14 @@ section is subdivided by package.
 ### `utsuroi` (Rust, crates.io)
 
 #### Added
+- `AdaptiveStepper::from_checked_state` and
+  `AdaptiveStepper853::from_checked_state`, and `validate_time_span` is public.
+  `advance_to` asks the event predicate about the state it starts from, since a
+  level-triggered event can already hold there; a stepper built for a segment
+  that continues where the previous one ended does not need to, and asking
+  again calls the predicate twice for one `(t, state)`. `validate_time_span`
+  lets a loop that splits its own span reject a target no solver would ever
+  see. ([#453](https://github.com/sksat/orts/pull/453))
 - `SegmentContext`, `SegmentSystem` and `DynamicalSystem::derivatives_in_segment`
   (default forwards to `derivatives`) — evaluating the right-hand side for the
   interval between two known discontinuities. Ending a step at a switch is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -772,8 +772,9 @@ section is subdivided by package.
   that is on over `[a, b)` reads off there, which costs RK4 the 1/6 its fourth
   stage weighs. Wrapping a system in `SegmentSystem` binds one segment and
   leaves every stage loop in the crate unchanged; building the wrapper per
-  segment also keeps an adaptive stepper's FSAL derivative from crossing the
-  switch. ([#453](https://github.com/sksat/orts/pull/453))
+  segment also keeps DP45 from opening the step after a switch with the `k7` it
+  cached on the other side of it; DOP853 leaves its `k1` empty after an accepted
+  step, so what a fresh stepper drops there is the adapted step size. ([#453](https://github.com/sksat/orts/pull/453))
 - `IntegrationError` now implements `core::error::Error` (by hand, no
   `thiserror`, works under `no_std`), so it participates in `?` chains and
   `Box<dyn Error>`. ([#147](https://github.com/sksat/orts/pull/147))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ section is subdivided by package.
 ### `orts` (Rust, crates.io)
 
 #### Added
+- `Model::eval_in_segment` and `ThrustProfile::throttle_in_segment`, taking an
+  `EvalSegment` — the segment in integration time plus the absolute time at its
+  start, which a system holding `epoch_0` can produce and a model cannot. Both
+  default to `eval` / `throttle`, and `ScheduledBurn` answers for the segment's
+  start, which keeps a window `[a, b)` on at the stage that lands on `b`. The
+  five systems that evaluate models and the two group composites forward the
+  segment to what they hold. Telemetry keeps calling `eval`, so
+  `model_breakdown` at a window's end still reads the window as over. ([#453](https://github.com/sksat/orts/pull/453))
+- `StateEffector::derivatives_in_segment` and
+  `InterSatelliteForce::acceleration_pair_in_segment`, both defaulting to their
+  stage-time counterparts. Either can report a boundary, so either can have a
+  schedule of its own to hold over a segment. A pair force takes
+  `SegmentContext` rather than `EvalSegment`, since `PairContext` carries no
+  epoch. ([#453](https://github.com/sksat/orts/pull/453))
 - Ground-station contact-window detection (`visibility` module): `GroundStation`
   (WGS-84 location + elevation mask), `ContactWindow` (interpolated AOS/LOS, max
   elevation, span-clip flags), the pure `PassTracker` state machine, and a
@@ -102,6 +116,28 @@ section is subdivided by package.
   0.33 m, and the three shorter Harris-Priester oracles by 20-40%. ([#359](https://github.com/sksat/orts/pull/359))
 
 #### Fixed
+- A scheduled burn is flown even when it is shorter than an integration step.
+  `IndependentGroup` and `CoupledGroup` ran the integrator from the current time
+  straight to the target, so a `BurnWindow` narrower than the largest gap
+  between adjacent stage times fell between them: `[0.1, 0.2)` under RK4 with
+  `dt = 1` spent none of its 3.399e-4 kg of propellant. Tightening the tolerance
+  does not help, because while no stage lands inside the window the error
+  estimate is exactly 0 and the controller accepts the step. A window covering a
+  whole step spent 5/6 of its propellant, the stage on its exclusive end reading
+  the throttle as off. Both loops now walk the boundaries the system reports and
+  integrate each segment on a system bound to it, with a fresh stepper per
+  segment. **Trajectories through a scheduled burn change**, as does the
+  propellant spent. ([#453](https://github.com/sksat/orts/pull/453))
+- `ConstantThrust` spreads its Δv over `[start, end)` rather than
+  `[start, end]`, and answers for the segment it is being integrated over. Its
+  burn used to count both of its own ends, so with the span split at those edges
+  the stage on the end of the segment before the burn and the one on the start
+  of the segment after it both read the thrust as on: measured on a 0.1 s burn
+  with RK4 at `dt = 1`, the propagation applied 4/3 of the Δv asked for. Keeping
+  the end inclusive is worse under segments than it was per stage, since the
+  segment beginning where the burn ends would thrust for its whole length.
+  **A burn's last instant no longer thrusts**, and the Δv over the burn is the
+  Δv given. ([#453](https://github.com/sksat/orts/pull/453))
 - `PanelSrp` and `PanelDrag` give a partly shadowed panel the share of the
   force its lit part earns, acting at the centre of that part, instead of a
   whole panel's force at the panel's own centre of pressure. The shadow test
@@ -721,6 +757,15 @@ section is subdivided by package.
 ### `utsuroi` (Rust, crates.io)
 
 #### Added
+- `SegmentContext`, `SegmentSystem` and `DynamicalSystem::derivatives_in_segment`
+  (default forwards to `derivatives`) — evaluating the right-hand side for the
+  interval between two known discontinuities. Ending a step at a switch is not
+  enough on its own: the solver's last stage lands on the step's end, and a term
+  that is on over `[a, b)` reads off there, which costs RK4 the 1/6 its fourth
+  stage weighs. Wrapping a system in `SegmentSystem` binds one segment and
+  leaves every stage loop in the crate unchanged; building the wrapper per
+  segment also keeps an adaptive stepper's FSAL derivative from crossing the
+  switch. ([#453](https://github.com/sksat/orts/pull/453))
 - `IntegrationError` now implements `core::error::Error` (by hand, no
   `thiserror`, works under `no_std`), so it participates in `?` chains and
   `Box<dyn Error>`. ([#147](https://github.com/sksat/orts/pull/147))

--- a/orts/src/attitude/augmented.rs
+++ b/orts/src/attitude/augmented.rs
@@ -6,14 +6,14 @@
 
 use arika::epoch::Epoch;
 use nalgebra::{Matrix3, Vector3};
-use utsuroi::DynamicalSystem;
+use utsuroi::{DynamicalSystem, SegmentContext};
 
 use crate::OrbitalState;
 use crate::attitude::DecoupledContext;
 use crate::attitude::state::AttitudeState;
 use crate::effector::{AugmentedState, AuxRegistry, StateEffector};
 use crate::model::ExternalLoads;
-use crate::model::Model;
+use crate::model::{EvalSegment, Model, eval_maybe_in_segment};
 
 /// Attitude dynamics with prescribed orbit, supporting both pure models
 /// and state effectors.
@@ -155,6 +155,86 @@ impl AugmentedAttitudeSystem {
     }
 }
 
+impl AugmentedAttitudeSystem {
+    /// Shared body of [`derivatives`](DynamicalSystem::derivatives) and
+    /// [`derivatives_in_segment`](DynamicalSystem::derivatives_in_segment).
+    ///
+    /// `segment` is `Some` only on the segment path, where it carries the
+    /// interval's start in both time bases so a model holding a schedule can
+    /// answer for it.
+    fn derivatives_for(
+        &self,
+        segment: Option<&EvalSegment<'_>>,
+        t: f64,
+        state: &AugmentedState<AttitudeState>,
+    ) -> AugmentedState<AttitudeState> {
+        let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
+
+        // 0. Validate auxiliary state length
+        assert_eq!(
+            state.aux.len(),
+            self.registry.total_dim(),
+            "Auxiliary state length ({}) does not match registry ({})",
+            state.aux.len(),
+            self.registry.total_dim()
+        );
+
+        // 1. Construct context with prescribed orbit and mass
+        let context = DecoupledContext {
+            attitude: state.plant.clone(),
+            orbit: (self.orbit_fn)(t),
+            mass: (self.mass_fn)(t),
+        };
+
+        // 2. Evaluate continuous models
+        let mut total = ExternalLoads::zeros();
+        for m in &self.models {
+            total += eval_maybe_in_segment(m, segment, t, &context, epoch.as_ref());
+        }
+
+        // 3. Evaluate state effectors
+        let mut aux_rates = vec![0.0; self.registry.total_dim()];
+        for (i, eff) in self.effectors.iter().enumerate() {
+            let entry = &self.registry.entries()[i];
+            let aux_slice = &state.aux[entry.offset..entry.offset + entry.dim];
+            let rates_slice = &mut aux_rates[entry.offset..entry.offset + entry.dim];
+            // TODO(#446): an effector that reports a boundary needs the same
+            // segment mode as the models. No effector carries a time
+            // schedule yet — a reaction wheel switches on its own momentum,
+            // which is a state event.
+            total += eff.derivatives(t, &context, aux_slice, rates_slice, epoch.as_ref());
+        }
+
+        // 4. Warn if models produce translational forces or mass changes (ignored here)
+        if total.acceleration_inertial.magnitude() > 1e-15 {
+            log::warn!(
+                "AugmentedAttitudeSystem ignoring non-zero acceleration_inertial: {:?}",
+                total.acceleration_inertial
+            );
+        }
+        if total.mass_rate.abs() > 1e-15 {
+            log::warn!(
+                "AugmentedAttitudeSystem ignoring non-zero mass_rate: {}",
+                total.mass_rate
+            );
+        }
+
+        // 5. Quaternion kinematics: dq/dt = 0.5 * q ⊗ (0, ω)
+        let q_dot = state.plant.q_dot();
+
+        // 5. Euler's rotation equation: dω/dt = I⁻¹(τ − ω × (I·ω))
+        let iw = self.inertia * state.plant.angular_velocity;
+        let alpha = self.inertia_inv
+            * (total.torque_body.into_inner() - state.plant.angular_velocity.cross(&iw));
+
+        AugmentedState {
+            plant: AttitudeState::from_derivative(q_dot, alpha),
+            aux: aux_rates,
+            aux_bounds: state.aux_bounds.clone(),
+        }
+    }
+}
+
 impl DynamicalSystem for AugmentedAttitudeSystem {
     type State = AugmentedState<AttitudeState>;
 
@@ -189,66 +269,21 @@ impl DynamicalSystem for AugmentedAttitudeSystem {
         t: f64,
         state: &AugmentedState<AttitudeState>,
     ) -> AugmentedState<AttitudeState> {
-        let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
+        self.derivatives_for(None, t, state)
+    }
 
-        // 0. Validate auxiliary state length
-        assert_eq!(
-            state.aux.len(),
-            self.registry.total_dim(),
-            "Auxiliary state length ({}) does not match registry ({})",
-            state.aux.len(),
-            self.registry.total_dim()
-        );
-
-        // 1. Construct context with prescribed orbit and mass
-        let context = DecoupledContext {
-            attitude: state.plant.clone(),
-            orbit: (self.orbit_fn)(t),
-            mass: (self.mass_fn)(t),
-        };
-
-        // 2. Evaluate continuous models
-        let mut total = ExternalLoads::zeros();
-        for m in &self.models {
-            total += m.eval(t, &context, epoch.as_ref());
-        }
-
-        // 3. Evaluate state effectors
-        let mut aux_rates = vec![0.0; self.registry.total_dim()];
-        for (i, eff) in self.effectors.iter().enumerate() {
-            let entry = &self.registry.entries()[i];
-            let aux_slice = &state.aux[entry.offset..entry.offset + entry.dim];
-            let rates_slice = &mut aux_rates[entry.offset..entry.offset + entry.dim];
-            total += eff.derivatives(t, &context, aux_slice, rates_slice, epoch.as_ref());
-        }
-
-        // 4. Warn if models produce translational forces or mass changes (ignored here)
-        if total.acceleration_inertial.magnitude() > 1e-15 {
-            log::warn!(
-                "AugmentedAttitudeSystem ignoring non-zero acceleration_inertial: {:?}",
-                total.acceleration_inertial
-            );
-        }
-        if total.mass_rate.abs() > 1e-15 {
-            log::warn!(
-                "AugmentedAttitudeSystem ignoring non-zero mass_rate: {}",
-                total.mass_rate
-            );
-        }
-
-        // 5. Quaternion kinematics: dq/dt = 0.5 * q ⊗ (0, ω)
-        let q_dot = state.plant.q_dot();
-
-        // 5. Euler's rotation equation: dω/dt = I⁻¹(τ − ω × (I·ω))
-        let iw = self.inertia * state.plant.angular_velocity;
-        let alpha = self.inertia_inv
-            * (total.torque_body.into_inner() - state.plant.angular_velocity.cross(&iw));
-
-        AugmentedState {
-            plant: AttitudeState::from_derivative(q_dot, alpha),
-            aux: aux_rates,
-            aux_bounds: state.aux_bounds.clone(),
-        }
+    fn derivatives_in_segment(
+        &self,
+        segment: &SegmentContext,
+        t: f64,
+        state: &AugmentedState<AttitudeState>,
+    ) -> AugmentedState<AttitudeState> {
+        let start_epoch = self.epoch_0.map(|e| e.add_si_seconds(segment.start));
+        self.derivatives_for(
+            Some(&EvalSegment::new(segment, start_epoch.as_ref())),
+            t,
+            state,
+        )
     }
 }
 

--- a/orts/src/attitude/augmented.rs
+++ b/orts/src/attitude/augmented.rs
@@ -11,7 +11,7 @@ use utsuroi::{DynamicalSystem, SegmentContext};
 use crate::OrbitalState;
 use crate::attitude::DecoupledContext;
 use crate::attitude::state::AttitudeState;
-use crate::effector::{AugmentedState, AuxRegistry, StateEffector};
+use crate::effector::{AugmentedState, AuxRegistry, StateEffector, effector_derivatives};
 use crate::model::ExternalLoads;
 use crate::model::{EvalSegment, Model, eval_maybe_in_segment};
 
@@ -198,11 +198,15 @@ impl AugmentedAttitudeSystem {
             let entry = &self.registry.entries()[i];
             let aux_slice = &state.aux[entry.offset..entry.offset + entry.dim];
             let rates_slice = &mut aux_rates[entry.offset..entry.offset + entry.dim];
-            // TODO(#446): an effector that reports a boundary needs the same
-            // segment mode as the models. No effector carries a time
-            // schedule yet — a reaction wheel switches on its own momentum,
-            // which is a state event.
-            total += eff.derivatives(t, &context, aux_slice, rates_slice, epoch.as_ref());
+            total += effector_derivatives(
+                eff.as_ref(),
+                segment,
+                t,
+                &context,
+                aux_slice,
+                rates_slice,
+                epoch.as_ref(),
+            );
         }
 
         // 4. Warn if models produce translational forces or mass changes (ignored here)

--- a/orts/src/attitude/decoupled.rs
+++ b/orts/src/attitude/decoupled.rs
@@ -1,11 +1,13 @@
 use arika::epoch::Epoch;
 use nalgebra::{Matrix3, Vector3};
-use utsuroi::DynamicalSystem;
+use utsuroi::{DynamicalSystem, SegmentContext};
 
 use crate::OrbitalState;
 use crate::attitude::AttitudeState;
 use crate::model::ExternalLoads;
-use crate::model::{HasAttitude, HasFrame, HasMass, HasOrbit, Model};
+use crate::model::{
+    EvalSegment, HasAttitude, HasFrame, HasMass, HasOrbit, Model, eval_maybe_in_segment,
+};
 
 /// Combined state providing attitude, orbit, and mass for decoupled models.
 ///
@@ -120,28 +122,19 @@ impl DecoupledAttitudeSystem {
     }
 }
 
-impl DynamicalSystem for DecoupledAttitudeSystem {
-    type State = AttitudeState;
-
-    /// The earliest boundary any model reports.
+impl DecoupledAttitudeSystem {
+    /// Shared body of [`derivatives`](DynamicalSystem::derivatives) and
+    /// [`derivatives_in_segment`](DynamicalSystem::derivatives_in_segment).
     ///
-    /// A model that switches on a schedule reports when; a system holding one
-    /// has to pass that on, or a propagation loop stepping the system would
-    /// never see it.
-    ///
-    /// `orbit_fn` and `mass_fn` are the caller's own functions, so their
-    /// breakpoints are not reported here — a caller who passes a piecewise one
-    /// holds its schedule already, and hands it to the propagation loop the same
-    /// way it hands over the span.
-    fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
-        let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
-        self.models
-            .iter()
-            .filter_map(|m| m.next_discontinuity_after(t, epoch.as_ref()))
-            .min_by(f64::total_cmp)
-    }
-
-    fn derivatives(&self, t: f64, state: &AttitudeState) -> AttitudeState {
+    /// `segment` is `Some` only on the segment path, where it carries the
+    /// interval's start in both time bases so a model holding a schedule can
+    /// answer for it.
+    fn derivatives_for(
+        &self,
+        segment: Option<&EvalSegment<'_>>,
+        t: f64,
+        state: &AttitudeState,
+    ) -> AttitudeState {
         let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
 
         // 1. Construct context with prescribed orbit and mass
@@ -157,7 +150,7 @@ impl DynamicalSystem for DecoupledAttitudeSystem {
         // 3. Total loads from all models
         let mut total = ExternalLoads::zeros();
         for m in &self.models {
-            total += m.eval(t, &context, epoch.as_ref());
+            total += eval_maybe_in_segment(m, segment, t, &context, epoch.as_ref());
         }
 
         // 4. Warn if models produce translational forces or mass changes (ignored here)
@@ -180,6 +173,46 @@ impl DynamicalSystem for DecoupledAttitudeSystem {
             self.inertia_inv * (total.torque_body.into_inner() - state.angular_velocity.cross(&iw));
 
         AttitudeState::from_derivative(q_dot, alpha)
+    }
+}
+
+impl DynamicalSystem for DecoupledAttitudeSystem {
+    type State = AttitudeState;
+
+    /// The earliest boundary any model reports.
+    ///
+    /// A model that switches on a schedule reports when; a system holding one
+    /// has to pass that on, or a propagation loop stepping the system would
+    /// never see it.
+    ///
+    /// `orbit_fn` and `mass_fn` are the caller's own functions, so their
+    /// breakpoints are not reported here — a caller who passes a piecewise one
+    /// holds its schedule already, and hands it to the propagation loop the same
+    /// way it hands over the span.
+    fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
+        let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
+        self.models
+            .iter()
+            .filter_map(|m| m.next_discontinuity_after(t, epoch.as_ref()))
+            .min_by(f64::total_cmp)
+    }
+
+    fn derivatives(&self, t: f64, state: &AttitudeState) -> AttitudeState {
+        self.derivatives_for(None, t, state)
+    }
+
+    fn derivatives_in_segment(
+        &self,
+        segment: &SegmentContext,
+        t: f64,
+        state: &AttitudeState,
+    ) -> AttitudeState {
+        let start_epoch = self.epoch_0.map(|e| e.add_si_seconds(segment.start));
+        self.derivatives_for(
+            Some(&EvalSegment::new(segment, start_epoch.as_ref())),
+            t,
+            state,
+        )
     }
 }
 

--- a/orts/src/attitude/system.rs
+++ b/orts/src/attitude/system.rs
@@ -1,8 +1,8 @@
 use arika::epoch::Epoch;
 use nalgebra::{Matrix3, Vector3};
-use utsuroi::DynamicalSystem;
+use utsuroi::{DynamicalSystem, SegmentContext};
 
-use crate::model::Model;
+use crate::model::{EvalSegment, Model, eval_maybe_in_segment};
 
 use super::state::AttitudeState;
 
@@ -60,6 +60,39 @@ impl AttitudeSystem {
     }
 }
 
+impl AttitudeSystem {
+    /// Shared body of [`derivatives`](DynamicalSystem::derivatives) and
+    /// [`derivatives_in_segment`](DynamicalSystem::derivatives_in_segment).
+    ///
+    /// `segment` is `Some` only on the segment path, where it carries the
+    /// interval's start in both time bases so a model holding a schedule can
+    /// answer for it.
+    fn derivatives_for(
+        &self,
+        segment: Option<&EvalSegment<'_>>,
+        t: f64,
+        state: &AttitudeState,
+    ) -> AttitudeState {
+        let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
+
+        // 1. Quaternion kinematics: dq/dt = 0.5 * q ⊗ (0, ω)
+        let q_dot = state.q_dot();
+
+        // 2. Total torque from all models
+        let mut tau = Vector3::zeros();
+        for m in &self.models {
+            let loads = eval_maybe_in_segment(m, segment, t, state, epoch.as_ref());
+            tau += loads.torque_body.into_inner();
+        }
+
+        // 3. Euler's rotation equation: dω/dt = I⁻¹(τ − ω × (I·ω))
+        let iw = self.inertia * state.angular_velocity;
+        let alpha = self.inertia_inv * (tau - state.angular_velocity.cross(&iw));
+
+        AttitudeState::from_derivative(q_dot, alpha)
+    }
+}
+
 impl DynamicalSystem for AttitudeSystem {
     type State = AttitudeState;
 
@@ -77,23 +110,21 @@ impl DynamicalSystem for AttitudeSystem {
     }
 
     fn derivatives(&self, t: f64, state: &AttitudeState) -> AttitudeState {
-        let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
+        self.derivatives_for(None, t, state)
+    }
 
-        // 1. Quaternion kinematics: dq/dt = 0.5 * q ⊗ (0, ω)
-        let q_dot = state.q_dot();
-
-        // 2. Total torque from all models
-        let mut tau = Vector3::zeros();
-        for m in &self.models {
-            let loads = m.eval(t, state, epoch.as_ref());
-            tau += loads.torque_body.into_inner();
-        }
-
-        // 3. Euler's rotation equation: dω/dt = I⁻¹(τ − ω × (I·ω))
-        let iw = self.inertia * state.angular_velocity;
-        let alpha = self.inertia_inv * (tau - state.angular_velocity.cross(&iw));
-
-        AttitudeState::from_derivative(q_dot, alpha)
+    fn derivatives_in_segment(
+        &self,
+        segment: &SegmentContext,
+        t: f64,
+        state: &AttitudeState,
+    ) -> AttitudeState {
+        let start_epoch = self.epoch_0.map(|e| e.add_si_seconds(segment.start));
+        self.derivatives_for(
+            Some(&EvalSegment::new(segment, start_epoch.as_ref())),
+            t,
+            state,
+        )
     }
 }
 

--- a/orts/src/effector.rs
+++ b/orts/src/effector.rs
@@ -72,6 +72,35 @@ pub trait StateEffector<S: HasFrame>: Send + Sync + std::any::Any {
         epoch: Option<&Epoch>,
     ) -> ExternalLoads<S::Frame>;
 
+    /// Loads and auxiliary rates for the segment a solver is stepping through.
+    ///
+    /// An effector that reports a boundary through
+    /// [`next_discontinuity_after`](Self::next_discontinuity_after) has its
+    /// switch turned into the end of a segment, and the stage that lands there
+    /// belongs to the step integrating the segment before it. Answering for
+    /// [`segment.start`](crate::model::EvalSegment::start) — and
+    /// [`segment.start_epoch`](crate::model::EvalSegment::start_epoch) for a
+    /// schedule written in epochs — keeps that stage on the inside of a
+    /// half-open interval ending there.
+    ///
+    /// `t`, `state`, `aux` and `epoch` still describe the stage, so an effector
+    /// whose contribution varies continuously — a reaction wheel following its
+    /// own momentum — keeps using them. Only a switch in time is held.
+    ///
+    /// The default ignores the segment and forwards to
+    /// [`derivatives`](Self::derivatives).
+    fn derivatives_in_segment(
+        &self,
+        _segment: &crate::model::EvalSegment<'_>,
+        t: f64,
+        state: &S,
+        aux: &[f64],
+        aux_rates: &mut [f64],
+        epoch: Option<&Epoch>,
+    ) -> ExternalLoads<S::Frame> {
+        self.derivatives(t, state, aux, aux_rates, epoch)
+    }
+
     /// Per-element (min, max) bounds for auxiliary state projection.
     ///
     /// By default returns unbounded `(-INF, +INF)` for each element.
@@ -79,6 +108,26 @@ pub trait StateEffector<S: HasFrame>: Send + Sync + std::any::Any {
     /// momentum saturation).
     fn aux_bounds(&self) -> Vec<(f64, f64)> {
         vec![(f64::NEG_INFINITY, f64::INFINITY); self.state_dim()]
+    }
+}
+
+/// Loads and auxiliary rates from `effector`, for the segment when there is one.
+///
+/// Every system that holds effectors evaluates them through this, so the
+/// segment reaches the effector instead of stopping at the system.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn effector_derivatives<S: HasFrame>(
+    effector: &(impl StateEffector<S> + ?Sized),
+    segment: Option<&crate::model::EvalSegment<'_>>,
+    t: f64,
+    state: &S,
+    aux: &[f64],
+    aux_rates: &mut [f64],
+    epoch: Option<&Epoch>,
+) -> ExternalLoads<S::Frame> {
+    match segment {
+        Some(segment) => effector.derivatives_in_segment(segment, t, state, aux, aux_rates, epoch),
+        None => effector.derivatives(t, state, aux, aux_rates, epoch),
     }
 }
 

--- a/orts/src/group/coupled.rs
+++ b/orts/src/group/coupled.rs
@@ -428,8 +428,9 @@ where
 
         // One segment at a time, so that no switch of the right-hand side
         // falls strictly inside a step and the stage on a segment's end reads
-        // the mode that held inside it. A fresh stepper per segment is what
-        // keeps a DP45 or DOP853 FSAL derivative from crossing the switch.
+        // the mode that held inside it. A fresh stepper per segment also keeps
+        // DP45 from opening the step after a switch with the `k7` it cached on
+        // the other side of it.
         let mut first_segment = true;
         while !self.terminated && self.t < t_target {
             let segment_end = self

--- a/orts/src/group/coupled.rs
+++ b/orts/src/group/coupled.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use nalgebra::Vector3;
 use utsuroi::{
     AdvanceOutcome, AdvanceOutcome853, Dop853, DormandPrince, DynamicalSystem, IntegrationError,
-    Integrator, OdeState, Rk4, Tolerances,
+    Integrator, OdeState, Rk4, SegmentContext, Tolerances, derivatives_maybe_in_segment,
 };
 
 use super::prop_group::{GroupSnapshot, PropGroupOutcome, SatId, SatelliteTermination};
@@ -153,6 +153,67 @@ where
     }
 }
 
+impl<D: DynamicalSystem> CoupledGroupDynamics<D>
+where
+    D::State: HasPosition + FromAcceleration,
+{
+    /// Shared body of [`derivatives`](DynamicalSystem::derivatives) and
+    /// [`derivatives_in_segment`](DynamicalSystem::derivatives_in_segment).
+    ///
+    /// On the segment path the satellites are asked for the same segment: a
+    /// composite that stepped its children outside it would leave their
+    /// schedules reading the stage time again.
+    fn derivatives_for(
+        &self,
+        segment: Option<&SegmentContext>,
+        t: f64,
+        state: &GroupState<D::State>,
+    ) -> GroupState<D::State> {
+        assert_eq!(
+            self.dynamics.len(),
+            state.states.len(),
+            "CoupledGroupDynamics: dynamics count ({}) != state count ({})",
+            self.dynamics.len(),
+            state.states.len()
+        );
+
+        // 1. Per-satellite derivatives (gravity, drag, etc.)
+        let mut derivs: Vec<D::State> = self
+            .dynamics
+            .iter()
+            .zip(&state.states)
+            .map(|(d, s)| derivatives_maybe_in_segment(d, segment, t, s))
+            .collect();
+
+        // 2. Add inter-satellite force accelerations
+        for pair in &self.interactions {
+            assert!(
+                pair.i < state.states.len() && pair.j < state.states.len(),
+                "InteractionPair indices ({}, {}) out of range for {} satellites",
+                pair.i,
+                pair.j,
+                state.states.len()
+            );
+
+            let pos_i = state.states[pair.i].position();
+            let pos_j = state.states[pair.j].position();
+            // TODO(#446): an inter-satellite force that reports a boundary needs
+            // the same segment mode as the models. Mutual gravitation, the
+            // only force here, is continuous.
+            let ctx = PairContext {
+                t,
+                pos_i: &pos_i,
+                pos_j: &pos_j,
+            };
+            let (a_i, a_j) = pair.force.acceleration_pair(&ctx);
+            derivs[pair.i] = derivs[pair.i].axpy(1.0, &D::State::from_acceleration(a_i));
+            derivs[pair.j] = derivs[pair.j].axpy(1.0, &D::State::from_acceleration(a_j));
+        }
+
+        GroupState { states: derivs }
+    }
+}
+
 impl<D: DynamicalSystem> DynamicalSystem for CoupledGroupDynamics<D>
 where
     D::State: HasPosition + FromAcceleration,
@@ -181,45 +242,16 @@ where
     }
 
     fn derivatives(&self, t: f64, state: &GroupState<D::State>) -> GroupState<D::State> {
-        assert_eq!(
-            self.dynamics.len(),
-            state.states.len(),
-            "CoupledGroupDynamics: dynamics count ({}) != state count ({})",
-            self.dynamics.len(),
-            state.states.len()
-        );
+        self.derivatives_for(None, t, state)
+    }
 
-        // 1. Per-satellite derivatives (gravity, drag, etc.)
-        let mut derivs: Vec<D::State> = self
-            .dynamics
-            .iter()
-            .zip(&state.states)
-            .map(|(d, s)| d.derivatives(t, s))
-            .collect();
-
-        // 2. Add inter-satellite force accelerations
-        for pair in &self.interactions {
-            assert!(
-                pair.i < state.states.len() && pair.j < state.states.len(),
-                "InteractionPair indices ({}, {}) out of range for {} satellites",
-                pair.i,
-                pair.j,
-                state.states.len()
-            );
-
-            let pos_i = state.states[pair.i].position();
-            let pos_j = state.states[pair.j].position();
-            let ctx = PairContext {
-                t,
-                pos_i: &pos_i,
-                pos_j: &pos_j,
-            };
-            let (a_i, a_j) = pair.force.acceleration_pair(&ctx);
-            derivs[pair.i] = derivs[pair.i].axpy(1.0, &D::State::from_acceleration(a_i));
-            derivs[pair.j] = derivs[pair.j].axpy(1.0, &D::State::from_acceleration(a_j));
-        }
-
-        GroupState { states: derivs }
+    fn derivatives_in_segment(
+        &self,
+        segment: &SegmentContext,
+        t: f64,
+        state: &GroupState<D::State>,
+    ) -> GroupState<D::State> {
+        self.derivatives_for(Some(segment), t, state)
     }
 }
 

--- a/orts/src/group/coupled.rs
+++ b/orts/src/group/coupled.rs
@@ -5,7 +5,7 @@ use nalgebra::Vector3;
 use utsuroi::{
     AdvanceOutcome, AdvanceOutcome853, Dop853, DormandPrince, DynamicalSystem, IntegrationError,
     Integrator, OdeState, Rk4, SegmentContext, SegmentSystem, Tolerances,
-    derivatives_maybe_in_segment, validate_time_span,
+    derivatives_maybe_in_segment,
 };
 
 use super::prop_group::{GroupSnapshot, PropGroupOutcome, SatId, SatelliteTermination};
@@ -406,6 +406,15 @@ where
     }
 
     pub fn propagate_to(&mut self, t_target: f64) -> Result<PropGroupOutcome, IntegrationError> {
+        // Before the no-op guard below: `self.t >= t_target` is false for
+        // `-inf` and for a NaN, so an invalid target would otherwise be
+        // reported as a span already covered.
+        if !t_target.is_finite() {
+            return Err(IntegrationError::InvalidTimeSpan {
+                t0: self.t,
+                t_end: t_target,
+            });
+        }
         if self.terminated || self.t >= t_target {
             return Ok(PropGroupOutcome {
                 terminations: Vec::new(),
@@ -416,10 +425,6 @@ where
         // fixed-step RK4 branch below would otherwise spin on `h = 0` (or walk
         // backwards for `dt < 0`) forever.
         self.integrator.validate()?;
-        // And reject a target no loop can walk to: the segment loop below tests
-        // `self.t < t_target` before building a stepper, so a non-finite target
-        // would take no step and report success from where it started.
-        validate_time_span(self.t, t_target)?;
 
         // One segment at a time, so that no switch of the right-hand side
         // falls strictly inside a step and the stage on a segment's end reads

--- a/orts/src/group/coupled.rs
+++ b/orts/src/group/coupled.rs
@@ -407,9 +407,12 @@ where
 
     pub fn propagate_to(&mut self, t_target: f64) -> Result<PropGroupOutcome, IntegrationError> {
         // Before the no-op guard below: `self.t >= t_target` is false for
-        // `-inf` and for a NaN, so an invalid target would otherwise be
-        // reported as a span already covered.
-        if !t_target.is_finite() {
+        // `-inf` and for a NaN, so an invalid span would otherwise be reported
+        // as one already covered. `set_t` takes any `f64`, so the current time
+        // is part of what has to be finite — the adaptive steppers used to
+        // reject it through `validate_time_span`, which the segment loop now
+        // reaches only after deciding to step.
+        if !self.t.is_finite() || !t_target.is_finite() {
             return Err(IntegrationError::InvalidTimeSpan {
                 t0: self.t,
                 t_end: t_target,

--- a/orts/src/group/coupled.rs
+++ b/orts/src/group/coupled.rs
@@ -44,6 +44,24 @@ pub trait InterSatelliteForce: Send + Sync {
     fn next_discontinuity_after(&self, _t: f64) -> Option<f64> {
         None
     }
+
+    /// The pair's accelerations for the segment a solver is stepping through.
+    ///
+    /// A force that reports a boundary has its switch turned into the end of a
+    /// segment, and the stage landing there belongs to the step integrating the
+    /// segment before it. Answering for `segment.start` keeps that stage on the
+    /// inside of a half-open interval ending there; `ctx` still describes the
+    /// stage, so a force that varies continuously keeps reading it.
+    ///
+    /// The default ignores the segment and forwards to
+    /// [`acceleration_pair`](Self::acceleration_pair).
+    fn acceleration_pair_in_segment(
+        &self,
+        _segment: &SegmentContext,
+        ctx: &PairContext<'_>,
+    ) -> (Vector3<f64>, Vector3<f64>) {
+        self.acceleration_pair(ctx)
+    }
 }
 
 /// A specific satellite-pair interaction: indices into the group + force model.
@@ -198,15 +216,15 @@ where
 
             let pos_i = state.states[pair.i].position();
             let pos_j = state.states[pair.j].position();
-            // TODO(#446): an inter-satellite force that reports a boundary needs
-            // the same segment mode as the models. Mutual gravitation, the
-            // only force here, is continuous.
             let ctx = PairContext {
                 t,
                 pos_i: &pos_i,
                 pos_j: &pos_j,
             };
-            let (a_i, a_j) = pair.force.acceleration_pair(&ctx);
+            let (a_i, a_j) = match segment {
+                Some(segment) => pair.force.acceleration_pair_in_segment(segment, &ctx),
+                None => pair.force.acceleration_pair(&ctx),
+            };
             derivs[pair.i] = derivs[pair.i].axpy(1.0, &D::State::from_acceleration(a_i));
             derivs[pair.j] = derivs[pair.j].axpy(1.0, &D::State::from_acceleration(a_j));
         }

--- a/orts/src/group/coupled.rs
+++ b/orts/src/group/coupled.rs
@@ -5,7 +5,7 @@ use nalgebra::Vector3;
 use utsuroi::{
     AdvanceOutcome, AdvanceOutcome853, Dop853, DormandPrince, DynamicalSystem, IntegrationError,
     Integrator, OdeState, Rk4, SegmentContext, SegmentSystem, Tolerances,
-    derivatives_maybe_in_segment,
+    derivatives_maybe_in_segment, validate_time_span,
 };
 
 use super::prop_group::{GroupSnapshot, PropGroupOutcome, SatId, SatelliteTermination};
@@ -416,6 +416,10 @@ where
         // fixed-step RK4 branch below would otherwise spin on `h = 0` (or walk
         // backwards for `dt < 0`) forever.
         self.integrator.validate()?;
+        // And reject a target no loop can walk to: the segment loop below tests
+        // `self.t < t_target` before building a stepper, so a non-finite target
+        // would take no step and report success from where it started.
+        validate_time_span(self.t, t_target)?;
 
         // One segment at a time, so that no switch of the right-hand side
         // falls strictly inside a step and the stage on a segment's end reads
@@ -440,6 +444,12 @@ where
                         *dt,
                         tolerances.clone(),
                     );
+                    // The state a later segment starts from is the one the
+                    // previous segment ended on, already checked after its last
+                    // accepted step.
+                    if !first_segment {
+                        stepper = stepper.from_checked_state();
+                    }
 
                     // Build group-level event checker that iterates over all satellites
                     let ids = self.ids.clone();
@@ -519,6 +529,12 @@ where
                 IntegratorConfig::Dop853 { dt, tolerances } => {
                     let mut stepper =
                         Dop853.stepper(&bound, self.state.clone(), self.t, *dt, tolerances.clone());
+                    // The state a later segment starts from is the one the
+                    // previous segment ended on, already checked after its last
+                    // accepted step.
+                    if !first_segment {
+                        stepper = stepper.from_checked_state();
+                    }
 
                     let ids = self.ids.clone();
                     let event_checker = &self.event_checker;

--- a/orts/src/group/coupled.rs
+++ b/orts/src/group/coupled.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use nalgebra::Vector3;
 use utsuroi::{
     AdvanceOutcome, AdvanceOutcome853, Dop853, DormandPrince, DynamicalSystem, IntegrationError,
-    Integrator, OdeState, Rk4, SegmentContext, Tolerances, derivatives_maybe_in_segment,
+    Integrator, OdeState, Rk4, SegmentContext, SegmentSystem, Tolerances,
+    derivatives_maybe_in_segment,
 };
 
 use super::prop_group::{GroupSnapshot, PropGroupOutcome, SatId, SatelliteTermination};
@@ -398,235 +399,193 @@ where
         // backwards for `dt < 0`) forever.
         self.integrator.validate()?;
 
-        match &self.integrator {
-            IntegratorConfig::Dp45 { dt, tolerances } => {
-                let mut stepper = DormandPrince.stepper(
-                    &self.dynamics,
-                    self.state.clone(),
-                    self.t,
-                    *dt,
-                    tolerances.clone(),
-                );
+        // One segment at a time, so that no switch of the right-hand side
+        // falls strictly inside a step and the stage on a segment's end reads
+        // the mode that held inside it. A fresh stepper per segment is what
+        // keeps a DP45 or DOP853 FSAL derivative from crossing the switch.
+        let mut first_segment = true;
+        while !self.terminated && self.t < t_target {
+            let segment_end = self
+                .dynamics
+                .next_discontinuity_after(self.t)
+                .filter(|next| *next > self.t && next.is_finite())
+                .map_or(t_target, |next| next.min(t_target));
+            let bound =
+                SegmentSystem::new(&self.dynamics, SegmentContext::new(self.t, segment_end));
 
-                // Build group-level event checker that iterates over all satellites
-                let ids = self.ids.clone();
-                let event_checker = &self.event_checker;
+            let outcome = match &self.integrator {
+                IntegratorConfig::Dp45 { dt, tolerances } => {
+                    let mut stepper = DormandPrince.stepper(
+                        &bound,
+                        self.state.clone(),
+                        self.t,
+                        *dt,
+                        tolerances.clone(),
+                    );
 
-                let result = if let Some(checker) = event_checker {
-                    stepper.advance_to(
-                        t_target,
-                        |_, _| {},
-                        |t: f64, gs: &GroupState<D::State>| {
-                            for (id, sat_state) in ids.iter().zip(&gs.states) {
-                                if let ControlFlow::Break(reason) = checker(t, sat_state) {
-                                    return ControlFlow::Break((id.clone(), reason));
+                    // Build group-level event checker that iterates over all satellites
+                    let ids = self.ids.clone();
+                    let event_checker = &self.event_checker;
+
+                    let result = if let Some(checker) = event_checker {
+                        stepper.advance_to(
+                            segment_end,
+                            |_, _| {},
+                            |t: f64, gs: &GroupState<D::State>| {
+                                for (id, sat_state) in ids.iter().zip(&gs.states) {
+                                    if let ControlFlow::Break(reason) = checker(t, sat_state) {
+                                        return ControlFlow::Break((id.clone(), reason));
+                                    }
                                 }
-                            }
-                            ControlFlow::Continue(())
-                        },
-                    )
-                } else {
-                    stepper.advance_to(
-                        t_target,
-                        |_, _| {},
-                        |_: f64, _: &GroupState<D::State>| {
-                            ControlFlow::<(SatId, String)>::Continue(())
-                        },
-                    )
-                };
+                                ControlFlow::Continue(())
+                            },
+                        )
+                    } else {
+                        stepper.advance_to(
+                            segment_end,
+                            |_, _| {},
+                            |_: f64, _: &GroupState<D::State>| {
+                                ControlFlow::<(SatId, String)>::Continue(())
+                            },
+                        )
+                    };
 
-                match result {
-                    Ok(AdvanceOutcome::Reached) => {
-                        self.state = stepper.into_state();
-                        self.t = t_target;
-                        Ok(PropGroupOutcome {
-                            terminations: Vec::new(),
-                        })
-                    }
-                    Ok(AdvanceOutcome::Event {
-                        reason: (sat_id, reason),
-                    }) => {
-                        let t = stepper.t();
-                        self.state = stepper.into_state();
-                        self.t = t;
-                        self.terminated = true;
-                        self.is_event_termination = true;
-                        let term = SatelliteTermination {
-                            satellite_id: sat_id,
-                            t,
-                            reason,
-                        };
-                        self.termination = Some(term.clone());
-                        Ok(PropGroupOutcome {
-                            terminations: vec![term],
-                        })
-                    }
-                    Err(e) => {
-                        self.terminated = true;
-                        // Pre-flight rejections (bad dt/tolerances) carry no
-                        // time of their own; attribute them to where the
-                        // stepper was asked to start.
-                        let t = e.time().unwrap_or(self.t);
-                        let term = SatelliteTermination {
-                            satellite_id: self
-                                .ids
-                                .first()
-                                .cloned()
-                                .unwrap_or_else(|| SatId::from("unknown")),
-                            t,
-                            reason: format!("{e:?}"),
-                        };
-                        self.termination = Some(term.clone());
-                        Ok(PropGroupOutcome {
-                            terminations: vec![term],
-                        })
-                    }
-                }
-            }
-            IntegratorConfig::Dop853 { dt, tolerances } => {
-                let mut stepper = Dop853.stepper(
-                    &self.dynamics,
-                    self.state.clone(),
-                    self.t,
-                    *dt,
-                    tolerances.clone(),
-                );
-
-                let ids = self.ids.clone();
-                let event_checker = &self.event_checker;
-
-                let result = if let Some(checker) = event_checker {
-                    stepper.advance_to(
-                        t_target,
-                        |_, _| {},
-                        |t: f64, gs: &GroupState<D::State>| {
-                            for (id, sat_state) in ids.iter().zip(&gs.states) {
-                                if let ControlFlow::Break(reason) = checker(t, sat_state) {
-                                    return ControlFlow::Break((id.clone(), reason));
-                                }
-                            }
-                            ControlFlow::Continue(())
-                        },
-                    )
-                } else {
-                    stepper.advance_to(
-                        t_target,
-                        |_, _| {},
-                        |_: f64, _: &GroupState<D::State>| {
-                            ControlFlow::<(SatId, String)>::Continue(())
-                        },
-                    )
-                };
-
-                match result {
-                    Ok(AdvanceOutcome853::Reached) => {
-                        self.state = stepper.into_state();
-                        self.t = t_target;
-                        Ok(PropGroupOutcome {
-                            terminations: Vec::new(),
-                        })
-                    }
-                    Ok(AdvanceOutcome853::Event {
-                        reason: (sat_id, reason),
-                    }) => {
-                        let t = stepper.t();
-                        self.state = stepper.into_state();
-                        self.t = t;
-                        self.terminated = true;
-                        self.is_event_termination = true;
-                        let term = SatelliteTermination {
-                            satellite_id: sat_id,
-                            t,
-                            reason,
-                        };
-                        self.termination = Some(term.clone());
-                        Ok(PropGroupOutcome {
-                            terminations: vec![term],
-                        })
-                    }
-                    Err(e) => {
-                        self.terminated = true;
-                        // Pre-flight rejections (bad dt/tolerances) carry no
-                        // time of their own; attribute them to where the
-                        // stepper was asked to start.
-                        let t = e.time().unwrap_or(self.t);
-                        let term = SatelliteTermination {
-                            satellite_id: self
-                                .ids
-                                .first()
-                                .cloned()
-                                .unwrap_or_else(|| SatId::from("unknown")),
-                            t,
-                            reason: format!("{e:?}"),
-                        };
-                        self.termination = Some(term.clone());
-                        Ok(PropGroupOutcome {
-                            terminations: vec![term],
-                        })
-                    }
-                }
-            }
-            IntegratorConfig::Rk4 { dt } => {
-                let dt = *dt;
-                let mut current_t = self.t;
-                let mut current_state = self.state.clone();
-
-                // The predicate is asked about the state this call starts
-                // from, before any step. A level-triggered event can already
-                // hold there, and stepping first reports it one step late.
-                if let Some(ref checker) = self.event_checker {
-                    for (id, sat_state) in self.ids.iter().zip(&current_state.states) {
-                        if let ControlFlow::Break(reason) = checker(current_t, sat_state) {
-                            self.state = current_state;
-                            self.t = current_t;
+                    match result {
+                        Ok(AdvanceOutcome::Reached) => {
+                            self.state = stepper.into_state();
+                            self.t = segment_end;
+                            Ok(PropGroupOutcome {
+                                terminations: Vec::new(),
+                            })
+                        }
+                        Ok(AdvanceOutcome::Event {
+                            reason: (sat_id, reason),
+                        }) => {
+                            let t = stepper.t();
+                            self.state = stepper.into_state();
+                            self.t = t;
                             self.terminated = true;
                             self.is_event_termination = true;
                             let term = SatelliteTermination {
-                                satellite_id: id.clone(),
-                                t: current_t,
+                                satellite_id: sat_id,
+                                t,
                                 reason,
                             };
                             self.termination = Some(term.clone());
-                            return Ok(PropGroupOutcome {
+                            Ok(PropGroupOutcome {
                                 terminations: vec![term],
-                            });
+                            })
+                        }
+                        Err(e) => {
+                            self.terminated = true;
+                            // Pre-flight rejections (bad dt/tolerances) carry no
+                            // time of their own; attribute them to where the
+                            // stepper was asked to start.
+                            let t = e.time().unwrap_or(self.t);
+                            let term = SatelliteTermination {
+                                satellite_id: self
+                                    .ids
+                                    .first()
+                                    .cloned()
+                                    .unwrap_or_else(|| SatId::from("unknown")),
+                                t,
+                                reason: format!("{e:?}"),
+                            };
+                            self.termination = Some(term.clone());
+                            Ok(PropGroupOutcome {
+                                terminations: vec![term],
+                            })
                         }
                     }
                 }
+                IntegratorConfig::Dop853 { dt, tolerances } => {
+                    let mut stepper =
+                        Dop853.stepper(&bound, self.state.clone(), self.t, *dt, tolerances.clone());
 
-                while current_t < t_target - 1e-12 {
-                    let h = dt.min(t_target - current_t);
-                    // `h > 0` after the validate() above, but for large
-                    // `|current_t|` it can still be below the f64 spacing there.
-                    if current_t + h == current_t {
-                        return Err(IntegrationError::TimeStagnated {
-                            t: current_t,
-                            dt: h,
-                        });
+                    let ids = self.ids.clone();
+                    let event_checker = &self.event_checker;
+
+                    let result = if let Some(checker) = event_checker {
+                        stepper.advance_to(
+                            segment_end,
+                            |_, _| {},
+                            |t: f64, gs: &GroupState<D::State>| {
+                                for (id, sat_state) in ids.iter().zip(&gs.states) {
+                                    if let ControlFlow::Break(reason) = checker(t, sat_state) {
+                                        return ControlFlow::Break((id.clone(), reason));
+                                    }
+                                }
+                                ControlFlow::Continue(())
+                            },
+                        )
+                    } else {
+                        stepper.advance_to(
+                            segment_end,
+                            |_, _| {},
+                            |_: f64, _: &GroupState<D::State>| {
+                                ControlFlow::<(SatId, String)>::Continue(())
+                            },
+                        )
+                    };
+
+                    match result {
+                        Ok(AdvanceOutcome853::Reached) => {
+                            self.state = stepper.into_state();
+                            self.t = segment_end;
+                            Ok(PropGroupOutcome {
+                                terminations: Vec::new(),
+                            })
+                        }
+                        Ok(AdvanceOutcome853::Event {
+                            reason: (sat_id, reason),
+                        }) => {
+                            let t = stepper.t();
+                            self.state = stepper.into_state();
+                            self.t = t;
+                            self.terminated = true;
+                            self.is_event_termination = true;
+                            let term = SatelliteTermination {
+                                satellite_id: sat_id,
+                                t,
+                                reason,
+                            };
+                            self.termination = Some(term.clone());
+                            Ok(PropGroupOutcome {
+                                terminations: vec![term],
+                            })
+                        }
+                        Err(e) => {
+                            self.terminated = true;
+                            // Pre-flight rejections (bad dt/tolerances) carry no
+                            // time of their own; attribute them to where the
+                            // stepper was asked to start.
+                            let t = e.time().unwrap_or(self.t);
+                            let term = SatelliteTermination {
+                                satellite_id: self
+                                    .ids
+                                    .first()
+                                    .cloned()
+                                    .unwrap_or_else(|| SatId::from("unknown")),
+                                t,
+                                reason: format!("{e:?}"),
+                            };
+                            self.termination = Some(term.clone());
+                            Ok(PropGroupOutcome {
+                                terminations: vec![term],
+                            })
+                        }
                     }
-                    current_state = Rk4.step(&self.dynamics, current_t, &current_state, h);
-                    current_t += h;
+                }
+                IntegratorConfig::Rk4 { dt } => {
+                    let dt = *dt;
+                    let mut current_t = self.t;
+                    let mut current_state = self.state.clone();
 
-                    if !current_state.is_finite() {
-                        self.state = current_state;
-                        self.t = current_t;
-                        self.terminated = true;
-                        let term = SatelliteTermination {
-                            satellite_id: self
-                                .ids
-                                .first()
-                                .cloned()
-                                .unwrap_or_else(|| SatId::from("unknown")),
-                            t: current_t,
-                            reason: "NonFiniteState".to_string(),
-                        };
-                        self.termination = Some(term.clone());
-                        return Ok(PropGroupOutcome {
-                            terminations: vec![term],
-                        });
-                    }
-
-                    if let Some(ref checker) = self.event_checker {
+                    // The predicate is asked about the state this call starts
+                    // from, before any step. A level-triggered event can already
+                    // hold there, and stepping first reports it one step late.
+                    // Later segments start from a state the loop already checked.
+                    if first_segment && let Some(ref checker) = self.event_checker {
                         for (id, sat_state) in self.ids.iter().zip(&current_state.states) {
                             if let ControlFlow::Break(reason) = checker(current_t, sat_state) {
                                 self.state = current_state;
@@ -645,15 +604,88 @@ where
                             }
                         }
                     }
-                }
 
-                self.state = current_state;
-                self.t = current_t;
-                Ok(PropGroupOutcome {
-                    terminations: Vec::new(),
-                })
+                    while current_t < segment_end {
+                        // The last step of a segment lands on its end exactly.
+                        // Accumulating `h` leaves `current_t` an ulp short, and the
+                        // next `h` is then small enough to stagnate.
+                        let last = segment_end - current_t <= dt;
+                        let h = if last { segment_end - current_t } else { dt };
+                        // `h > 0` after the validate() above, but for large
+                        // `|current_t|` it can still be below the f64 spacing there.
+                        if current_t + h == current_t {
+                            if last {
+                                // The segment is narrower than the spacing of f64
+                                // here: no step size crosses it, and no change of
+                                // state over it is representable either.
+                                current_t = segment_end;
+                                continue;
+                            }
+                            return Err(IntegrationError::TimeStagnated {
+                                t: current_t,
+                                dt: h,
+                            });
+                        }
+                        current_state = Rk4.step(&bound, current_t, &current_state, h);
+                        current_t = if last { segment_end } else { current_t + h };
+
+                        if !current_state.is_finite() {
+                            self.state = current_state;
+                            self.t = current_t;
+                            self.terminated = true;
+                            let term = SatelliteTermination {
+                                satellite_id: self
+                                    .ids
+                                    .first()
+                                    .cloned()
+                                    .unwrap_or_else(|| SatId::from("unknown")),
+                                t: current_t,
+                                reason: "NonFiniteState".to_string(),
+                            };
+                            self.termination = Some(term.clone());
+                            return Ok(PropGroupOutcome {
+                                terminations: vec![term],
+                            });
+                        }
+
+                        if let Some(ref checker) = self.event_checker {
+                            for (id, sat_state) in self.ids.iter().zip(&current_state.states) {
+                                if let ControlFlow::Break(reason) = checker(current_t, sat_state) {
+                                    self.state = current_state;
+                                    self.t = current_t;
+                                    self.terminated = true;
+                                    self.is_event_termination = true;
+                                    let term = SatelliteTermination {
+                                        satellite_id: id.clone(),
+                                        t: current_t,
+                                        reason,
+                                    };
+                                    self.termination = Some(term.clone());
+                                    return Ok(PropGroupOutcome {
+                                        terminations: vec![term],
+                                    });
+                                }
+                            }
+                        }
+                    }
+
+                    self.state = current_state;
+                    self.t = current_t;
+                    Ok(PropGroupOutcome {
+                        terminations: Vec::new(),
+                    })
+                }
+            };
+
+            if self.terminated {
+                return outcome;
             }
+            first_segment = false;
         }
+
+        Ok(PropGroupOutcome {
+            terminations: Vec::new(),
+        })
     }
 
     pub fn snapshot(&self) -> GroupSnapshot {

--- a/orts/src/group/dynamics.rs
+++ b/orts/src/group/dynamics.rs
@@ -1,4 +1,4 @@
-use utsuroi::DynamicalSystem;
+use utsuroi::{DynamicalSystem, SegmentContext, derivatives_maybe_in_segment};
 
 use super::state::GroupState;
 
@@ -18,10 +18,19 @@ impl<D: DynamicalSystem> IndependentGroupDynamics<D> {
     }
 }
 
-impl<D: DynamicalSystem> DynamicalSystem for IndependentGroupDynamics<D> {
-    type State = GroupState<D::State>;
-
-    fn derivatives(&self, t: f64, state: &GroupState<D::State>) -> GroupState<D::State> {
+impl<D: DynamicalSystem> IndependentGroupDynamics<D> {
+    /// Shared body of [`derivatives`](DynamicalSystem::derivatives) and
+    /// [`derivatives_in_segment`](DynamicalSystem::derivatives_in_segment).
+    ///
+    /// On the segment path the children are asked for the same segment: a
+    /// composite that stepped its children outside it would leave their
+    /// schedules reading the stage time again.
+    fn derivatives_for(
+        &self,
+        segment: Option<&SegmentContext>,
+        t: f64,
+        state: &GroupState<D::State>,
+    ) -> GroupState<D::State> {
         assert_eq!(
             self.dynamics.len(),
             state.states.len(),
@@ -34,9 +43,26 @@ impl<D: DynamicalSystem> DynamicalSystem for IndependentGroupDynamics<D> {
                 .dynamics
                 .iter()
                 .zip(&state.states)
-                .map(|(dyn_sys, s)| dyn_sys.derivatives(t, s))
+                .map(|(dyn_sys, s)| derivatives_maybe_in_segment(dyn_sys, segment, t, s))
                 .collect(),
         }
+    }
+}
+
+impl<D: DynamicalSystem> DynamicalSystem for IndependentGroupDynamics<D> {
+    type State = GroupState<D::State>;
+
+    fn derivatives(&self, t: f64, state: &GroupState<D::State>) -> GroupState<D::State> {
+        self.derivatives_for(None, t, state)
+    }
+
+    fn derivatives_in_segment(
+        &self,
+        segment: &SegmentContext,
+        t: f64,
+        state: &GroupState<D::State>,
+    ) -> GroupState<D::State> {
+        self.derivatives_for(Some(segment), t, state)
     }
 
     /// The earliest boundary any satellite reports.

--- a/orts/src/group/independent.rs
+++ b/orts/src/group/independent.rs
@@ -3,7 +3,6 @@ use std::ops::ControlFlow;
 use utsuroi::{
     AdvanceOutcome, AdvanceOutcome853, Dop853, DormandPrince, DynamicalSystem, IntegrationError,
     Integrator, OdeState, Rk4, SegmentContext, SegmentSystem, Tolerances, validate_step_size,
-    validate_time_span,
 };
 
 use super::HasPosition;
@@ -294,6 +293,19 @@ where
         let event_checker = &self.event_checker;
 
         for (entry, dynamics) in &mut self.satellites {
+            // The target the caller asked for, before any guard or clamp reads
+            // it. Each of the three below hides a non-finite target instead of
+            // rejecting it: `entry.t >= t_target` is true for `-inf` and skips
+            // the satellite, `f64::min` drops a NaN in favour of a finite
+            // `end_time`, and the segment loop tests `entry.t <
+            // effective_target` before building a stepper, so no solver ever
+            // sees the target either.
+            if !t_target.is_finite() {
+                return Err(IntegrationError::InvalidTimeSpan {
+                    t0: entry.t,
+                    t_end: t_target,
+                });
+            }
             if entry.terminated || entry.t >= t_target {
                 continue;
             }
@@ -307,13 +319,6 @@ where
             if entry.t >= effective_target {
                 continue;
             }
-            // Past that guard the target is ahead of this satellite, or it is
-            // not a number. The segment loop below tests `entry.t <
-            // effective_target` before it builds a stepper, so a non-finite
-            // target would take no step and report success from where the
-            // satellite started, without any solver seeing the target to
-            // reject it.
-            validate_time_span(entry.t, effective_target)?;
 
             // One segment at a time, so that no switch of the right-hand side
             // falls strictly inside a step and the stage on a segment's end

--- a/orts/src/group/independent.rs
+++ b/orts/src/group/independent.rs
@@ -322,9 +322,9 @@ where
 
             // One segment at a time, so that no switch of the right-hand side
             // falls strictly inside a step and the stage on a segment's end
-            // reads the mode that held inside it. A fresh stepper per segment is
-            // what keeps a DP45 or DOP853 FSAL derivative from crossing the
-            // switch.
+            // reads the mode that held inside it. A fresh stepper per segment
+            // also keeps DP45 from opening the step after a switch with the
+            // `k7` it cached on the other side of it.
             let mut first_segment = true;
             while !entry.terminated && entry.t < effective_target {
                 let segment_end = dynamics

--- a/orts/src/group/independent.rs
+++ b/orts/src/group/independent.rs
@@ -326,6 +326,15 @@ where
 
             // Clamp to per-satellite end_time if set
             let effective_target = match entry.end_time {
+                // `f64::min` returns the other operand for a NaN, so a NaN end
+                // time would quietly mean the opposite of what it says: no end
+                // at all. `add_satellite_until` takes any `f64`.
+                Some(et) if et.is_nan() => {
+                    return Err(IntegrationError::InvalidTimeSpan {
+                        t0: entry.t,
+                        t_end: et,
+                    });
+                }
                 Some(et) => t_target.min(et),
                 None => t_target,
             };

--- a/orts/src/group/independent.rs
+++ b/orts/src/group/independent.rs
@@ -3,6 +3,7 @@ use std::ops::ControlFlow;
 use utsuroi::{
     AdvanceOutcome, AdvanceOutcome853, Dop853, DormandPrince, DynamicalSystem, IntegrationError,
     Integrator, OdeState, Rk4, SegmentContext, SegmentSystem, Tolerances, validate_step_size,
+    validate_time_span,
 };
 
 use super::HasPosition;
@@ -306,6 +307,13 @@ where
             if entry.t >= effective_target {
                 continue;
             }
+            // Past that guard the target is ahead of this satellite, or it is
+            // not a number. The segment loop below tests `entry.t <
+            // effective_target` before it builds a stepper, so a non-finite
+            // target would take no step and report success from where the
+            // satellite started, without any solver seeing the target to
+            // reject it.
+            validate_time_span(entry.t, effective_target)?;
 
             // One segment at a time, so that no switch of the right-hand side
             // falls strictly inside a step and the stage on a segment's end
@@ -330,6 +338,12 @@ where
                             *dt,
                             tolerances.clone(),
                         );
+                        // The state a later segment starts from is the one the
+                        // previous segment ended on, and the loop checked it
+                        // after that segment's last accepted step.
+                        if !first_segment {
+                            stepper = stepper.from_checked_state();
+                        }
 
                         let result = stepper.advance_to(
                             segment_end,
@@ -378,6 +392,12 @@ where
                             *dt,
                             tolerances.clone(),
                         );
+                        // The state a later segment starts from is the one the
+                        // previous segment ended on, and the loop checked it
+                        // after that segment's last accepted step.
+                        if !first_segment {
+                            stepper = stepper.from_checked_state();
+                        }
 
                         let result = stepper.advance_to(
                             segment_end,

--- a/orts/src/group/independent.rs
+++ b/orts/src/group/independent.rs
@@ -287,20 +287,34 @@ where
         // satellite: the fixed-step RK4 branch below would otherwise spin on
         // `h = 0` (or walk backwards for `dt < 0`) forever.
         self.integrator.validate()?;
+        // The target the caller asked for, before the loop reshapes it per
+        // satellite. Each of the three steps below hides a non-finite target
+        // instead of rejecting it: `entry.t >= t_target` is true for `-inf` and
+        // skips the satellite, `f64::min` drops a NaN in favour of a finite
+        // `end_time`, and the segment loop tests `entry.t < effective_target`
+        // before building a stepper, so no solver ever sees the target. A group
+        // with no satellites has nothing to name as the start of the span, and
+        // a satellite added without a time of its own starts at zero.
+        if !t_target.is_finite() {
+            return Err(IntegrationError::InvalidTimeSpan {
+                t0: self.satellites.first().map_or(0.0, |(entry, _)| entry.t),
+                t_end: t_target,
+            });
+        }
 
         let mut terminations = Vec::new();
         let integrator = self.integrator.clone();
         let event_checker = &self.event_checker;
 
         for (entry, dynamics) in &mut self.satellites {
-            // The target the caller asked for, before any guard or clamp reads
-            // it. Each of the three below hides a non-finite target instead of
-            // rejecting it: `entry.t >= t_target` is true for `-inf` and skips
-            // the satellite, `f64::min` drops a NaN in favour of a finite
-            // `end_time`, and the segment loop tests `entry.t <
-            // effective_target` before building a stepper, so no solver ever
-            // sees the target either.
-            if !t_target.is_finite() {
+            // A satellite's own time, before the guards read it.
+            // `add_satellite_at` takes any `f64`, and every comparison below is
+            // false for a NaN: the guard would not skip it, and the segment
+            // loop's `entry.t < effective_target` would end the loop before a
+            // solver saw the span. The adaptive steppers used to reject it
+            // through `validate_time_span`, which the segment loop now reaches
+            // only after deciding to step.
+            if !entry.t.is_finite() {
                 return Err(IntegrationError::InvalidTimeSpan {
                     t0: entry.t,
                     t_end: t_target,

--- a/orts/src/group/independent.rs
+++ b/orts/src/group/independent.rs
@@ -2,7 +2,7 @@ use std::ops::ControlFlow;
 
 use utsuroi::{
     AdvanceOutcome, AdvanceOutcome853, Dop853, DormandPrince, DynamicalSystem, IntegrationError,
-    Integrator, OdeState, Rk4, Tolerances, validate_step_size,
+    Integrator, OdeState, Rk4, SegmentContext, SegmentSystem, Tolerances, validate_step_size,
 };
 
 use super::HasPosition;
@@ -307,157 +307,132 @@ where
                 continue;
             }
 
-            match &integrator {
-                IntegratorConfig::Dp45 { dt, tolerances } => {
-                    let mut stepper = DormandPrince.stepper(
-                        dynamics,
-                        entry.state.clone(),
-                        entry.t,
-                        *dt,
-                        tolerances.clone(),
-                    );
+            // One segment at a time, so that no switch of the right-hand side
+            // falls strictly inside a step and the stage on a segment's end
+            // reads the mode that held inside it. A fresh stepper per segment is
+            // what keeps a DP45 or DOP853 FSAL derivative from crossing the
+            // switch.
+            let mut first_segment = true;
+            while !entry.terminated && entry.t < effective_target {
+                let segment_end = dynamics
+                    .next_discontinuity_after(entry.t)
+                    .filter(|next| *next > entry.t && next.is_finite())
+                    .map_or(effective_target, |next| next.min(effective_target));
+                let bound =
+                    SegmentSystem::new(&*dynamics, SegmentContext::new(entry.t, segment_end));
 
-                    let result = stepper.advance_to(
-                        effective_target,
-                        |t, s| observer(&entry.id, t, s),
-                        |t, s| match event_checker {
-                            Some(checker) => checker(t, s),
-                            None => ControlFlow::Continue(()),
-                        },
-                    );
+                match &integrator {
+                    IntegratorConfig::Dp45 { dt, tolerances } => {
+                        let mut stepper = DormandPrince.stepper(
+                            &bound,
+                            entry.state.clone(),
+                            entry.t,
+                            *dt,
+                            tolerances.clone(),
+                        );
 
-                    match result {
-                        Ok(AdvanceOutcome::Reached) => {
-                            entry.state = stepper.into_state();
-                            entry.t = effective_target;
-                        }
-                        Ok(AdvanceOutcome::Event { reason }) => {
-                            let t = stepper.t();
-                            entry.state = stepper.into_state();
-                            entry.t = t;
-                            entry.terminated = true;
-                            terminations.push(SatelliteTermination {
-                                satellite_id: entry.id.clone(),
-                                t,
-                                reason,
-                            });
-                        }
-                        Err(e) => {
-                            entry.terminated = true;
-                            // Pre-flight rejections (bad dt/tolerances) carry
-                            // no time of their own; attribute them to where
-                            // the stepper was asked to start.
-                            let t = e.time().unwrap_or(entry.t);
-                            terminations.push(SatelliteTermination {
-                                satellite_id: entry.id.clone(),
-                                t,
-                                reason: format!("{e:?}"),
-                            });
-                        }
-                    }
-                }
-                IntegratorConfig::Dop853 { dt, tolerances } => {
-                    let mut stepper = Dop853.stepper(
-                        dynamics,
-                        entry.state.clone(),
-                        entry.t,
-                        *dt,
-                        tolerances.clone(),
-                    );
+                        let result = stepper.advance_to(
+                            segment_end,
+                            |t, s| observer(&entry.id, t, s),
+                            |t, s| match event_checker {
+                                Some(checker) => checker(t, s),
+                                None => ControlFlow::Continue(()),
+                            },
+                        );
 
-                    let result = stepper.advance_to(
-                        effective_target,
-                        |t, s| observer(&entry.id, t, s),
-                        |t, s| match event_checker {
-                            Some(checker) => checker(t, s),
-                            None => ControlFlow::Continue(()),
-                        },
-                    );
-
-                    match result {
-                        Ok(AdvanceOutcome853::Reached) => {
-                            entry.state = stepper.into_state();
-                            entry.t = effective_target;
-                        }
-                        Ok(AdvanceOutcome853::Event { reason }) => {
-                            let t = stepper.t();
-                            entry.state = stepper.into_state();
-                            entry.t = t;
-                            entry.terminated = true;
-                            terminations.push(SatelliteTermination {
-                                satellite_id: entry.id.clone(),
-                                t,
-                                reason,
-                            });
-                        }
-                        Err(e) => {
-                            entry.terminated = true;
-                            // Pre-flight rejections (bad dt/tolerances) carry
-                            // no time of their own; attribute them to where
-                            // the stepper was asked to start.
-                            let t = e.time().unwrap_or(entry.t);
-                            terminations.push(SatelliteTermination {
-                                satellite_id: entry.id.clone(),
-                                t,
-                                reason: format!("{e:?}"),
-                            });
+                        match result {
+                            Ok(AdvanceOutcome::Reached) => {
+                                entry.state = stepper.into_state();
+                                entry.t = segment_end;
+                            }
+                            Ok(AdvanceOutcome::Event { reason }) => {
+                                let t = stepper.t();
+                                entry.state = stepper.into_state();
+                                entry.t = t;
+                                entry.terminated = true;
+                                terminations.push(SatelliteTermination {
+                                    satellite_id: entry.id.clone(),
+                                    t,
+                                    reason,
+                                });
+                            }
+                            Err(e) => {
+                                entry.terminated = true;
+                                // Pre-flight rejections (bad dt/tolerances) carry
+                                // no time of their own; attribute them to where
+                                // the stepper was asked to start.
+                                let t = e.time().unwrap_or(entry.t);
+                                terminations.push(SatelliteTermination {
+                                    satellite_id: entry.id.clone(),
+                                    t,
+                                    reason: format!("{e:?}"),
+                                });
+                            }
                         }
                     }
-                }
-                IntegratorConfig::Rk4 { dt } => {
-                    let dt = *dt;
-                    let mut current_t = entry.t;
-                    let mut current_state = entry.state.clone();
+                    IntegratorConfig::Dop853 { dt, tolerances } => {
+                        let mut stepper = Dop853.stepper(
+                            &bound,
+                            entry.state.clone(),
+                            entry.t,
+                            *dt,
+                            tolerances.clone(),
+                        );
 
-                    let mut terminated = false;
-                    // The predicate is asked about the state this call starts from,
-                    // before any step. A level-triggered event can already hold there,
-                    // and stepping first reports it one step late.
-                    if let Some(checker) = event_checker
-                        && let ControlFlow::Break(reason) = checker(current_t, &current_state)
-                    {
-                        entry.terminated = true;
-                        terminated = true;
-                        terminations.push(SatelliteTermination {
-                            satellite_id: entry.id.clone(),
-                            t: current_t,
-                            reason,
-                        });
+                        let result = stepper.advance_to(
+                            segment_end,
+                            |t, s| observer(&entry.id, t, s),
+                            |t, s| match event_checker {
+                                Some(checker) => checker(t, s),
+                                None => ControlFlow::Continue(()),
+                            },
+                        );
+
+                        match result {
+                            Ok(AdvanceOutcome853::Reached) => {
+                                entry.state = stepper.into_state();
+                                entry.t = segment_end;
+                            }
+                            Ok(AdvanceOutcome853::Event { reason }) => {
+                                let t = stepper.t();
+                                entry.state = stepper.into_state();
+                                entry.t = t;
+                                entry.terminated = true;
+                                terminations.push(SatelliteTermination {
+                                    satellite_id: entry.id.clone(),
+                                    t,
+                                    reason,
+                                });
+                            }
+                            Err(e) => {
+                                entry.terminated = true;
+                                // Pre-flight rejections (bad dt/tolerances) carry
+                                // no time of their own; attribute them to where
+                                // the stepper was asked to start.
+                                let t = e.time().unwrap_or(entry.t);
+                                terminations.push(SatelliteTermination {
+                                    satellite_id: entry.id.clone(),
+                                    t,
+                                    reason: format!("{e:?}"),
+                                });
+                            }
+                        }
                     }
-                    while !terminated && current_t < effective_target - 1e-12 {
-                        let h = dt.min(effective_target - current_t);
-                        // `h > 0` after the validate() above, but for large
-                        // `|current_t|` it can still be below the f64 spacing
-                        // there.
-                        if current_t + h == current_t {
-                            return Err(IntegrationError::TimeStagnated {
-                                t: current_t,
-                                dt: h,
-                            });
-                        }
-                        current_state = Rk4.step(dynamics, current_t, &current_state, h);
-                        current_t += h;
+                    IntegratorConfig::Rk4 { dt } => {
+                        let dt = *dt;
+                        let mut current_t = entry.t;
+                        let mut current_state = entry.state.clone();
 
-                        if !current_state.is_finite() {
-                            entry.t = current_t;
-                            entry.terminated = true;
-                            terminated = true;
-                            terminations.push(SatelliteTermination {
-                                satellite_id: entry.id.clone(),
-                                t: current_t,
-                                reason: "NonFiniteState".to_string(),
-                            });
-                            break;
-                        }
-
-                        // Same ordering as the adaptive steppers: observe the
-                        // accepted step before the event check.
-                        observer(&entry.id, current_t, &current_state);
-
-                        if let Some(checker) = event_checker
+                        let mut terminated = false;
+                        // The predicate is asked about the state this call starts from,
+                        // before any step. A level-triggered event can already hold there,
+                        // and stepping first reports it one step late. Later segments
+                        // start where the previous one ended, whose state the loop
+                        // already checked.
+                        if first_segment
+                            && let Some(checker) = event_checker
                             && let ControlFlow::Break(reason) = checker(current_t, &current_state)
                         {
-                            entry.t = current_t;
                             entry.terminated = true;
                             terminated = true;
                             terminations.push(SatelliteTermination {
@@ -465,15 +440,74 @@ where
                                 t: current_t,
                                 reason,
                             });
-                            break;
+                        }
+                        while !terminated && current_t < segment_end {
+                            // The last step of a segment lands on its end exactly.
+                            // Accumulating `h` instead leaves `current_t` an ulp
+                            // short, and the next `h` is then small enough to
+                            // stagnate. The segment's end is a switch of the
+                            // right-hand side, so landing near it is not enough.
+                            let last = segment_end - current_t <= dt;
+                            let h = if last { segment_end - current_t } else { dt };
+                            // `h > 0` after the validate() above, but for large
+                            // `|current_t|` it can still be below the f64 spacing
+                            // there.
+                            if current_t + h == current_t {
+                                if last {
+                                    // The segment is narrower than the spacing of
+                                    // f64 here. No step size crosses it, and no
+                                    // change of state over it is representable
+                                    // either.
+                                    current_t = segment_end;
+                                    continue;
+                                }
+                                return Err(IntegrationError::TimeStagnated {
+                                    t: current_t,
+                                    dt: h,
+                                });
+                            }
+                            current_state = Rk4.step(&bound, current_t, &current_state, h);
+                            current_t = if last { segment_end } else { current_t + h };
+
+                            if !current_state.is_finite() {
+                                entry.t = current_t;
+                                entry.terminated = true;
+                                terminated = true;
+                                terminations.push(SatelliteTermination {
+                                    satellite_id: entry.id.clone(),
+                                    t: current_t,
+                                    reason: "NonFiniteState".to_string(),
+                                });
+                                break;
+                            }
+
+                            // Same ordering as the adaptive steppers: observe the
+                            // accepted step before the event check.
+                            observer(&entry.id, current_t, &current_state);
+
+                            if let Some(checker) = event_checker
+                                && let ControlFlow::Break(reason) =
+                                    checker(current_t, &current_state)
+                            {
+                                entry.t = current_t;
+                                entry.terminated = true;
+                                terminated = true;
+                                terminations.push(SatelliteTermination {
+                                    satellite_id: entry.id.clone(),
+                                    t: current_t,
+                                    reason,
+                                });
+                                break;
+                            }
+                        }
+
+                        entry.state = current_state;
+                        if !terminated {
+                            entry.t = current_t;
                         }
                     }
-
-                    entry.state = current_state;
-                    if !terminated {
-                        entry.t = current_t;
-                    }
                 }
+                first_segment = false;
             }
         }
 

--- a/orts/src/model.rs
+++ b/orts/src/model.rs
@@ -18,6 +18,7 @@ use arika::epoch::Epoch;
 use arika::frame::SimpleEci;
 use arika::frame::{self, Body, Rotation, Vec3};
 use nalgebra::Vector3;
+use utsuroi::SegmentContext;
 
 use crate::OrbitalState;
 use crate::attitude::AttitudeState;
@@ -211,6 +212,76 @@ pub trait Model<S: HasFrame>: Send + Sync {
     fn next_discontinuity_after(&self, _t: f64, _epoch: Option<&Epoch>) -> Option<f64> {
         None
     }
+
+    /// Evaluate the model for the segment a solver is stepping through.
+    ///
+    /// The stage on a segment's end has to read the loads that held inside the
+    /// segment: a burn window `[a, b)` is over at `b`, but the stage there is
+    /// the last one of the step that integrates the window, and RK4 weights it
+    /// `1/6`. A model that switches on a schedule answers for
+    /// [`segment.start`](EvalSegment::start) — and for
+    /// [`segment.start_epoch`](EvalSegment::start_epoch) if its schedule is
+    /// written in epochs — however late in the segment `t` falls.
+    ///
+    /// `t`, `state` and `epoch` still describe the stage, so a model whose
+    /// loads vary continuously keeps using them. Only the switch is held.
+    ///
+    /// The default ignores the segment and forwards to [`eval`](Self::eval),
+    /// which is right for every model that has no schedule to hold.
+    /// Telemetry keeps calling `eval`, so a breakdown at a window's end reads
+    /// the window as over.
+    fn eval_in_segment(
+        &self,
+        _segment: &EvalSegment<'_>,
+        t: f64,
+        state: &S,
+        epoch: Option<&Epoch>,
+    ) -> ExternalLoads<S::Frame> {
+        self.eval(t, state, epoch)
+    }
+}
+
+/// The segment a model is being evaluated for, in both time bases.
+///
+/// `start` and `end` are integration times, as [`Model::eval`] receives `t`.
+/// `start_epoch` is the absolute time at `start`, which a system holding
+/// `epoch_0` can produce and a model cannot.
+#[derive(Debug, Clone, Copy)]
+pub struct EvalSegment<'a> {
+    /// Integration time the segment starts at.
+    pub start: f64,
+    /// Integration time the segment ends at.
+    pub end: f64,
+    /// Absolute time at `start`, or `None` when no initial epoch was given.
+    pub start_epoch: Option<&'a Epoch>,
+}
+
+impl<'a> EvalSegment<'a> {
+    /// The segment `times` spans, with the absolute time at its start.
+    pub fn new(times: &SegmentContext, start_epoch: Option<&'a Epoch>) -> Self {
+        Self {
+            start: times.start,
+            end: times.end,
+            start_epoch,
+        }
+    }
+}
+
+/// Loads from `model`, for the segment when there is one.
+///
+/// Every system that holds models evaluates them through this, so the segment
+/// reaches the models it holds instead of stopping at the system.
+pub(crate) fn eval_maybe_in_segment<S: HasFrame>(
+    model: &(impl Model<S> + ?Sized),
+    segment: Option<&EvalSegment<'_>>,
+    t: f64,
+    state: &S,
+    epoch: Option<&Epoch>,
+) -> ExternalLoads<S::Frame> {
+    match segment {
+        Some(segment) => model.eval_in_segment(segment, t, state, epoch),
+        None => model.eval(t, state, epoch),
+    }
 }
 
 // Blanket impl so Box<dyn Model<S>> also satisfies Model<S>.
@@ -226,6 +297,16 @@ impl<S: HasFrame> Model<S> for Box<dyn Model<S>> {
 
     fn next_discontinuity_after(&self, t: f64, epoch: Option<&Epoch>) -> Option<f64> {
         (**self).next_discontinuity_after(t, epoch)
+    }
+
+    fn eval_in_segment(
+        &self,
+        segment: &EvalSegment<'_>,
+        t: f64,
+        state: &S,
+        epoch: Option<&Epoch>,
+    ) -> ExternalLoads<S::Frame> {
+        (**self).eval_in_segment(segment, t, state, epoch)
     }
 }
 

--- a/orts/src/orbital/system.rs
+++ b/orts/src/orbital/system.rs
@@ -2,10 +2,10 @@ use std::marker::PhantomData;
 
 use arika::epoch::Epoch;
 use arika::frame::{Eci, SimpleEci};
-use utsuroi::DynamicalSystem;
+use utsuroi::{DynamicalSystem, SegmentContext};
 
 use super::gravity::GravityField;
-use crate::model::Model;
+use crate::model::{EvalSegment, Model, eval_maybe_in_segment};
 use crate::orbital::OrbitalState;
 
 /// Orbital dynamics system combining a gravity field model with perturbation forces.
@@ -76,6 +76,29 @@ impl<F: Eci> OrbitalSystem<F> {
     }
 }
 
+impl<F: Eci> OrbitalSystem<F> {
+    /// Shared body of [`derivatives`](DynamicalSystem::derivatives) and
+    /// [`derivatives_in_segment`](DynamicalSystem::derivatives_in_segment).
+    ///
+    /// `segment` is `Some` only on the segment path, where it carries the
+    /// interval's start in both time bases so a model holding a schedule can
+    /// answer for it.
+    fn derivatives_for(
+        &self,
+        segment: Option<&EvalSegment<'_>>,
+        t: f64,
+        state: &OrbitalState<F>,
+    ) -> OrbitalState<F> {
+        let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
+        let mut accel = self.gravity.acceleration(self.mu, state.position());
+        for m in &self.models {
+            let loads = eval_maybe_in_segment(m, segment, t, state, epoch.as_ref());
+            accel += loads.acceleration_inertial.into_inner();
+        }
+        OrbitalState::from_derivative_in_frame(*state.velocity(), accel)
+    }
+}
+
 impl<F: Eci> DynamicalSystem for OrbitalSystem<F> {
     type State = OrbitalState<F>;
 
@@ -95,13 +118,21 @@ impl<F: Eci> DynamicalSystem for OrbitalSystem<F> {
     }
 
     fn derivatives(&self, t: f64, state: &OrbitalState<F>) -> OrbitalState<F> {
-        let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
-        let mut accel = self.gravity.acceleration(self.mu, state.position());
-        for m in &self.models {
-            let loads = m.eval(t, state, epoch.as_ref());
-            accel += loads.acceleration_inertial.into_inner();
-        }
-        OrbitalState::from_derivative_in_frame(*state.velocity(), accel)
+        self.derivatives_for(None, t, state)
+    }
+
+    fn derivatives_in_segment(
+        &self,
+        segment: &SegmentContext,
+        t: f64,
+        state: &OrbitalState<F>,
+    ) -> OrbitalState<F> {
+        let start_epoch = self.epoch_0.map(|e| e.add_si_seconds(segment.start));
+        self.derivatives_for(
+            Some(&EvalSegment::new(segment, start_epoch.as_ref())),
+            t,
+            state,
+        )
     }
 }
 

--- a/orts/src/perturbations/constant_thrust.rs
+++ b/orts/src/perturbations/constant_thrust.rs
@@ -6,8 +6,11 @@ use crate::model::{EvalSegment, HasFrame, HasOrbit, Model};
 
 /// Constant-thrust force model active over a fixed epoch interval.
 ///
-/// Applies a uniform acceleration (in ECI) from `start` to `end`
-/// (inclusive on both ends), and zero acceleration outside that window.
+/// Applies a uniform acceleration (in ECI) over `[start, end)` — the start
+/// counts, the end does not — and zero acceleration outside that window. The
+/// half-open interval is the one [`BurnWindow`](crate::spacecraft::BurnWindow)
+/// uses, and it is what lets a propagation loop hold the burn's state over the
+/// segment that begins where the burn ends.
 /// Acceleration is stored pre-computed as `total_dv / duration` so the
 /// hot-path `eval()` is branch-and-lookup only.
 ///
@@ -61,9 +64,11 @@ use crate::model::{EvalSegment, HasFrame, HasOrbit, Model};
 pub struct ConstantThrust<F: Eci = frame::SimpleEci> {
     /// Human-readable name (e.g. `"DRI"`, `"thrust_burn3"`).
     pub name: &'static str,
-    /// First epoch at which the thrust is active (inclusive).
+    /// First epoch at which the thrust is active; it counts.
     pub start: Epoch,
-    /// Last epoch at which the thrust is active (inclusive).
+    /// Epoch at which the thrust stops; it does not count. The last instant
+    /// that thrusts is the one before it, so the burn lasts exactly
+    /// `end - start`.
     pub end: Epoch,
     /// Pre-computed constant acceleration vector [km/s²], in the inertial
     /// frame `F` the Δv was given in.

--- a/orts/src/perturbations/constant_thrust.rs
+++ b/orts/src/perturbations/constant_thrust.rs
@@ -2,7 +2,7 @@ use arika::epoch::Epoch;
 use arika::frame::{self, Eci, Vec3};
 
 use crate::model::ExternalLoads;
-use crate::model::{HasFrame, HasOrbit, Model};
+use crate::model::{EvalSegment, HasFrame, HasOrbit, Model};
 
 /// Constant-thrust force model active over a fixed epoch interval.
 ///
@@ -111,12 +111,24 @@ impl<F: Eci> ConstantThrust<F> {
     }
 
     /// Returns the total Δv that this thrust model integrates to over
-    /// `[start, end]` (= acceleration × duration).
+    /// `[start, end)` (= acceleration × duration).
     pub fn total_dv_kms(&self) -> Vec3<F> {
         self.acceleration * self.duration_seconds()
     }
 
-    /// Returns `true` if `epoch` falls within `[start, end]` (inclusive).
+    /// Returns `true` if `epoch` falls within `[start, end)` — the start
+    /// counts, the end does not.
+    ///
+    /// The half-open interval is the one
+    /// [`BurnWindow`](crate::spacecraft::BurnWindow) uses, and it is what makes
+    /// abutting burns add up to their own lengths rather than sharing an
+    /// instant. It also matters beyond that instant once a propagation loop
+    /// splits its span at the edges this model reports and holds the burn's
+    /// state over each segment: with the end counted as active, the segment
+    /// starting at `end` would thrust for its whole length. Measured on a 0.1 s
+    /// burn split into segments, RK4 with `dt = 1` applied 4/3 of the Δv asked
+    /// for, the stages on the two edges leaking a sixth apiece into the
+    /// segments on either side.
     ///
     /// Measured on the canonical TAI timeline, as [`duration_seconds`] and the
     /// edges reported by [`next_edge_after`] are. UTC Julian Dates do not
@@ -128,7 +140,7 @@ impl<F: Eci> ConstantThrust<F> {
     /// [`next_edge_after`]: Self::next_edge_after
     fn is_active(&self, epoch: &Epoch) -> bool {
         epoch.duration_since(&self.start).as_si_seconds() >= 0.0
-            && self.end.duration_since(epoch).as_si_seconds() >= 0.0
+            && self.end.duration_since(epoch).as_si_seconds() > 0.0
     }
 }
 
@@ -194,6 +206,23 @@ impl<S: HasFrame<Frame = frame::SimpleEci> + HasOrbit> Model<S>
         self.loads(epoch)
     }
 
+    /// The burn's state at the segment's start, held for the whole segment.
+    ///
+    /// A propagation loop splits its span at the edges
+    /// [`next_discontinuity_after`](Self::next_discontinuity_after) reports, so
+    /// no edge falls strictly inside a segment and the start speaks for all of
+    /// it. What this changes is the stage on the segment's end, which reading
+    /// the epoch of the stage would find already outside a burn ending there.
+    fn eval_in_segment(
+        &self,
+        segment: &EvalSegment<'_>,
+        _t: f64,
+        _state: &S,
+        _epoch: Option<&Epoch>,
+    ) -> ExternalLoads<S::Frame> {
+        self.loads(segment.start_epoch)
+    }
+
     fn next_discontinuity_after(&self, t: f64, epoch: Option<&Epoch>) -> Option<f64> {
         self.next_edge_after(t, epoch)
     }
@@ -206,6 +235,23 @@ impl<S: HasFrame<Frame = frame::Gcrs> + HasOrbit> Model<S> for ConstantThrust<fr
 
     fn eval(&self, _t: f64, _state: &S, epoch: Option<&Epoch>) -> ExternalLoads<S::Frame> {
         self.loads(epoch)
+    }
+
+    /// The burn's state at the segment's start, held for the whole segment.
+    ///
+    /// A propagation loop splits its span at the edges
+    /// [`next_discontinuity_after`](Self::next_discontinuity_after) reports, so
+    /// no edge falls strictly inside a segment and the start speaks for all of
+    /// it. What this changes is the stage on the segment's end, which reading
+    /// the epoch of the stage would find already outside a burn ending there.
+    fn eval_in_segment(
+        &self,
+        segment: &EvalSegment<'_>,
+        _t: f64,
+        _state: &S,
+        _epoch: Option<&Epoch>,
+    ) -> ExternalLoads<S::Frame> {
+        self.loads(segment.start_epoch)
     }
 
     fn next_discontinuity_after(&self, t: f64, epoch: Option<&Epoch>) -> Option<f64> {
@@ -306,7 +352,13 @@ mod tests {
         let thrust =
             ConstantThrust::<frame::SimpleEci>::new("mid", start, end, Vec3::new(0.01, 0.0, 0.0));
         let expected = vector![1e-4, 0.0, 0.0];
-        for probe_sec in [100.0, 120.0, 150.0, 180.0, 200.0] {
+        // 199.99 rather than 200.0: the window is half-open, so its own end is
+        // outside it, and `epoch_seconds_from_j2000` goes through a Julian Date
+        // whose resolution here is about 40 us — a probe a microsecond short of
+        // the end rounds onto it. `eval_at_the_start_thrusts_and_at_the_end_does_not`
+        // pins the end itself, and `eval_just_before_the_end_thrusts` the
+        // instant before it, on the SI timeline where that is representable.
+        for probe_sec in [100.0, 120.0, 150.0, 180.0, 199.99] {
             let probe = epoch_seconds_from_j2000(probe_sec);
             let loads = thrust.eval(0.0, &test_state(), Some(&probe));
             let a = loads.acceleration_inertial.into_inner();
@@ -332,8 +384,9 @@ mod tests {
     }
 
     #[test]
-    fn eval_at_exact_boundaries_is_active() {
-        // Inclusive on both ends: start and end epochs return thrust, not zero.
+    fn eval_at_the_start_thrusts_and_at_the_end_does_not() {
+        // Half-open, as `BurnWindow` is: the start counts, the end does not, so
+        // a segment beginning where the burn ends does not thrust.
         let start = epoch_seconds_from_j2000(100.0);
         let end = epoch_seconds_from_j2000(200.0);
         let thrust =
@@ -343,7 +396,24 @@ mod tests {
         let loads_start = thrust.eval(0.0, &test_state(), Some(&start));
         let loads_end = thrust.eval(0.0, &test_state(), Some(&end));
         assert!((loads_start.acceleration_inertial.into_inner() - expected).magnitude() < 1e-8);
-        assert!((loads_end.acceleration_inertial.into_inner() - expected).magnitude() < 1e-8);
+        assert_eq!(
+            loads_end.acceleration_inertial.into_inner(),
+            Vector3::zeros()
+        );
+    }
+
+    /// The last instant before the end still thrusts: the interval is
+    /// half-open, not short of its own length.
+    #[test]
+    fn eval_just_before_the_end_thrusts() {
+        let start = epoch_seconds_from_j2000(100.0);
+        let end = epoch_seconds_from_j2000(200.0);
+        let thrust =
+            ConstantThrust::<frame::SimpleEci>::new("bd", start, end, Vec3::new(0.01, 0.0, 0.0));
+        let expected = vector![1e-4, 0.0, 0.0];
+
+        let loads = thrust.eval(0.0, &test_state(), Some(&end.add_si_seconds(-1e-9)));
+        assert!((loads.acceleration_inertial.into_inner() - expected).magnitude() < 1e-8);
     }
 
     #[test]

--- a/orts/src/spacecraft/dynamics.rs
+++ b/orts/src/spacecraft/dynamics.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::effector::{AugmentedState, AuxRegistry, StateEffector};
+use crate::effector::{AugmentedState, AuxRegistry, StateEffector, effector_derivatives};
 use crate::model::{EvalSegment, Model, eval_maybe_in_segment};
 use crate::orbital::gravity::GravityField;
 use arika::epoch::Epoch;
@@ -272,11 +272,15 @@ impl<G: GravityField, F: Eci + 'static> SpacecraftDynamics<G, F> {
             let entry = &self.registry.entries()[i];
             let aux_slice = &state.aux[entry.offset..entry.offset + entry.dim];
             let rates_slice = &mut aux_rates[entry.offset..entry.offset + entry.dim];
-            // TODO(#446): an effector that reports a boundary needs the same
-            // segment mode as the models. No effector carries a time
-            // schedule yet — a reaction wheel switches on its own momentum,
-            // which is a state event.
-            total += eff.derivatives(t, &state.plant, aux_slice, rates_slice, epoch.as_ref());
+            total += effector_derivatives(
+                eff.as_ref(),
+                segment,
+                t,
+                &state.plant,
+                aux_slice,
+                rates_slice,
+                epoch.as_ref(),
+            );
         }
 
         // Total translational acceleration

--- a/orts/src/spacecraft/dynamics.rs
+++ b/orts/src/spacecraft/dynamics.rs
@@ -1,12 +1,12 @@
 use std::marker::PhantomData;
 
 use crate::effector::{AugmentedState, AuxRegistry, StateEffector};
-use crate::model::Model;
+use crate::model::{EvalSegment, Model, eval_maybe_in_segment};
 use crate::orbital::gravity::GravityField;
 use arika::epoch::Epoch;
 use arika::frame::{Eci, SimpleEci};
 use nalgebra::Matrix3;
-use utsuroi::DynamicalSystem;
+use utsuroi::{DynamicalSystem, SegmentContext};
 
 use super::{ExternalLoads, SpacecraftState};
 
@@ -229,6 +229,81 @@ impl<G: GravityField, F: Eci + 'static> SpacecraftDynamics<G, F> {
     }
 }
 
+impl<G: GravityField, F: Eci + 'static> SpacecraftDynamics<G, F> {
+    /// Shared body of [`derivatives`](DynamicalSystem::derivatives) and
+    /// [`derivatives_in_segment`](DynamicalSystem::derivatives_in_segment).
+    ///
+    /// `segment` is `Some` only on the segment path, where it carries the
+    /// interval's start in both time bases so a model holding a schedule can
+    /// answer for it.
+    fn derivatives_for(
+        &self,
+        segment: Option<&EvalSegment<'_>>,
+        t: f64,
+        state: &AugmentedState<SpacecraftState<F>>,
+    ) -> AugmentedState<SpacecraftState<F>> {
+        let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
+
+        // Gravitational acceleration
+        let grav_accel = self
+            .gravity
+            .acceleration(self.mu, state.plant.orbit.position());
+
+        // Accumulate external loads from models
+        let mut total = ExternalLoads::<F>::zeros();
+        for model in &self.models {
+            total += eval_maybe_in_segment(model, segment, t, &state.plant, epoch.as_ref());
+        }
+
+        // Evaluate state effectors.
+        //
+        // INVARIANT: a `StateEffector<S>` returns `ExternalLoads<S::Frame>` —
+        // already expressed in the frame this system propagates in — so loads
+        // accumulate directly with no coordinate re-tag. Torque-only effectors
+        // (reaction wheels) write `impl<S: HasFrame + HasAttitude>
+        // StateEffector<S>` and leave the acceleration zero, since body-frame
+        // torque names no inertial frame; a translational effector must rotate
+        // its body-frame vector through the state's own attitude. The loads
+        // frame is not a separate parameter that could disagree with the
+        // state's, which is what makes the SimpleEci mislabel from issue #103
+        // unrepresentable.
+        let mut aux_rates = vec![0.0; self.registry.total_dim()];
+        for (i, eff) in self.effectors.iter().enumerate() {
+            let entry = &self.registry.entries()[i];
+            let aux_slice = &state.aux[entry.offset..entry.offset + entry.dim];
+            let rates_slice = &mut aux_rates[entry.offset..entry.offset + entry.dim];
+            // TODO(#446): an effector that reports a boundary needs the same
+            // segment mode as the models. No effector carries a time
+            // schedule yet — a reaction wheel switches on its own momentum,
+            // which is a state event.
+            total += eff.derivatives(t, &state.plant, aux_slice, rates_slice, epoch.as_ref());
+        }
+
+        // Total translational acceleration
+        let total_accel = grav_accel + total.acceleration_inertial.into_inner();
+
+        // Quaternion kinematics: dq/dt = ½ q ⊗ (0, ω)
+        let q_dot = state.plant.attitude.q_dot();
+
+        // Euler's rotation equation: dω/dt = I⁻¹(τ − ω × (I·ω))
+        let iw = self.inertia * state.plant.attitude.angular_velocity;
+        let alpha = self.inertia_inv
+            * (total.torque_body.into_inner() - state.plant.attitude.angular_velocity.cross(&iw));
+
+        AugmentedState {
+            plant: SpacecraftState::from_derivative(
+                *state.plant.orbit.velocity(),
+                total_accel,
+                q_dot,
+                alpha,
+                total.mass_rate,
+            ),
+            aux: aux_rates,
+            aux_bounds: state.aux_bounds.clone(),
+        }
+    }
+}
+
 impl<G: GravityField, F: Eci + 'static> DynamicalSystem for SpacecraftDynamics<G, F> {
     type State = AugmentedState<SpacecraftState<F>>;
 
@@ -258,61 +333,21 @@ impl<G: GravityField, F: Eci + 'static> DynamicalSystem for SpacecraftDynamics<G
         t: f64,
         state: &AugmentedState<SpacecraftState<F>>,
     ) -> AugmentedState<SpacecraftState<F>> {
-        let epoch = self.epoch_0.map(|e| e.add_si_seconds(t));
+        self.derivatives_for(None, t, state)
+    }
 
-        // Gravitational acceleration
-        let grav_accel = self
-            .gravity
-            .acceleration(self.mu, state.plant.orbit.position());
-
-        // Accumulate external loads from models
-        let mut total = ExternalLoads::<F>::zeros();
-        for model in &self.models {
-            total += model.eval(t, &state.plant, epoch.as_ref());
-        }
-
-        // Evaluate state effectors.
-        //
-        // INVARIANT: a `StateEffector<S>` returns `ExternalLoads<S::Frame>` —
-        // already expressed in the frame this system propagates in — so loads
-        // accumulate directly with no coordinate re-tag. Torque-only effectors
-        // (reaction wheels) write `impl<S: HasFrame + HasAttitude>
-        // StateEffector<S>` and leave the acceleration zero, since body-frame
-        // torque names no inertial frame; a translational effector must rotate
-        // its body-frame vector through the state's own attitude. The loads
-        // frame is not a separate parameter that could disagree with the
-        // state's, which is what makes the SimpleEci mislabel from issue #103
-        // unrepresentable.
-        let mut aux_rates = vec![0.0; self.registry.total_dim()];
-        for (i, eff) in self.effectors.iter().enumerate() {
-            let entry = &self.registry.entries()[i];
-            let aux_slice = &state.aux[entry.offset..entry.offset + entry.dim];
-            let rates_slice = &mut aux_rates[entry.offset..entry.offset + entry.dim];
-            total += eff.derivatives(t, &state.plant, aux_slice, rates_slice, epoch.as_ref());
-        }
-
-        // Total translational acceleration
-        let total_accel = grav_accel + total.acceleration_inertial.into_inner();
-
-        // Quaternion kinematics: dq/dt = ½ q ⊗ (0, ω)
-        let q_dot = state.plant.attitude.q_dot();
-
-        // Euler's rotation equation: dω/dt = I⁻¹(τ − ω × (I·ω))
-        let iw = self.inertia * state.plant.attitude.angular_velocity;
-        let alpha = self.inertia_inv
-            * (total.torque_body.into_inner() - state.plant.attitude.angular_velocity.cross(&iw));
-
-        AugmentedState {
-            plant: SpacecraftState::from_derivative(
-                *state.plant.orbit.velocity(),
-                total_accel,
-                q_dot,
-                alpha,
-                total.mass_rate,
-            ),
-            aux: aux_rates,
-            aux_bounds: state.aux_bounds.clone(),
-        }
+    fn derivatives_in_segment(
+        &self,
+        segment: &SegmentContext,
+        t: f64,
+        state: &AugmentedState<SpacecraftState<F>>,
+    ) -> AugmentedState<SpacecraftState<F>> {
+        let start_epoch = self.epoch_0.map(|e| e.add_si_seconds(segment.start));
+        self.derivatives_for(
+            Some(&EvalSegment::new(segment, start_epoch.as_ref())),
+            t,
+            state,
+        )
     }
 }
 

--- a/orts/src/spacecraft/thruster.rs
+++ b/orts/src/spacecraft/thruster.rs
@@ -1,7 +1,7 @@
 use arika::epoch::Epoch;
 use nalgebra::Vector3;
 
-use crate::model::{HasAttitude, HasFrame, HasMass, HasOrbit, Model};
+use crate::model::{EvalSegment, HasAttitude, HasFrame, HasMass, HasOrbit, Model};
 
 use super::{ExternalLoads, SpacecraftState};
 
@@ -38,6 +38,28 @@ pub trait ThrustProfile: Send + Sync {
     /// Must be finite and strictly greater than `t`.
     fn next_throttle_jump_after(&self, _t: f64, _epoch: Option<&Epoch>) -> Option<f64> {
         None
+    }
+
+    /// Throttle for the segment a solver is stepping through.
+    ///
+    /// A schedule answers for the segment's start, so a window `[a, b)` is
+    /// still on at the stage that lands on `b` — that stage belongs to the step
+    /// integrating the window, and dropping it costs the stage's weight (1/6
+    /// of an RK4 step). The segment's ends are the schedule's own edges, so
+    /// holding the schedule for the segment changes nothing but the endpoint.
+    ///
+    /// A law that reads the state keeps reading `state` at every stage: the
+    /// default forwards to [`throttle`](Self::throttle), and a profile that
+    /// combines a schedule with feedback holds only the schedule
+    /// (`schedule(segment.start) * feedback(t, state)`).
+    fn throttle_in_segment(
+        &self,
+        _segment: &EvalSegment<'_>,
+        t: f64,
+        state: &SpacecraftState,
+        epoch: Option<&Epoch>,
+    ) -> f64 {
+        self.throttle(t, state, epoch)
     }
 }
 
@@ -102,6 +124,24 @@ impl ThrustProfile for ScheduledBurn {
             .flat_map(|w| [w.start, w.end])
             .filter(|edge| *edge > t && edge.is_finite())
             .min_by(f64::total_cmp)
+    }
+
+    /// The throttle that holds over the whole segment: the one at its start.
+    ///
+    /// A propagation loop ends its segments at the times
+    /// [`next_throttle_jump_after`](Self::next_throttle_jump_after) reports, so
+    /// no window edge falls strictly inside a segment and one lookup answers
+    /// for all of it. What this changes is the stage on `segment.end`, which
+    /// reading the schedule at its own stage time would find already outside a
+    /// window ending there.
+    fn throttle_in_segment(
+        &self,
+        segment: &EvalSegment<'_>,
+        _t: f64,
+        state: &SpacecraftState,
+        _epoch: Option<&Epoch>,
+    ) -> f64 {
+        self.throttle(segment.start, state, segment.start_epoch)
     }
 }
 
@@ -267,6 +307,22 @@ impl Thruster {
         let throttle = self.profile.throttle(t, state, epoch);
         self.spec.loads_for_throttle(throttle, state, epoch)
     }
+
+    /// Loads with the profile's throttle held for `segment`.
+    ///
+    /// Only the throttle is taken from the segment. Thrust, `Isp` and the
+    /// geometry come from the spec, and the mass flow follows the state at this
+    /// stage, so `loads_for_throttle` keeps the stage's `state` and `epoch`.
+    pub(crate) fn loads_in_segment(
+        &self,
+        segment: &EvalSegment<'_>,
+        t: f64,
+        state: &SpacecraftState,
+        epoch: Option<&Epoch>,
+    ) -> ExternalLoads {
+        let throttle = self.profile.throttle_in_segment(segment, t, state, epoch);
+        self.spec.loads_for_throttle(throttle, state, epoch)
+    }
 }
 
 impl<S: HasFrame<Frame = arika::frame::SimpleEci> + HasAttitude + HasOrbit + HasMass> Model<S>
@@ -284,6 +340,21 @@ impl<S: HasFrame<Frame = arika::frame::SimpleEci> + HasAttitude + HasOrbit + Has
             mass: state.mass(),
         };
         self.loads(t, &sc_state, epoch)
+    }
+
+    fn eval_in_segment(
+        &self,
+        segment: &EvalSegment<'_>,
+        t: f64,
+        state: &S,
+        epoch: Option<&Epoch>,
+    ) -> ExternalLoads {
+        let sc_state = SpacecraftState {
+            orbit: state.orbit().clone(),
+            attitude: state.attitude().clone(),
+            mass: state.mass(),
+        };
+        self.loads_in_segment(segment, t, &sc_state, epoch)
     }
 
     /// Whatever the profile knows. Propellant exhaustion is left out: its time

--- a/orts/tests/burn_window_segments.rs
+++ b/orts/tests/burn_window_segments.rs
@@ -1,0 +1,262 @@
+//! Propagating a group through a scheduled burn.
+//!
+//! A solver evaluates the right-hand side at stage times of its own choosing,
+//! so a burn window narrower than the gap between two of them contributes
+//! nothing, and one that covers a whole step loses the weight of the stage
+//! sitting on its exclusive end. Both are measured below against the same
+//! oracle: the propellant a constant-thrust burn spends is `thrust / (Isp *
+//! g0)` times the burn's length, whatever the trajectory does, because the mass
+//! flow of a thruster at full throttle does not depend on the state.
+//!
+//! The propagation loop ends its steps at the window edges the thruster
+//! reports, and hands the solver a system bound to each segment, which is what
+//! makes these agree with the oracle rather than with the stage times.
+
+use nalgebra::{Matrix3, Vector3};
+use orts::OrbitalState;
+use orts::attitude::AttitudeState;
+use orts::effector::AugmentedState;
+use orts::group::IntegratorConfig;
+use orts::group::independent::IndependentGroup;
+use orts::orbital::gravity::PointMass;
+use orts::spacecraft::{
+    BurnWindow, G0, ScheduledBurn, SpacecraftDynamics, SpacecraftState, Thruster,
+};
+use utsuroi::Tolerances;
+
+const THRUST_N: f64 = 10.0;
+const ISP_S: f64 = 300.0;
+const MASS_KG: f64 = 100.0;
+const SPAN_S: f64 = 10.0;
+
+/// How sharply a spent-propellant figure can be compared, in kg.
+///
+/// The propellant is the difference of two masses near `MASS_KG`, so it carries
+/// the resolution of f64 there — `100 * f64::EPSILON` is 2.2e-14 — however
+/// exactly the mass flow was integrated. Four of those is loose enough for the
+/// subtraction and tight enough to see the failures these tests are about: a
+/// missed window spends nothing, and a window whose end stage reads off spends
+/// 5/6.
+const PROPELLANT_TOL_KG: f64 = 4.0 * MASS_KG * f64::EPSILON;
+
+/// Propellant a full-throttle burn of `length` seconds spends, in kg.
+fn propellant_for(length: f64) -> f64 {
+    THRUST_N / (ISP_S * G0) * length
+}
+
+fn dynamics_with(windows: Vec<BurnWindow>) -> SpacecraftDynamics<PointMass> {
+    let thruster = Thruster::new(THRUST_N, ISP_S, Vector3::x())
+        .with_profile(Box::new(ScheduledBurn { windows }));
+    SpacecraftDynamics::new(arika::earth::MU, PointMass, Matrix3::identity()).with_model(thruster)
+}
+
+fn initial_state() -> AugmentedState<SpacecraftState> {
+    // 400 km circular orbit, thrusting along +x of the body frame.
+    let r = arika::earth::R + 400.0;
+    let v = (arika::earth::MU / r).sqrt();
+    AugmentedState {
+        plant: SpacecraftState {
+            orbit: OrbitalState::new(Vector3::new(r, 0.0, 0.0), Vector3::new(0.0, v, 0.0)),
+            attitude: AttitudeState::identity(),
+            mass: MASS_KG,
+        },
+        aux: vec![],
+        aux_bounds: vec![],
+    }
+}
+
+/// Propellant spent over `SPAN_S` seconds, propagating with `integrator`.
+fn propellant_spent(windows: Vec<BurnWindow>, integrator: IntegratorConfig) -> f64 {
+    let mut group = IndependentGroup::new(integrator).add_satellite(
+        "sat",
+        initial_state(),
+        dynamics_with(windows),
+    );
+    let mut final_mass = MASS_KG;
+    group
+        .propagate_to_with(SPAN_S, |_, _, state| final_mass = state.plant.mass)
+        .expect("the burn and the orbit are finite everywhere");
+    MASS_KG - final_mass
+}
+
+fn integrators() -> Vec<(&'static str, IntegratorConfig)> {
+    vec![
+        ("RK4 dt=1", IntegratorConfig::Rk4 { dt: 1.0 }),
+        (
+            "DP45",
+            IntegratorConfig::Dp45 {
+                dt: 1.0,
+                tolerances: Tolerances::default(),
+            },
+        ),
+        (
+            "DOP853",
+            IntegratorConfig::Dop853 {
+                dt: 1.0,
+                tolerances: Tolerances::default(),
+            },
+        ),
+    ]
+}
+
+/// A window narrower than the largest gap between adjacent stage times. With
+/// `dt = 1` the RK4 stages fall at 0, 0.5, 0.5 and 1, so `[0.1, 0.2)` used to
+/// be sampled at none of them and the burn spent nothing at all.
+#[test]
+fn a_window_shorter_than_a_step_spends_its_propellant() {
+    let expected = propellant_for(0.1);
+    for (name, integrator) in integrators() {
+        let spent = propellant_spent(vec![BurnWindow::full(0.1, 0.2)], integrator);
+        assert!(
+            (spent - expected).abs() < PROPELLANT_TOL_KG,
+            "{name} spent {spent} kg, expected {expected} kg"
+        );
+    }
+}
+
+/// A window covering a whole step. The stage on its exclusive end reads the
+/// throttle as off, and RK4 weights that stage 1/6, so this used to spend 5/6
+/// of the propellant.
+#[test]
+fn a_window_covering_a_whole_step_spends_all_of_its_propellant() {
+    let expected = propellant_for(1.0);
+    for (name, integrator) in integrators() {
+        let spent = propellant_spent(vec![BurnWindow::full(0.0, 1.0)], integrator);
+        assert!(
+            (spent - expected).abs() < PROPELLANT_TOL_KG,
+            "{name} spent {spent} kg, expected {expected} kg"
+        );
+    }
+}
+
+/// Two windows that abut share an edge, and the burn runs across it without
+/// the shared time counting twice or dropping out.
+#[test]
+fn abutting_windows_burn_as_one() {
+    let expected = propellant_for(2.0);
+    for (name, integrator) in integrators() {
+        let spent = propellant_spent(
+            vec![BurnWindow::full(1.0, 2.0), BurnWindow::full(2.0, 3.0)],
+            integrator,
+        );
+        assert!(
+            (spent - expected).abs() < PROPELLANT_TOL_KG,
+            "{name} spent {spent} kg, expected {expected} kg"
+        );
+    }
+}
+
+/// A burn whose window ends exactly where the propagation does. The last
+/// segment ends at the span's end, and the throttle holds to it.
+#[test]
+fn a_window_ending_with_the_span_burns_to_the_end() {
+    let expected = propellant_for(1.0);
+    for (name, integrator) in integrators() {
+        let spent = propellant_spent(vec![BurnWindow::full(SPAN_S - 1.0, SPAN_S)], integrator);
+        assert!(
+            (spent - expected).abs() < PROPELLANT_TOL_KG,
+            "{name} spent {spent} kg, expected {expected} kg"
+        );
+    }
+}
+
+/// Splitting the call must not change the answer: segment modes and stepper
+/// state belong to a segment, not to a call.
+#[test]
+fn splitting_the_propagation_call_spends_the_same_propellant() {
+    let expected = propellant_for(0.1);
+    for (name, integrator) in integrators() {
+        let mut group = IndependentGroup::new(integrator).add_satellite(
+            "sat",
+            initial_state(),
+            dynamics_with(vec![BurnWindow::full(0.1, 0.2)]),
+        );
+        let mut final_mass = MASS_KG;
+        for target in [0.15, 1.0, SPAN_S] {
+            group
+                .propagate_to_with(target, |_, _, state| final_mass = state.plant.mass)
+                .expect("the burn and the orbit are finite everywhere");
+        }
+        let spent = MASS_KG - final_mass;
+        assert!(
+            (spent - expected).abs() < PROPELLANT_TOL_KG,
+            "{name} spent {spent} kg across three calls, expected {expected} kg"
+        );
+    }
+}
+
+/// A burn shorter than a step, in the group that propagates satellites
+/// together. `CoupledGroup` needs a state it can add an acceleration to, so
+/// this flies `OrbitalSystem` with `ConstantThrust` — the orbital model whose
+/// schedule is written in epochs — rather than the thruster above.
+///
+/// With no interactions the two group loops are the same problem, so the
+/// independent one is the oracle: it splits the span at the same edges, and a
+/// coupled loop that integrated straight through them would come out
+/// elsewhere: measured, integrating straight through leaves the position
+/// 2.8e-5 km away with RK4. The burn's own displacement over the rest of the
+/// span is 9.9e-6 km with DOP853, and the RK4 figure is larger because
+/// splitting the span at the edges also changes its step grid.
+#[test]
+fn a_coupled_group_flies_a_short_burn_like_an_independent_one() {
+    use arika::epoch::Epoch;
+    use arika::frame::Vec3;
+    use orts::group::coupled::CoupledGroup;
+    use orts::orbital::OrbitalSystem;
+    use orts::perturbations::ConstantThrust;
+
+    let epoch_0 = Epoch::j2000();
+    let burn = || {
+        ConstantThrust::new(
+            "burn",
+            epoch_0.add_si_seconds(0.1),
+            epoch_0.add_si_seconds(0.2),
+            Vec3::new(1e-6, 0.0, 0.0),
+        )
+    };
+    let system = || {
+        OrbitalSystem::new(arika::earth::MU, Box::new(PointMass))
+            .with_model(burn())
+            .with_epoch(epoch_0)
+    };
+    let r = arika::earth::R + 400.0;
+    let v = (arika::earth::MU / r).sqrt();
+    let state = || OrbitalState::new(Vector3::new(r, 0.0, 0.0), Vector3::new(0.0, v, 0.0));
+
+    let coast = || OrbitalSystem::new(arika::earth::MU, Box::new(PointMass)).with_epoch(epoch_0);
+
+    for (name, integrator) in integrators() {
+        let integrator_for_baseline = integrator.clone();
+        let mut independent =
+            IndependentGroup::new(integrator.clone()).add_satellite("sat", state(), system());
+        independent
+            .propagate_to(SPAN_S)
+            .expect("the burn and the orbit are finite everywhere");
+
+        let mut coupled = CoupledGroup::new(integrator).add_satellite("sat", state(), system());
+        coupled
+            .propagate_to(SPAN_S)
+            .expect("the burn and the orbit are finite everywhere");
+
+        // Comparing the two loops alone would pass if both missed the burn,
+        // so this also measures the burn against a run without one.
+        let mut coasting =
+            IndependentGroup::new(integrator_for_baseline).add_satellite("sat", state(), coast());
+        coasting
+            .propagate_to(SPAN_S)
+            .expect("the orbit is finite everywhere");
+
+        let alone = independent.snapshot().positions[0].1;
+        let together = coupled.snapshot().positions[0].1;
+        let unburnt = coasting.snapshot().positions[0].1;
+        let gap = (alone - together).norm();
+        let moved = (alone - unburnt).norm();
+        println!("{name}: gap {gap:e} km, burn moved {moved:e} km");
+        assert!(gap < 1e-15, "{name}: the two loops differ by {gap:e} km");
+        assert!(
+            moved > 1e-6,
+            "{name}: the burn moved the satellite only {moved:e} km, so this \
+             comparison cannot tell a missed burn from a flown one"
+        );
+    }
+}

--- a/orts/tests/burn_window_segments.rs
+++ b/orts/tests/burn_window_segments.rs
@@ -324,3 +324,207 @@ fn an_epoch_scheduled_burn_applies_the_delta_v_it_was_given() {
         );
     }
 }
+
+/// An effector on a schedule of its own, integrated through the same loop.
+///
+/// The aux rate is 1 while the window is open, so the aux state a propagation
+/// reaches is the window's length. Reading the schedule at the stage time
+/// instead costs the stage on the window's end its weight — 1/6 of a step under
+/// RK4 — which is what the segment evaluation is for.
+///
+/// The window sits at `[0.15, 0.25)` so the segment before it is longer than
+/// the window: with both 0.1 s long, the `h/6` a stage-time reading leaks into
+/// the earlier segment and the `h/6` it drops from the window's own last stage
+/// cancel exactly under RK4, and only DP45 and DOP853 would see the mistake.
+mod scheduled_effector {
+    use super::*;
+    use arika::epoch::Epoch;
+    use orts::effector::StateEffector;
+    use orts::model::{EvalSegment, ExternalLoads};
+    use orts::spacecraft::SpacecraftDynamics;
+
+    struct WindowedCounter {
+        start: f64,
+        end: f64,
+    }
+
+    impl WindowedCounter {
+        fn rate_at(&self, t: f64) -> f64 {
+            if t >= self.start && t < self.end {
+                1.0
+            } else {
+                0.0
+            }
+        }
+    }
+
+    impl StateEffector<SpacecraftState> for WindowedCounter {
+        fn name(&self) -> &str {
+            "windowed_counter"
+        }
+
+        fn state_dim(&self) -> usize {
+            1
+        }
+
+        fn next_discontinuity_after(&self, t: f64, _epoch: Option<&Epoch>) -> Option<f64> {
+            [self.start, self.end]
+                .into_iter()
+                .filter(|edge| *edge > t)
+                .min_by(f64::total_cmp)
+        }
+
+        fn derivatives(
+            &self,
+            t: f64,
+            _state: &SpacecraftState,
+            _aux: &[f64],
+            aux_rates: &mut [f64],
+            _epoch: Option<&Epoch>,
+        ) -> ExternalLoads {
+            aux_rates[0] = self.rate_at(t);
+            ExternalLoads::zeros()
+        }
+
+        fn derivatives_in_segment(
+            &self,
+            segment: &EvalSegment<'_>,
+            _t: f64,
+            _state: &SpacecraftState,
+            _aux: &[f64],
+            aux_rates: &mut [f64],
+            _epoch: Option<&Epoch>,
+        ) -> ExternalLoads {
+            aux_rates[0] = self.rate_at(segment.start);
+            ExternalLoads::zeros()
+        }
+    }
+
+    #[test]
+    fn a_scheduled_effector_integrates_its_whole_window() {
+        for (name, integrator) in integrators() {
+            let dynamics =
+                SpacecraftDynamics::new(arika::earth::MU, PointMass, Matrix3::identity())
+                    .with_effector(WindowedCounter {
+                        start: 0.15,
+                        end: 0.25,
+                    });
+            let mut state = initial_state();
+            state.aux = vec![0.0];
+            state.aux_bounds = vec![(f64::NEG_INFINITY, f64::INFINITY)];
+            let mut group = IndependentGroup::new(integrator).add_satellite("sat", state, dynamics);
+            let mut counted = 0.0;
+            group
+                .propagate_to_with(SPAN_S, |_, _, s| counted = s.aux[0])
+                .expect("the orbit is finite everywhere");
+            assert!(
+                (counted - 0.1).abs() < 1e-15,
+                "{name} integrated the window to {counted}, expected 0.1"
+            );
+        }
+    }
+}
+
+/// A force between two satellites on a schedule of its own.
+///
+/// The force pushes satellite 0 along +x while its window is open, so the Δv it
+/// applies is the acceleration times the window's length. `PairContext` carries
+/// no epoch, so the segment here is the interval in integration time alone.
+mod scheduled_pair_force {
+    use super::*;
+    use std::sync::Arc;
+
+    use orts::group::coupled::{CoupledGroup, InterSatelliteForce, PairContext};
+    use orts::orbital::OrbitalSystem;
+    use utsuroi::SegmentContext;
+
+    const ACCELERATION: f64 = 1e-5;
+    /// Displacement the push earns by the end of the span, in km.
+    ///
+    /// Under constant acceleration `a` over a window of length `T`, the
+    /// satellite gains `a T^2 / 2` inside the window and `a T` of velocity to
+    /// carry for the `0.1 s` between the window's end and the span's: with
+    /// `a = 1e-5` and `T = 0.1`, that is `5e-8 + 1e-7` km.
+    const ANALYTIC: f64 = ACCELERATION * 0.1 * 0.1 / 2.0 + ACCELERATION * 0.1 * 0.1;
+
+    struct WindowedPush {
+        start: f64,
+        end: f64,
+    }
+
+    impl WindowedPush {
+        fn push_at(&self, t: f64) -> (Vector3<f64>, Vector3<f64>) {
+            if t >= self.start && t < self.end {
+                (Vector3::new(ACCELERATION, 0.0, 0.0), Vector3::zeros())
+            } else {
+                (Vector3::zeros(), Vector3::zeros())
+            }
+        }
+    }
+
+    impl InterSatelliteForce for WindowedPush {
+        fn name(&self) -> &str {
+            "windowed_push"
+        }
+
+        fn acceleration_pair(&self, ctx: &PairContext<'_>) -> (Vector3<f64>, Vector3<f64>) {
+            self.push_at(ctx.t)
+        }
+
+        fn acceleration_pair_in_segment(
+            &self,
+            segment: &SegmentContext,
+            _ctx: &PairContext<'_>,
+        ) -> (Vector3<f64>, Vector3<f64>) {
+            self.push_at(segment.start)
+        }
+
+        fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
+            [self.start, self.end]
+                .into_iter()
+                .filter(|edge| *edge > t)
+                .min_by(f64::total_cmp)
+        }
+    }
+
+    #[test]
+    fn a_scheduled_pair_force_pushes_for_its_whole_window() {
+        let r = arika::earth::R + 400.0;
+        let v = (arika::earth::MU / r).sqrt();
+        let state = || OrbitalState::new(Vector3::new(r, 0.0, 0.0), Vector3::new(0.0, v, 0.0));
+        let system = || OrbitalSystem::new(arika::earth::MU, Box::new(PointMass));
+
+        for (name, integrator) in integrators() {
+            let mut pushed = CoupledGroup::new(integrator.clone())
+                .add_satellite("a", state(), system())
+                .add_satellite("b", state(), system())
+                .with_interaction(
+                    0,
+                    1,
+                    Arc::new(WindowedPush {
+                        start: 0.15,
+                        end: 0.25,
+                    }),
+                );
+            let mut coasting = CoupledGroup::new(integrator)
+                .add_satellite("a", state(), system())
+                .add_satellite("b", state(), system());
+            pushed.propagate_to(0.35).expect("finite everywhere");
+            coasting.propagate_to(0.35).expect("finite everywhere");
+
+            let moved = pushed.snapshot().positions[0].1;
+            let unmoved = coasting.snapshot().positions[0].1;
+            // Position, not velocity: `CoupledGroup` reports positions.
+            let displaced = (moved - unmoved).norm();
+            assert!(
+                // 1e-5 relative: the two runs stop sharing gravity once the
+                // push has moved one of them, which measures 1.6e-6 of the
+                // displacement here. A stage lost at the window's end costs
+                // far more — 8e-2 of the Δv, measured on the same shape.
+                (displaced / ANALYTIC - 1.0).abs() < 1e-5,
+                "{name} moved the satellite {displaced:e} km against the {ANALYTIC:e} km \
+                 the push earns"
+            );
+        }
+    }
+}

--- a/orts/tests/burn_window_segments.rs
+++ b/orts/tests/burn_window_segments.rs
@@ -538,7 +538,12 @@ mod scheduled_pair_force {
 /// the target compare `t >= target`, which is false there, so a check placed
 /// after them would let it through. So does a satellite with an `end_time`:
 /// `f64::min` returns the finite end time for both a NaN and `+inf`, and the
-/// group would propagate to that instead of rejecting the call.
+/// group would propagate to that instead of rejecting the call. A group with no
+/// satellites has no entry to check the target against, and a satellite whose
+/// own time is not a number fails every comparison in the loop, so both are
+/// checked here too — the adaptive steppers used to reject the second through
+/// `validate_time_span`, which the segment loop reaches only after deciding to
+/// step.
 #[test]
 fn a_non_finite_target_is_rejected() {
     use orts::group::coupled::CoupledGroup;
@@ -585,7 +590,44 @@ fn a_non_finite_target_is_rejected() {
                 ),
                 "{name}: a satellite with an end time accepted the target {target}"
             );
+
+            let mut empty: IndependentGroup<OrbitalSystem> =
+                IndependentGroup::new(integrator.clone());
+            assert!(
+                matches!(
+                    empty.propagate_to(target),
+                    Err(IntegrationError::InvalidTimeSpan { .. })
+                ),
+                "{name}: a group with no satellites accepted the target {target}"
+            );
         }
+
+        // A satellite whose own time is not a number, propagated to a target
+        // that is perfectly good.
+        let mut started_at_nan = IndependentGroup::new(integrator.clone()).add_satellite_at(
+            "sat",
+            state(),
+            f64::NAN,
+            system(),
+        );
+        assert!(
+            matches!(
+                started_at_nan.propagate_to(1.0),
+                Err(IntegrationError::InvalidTimeSpan { .. })
+            ),
+            "{name}: a satellite starting at NaN was propagated"
+        );
+
+        let mut coupled_at_nan =
+            CoupledGroup::new(integrator).add_satellite("sat", state(), system());
+        coupled_at_nan.set_t(f64::NAN);
+        assert!(
+            matches!(
+                coupled_at_nan.propagate_to(1.0),
+                Err(IntegrationError::InvalidTimeSpan { .. })
+            ),
+            "{name}: a coupled group whose clock is NaN was propagated"
+        );
     }
 }
 

--- a/orts/tests/burn_window_segments.rs
+++ b/orts/tests/burn_window_segments.rs
@@ -618,6 +618,22 @@ fn a_non_finite_target_is_rejected() {
             "{name}: a satellite starting at NaN was propagated"
         );
 
+        // An end time that is not a number: `f64::min` would drop it and
+        // propagate to the target, which is the opposite of what it says.
+        let mut ends_at_nan = IndependentGroup::new(integrator.clone()).add_satellite_until(
+            "sat",
+            state(),
+            f64::NAN,
+            system(),
+        );
+        assert!(
+            matches!(
+                ends_at_nan.propagate_to(1.0),
+                Err(IntegrationError::InvalidTimeSpan { .. })
+            ),
+            "{name}: a satellite whose end time is NaN was propagated"
+        );
+
         let mut coupled_at_nan =
             CoupledGroup::new(integrator).add_satellite("sat", state(), system());
         coupled_at_nan.set_t(f64::NAN);

--- a/orts/tests/burn_window_segments.rs
+++ b/orts/tests/burn_window_segments.rs
@@ -341,7 +341,6 @@ mod scheduled_effector {
     use arika::epoch::Epoch;
     use orts::effector::StateEffector;
     use orts::model::{EvalSegment, ExternalLoads};
-    use orts::spacecraft::SpacecraftDynamics;
 
     struct WindowedCounter {
         start: f64,
@@ -525,6 +524,106 @@ mod scheduled_pair_force {
                 "{name} moved the satellite {displaced:e} km against the {ANALYTIC:e} km \
                  the push earns"
             );
+        }
+    }
+}
+
+/// A target no loop can walk to is rejected, whichever integrator runs.
+///
+/// The segment loop tests `t < target` before it builds a stepper, so a
+/// non-finite target takes no step and the solver never sees it. Without a
+/// check of its own, the loop would report success from where it started.
+#[test]
+fn a_non_finite_target_is_rejected() {
+    use orts::group::coupled::CoupledGroup;
+    use orts::orbital::OrbitalSystem;
+    use utsuroi::IntegrationError;
+
+    let r = arika::earth::R + 400.0;
+    let v = (arika::earth::MU / r).sqrt();
+    let state = || OrbitalState::new(Vector3::new(r, 0.0, 0.0), Vector3::new(0.0, v, 0.0));
+    let system = || OrbitalSystem::new(arika::earth::MU, Box::new(PointMass));
+
+    for (name, integrator) in integrators() {
+        for target in [f64::NAN, f64::INFINITY] {
+            let mut independent =
+                IndependentGroup::new(integrator.clone()).add_satellite("sat", state(), system());
+            assert!(
+                matches!(
+                    independent.propagate_to(target),
+                    Err(IntegrationError::InvalidTimeSpan { .. })
+                ),
+                "{name}: an independent group accepted the target {target}"
+            );
+
+            let mut coupled =
+                CoupledGroup::new(integrator.clone()).add_satellite("sat", state(), system());
+            assert!(
+                matches!(
+                    coupled.propagate_to(target),
+                    Err(IntegrationError::InvalidTimeSpan { .. })
+                ),
+                "{name}: a coupled group accepted the target {target}"
+            );
+        }
+    }
+}
+
+/// The event predicate is asked about each state once, however many segments
+/// the span is split into.
+///
+/// A stepper asks about the state it starts from, since a level-triggered
+/// event can already hold there. The state a later segment starts from is the
+/// one the previous segment ended on, which the loop has already asked about
+/// after that segment's last accepted step, so a stepper built for a
+/// continuation segment must not ask again — a predicate that counts its own
+/// calls would otherwise answer differently for the same trajectory.
+mod event_checks {
+    use super::*;
+    use std::ops::ControlFlow;
+    use std::sync::{Arc, Mutex};
+
+    use orts::spacecraft::SpacecraftDynamics;
+
+    fn times_checked(windows: Vec<BurnWindow>, integrator: IntegratorConfig) -> Vec<f64> {
+        let seen: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(Vec::new()));
+        let recorder = {
+            let seen = Arc::clone(&seen);
+            move |t: f64, _: &_| -> ControlFlow<String> {
+                seen.lock().expect("the recorder is never poisoned").push(t);
+                ControlFlow::Continue(())
+            }
+        };
+        let mut group = IndependentGroup::new(integrator)
+            .add_satellite("sat", initial_state(), dynamics_with(windows))
+            .with_event_checker(recorder);
+        group
+            .propagate_to(1.0)
+            .expect("the burn and the orbit are finite everywhere");
+        seen.lock().expect("the recorder is never poisoned").clone()
+    }
+
+    #[test]
+    fn a_segment_boundary_is_not_checked_twice() {
+        for (name, integrator) in integrators() {
+            let split = times_checked(vec![BurnWindow::full(0.15, 0.25)], integrator.clone());
+            let duplicates: Vec<f64> = split
+                .windows(2)
+                .filter(|pair| pair[0] == pair[1])
+                .map(|pair| pair[0])
+                .collect();
+            assert!(
+                duplicates.is_empty(),
+                "{name} asked about {duplicates:?} twice in a row, out of {split:?}"
+            );
+            // The boundaries themselves are among the times asked about, so the
+            // check above is about states the loop reached, not an empty list.
+            for edge in [0.15, 0.25] {
+                assert!(
+                    split.iter().any(|t| (t - edge).abs() < 1e-12),
+                    "{name} never asked about the boundary at {edge}, only {split:?}"
+                );
+            }
         }
     }
 }

--- a/orts/tests/burn_window_segments.rs
+++ b/orts/tests/burn_window_segments.rs
@@ -260,3 +260,67 @@ fn a_coupled_group_flies_a_short_burn_like_an_independent_one() {
         );
     }
 }
+
+/// The Δv an epoch-scheduled burn applies, against the Δv it was given.
+///
+/// `ConstantThrust` spreads a Δv over `[start, end)`, so what a propagation
+/// applies is that Δv and nothing more. Comparing the two group loops cannot
+/// see this: both would be wrong together. Measured before the burn's interval
+/// became half-open, RK4 with `dt = 1` applied 4/3 of it — the stages on the
+/// two edges each leaked a sixth of a step into the segment beyond.
+///
+/// The span stops just after the burn so the orbit's own evolution stays small,
+/// and the run is compared against a coasting one. The 1e-7 tolerance covers
+/// the gravity the two runs no longer share once the burn has moved one of
+/// them: RK4 and DOP853 agree on the excess to 1e-12, so it is not truncation.
+///
+/// The burn sits at `[0.15, 0.25)` rather than `[0.1, 0.2)` so that the
+/// segment before it is longer than the burn itself. With both 0.1 s long, a
+/// stage-time reading leaks `h/6` of thrust into the segment before the burn
+/// and drops the same `h/6` from the burn's own last stage, and the two cancel
+/// exactly under RK4 — measured, that made RK4 agree with the oracle for the
+/// wrong reason.
+#[test]
+fn an_epoch_scheduled_burn_applies_the_delta_v_it_was_given() {
+    use arika::epoch::Epoch;
+    use arika::frame::Vec3;
+    use orts::orbital::OrbitalSystem;
+    use orts::perturbations::ConstantThrust;
+
+    let epoch_0 = Epoch::j2000();
+    let asked = 1e-6;
+    let system = || {
+        OrbitalSystem::new(arika::earth::MU, Box::new(PointMass))
+            .with_model(ConstantThrust::new(
+                "burn",
+                epoch_0.add_si_seconds(0.15),
+                epoch_0.add_si_seconds(0.25),
+                Vec3::new(asked, 0.0, 0.0),
+            ))
+            .with_epoch(epoch_0)
+    };
+    let coast = || OrbitalSystem::new(arika::earth::MU, Box::new(PointMass)).with_epoch(epoch_0);
+    let r = arika::earth::R + 400.0;
+    let v = (arika::earth::MU / r).sqrt();
+    let state = || OrbitalState::new(Vector3::new(r, 0.0, 0.0), Vector3::new(0.0, v, 0.0));
+
+    for (name, integrator) in integrators() {
+        let mut burning =
+            IndependentGroup::new(integrator.clone()).add_satellite("sat", state(), system());
+        let mut coasting = IndependentGroup::new(integrator).add_satellite("sat", state(), coast());
+        let mut burnt_velocity = Vector3::zeros();
+        let mut coast_velocity = Vector3::zeros();
+        burning
+            .propagate_to_with(0.35, |_, _, s| burnt_velocity = *s.velocity())
+            .expect("the burn and the orbit are finite everywhere");
+        coasting
+            .propagate_to_with(0.35, |_, _, s| coast_velocity = *s.velocity())
+            .expect("the orbit is finite everywhere");
+
+        let applied = (burnt_velocity - coast_velocity).norm();
+        assert!(
+            (applied / asked - 1.0).abs() < 1e-7,
+            "{name} applied {applied:e} km/s of the {asked:e} km/s asked for"
+        );
+    }
+}

--- a/orts/tests/burn_window_segments.rs
+++ b/orts/tests/burn_window_segments.rs
@@ -533,6 +533,12 @@ mod scheduled_pair_force {
 /// The segment loop tests `t < target` before it builds a stepper, so a
 /// non-finite target takes no step and the solver never sees it. Without a
 /// check of its own, the loop would report success from where it started.
+///
+/// `-inf` needs its own case: the guards that skip a satellite already past
+/// the target compare `t >= target`, which is false there, so a check placed
+/// after them would let it through. So does a satellite with an `end_time`:
+/// `f64::min` returns the finite end time for both a NaN and `+inf`, and the
+/// group would propagate to that instead of rejecting the call.
 #[test]
 fn a_non_finite_target_is_rejected() {
     use orts::group::coupled::CoupledGroup;
@@ -545,7 +551,7 @@ fn a_non_finite_target_is_rejected() {
     let system = || OrbitalSystem::new(arika::earth::MU, Box::new(PointMass));
 
     for (name, integrator) in integrators() {
-        for target in [f64::NAN, f64::INFINITY] {
+        for target in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
             let mut independent =
                 IndependentGroup::new(integrator.clone()).add_satellite("sat", state(), system());
             assert!(
@@ -564,6 +570,20 @@ fn a_non_finite_target_is_rejected() {
                     Err(IntegrationError::InvalidTimeSpan { .. })
                 ),
                 "{name}: a coupled group accepted the target {target}"
+            );
+
+            let mut bounded = IndependentGroup::new(integrator.clone()).add_satellite_until(
+                "sat",
+                state(),
+                5.0,
+                system(),
+            );
+            assert!(
+                matches!(
+                    bounded.propagate_to(target),
+                    Err(IntegrationError::InvalidTimeSpan { .. })
+                ),
+                "{name}: a satellite with an end time accepted the target {target}"
             );
         }
     }

--- a/utsuroi/src/error.rs
+++ b/utsuroi/src/error.rs
@@ -113,14 +113,7 @@ pub fn validate_step_size(dt: f64) -> Result<(), IntegrationError> {
 }
 
 /// Reject a time span the monotonically-increasing loops cannot cover.
-/// Rejects a span a loop cannot walk: a non-finite end, or one before the
-/// start.
-///
-/// A propagation loop that splits its span at known boundaries has to check
-/// this itself: with a non-finite target, `t < t_target` is false on the first
-/// test, so the loop takes no step and no solver ever sees the target to
-/// reject it.
-pub fn validate_time_span(t0: f64, t_end: f64) -> Result<(), IntegrationError> {
+pub(crate) fn validate_time_span(t0: f64, t_end: f64) -> Result<(), IntegrationError> {
     if t0.is_finite() && t_end.is_finite() && t_end >= t0 {
         Ok(())
     } else {

--- a/utsuroi/src/error.rs
+++ b/utsuroi/src/error.rs
@@ -113,7 +113,14 @@ pub fn validate_step_size(dt: f64) -> Result<(), IntegrationError> {
 }
 
 /// Reject a time span the monotonically-increasing loops cannot cover.
-pub(crate) fn validate_time_span(t0: f64, t_end: f64) -> Result<(), IntegrationError> {
+/// Rejects a span a loop cannot walk: a non-finite end, or one before the
+/// start.
+///
+/// A propagation loop that splits its span at known boundaries has to check
+/// this itself: with a non-finite target, `t < t_target` is false on the first
+/// test, so the loop takes no step and no solver ever sees the target to
+/// reject it.
+pub fn validate_time_span(t0: f64, t_end: f64) -> Result<(), IntegrationError> {
     if t0.is_finite() && t_end.is_finite() && t_end >= t0 {
         Ok(())
     } else {

--- a/utsuroi/src/lib.rs
+++ b/utsuroi/src/lib.rs
@@ -16,9 +16,7 @@ mod projection;
 #[cfg(test)]
 pub(crate) mod test_systems;
 
-pub use error::{
-    IntegrationError, IntegrationOutcome, Tolerances, validate_step_size, validate_time_span,
-};
+pub use error::{IntegrationError, IntegrationOutcome, Tolerances, validate_step_size};
 pub use integrator::Integrator;
 pub use segment::{SegmentContext, SegmentSystem, derivatives_maybe_in_segment};
 pub use solver::dop853::{AdaptiveStepper853, AdvanceOutcome853, Dop853};

--- a/utsuroi/src/lib.rs
+++ b/utsuroi/src/lib.rs
@@ -16,7 +16,9 @@ mod projection;
 #[cfg(test)]
 pub(crate) mod test_systems;
 
-pub use error::{IntegrationError, IntegrationOutcome, Tolerances, validate_step_size};
+pub use error::{
+    IntegrationError, IntegrationOutcome, Tolerances, validate_step_size, validate_time_span,
+};
 pub use integrator::Integrator;
 pub use segment::{SegmentContext, SegmentSystem, derivatives_maybe_in_segment};
 pub use solver::dop853::{AdaptiveStepper853, AdvanceOutcome853, Dop853};

--- a/utsuroi/src/lib.rs
+++ b/utsuroi/src/lib.rs
@@ -18,7 +18,7 @@ pub(crate) mod test_systems;
 
 pub use error::{IntegrationError, IntegrationOutcome, Tolerances, validate_step_size};
 pub use integrator::Integrator;
-pub use segment::{SegmentContext, SegmentSystem};
+pub use segment::{SegmentContext, SegmentSystem, derivatives_maybe_in_segment};
 pub use solver::dop853::{AdaptiveStepper853, AdvanceOutcome853, Dop853};
 pub use solver::dp45::{AdaptiveStepper, AdvanceOutcome, DormandPrince};
 pub use solver::rk4::Rk4;

--- a/utsuroi/src/lib.rs
+++ b/utsuroi/src/lib.rs
@@ -3,6 +3,7 @@
 mod error;
 mod integrator;
 pub(crate) mod math;
+mod segment;
 mod solver;
 mod state;
 
@@ -17,6 +18,7 @@ pub(crate) mod test_systems;
 
 pub use error::{IntegrationError, IntegrationOutcome, Tolerances, validate_step_size};
 pub use integrator::Integrator;
+pub use segment::{SegmentContext, SegmentSystem};
 pub use solver::dop853::{AdaptiveStepper853, AdvanceOutcome853, Dop853};
 pub use solver::dp45::{AdaptiveStepper, AdvanceOutcome, DormandPrince};
 pub use solver::rk4::Rk4;

--- a/utsuroi/src/segment.rs
+++ b/utsuroi/src/segment.rs
@@ -80,6 +80,23 @@ impl<S: DynamicalSystem> DynamicalSystem for SegmentSystem<'_, S> {
     }
 }
 
+/// Derivatives from `system`, for the segment when there is one.
+///
+/// A system that holds other systems calls this on each of them, so a segment
+/// reaches the part of the right-hand side that switches instead of stopping at
+/// the system on top.
+pub fn derivatives_maybe_in_segment<S: DynamicalSystem>(
+    system: &S,
+    segment: Option<&SegmentContext>,
+    t: f64,
+    state: &S::State,
+) -> S::State {
+    match segment {
+        Some(segment) => system.derivatives_in_segment(segment, t, state),
+        None => system.derivatives(t, state),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use core::ops::ControlFlow;

--- a/utsuroi/src/segment.rs
+++ b/utsuroi/src/segment.rs
@@ -48,9 +48,11 @@ impl SegmentContext {
 /// [`derivatives_in_segment`](DynamicalSystem::derivatives_in_segment) with the
 /// bound segment, so every stage the solver evaluates — including the one at
 /// the segment's end — reads the segment's mode. Build one per segment and drop
-/// it at the end: an adaptive stepper built on it holds its FSAL derivative for
-/// the segment's lifetime only, which is what keeps a derivative from one side
-/// of a switch out of the step on the other side.
+/// it at the end: DP45 carries `k7` from an accepted step into the next step as
+/// its `k1`, so a stepper living across a switch would open the step after it
+/// with a derivative taken on the other side. DOP853's `k1` is empty after an
+/// accepted step — it caches one only to retry a rejected step — so there it is
+/// the adapted step size, not a derivative, that a fresh stepper drops.
 pub struct SegmentSystem<'a, S> {
     system: &'a S,
     segment: SegmentContext,

--- a/utsuroi/src/segment.rs
+++ b/utsuroi/src/segment.rs
@@ -1,0 +1,231 @@
+//! Integrating between two known discontinuities.
+//!
+//! [`DynamicalSystem::next_discontinuity_after`] lets a system say when its
+//! right-hand side switches, so a propagation loop can end a step there. That
+//! alone leaves the switch time itself ambiguous: a solver's last stage lands
+//! on the step's end, and a term that is on over `[a, b)` reads off there. RK4
+//! weights that stage `1/6`, so a burn covering a whole step integrates to
+//! `5/6` of its value — measured on `[0, 1)` with `dt = 1`.
+//!
+//! A segment fixes which side of its ends the right-hand side is read on:
+//! every stage of a segment `[a, b]`, the one at `b` included, reads the mode
+//! that holds over `[a, b)`, and the next segment reads the mode that starts
+//! at `b`. [`SegmentSystem`] carries that choice by wrapping the system a
+//! solver steps, so no solver needs to know about segments at all.
+
+use crate::state::DynamicalSystem;
+
+/// The interval a solver is stepping through, between two switches of the
+/// right-hand side.
+///
+/// `start` and `end` are integration times, `start < end`. A system that reads
+/// a schedule answers for the whole segment as it stood at `start`, whatever
+/// stage time it is handed.
+///
+/// The state at `start` is deliberately absent. Freezing a state-dependent
+/// term over a segment would turn a continuous-time feedback law into a
+/// sampled-data one, and make the result depend on how the span happens to be
+/// split. A schedule in time is what a segment fixes; a term that reads the
+/// state keeps reading the stage state.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SegmentContext {
+    /// Integration time the segment starts at.
+    pub start: f64,
+    /// Integration time the segment ends at.
+    pub end: f64,
+}
+
+impl SegmentContext {
+    /// A segment spanning `[start, end]`.
+    pub fn new(start: f64, end: f64) -> Self {
+        Self { start, end }
+    }
+}
+
+/// A system bound to one segment, for handing to a solver.
+///
+/// [`derivatives`](DynamicalSystem::derivatives) forwards to
+/// [`derivatives_in_segment`](DynamicalSystem::derivatives_in_segment) with the
+/// bound segment, so every stage the solver evaluates — including the one at
+/// the segment's end — reads the segment's mode. Build one per segment and drop
+/// it at the end: an adaptive stepper built on it holds its FSAL derivative for
+/// the segment's lifetime only, which is what keeps a derivative from one side
+/// of a switch out of the step on the other side.
+pub struct SegmentSystem<'a, S> {
+    system: &'a S,
+    segment: SegmentContext,
+}
+
+impl<'a, S: DynamicalSystem> SegmentSystem<'a, S> {
+    /// Bind `system` to `segment`.
+    pub fn new(system: &'a S, segment: SegmentContext) -> Self {
+        Self { system, segment }
+    }
+
+    /// The segment this system is bound to.
+    pub fn segment(&self) -> &SegmentContext {
+        &self.segment
+    }
+}
+
+impl<S: DynamicalSystem> DynamicalSystem for SegmentSystem<'_, S> {
+    type State = S::State;
+
+    fn derivatives(&self, t: f64, state: &Self::State) -> Self::State {
+        self.system.derivatives_in_segment(&self.segment, t, state)
+    }
+
+    fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
+        self.system.next_discontinuity_after(t)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::ops::ControlFlow;
+
+    use nalgebra::Vector1;
+
+    use super::*;
+    use crate::{Dop853, DormandPrince, Integrator, Rk4, State, Tolerances};
+
+    fn rate(value: f64) -> State<1, 1> {
+        State {
+            components: [Vector1::new(value)],
+        }
+    }
+
+    /// `y' = 1` while `t` is in `[0.1, 0.2)`, `y' = 0` elsewhere.
+    ///
+    /// The analytic answer over `[0, 1]` is `0.1`, and nothing else in the
+    /// system moves, so what a solver returns is the length of the gate it
+    /// actually sampled. A stage on the gate's end reading off costs that
+    /// stage's weight; missing the gate entirely returns `0`.
+    struct Gate {
+        start: f64,
+        end: f64,
+    }
+
+    impl Gate {
+        fn open_at(&self, t: f64) -> f64 {
+            if t >= self.start && t < self.end {
+                1.0
+            } else {
+                0.0
+            }
+        }
+    }
+
+    impl DynamicalSystem for Gate {
+        type State = State<1, 1>;
+
+        fn derivatives(&self, t: f64, _state: &Self::State) -> Self::State {
+            rate(self.open_at(t))
+        }
+
+        fn derivatives_in_segment(
+            &self,
+            segment: &SegmentContext,
+            _t: f64,
+            _state: &Self::State,
+        ) -> Self::State {
+            rate(self.open_at(segment.start))
+        }
+
+        fn next_discontinuity_after(&self, t: f64) -> Option<f64> {
+            [self.start, self.end]
+                .into_iter()
+                .filter(|edge| *edge > t)
+                .min_by(f64::total_cmp)
+        }
+    }
+
+    const GATE: Gate = Gate {
+        start: 0.1,
+        end: 0.2,
+    };
+    const T_END: f64 = 1.0;
+
+    /// Walk the segments the system declares, integrating each with its own
+    /// stepper, the way a propagation loop is meant to.
+    fn integrate_by_segment(
+        step: impl Fn(&SegmentSystem<'_, Gate>, f64, f64, State<1, 1>) -> State<1, 1>,
+    ) -> f64 {
+        let mut t = 0.0;
+        let mut y = rate(0.0);
+        while t < T_END {
+            let end = GATE
+                .next_discontinuity_after(t)
+                .map_or(T_END, |next| next.min(T_END));
+            let bound = SegmentSystem::new(&GATE, SegmentContext::new(t, end));
+            y = step(&bound, t, end, y);
+            t = end;
+        }
+        y.components[0][0]
+    }
+
+    #[test]
+    fn a_gate_shorter_than_a_step_is_integrated_once_the_span_is_split_at_its_edges() {
+        // One RK4 step over the whole span samples t = 0, 0.5, 0.5, 1 and
+        // never opens the gate.
+        let missed = Rk4.integrate(&GATE, rate(0.0), 0.0, T_END, T_END, |_, _| {});
+        assert_eq!(missed.components[0][0], 0.0);
+
+        let integrated = integrate_by_segment(|bound, t, end, y| {
+            Rk4.integrate(bound, y, t, end, end - t, |_, _| {})
+        });
+        assert!(
+            (integrated - 0.1).abs() < 1e-15,
+            "expected the gate's length 0.1, got {integrated}"
+        );
+    }
+
+    #[test]
+    fn the_stage_on_a_segment_end_reads_the_mode_that_held_inside_it() {
+        // The gate covers this segment exactly. Read at the stage times, the
+        // stage at t = 0.2 is outside `[0.1, 0.2)` and RK4 would lose its
+        // weight 1/6, leaving 5/6 of the interval.
+        let by_stage_time = Rk4.integrate(&GATE, rate(0.0), 0.1, 0.2, 0.1, |_, _| {});
+        assert!(
+            (by_stage_time.components[0][0] - 0.1 * 5.0 / 6.0).abs() < 1e-15,
+            "expected 5/6 of the interval, got {}",
+            by_stage_time.components[0][0]
+        );
+
+        let bound = SegmentSystem::new(&GATE, SegmentContext::new(0.1, 0.2));
+        let in_segment = Rk4.integrate(&bound, rate(0.0), 0.1, 0.2, 0.1, |_, _| {});
+        assert!(
+            (in_segment.components[0][0] - 0.1).abs() < 1e-15,
+            "expected the whole interval 0.1, got {}",
+            in_segment.components[0][0]
+        );
+    }
+
+    #[test]
+    fn every_solver_integrates_the_gate_to_its_length() {
+        let rk4 = integrate_by_segment(|bound, t, end, y| {
+            Rk4.integrate(bound, y, t, end, end - t, |_, _| {})
+        });
+        let dp45 = integrate_by_segment(|bound, t, end, y| {
+            let mut stepper = DormandPrince.stepper(bound, y, t, end - t, Tolerances::default());
+            stepper
+                .advance_to(end, |_, _| {}, |_, _| ControlFlow::<()>::Continue(()))
+                .expect("the gate is finite everywhere");
+            stepper.into_state()
+        });
+        let dop853 = integrate_by_segment(|bound, t, end, y| {
+            let mut stepper = Dop853.stepper(bound, y, t, end - t, Tolerances::default());
+            stepper
+                .advance_to(end, |_, _| {}, |_, _| ControlFlow::<()>::Continue(()))
+                .expect("the gate is finite everywhere");
+            stepper.into_state()
+        });
+
+        for (name, got) in [("RK4", rk4), ("DP45", dp45), ("DOP853", dop853)] {
+            assert!(
+                (got - 0.1).abs() < 1e-12,
+                "{name} integrated the gate to {got}, expected 0.1"
+            );
+        }
+    }
+}

--- a/utsuroi/src/solver/dop853/mod.rs
+++ b/utsuroi/src/solver/dop853/mod.rs
@@ -242,9 +242,31 @@ pub struct AdaptiveStepper853<'a, S: DynamicalSystem> {
     tol: Tolerances,
     /// Minimum step size below which integration fails.
     pub dt_min: f64,
+    /// Whether the state this stepper starts from has already been checked
+    /// for events.
+    ///
+    /// [`advance_to`](Self::advance_to) asks the predicate about the state it
+    /// starts from, because a level-triggered event can already hold there. A
+    /// propagation loop that splits its span at known boundaries hands each
+    /// segment the state the previous segment ended on, and has already asked
+    /// about it after that segment's last accepted step; asking again calls the
+    /// predicate twice for one `(t, state)`, which a predicate counting its own
+    /// calls would answer differently. Set through
+    /// [`from_checked_state`](Self::from_checked_state).
+    start_is_checked: bool,
 }
 
 impl<'a, S: DynamicalSystem> AdaptiveStepper853<'a, S> {
+    /// Skip the event check on the state this stepper starts from.
+    ///
+    /// For a segment that continues where the previous one ended: the caller
+    /// has asked its predicate about that state already. Checks after accepted
+    /// steps are unaffected.
+    pub fn from_checked_state(mut self) -> Self {
+        self.start_is_checked = true;
+        self
+    }
+
     /// Advance adaptively to `t_target`.
     ///
     /// - For a target that advances, `event_check` runs first on the state the
@@ -283,7 +305,8 @@ impl<'a, S: DynamicalSystem> AdaptiveStepper853<'a, S> {
         // step late with a state the caller's own predicate calls invalid.
         // Only for a target that advances: `advance_to(self.t, ..)` takes no
         // step, so it reports nothing and asks nothing.
-        if self.t < t_target
+        if !self.start_is_checked
+            && self.t < t_target
             && let ControlFlow::Break(reason) = event_check(self.t, &self.state)
         {
             return Ok(AdvanceOutcome853::Event { reason });
@@ -414,6 +437,7 @@ impl Dop853 {
             k1: None,
             tol,
             dt_min,
+            start_is_checked: false,
         }
     }
 

--- a/utsuroi/src/solver/dp45/mod.rs
+++ b/utsuroi/src/solver/dp45/mod.rs
@@ -127,9 +127,31 @@ pub struct AdaptiveStepper<'a, S: DynamicalSystem> {
     /// Minimum step size below which integration fails. Can be overridden
     /// after construction to match the total integration interval.
     pub dt_min: f64,
+    /// Whether the state this stepper starts from has already been checked
+    /// for events.
+    ///
+    /// [`advance_to`](Self::advance_to) asks the predicate about the state it
+    /// starts from, because a level-triggered event can already hold there. A
+    /// propagation loop that splits its span at known boundaries hands each
+    /// segment the state the previous segment ended on, and has already asked
+    /// about it after that segment's last accepted step; asking again calls the
+    /// predicate twice for one `(t, state)`, which a predicate counting its own
+    /// calls would answer differently. Set through
+    /// [`from_checked_state`](Self::from_checked_state).
+    start_is_checked: bool,
 }
 
 impl<'a, S: DynamicalSystem> AdaptiveStepper<'a, S> {
+    /// Skip the event check on the state this stepper starts from.
+    ///
+    /// For a segment that continues where the previous one ended: the caller
+    /// has asked its predicate about that state already. Checks after accepted
+    /// steps are unaffected.
+    pub fn from_checked_state(mut self) -> Self {
+        self.start_is_checked = true;
+        self
+    }
+
     /// Advance adaptively to `t_target`.
     ///
     /// - For a target that advances, `event_check` runs first on the state the
@@ -168,7 +190,8 @@ impl<'a, S: DynamicalSystem> AdaptiveStepper<'a, S> {
         // step late with a state the caller's own predicate calls invalid.
         // Only for a target that advances: `advance_to(self.t, ..)` takes no
         // step, so it reports nothing and asks nothing.
-        if self.t < t_target
+        if !self.start_is_checked
+            && self.t < t_target
             && let ControlFlow::Break(reason) = event_check(self.t, &self.state)
         {
             return Ok(AdvanceOutcome::Event { reason });
@@ -300,6 +323,7 @@ impl DormandPrince {
             k1: None,
             tol,
             dt_min,
+            start_is_checked: false,
         }
     }
 

--- a/utsuroi/src/state.rs
+++ b/utsuroi/src/state.rs
@@ -315,4 +315,30 @@ pub trait DynamicalSystem {
     fn next_discontinuity_after(&self, _t: f64) -> Option<f64> {
         None
     }
+
+    /// Derivatives at `t`, evaluated for the segment the solver is stepping
+    /// through.
+    ///
+    /// A solver reaches this through [`SegmentSystem`], which binds one
+    /// segment and forwards [`derivatives`](Self::derivatives) here. A term
+    /// that switches on a schedule answers for `segment.start` however late in
+    /// the segment `t` falls, which is what keeps the stage on `segment.end`
+    /// on the inside of a half-open interval that ends there.
+    ///
+    /// A term that reads the state keeps reading `state`: a segment fixes a
+    /// schedule in time, not a feedback law.
+    ///
+    /// The default ignores the segment and forwards to
+    /// [`derivatives`](Self::derivatives), which is right for every system
+    /// whose right-hand side is continuous.
+    ///
+    /// [`SegmentSystem`]: crate::SegmentSystem
+    fn derivatives_in_segment(
+        &self,
+        _segment: &crate::SegmentContext,
+        t: f64,
+        state: &Self::State,
+    ) -> Self::State {
+        self.derivatives(t, state)
+    }
 }


### PR DESCRIPTION
## 概要

`ScheduledBurn` に指定した燃焼が伝播に入らない。伝播ループが現在時刻から目標時刻まで積分器を
1 回走らせるので、燃焼区間が評価点の最大間隔($h/2$)より短いと評価点が 1 つも入らず、推進剤も
速度変化も 0 になる。区間がステップ全体を覆う場合も、終端に乗るステージが区間の外を読むので、
RK4 では重み $1/6$ が落ちる。

推力 10 N、Isp 300 s、質量 100 kg、400 km 円軌道を 10 s 伝播した実測:

| 燃焼区間 | 刻み | 修正前の推進剤 [kg] | 解析解 [kg] |
|---|---|---|---|
| `[0.1, 0.2)` | RK4 $dt = 1$ | $0$ | $3.399 \times 10^{-4}$ |
| `[0.0, 1.0)` | RK4 $dt = 1$ | $2.833 \times 10^{-3}$ | $3.399 \times 10^{-3}$ |

![境界で区切る前と後の評価点](https://github.com/user-attachments/assets/a5d26898-6297-40aa-8488-0c079279f1fa)

**両方の group ループが、system の報告する境界で span を区切り、segment ごとに stepper を作って
積分するようにした。**#452 で system が境界を返せるようになったので、ループがそれを使う側になる。

## 直した形

segment を束縛した system を solver に渡す。solver のステージ実装は変更していない。

```rust
// utsuroi
pub struct SegmentContext { pub start: f64, pub end: f64 }
fn derivatives_in_segment(&self, segment: &SegmentContext, t: f64, state: &Self::State) -> Self::State;
let bound = SegmentSystem::new(dynamics, SegmentContext::new(t, segment_end));
```

`SegmentSystem::derivatives` が `derivatives_in_segment` に転送するので、segment の終端に乗る
ステージも segment の mode を読む。orts 側は `Model::eval_in_segment` /
`ThrustProfile::throttle_in_segment` / `StateEffector::derivatives_in_segment` /
`InterSatelliteForce::acceleration_pair_in_segment` で受け、model を持つ 5 system と composite
2 つが配下に転送する。固定するのは時間の schedule だけで、state を読む項は各ステージの state を
読み続ける(segment 内で凍結すると、連続時間の feedback law が sampled-data になる)。

`ConstantThrust` は燃焼区間を半開 `[start, end)` に変えた。両端を数えていたので、その端で span を
区切ると前後の segment に推力が漏れ、要求 ΔV の 4/3 倍になっていた。**燃焼の最後の瞬間は噴射
しなくなる。**

伝播ループが solver から引き取った判断が 2 つある。span の検証(`t < target` が偽だと stepper を
作らないので solver に届かない → target・現在時刻・`end_time` の有限性をループ側で検査する)と、
開始状態の event 検査(segment ごとに繰り返されるので、継続 segment は `from_checked_state()` で
1 回に戻す)。

RK4 分岐は `t_target - 1e-12` の絶対 tolerance をやめ(1e-12 より狭い segment を飛ばす)、segment
の最後のステップを端に厳密に着地させた(`h` を足し込むと 1 ulp 手前に残り、次の `h` が stagnation
検査に掛かる)。

## 検証

oracle は解析解。全推力の燃焼が消す推進剤は `thrust / (Isp * g0)` × 燃焼長で、質量流量が state に
依らないので軌道がどうであっても変わらない。RK4 / DP45 / DOP853 の 3 つで、ステップより短い区間・
ステップ全体を覆う区間・隣接する 2 区間・span の終端で終わる区間・呼び出しを 3 分割した場合を
検査した。schedule を持つ effector は窓の長さ、衛星間力は変位($1.500 \times 10^{-7}$ km)、
`ConstantThrust` は ΔV そのものが oracle。

mutation で、どのテストが何を守っているか測った:

| mutation | 結果 |
|---|---|
| `ScheduledBurn` が stage 時刻の schedule を読む | 推進剤が $5/6$ |
| independent ループが span を区切らない | 推進剤が 10 倍(区切らないと segment が span 全体になり、その throttle が保持される) |
| coupled ループが span を区切らない | 位置が $2.783 \times 10^{-5}$ km ずれる |
| `ConstantThrust` が stage 時刻の epoch を読む | ΔV が RK4 1.0833 / DP45 1.00004 / DOP853 1.00039 倍 |
| effector が stage 時刻で評価 | 窓の積分が 0.10833(期待 0.1) |
| 衛星間力が stage 時刻で評価 | 変位が $1.833 \times 10^{-7}$ km(解析値 $1.500 \times 10^{-7}$) |

窓は `[0.15, 0.25)` に置いた。`[0.1, 0.2)` だと窓とその直前の segment がどちらも 0.1 s になり、
stage 時刻で読んだときに前へ漏れる $h/6$ と窓の最終ステージから落ちる $h/6$ が RK4 で厳密に
打ち消す。最初はそう書いて、RK4 が誤った理由で oracle に一致していた。

## 関連

#446 の PR 1。残るのは utsuroi の root event、RW 飽和、dry mass 枯渇で、いずれも時刻が state で
決まる境界。controlled loop に残る同型の欠落は #454。
