### PR TITLE
fix(cli): propagate the controlled loop one segment at a time

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -394,6 +394,14 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   client への error も無い状態になっていた。([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
+- controlled loop が、積分 step より短い燃焼も伝播に入れるようになった。
+  `propagate_controlled` は span の始まりから終わりまで積分器を 1 回走らせていたので、schedule を
+  持つ dynamics では #453 以前の group ループと同じ取りこぼしが起きていた。`ScheduledBurn` で
+  `[0.15, 0.25)` を指定し RK4 `dt = 1` で伝播した実測で、燃焼が要求する推進剤 3.399e-4 kg を
+  1 つも消さない。dynamics が報告する境界でループを区切り、segment を束縛した system で積分する
+  ようにした。非有限の span は「すでに終わっている」ではなく拒否する (`t1 <= t0` も、ループ自身の
+  条件も NaN では偽になる)。CLI の config から構築されるもので境界を宣言するものは今はないので、
+  影響を受けるのは `ControlledSatellite` を自分で組む呼び出し元。([#455](https://github.com/sksat/orts/pull/455))
 - `duration` が各衛星の軌道周期を置き換えなくなった。`duration` は run の終了時刻だが
   両方が 1 つの field に載っていたため、`--duration 120` は CSV header・RRD の
   `meta/sim/period`・WebSocket の `SatelliteInfo` のすべてに、5553.6 s かかる軌道の

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -467,6 +467,16 @@ section is subdivided by package.
   no error to the client. ([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
+- The controlled loop flies a scheduled burn shorter than an integration step.
+  `propagate_controlled` ran the integrator from the span's start straight to
+  its end, so dynamics carrying a schedule lost it the way the group loops did
+  before #453: measured on a `ScheduledBurn` over `[0.15, 0.25)` with RK4 at
+  `dt = 1`, the loop spent none of the 3.399e-4 kg of propellant the burn asks
+  for. It now walks the boundaries the dynamics report, integrating each segment
+  on a system bound to it. A non-finite span is rejected rather than reported as
+  covered — `t1 <= t0` is false for a NaN, and so is the loop's own condition.
+  Nothing the CLI builds from config declares a boundary today, so this reaches
+  a caller assembling a `ControlledSatellite` itself. ([#455](https://github.com/sksat/orts/pull/455))
 - `duration` no longer replaces each satellite's orbital period. It is the
   run's end time, but both were carried in one field, so `--duration 120` left
   the CSV header, the RRD `meta/sim/period` and the WebSocket `SatelliteInfo`

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -482,6 +482,15 @@ pub fn propagate_controlled(
                 // a bad step or a stalled clock, and this returns `Result` so
                 // serve can send the client an Error down its graceful-halt
                 // path.
+                //
+                // Its clock accumulates (`t += h`), unlike the group loops,
+                // which assign the segment's end on the last step. The residual
+                // is the exactly representable `segment_end - t`, so the clock
+                // still arrives on `segment_end` — measured over spans with
+                // inexact accumulation and at times as large as 1e15, it lands
+                // there in every case and never stagnates. What it costs is one
+                // extra step of an ulp's width, which moves the state by less
+                // than its own resolution.
                 sat.state = Rk4
                     .try_integrate(&bound, sat.state.clone(), t, segment_end, dt_ode, |_, _| {})
                     .map_err(span)?;
@@ -1513,28 +1522,47 @@ path = "does-not-exist.wasm"
     /// than the burn. With both 0.1 s long, the `h/6` a stage-time reading
     /// leaks into the earlier segment and the `h/6` it drops from the burn's
     /// last stage cancel exactly under RK4.
+    ///
+    /// The second case gives the burn's own segment several RK4 steps — a
+    /// 0.4 s window at `dt = 0.1` — so the propellant also pins the multi-step
+    /// path, where `try_integrate` accumulates its clock and covers the
+    /// residual with one more step.
     #[test]
     fn a_burn_shorter_than_a_step_is_flown_by_the_controlled_loop() {
-        use orts::spacecraft::{BurnWindow, G0, ScheduledBurn, Thruster};
+        use orts::spacecraft::G0;
+
+        const THRUST_N: f64 = 10.0;
+        const ISP_S: f64 = 300.0;
+
+        for (window, dt) in
+            [(0.15, 0.25, 1.0), (0.15, 0.55, 0.1)].map(|(start, end, dt)| ((start, end), dt))
+        {
+            let expected = THRUST_N / (ISP_S * G0) * (window.1 - window.0);
+            run_burn_case(window, dt, expected);
+        }
+    }
+
+    /// Fly one burn window with each integrator and check the propellant.
+    fn run_burn_case(window: (f64, f64), dt: f64, expected: f64) {
+        use orts::spacecraft::{BurnWindow, ScheduledBurn, Thruster};
         use utsuroi::Tolerances;
 
         const THRUST_N: f64 = 10.0;
         const ISP_S: f64 = 300.0;
 
-        let expected = THRUST_N / (ISP_S * G0) * 0.1;
         for (name, integrator) in [
-            ("RK4", IntegratorConfig::Rk4 { dt: 1.0 }),
+            ("RK4", IntegratorConfig::Rk4 { dt }),
             (
                 "DP45",
                 IntegratorConfig::Dp45 {
-                    dt: 1.0,
+                    dt,
                     tolerances: Tolerances::default(),
                 },
             ),
             (
                 "DOP853",
                 IntegratorConfig::Dop853 {
-                    dt: 1.0,
+                    dt,
                     tolerances: Tolerances::default(),
                 },
             ),
@@ -1551,7 +1579,7 @@ path = "does-not-exist.wasm"
             .with_model(
                 Thruster::new(THRUST_N, ISP_S, Vector3::x()).with_profile(Box::new(
                     ScheduledBurn {
-                        windows: vec![BurnWindow::full(0.15, 0.25)],
+                        windows: vec![BurnWindow::full(window.0, window.1)],
                     },
                 )),
             );
@@ -1567,7 +1595,9 @@ path = "does-not-exist.wasm"
             let tol = 4.0 * mass_before * f64::EPSILON;
             assert!(
                 (spent - expected).abs() < tol,
-                "{name} spent {spent} kg, expected {expected} kg"
+                "{name} at dt={dt} spent {spent} kg over [{}, {}), expected {expected} kg",
+                window.0,
+                window.1
             );
         }
     }

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -24,7 +24,10 @@ use orts::spacecraft::{
     ThrusterAssemblyCore, ThrusterSpec,
 };
 use tobari::magnetic::igrf::Igrf;
-use utsuroi::{Dop853, DormandPrince, IntegrationError, Integrator, Rk4};
+use utsuroi::{
+    Dop853, DormandPrince, DynamicalSystem, IntegrationError, Integrator, Rk4, SegmentContext,
+    SegmentSystem,
+};
 
 use crate::config::{ControllerConfig, MtqConfig, ReactionWheelConfig, SensorChoice};
 use crate::satellite::SatelliteSpec;
@@ -443,47 +446,82 @@ pub fn propagate_controlled(
     t1: f64,
     integrator: &IntegratorConfig,
 ) -> Result<(), String> {
+    let span = |e: IntegrationError| format!("integration failed on [{t0:.3}, {t1:.3}]: {e}");
+
+    // The span the caller asked for, before the segment loop below reads it.
+    // `t1 <= t0` is false for a NaN, and `t < t1` is false too, so the loop
+    // would take no step and report success — the solvers used to reject the
+    // span themselves, which they now only see one segment at a time.
+    if !t0.is_finite() || !t1.is_finite() {
+        return Err(span(IntegrationError::InvalidTimeSpan { t0, t_end: t1 }));
+    }
     if t1 <= t0 {
         return Ok(());
     }
-    let span = |e: IntegrationError| format!("integration failed on [{t0:.3}, {t1:.3}]: {e}");
 
-    match integrator {
-        IntegratorConfig::Rk4 { dt } => {
-            let dt_ode = dt.min(t1 - t0);
-            // `try_integrate` rather than `integrate`: the latter panics on a
-            // bad step or a stalled clock, and this returns `Result` so serve
-            // can send the client an Error down its graceful-halt path.
-            sat.state = Rk4
-                .try_integrate(&sat.dynamics, sat.state.clone(), t0, t1, dt_ode, |_, _| {})
-                .map_err(span)?;
+    // One segment at a time, so that no switch of the right-hand side falls
+    // strictly inside a step and the stage on a segment's end reads the mode
+    // that held inside it. Without this, a burn window narrower than the
+    // largest gap between adjacent stage times contributes nothing at all, and
+    // one covering a whole step loses the weight of the stage on its exclusive
+    // end.
+    let mut t = t0;
+    let mut first_segment = true;
+    while t < t1 {
+        let segment_end = sat
+            .dynamics
+            .next_discontinuity_after(t)
+            .filter(|next| *next > t && next.is_finite())
+            .map_or(t1, |next| next.min(t1));
+        let bound = SegmentSystem::new(&sat.dynamics, SegmentContext::new(t, segment_end));
+
+        match integrator {
+            IntegratorConfig::Rk4 { dt } => {
+                let dt_ode = dt.min(segment_end - t);
+                // `try_integrate` rather than `integrate`: the latter panics on
+                // a bad step or a stalled clock, and this returns `Result` so
+                // serve can send the client an Error down its graceful-halt
+                // path.
+                sat.state = Rk4
+                    .try_integrate(&bound, sat.state.clone(), t, segment_end, dt_ode, |_, _| {})
+                    .map_err(span)?;
+            }
+            IntegratorConfig::Dp45 { dt, tolerances } => {
+                let mut stepper =
+                    DormandPrince.stepper(&bound, sat.state.clone(), t, *dt, tolerances.clone());
+                // A later segment starts from the state the previous one ended
+                // on, which this loop asks no predicate about at all.
+                if !first_segment {
+                    stepper = stepper.from_checked_state();
+                }
+                stepper
+                    .advance_to(
+                        segment_end,
+                        |_, _| {},
+                        |_, _| ControlFlow::<String>::Continue(()),
+                    )
+                    .map_err(span)?;
+                sat.state = stepper.into_state();
+            }
+            IntegratorConfig::Dop853 { dt, tolerances } => {
+                let mut stepper =
+                    Dop853.stepper(&bound, sat.state.clone(), t, *dt, tolerances.clone());
+                if !first_segment {
+                    stepper = stepper.from_checked_state();
+                }
+                stepper
+                    .advance_to(
+                        segment_end,
+                        |_, _| {},
+                        |_, _| ControlFlow::<String>::Continue(()),
+                    )
+                    .map_err(span)?;
+                sat.state = stepper.into_state();
+            }
         }
-        IntegratorConfig::Dp45 { dt, tolerances } => {
-            let mut stepper = DormandPrince.stepper(
-                &sat.dynamics,
-                sat.state.clone(),
-                t0,
-                *dt,
-                tolerances.clone(),
-            );
-            stepper
-                .advance_to(t1, |_, _| {}, |_, _| ControlFlow::<String>::Continue(()))
-                .map_err(span)?;
-            sat.state = stepper.into_state();
-        }
-        IntegratorConfig::Dop853 { dt, tolerances } => {
-            let mut stepper = Dop853.stepper(
-                &sat.dynamics,
-                sat.state.clone(),
-                t0,
-                *dt,
-                tolerances.clone(),
-            );
-            stepper
-                .advance_to(t1, |_, _| {}, |_, _| ControlFlow::<String>::Continue(()))
-                .map_err(span)?;
-            sat.state = stepper.into_state();
-        }
+
+        t = segment_end;
+        first_segment = false;
     }
     Ok(())
 }
@@ -1458,6 +1496,101 @@ path = "does-not-exist.wasm"
             assert!(
                 !err.contains("magnetorquer"),
                 "{body}: the magnetorquer should not stop the build: {err}"
+            );
+        }
+    }
+
+    /// A burn shorter than an integration step is flown by the controlled loop.
+    ///
+    /// `propagate_controlled` used to run the integrator from `t0` straight to
+    /// `t1`, so a `ScheduledBurn` narrower than the largest gap between
+    /// adjacent stage times fell between them and spent nothing. The oracle is
+    /// the analytic propellant, `thrust / (Isp * g0)` times the burn's length,
+    /// which the trajectory cannot change: the mass flow of a thruster at full
+    /// throttle does not depend on the state.
+    ///
+    /// The window sits at `[0.15, 0.25)` so the segment before it is longer
+    /// than the burn. With both 0.1 s long, the `h/6` a stage-time reading
+    /// leaks into the earlier segment and the `h/6` it drops from the burn's
+    /// last stage cancel exactly under RK4.
+    #[test]
+    fn a_burn_shorter_than_a_step_is_flown_by_the_controlled_loop() {
+        use orts::spacecraft::{BurnWindow, G0, ScheduledBurn, Thruster};
+        use utsuroi::Tolerances;
+
+        const THRUST_N: f64 = 10.0;
+        const ISP_S: f64 = 300.0;
+
+        let expected = THRUST_N / (ISP_S * G0) * 0.1;
+        for (name, integrator) in [
+            ("RK4", IntegratorConfig::Rk4 { dt: 1.0 }),
+            (
+                "DP45",
+                IntegratorConfig::Dp45 {
+                    dt: 1.0,
+                    tolerances: Tolerances::default(),
+                },
+            ),
+            (
+                "DOP853",
+                IntegratorConfig::Dop853 {
+                    dt: 1.0,
+                    tolerances: Tolerances::default(),
+                },
+            ),
+        ] {
+            let (mut sat, _) = satellite_with(1.0, 0.0);
+            sat.dynamics = std::mem::replace(
+                &mut sat.dynamics,
+                orts::spacecraft::SpacecraftDynamics::new(
+                    arika::earth::MU,
+                    Box::new(orts::orbital::gravity::PointMass),
+                    nalgebra::Matrix3::identity(),
+                ),
+            )
+            .with_model(
+                Thruster::new(THRUST_N, ISP_S, Vector3::x()).with_profile(Box::new(
+                    ScheduledBurn {
+                        windows: vec![BurnWindow::full(0.15, 0.25)],
+                    },
+                )),
+            );
+            let mass_before = sat.state.plant.mass;
+
+            propagate_controlled(&mut sat, 0.0, 10.0, &integrator)
+                .expect("the burn and the orbit are finite everywhere");
+
+            let spent = mass_before - sat.state.plant.mass;
+            // The propellant is the difference of two masses near 500 kg, so it
+            // carries the resolution of f64 there however exactly the mass flow
+            // was integrated.
+            let tol = 4.0 * mass_before * f64::EPSILON;
+            assert!(
+                (spent - expected).abs() < tol,
+                "{name} spent {spent} kg, expected {expected} kg"
+            );
+        }
+    }
+
+    /// A span the loop cannot walk is rejected rather than reported as done.
+    ///
+    /// The segment loop tests `t < t1` before it builds a stepper, so a
+    /// non-finite bound takes no step and the solvers — which validate the span
+    /// themselves — never see it.
+    #[test]
+    fn a_non_finite_span_is_rejected_by_the_controlled_loop() {
+        for bound in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let (mut sat, _) = satellite_with(1.0, 0.0);
+            assert!(
+                propagate_controlled(&mut sat, 0.0, bound, &IntegratorConfig::Rk4 { dt: 1.0 })
+                    .is_err(),
+                "a target of {bound} was accepted"
+            );
+            let (mut sat, _) = satellite_with(1.0, 0.0);
+            assert!(
+                propagate_controlled(&mut sat, bound, 10.0, &IntegratorConfig::Rk4 { dt: 1.0 })
+                    .is_err(),
+                "a start of {bound} was accepted"
             );
         }
     }

--- a/cli/src/sim/controlled.rs
+++ b/cli/src/sim/controlled.rs
@@ -465,6 +465,12 @@ pub fn propagate_controlled(
     // largest gap between adjacent stage times contributes nothing at all, and
     // one covering a whole step loses the weight of the stage on its exclusive
     // end.
+    // The state stays local until every segment has succeeded. A satellite
+    // carries no integration time of its own, so committing each segment would
+    // leave a failed span with the state at the last boundary while the caller
+    // still holds `t0` — and serve pauses on such an error and can resume from
+    // there, propagating a state that belongs to a later instant.
+    let mut state = sat.state.clone();
     let mut t = t0;
     let mut first_segment = true;
     while t < t1 {
@@ -491,13 +497,13 @@ pub fn propagate_controlled(
                 // there in every case and never stagnates. What it costs is one
                 // extra step of an ulp's width, which moves the state by less
                 // than its own resolution.
-                sat.state = Rk4
-                    .try_integrate(&bound, sat.state.clone(), t, segment_end, dt_ode, |_, _| {})
+                state = Rk4
+                    .try_integrate(&bound, state, t, segment_end, dt_ode, |_, _| {})
                     .map_err(span)?;
             }
             IntegratorConfig::Dp45 { dt, tolerances } => {
                 let mut stepper =
-                    DormandPrince.stepper(&bound, sat.state.clone(), t, *dt, tolerances.clone());
+                    DormandPrince.stepper(&bound, state.clone(), t, *dt, tolerances.clone());
                 // A later segment starts from the state the previous one ended
                 // on, which this loop asks no predicate about at all.
                 if !first_segment {
@@ -510,11 +516,10 @@ pub fn propagate_controlled(
                         |_, _| ControlFlow::<String>::Continue(()),
                     )
                     .map_err(span)?;
-                sat.state = stepper.into_state();
+                state = stepper.into_state();
             }
             IntegratorConfig::Dop853 { dt, tolerances } => {
-                let mut stepper =
-                    Dop853.stepper(&bound, sat.state.clone(), t, *dt, tolerances.clone());
+                let mut stepper = Dop853.stepper(&bound, state.clone(), t, *dt, tolerances.clone());
                 if !first_segment {
                     stepper = stepper.from_checked_state();
                 }
@@ -525,13 +530,15 @@ pub fn propagate_controlled(
                         |_, _| ControlFlow::<String>::Continue(()),
                     )
                     .map_err(span)?;
-                sat.state = stepper.into_state();
+                state = stepper.into_state();
             }
         }
 
         t = segment_end;
         first_segment = false;
     }
+
+    sat.state = state;
     Ok(())
 }
 
@@ -1623,5 +1630,77 @@ path = "does-not-exist.wasm"
                 "a start of {bound} was accepted"
             );
         }
+    }
+
+    /// A span that fails partway leaves the satellite where it started.
+    ///
+    /// A `ControlledSatellite` carries no integration time of its own, so a
+    /// state committed at a segment boundary belongs to an instant the caller
+    /// has no record of: serve pauses on the error and can resume, propagating
+    /// a state from the wrong time. The state has to move only when the whole
+    /// span succeeds.
+    #[test]
+    fn a_span_that_fails_partway_leaves_the_state_untouched() {
+        use arika::epoch::Epoch;
+        use orts::model::{ExternalLoads, Model};
+        use orts::spacecraft::SpacecraftState;
+
+        /// Finite up to and including `breaks_at`, not after it — with the
+        /// boundary declared, so the loop splits the span there and it is the
+        /// *second* segment that fails. The stage on the first segment's end
+        /// has to stay finite: this model keeps the default stage-time
+        /// evaluation, so that stage reads `breaks_at` itself.
+        struct BreaksAfter {
+            breaks_at: f64,
+        }
+
+        impl Model<SpacecraftState> for BreaksAfter {
+            fn name(&self) -> &str {
+                "breaks_after"
+            }
+
+            fn eval(
+                &self,
+                t: f64,
+                _state: &SpacecraftState,
+                _epoch: Option<&Epoch>,
+            ) -> ExternalLoads {
+                let mut loads = ExternalLoads::zeros();
+                if t > self.breaks_at {
+                    loads.acceleration_inertial =
+                        arika::frame::Vec3::from_raw(Vector3::new(f64::NAN, 0.0, 0.0));
+                }
+                loads
+            }
+
+            fn next_discontinuity_after(&self, t: f64, _epoch: Option<&Epoch>) -> Option<f64> {
+                (self.breaks_at > t).then_some(self.breaks_at)
+            }
+        }
+
+        let (mut sat, _) = satellite_with(1.0, 0.0);
+        sat.dynamics = std::mem::replace(
+            &mut sat.dynamics,
+            orts::spacecraft::SpacecraftDynamics::new(
+                arika::earth::MU,
+                Box::new(orts::orbital::gravity::PointMass),
+                nalgebra::Matrix3::identity(),
+            ),
+        )
+        .with_model(BreaksAfter { breaks_at: 0.2 });
+        let before = sat.state.clone();
+
+        let err = propagate_controlled(&mut sat, 0.0, 1.0, &IntegratorConfig::Rk4 { dt: 1.0 })
+            .expect_err("the second segment is not finite");
+        assert!(err.contains("non-finite state"), "unexpected error: {err}");
+        assert_eq!(
+            sat.state.plant.orbit.position(),
+            before.plant.orbit.position(),
+            "the failed span moved the satellite"
+        );
+        assert_eq!(
+            sat.state.plant.mass, before.plant.mass,
+            "the failed span changed the mass"
+        );
     }
 }

--- a/orts/src/group/coupled.rs
+++ b/orts/src/group/coupled.rs
@@ -650,8 +650,8 @@ where
 
                     while current_t < segment_end {
                         // The last step of a segment lands on its end exactly.
-                        // Accumulating `h` leaves `current_t` an ulp short, and the
-                        // next `h` is then small enough to stagnate.
+                        // Accumulating `h` instead can leave `current_t` an ulp
+                        // short and spend a whole extra step covering that ulp.
                         let last = segment_end - current_t <= dt;
                         let h = if last { segment_end - current_t } else { dt };
                         // `h > 0` after the validate() above, but for large

--- a/orts/src/group/independent.rs
+++ b/orts/src/group/independent.rs
@@ -490,11 +490,14 @@ where
                             });
                         }
                         while !terminated && current_t < segment_end {
-                            // The last step of a segment lands on its end exactly.
-                            // Accumulating `h` instead leaves `current_t` an ulp
-                            // short, and the next `h` is then small enough to
-                            // stagnate. The segment's end is a switch of the
-                            // right-hand side, so landing near it is not enough.
+                            // The last step of a segment lands on its end
+                            // exactly. Accumulating `h` instead can leave
+                            // `current_t` an ulp short and spend a whole extra
+                            // step covering that ulp — measured, a span of
+                            // `[0, 1]` in steps of `0.1` takes eleven. The
+                            // segment's end is a switch of the right-hand side,
+                            // so the state has to be the state there, not the
+                            // state an ulp before it.
                             let last = segment_end - current_t <= dt;
                             let h = if last { segment_end - current_t } else { dt };
                             // `h > 0` after the validate() above, but for large


### PR DESCRIPTION
## 概要

#453 が両方の group ループで直したのと同じ取りこぼしが、controlled loop に残っていた。
`propagate_controlled` は `t0` から `t1` まで積分器を 1 回走らせるので、`sat.dynamics` が
`next_discontinuity_after` で境界を返してもループはそれを訊かない。

`ScheduledBurn` で `[0.15, 0.25)` を指定し、RK4 `dt = 1` で 10 s 伝播した実測(推力 10 N、
Isp 300 s):

| | 推進剤 [kg] |
|---|---|
| 修正前 | $0$ |
| 解析解 | $3.399 \times 10^{-4}$ |

**ループを segment ごとに区切り、#453 で入った `SegmentSystem` を渡すようにした。**adaptive は
segment ごとに stepper を作り、2 つ目以降は `from_checked_state()` を使う(開始状態について、
このループは predicate に何も訊かない)。

あわせて span の検証をループの前に置いた。`t1 <= t0` も `t < t1` も NaN では偽になるので、
ループが 1 ステップも踏まずに成功を返してしまう。solver は segment 単位でしか span を見ない。

RK4 の腕は `try_integrate` に委譲したままで、その時計は累積する(group ループは最後のステップで
端を代入する)。残差は正確に表現できる `segment_end - t` なので時計は端に着地する — 累積が
不正確な span や $10^{15}$ の時刻でも実測で毎回着地し、stagnation は起きない。代償は 1 ulp 幅の
ステップ 1 つで、状態はそれ自身の解像度より小さくしか動かない。

## 到達性

CLI の config から構築されるもので境界を宣言するものは今はない。`ConstantThrust` を構築するのは
artemis1 example とテストだけで、`ScheduledBurn` を構築するのも定義とテストだけ。したがって
影響を受けるのは、`ControlledSatellite` を自分で組んで schedule を持つ model を積む呼び出し元。

controlled loop の span は controller tick と出力サンプルで区切られているが、tick は
`PluginController::sample_period` の固定周期なので、model の schedule の端とは一致しない。

## 検証

oracle は解析解。全推力の燃焼が消す推進剤は `thrust / (Isp * g0)` × 燃焼長で、質量流量が state に
依らない。RK4 / DP45 / DOP853 の 3 つで検査した。許容は $4 \times 500 \times \varepsilon$ —
推進剤は 500 kg 付近の 2 つの質量の差なので、f64 の解像度が残る。

燃焼は `[0.15, 0.25)` に置いた。`[0.1, 0.2)` だと燃焼前の segment と燃焼 segment がどちらも
0.1 s になり、stage 時刻で読んだときに前へ漏れる $h/6$ と燃焼 segment の最終ステージから落ちる
$h/6$ が RK4 で厳密に打ち消す(#453 で 3 回踏んだ)。

mutation:

| mutation | 結果 |
|---|---|
| ループが span を区切らない | RK4 の推進剤が $0$ |
| span を検証しない | NaN の target が受理される |

## 関連

#454 を close する。#446 に残るのは utsuroi の root event、RW 飽和、dry mass 枯渇で、
いずれも時刻が state で決まる境界。
