### PR TITLE
bench(orts): measure what the panel shadow geometry costs per evaluation

### DIFF
--- a/orts/Cargo.toml
+++ b/orts/Cargo.toml
@@ -82,3 +82,7 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync", 
 name = "fiber_overhead"
 harness = false
 required-features = ["plugin-wasm"]
+
+[[bench]]
+name = "panel_shadow"
+harness = false

--- a/orts/benches/panel_shadow.rs
+++ b/orts/benches/panel_shadow.rs
@@ -125,13 +125,14 @@ fn bench(c: &mut Criterion) {
     }
     group.finish();
 
-    // The denominator: one derivative evaluation of the whole spacecraft, with
-    // the two panel models installed alongside the gravity the integrator has
-    // to do anyway. Per-model figures only say what they cost relative to
-    // this.
+    // One derivative evaluation of the whole spacecraft, with the two panel
+    // models installed alongside the gravity the integrator has to do anyway.
+    // A per-model figure only says what it costs against this, so every shape
+    // measured above is measured here too.
     let mut group = c.benchmark_group("spacecraft_derivatives");
     for (name, panels) in [
         ("outline_free", outline_free()),
+        ("cube", cube()),
         ("bus_and_arrays", bus_and_arrays(1)),
         ("segmented_array", bus_and_arrays(8)),
     ] {

--- a/orts/benches/panel_shadow.rs
+++ b/orts/benches/panel_shadow.rs
@@ -1,0 +1,175 @@
+//! Benchmark: what the shadow geometry costs per derivative evaluation.
+//!
+//! `PanelSrp` and `PanelDrag` ask `lit_region` how much of each panel the
+//! source reaches, which scans every other panel for every panel. The cost
+//! depends on what the shape is, not only on how many panels it has, so the
+//! cases below separate the parts:
+//!
+//! - `outline_free` — panels with an area and no boundary. They take no part in
+//!   the geometry at all, which is the floor: the force law alone.
+//! - `cube` — the six faces of a cube, which carry outlines and stand at right
+//!   angles, so the scan runs and finds almost nothing.
+//! - `bus_and_arrays` — the shape issue #407 measures on: a 1 m cube bus with a
+//!   2 m x 1 m array either side, at a Sun angle where the bus face is partly
+//!   shadowed. The full path, including the subtraction.
+//! - `segmented_array` — the same bus with each array written as eight
+//!   segments, 22 panels in all. Panels shadow each other in numbers here, so
+//!   this is where the quadratic scan and the piece count show up.
+//!
+//! Run:
+//!   cargo bench -p orts --bench panel_shadow
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use nalgebra::Vector3;
+
+use orts::OrbitalState;
+use orts::SpacecraftState;
+use orts::attitude::AttitudeState;
+use orts::model::Model;
+use orts::spacecraft::{PanelDrag, PanelOptics, PanelSrp, SpacecraftShape, SurfacePanel};
+
+/// A 400 km circular orbit with the body axes on the inertial ones, so the Sun
+/// direction in the body frame is whatever the ephemeris gives.
+fn state() -> SpacecraftState {
+    let r = arika::earth::R + 400.0;
+    let v = (arika::earth::MU / r).sqrt();
+    SpacecraftState {
+        orbit: OrbitalState::new(Vector3::new(r, 0.0, 0.0), Vector3::new(0.0, v, 0.0)),
+        attitude: AttitudeState::identity(),
+        mass: 500.0,
+    }
+}
+
+/// The same orbit with the velocity turned 45 deg in the x-y plane.
+///
+/// In `state` the flow arrives along `-y`, which the arrays' `+-x` normals meet
+/// edge-on: the force cutoff drops them before any geometry runs, so the drag
+/// figures there are a best case that says nothing about the shadow work. Here
+/// the flow hits the arrays.
+fn oblique_state() -> SpacecraftState {
+    let r = arika::earth::R + 400.0;
+    let v = (arika::earth::MU / r).sqrt();
+    let s = std::f64::consts::FRAC_1_SQRT_2;
+    SpacecraftState {
+        orbit: OrbitalState::new(
+            Vector3::new(r * s, r * s, 0.0),
+            Vector3::new(-v * s, v * s, 0.0),
+        ),
+        attitude: AttitudeState::identity(),
+        mass: 500.0,
+    }
+}
+
+fn optics() -> PanelOptics {
+    PanelOptics::new(0.2, 0.1)
+}
+
+/// Six panels with an area and no boundary: no geometry, only the force law.
+fn outline_free() -> Vec<SurfacePanel> {
+    let axes = [
+        Vector3::x(),
+        -Vector3::x(),
+        Vector3::y(),
+        -Vector3::y(),
+        Vector3::z(),
+        -Vector3::z(),
+    ];
+    axes.iter()
+        .map(|n| SurfacePanel::at_com(1.0, *n, 2.2, optics()).with_cp_offset(n * 0.5))
+        .collect()
+}
+
+fn cube() -> Vec<SurfacePanel> {
+    let SpacecraftShape::Panels(faces) = SpacecraftShape::cube(0.5, 2.2, optics()) else {
+        unreachable!("cube is panelled")
+    };
+    faces
+}
+
+/// One solar array: a rectangle in the y-z plane, `segments` panels long,
+/// reaching from `y = 0.6` to `y = 2.6` on the given side.
+fn array(side: f64, segments: usize) -> Vec<SurfacePanel> {
+    let span = 2.0 / segments as f64;
+    (0..segments)
+        .map(|i| {
+            let centre = side * (0.6 + span * (i as f64 + 0.5));
+            SurfacePanel::rectangle([span / 2.0, 0.5], Vector3::y(), Vector3::x(), 2.2, optics())
+                .with_cp_offset(Vector3::new(0.0, centre, 0.0))
+        })
+        .collect()
+}
+
+fn bus_and_arrays(segments: usize) -> Vec<SurfacePanel> {
+    let mut panels = cube();
+    panels.extend(array(1.0, segments));
+    panels.extend(array(-1.0, segments));
+    panels
+}
+
+fn bench(c: &mut Criterion) {
+    let state = state();
+    let epoch = arika::epoch::Epoch::from_jd(2460000.5);
+
+    let mut group = c.benchmark_group("panel_srp_eval");
+    for (name, panels) in [
+        ("outline_free", outline_free()),
+        ("cube", cube()),
+        ("bus_and_arrays", bus_and_arrays(1)),
+        ("segmented_array", bus_and_arrays(8)),
+    ] {
+        let n = panels.len();
+        let srp = PanelSrp::for_earth(SpacecraftShape::Panels(panels));
+        group.bench_function(format!("{name}_{n}_panels"), |b| {
+            b.iter(|| srp.eval(0.0, &state, Some(&epoch)))
+        });
+    }
+    group.finish();
+
+    // The denominator: one derivative evaluation of the whole spacecraft, with
+    // the two panel models installed alongside the gravity the integrator has
+    // to do anyway. Per-model figures only say what they cost relative to
+    // this.
+    let mut group = c.benchmark_group("spacecraft_derivatives");
+    for (name, panels) in [
+        ("outline_free", outline_free()),
+        ("bus_and_arrays", bus_and_arrays(1)),
+        ("segmented_array", bus_and_arrays(8)),
+    ] {
+        let n = panels.len();
+        let inertia = nalgebra::Matrix3::from_diagonal(&Vector3::new(10.0, 12.0, 8.0));
+        let dynamics = orts::spacecraft::SpacecraftDynamics::new(
+            arika::earth::MU,
+            orts::orbital::gravity::PointMass,
+            inertia,
+        )
+        .with_epoch(epoch)
+        .with_model(PanelSrp::for_earth(SpacecraftShape::Panels(panels.clone())))
+        .with_model(PanelDrag::for_earth(SpacecraftShape::Panels(panels)));
+        let augmented = orts::effector::AugmentedState::from(state.clone());
+        group.bench_function(format!("{name}_{n}_panels"), |b| {
+            b.iter(|| utsuroi::DynamicalSystem::derivatives(&dynamics, 0.0, &augmented))
+        });
+    }
+    group.finish();
+
+    let oblique = oblique_state();
+    let mut group = c.benchmark_group("panel_drag_eval");
+    for (name, panels, st) in [
+        ("outline_free", outline_free(), &state),
+        ("cube", cube(), &state),
+        ("bus_and_arrays_edge_on_arrays", bus_and_arrays(1), &state),
+        ("segmented_array_edge_on_arrays", bus_and_arrays(8), &state),
+        ("bus_and_arrays_oblique", bus_and_arrays(1), &oblique),
+        ("segmented_array_oblique", bus_and_arrays(8), &oblique),
+    ] {
+        let n = panels.len();
+        let drag = PanelDrag::for_earth(SpacecraftShape::Panels(panels));
+        group.bench_function(format!("{name}_{n}_panels"), |b| {
+            b.iter(|| drag.eval(0.0, st, None))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);


### PR DESCRIPTION
#444 は影の幾何の計算量について数字を書いているが、それを測るものがリポジトリに無い。次に `lit_region` を触ったとき、遅くなったかどうかを確かめる手段が無い状態である。criterion のベンチマークを 1 本追加する。

## 測っているもの

`PanelSrp::eval` と `PanelDrag::eval` の 1 回、それと機体全体の導関数 1 回（PointMass 重力 + SRP + drag）。per-model の数字は、機体全体にかかる時間と並べないと意味が読めない。

形状は 4 つで、コストがどこから出ているかを分けるために選んだ。

- 輪郭なし 6 枚 — 幾何に参加しないので、力の法則だけの時間
- 立方体 6 面 — 輪郭は持つが直角に立っているので、走査は回るがほとんど何も見つからない
- 本体 + SAP 8 枚 — #407 が測っている形状。部分的に影に入る面がある
- SAP を 8 分割して 22 枚 — パネル同士が数多く影を落とすので、走査と分割の両方が出る

## 手元での結果（load average 0.7〜1.6）

| | SRP | 導関数全体 | SRP の割合 |
|---|---|---|---|
| 輪郭なし 6 枚 | 301 ns | 549 ns | 55% |
| 立方体 6 面 | 1.50 µs | 2.10 µs | 71% |
| 本体 + SAP 8 枚 | 8.2 µs | 9.24 µs | 89% |
| 22 枚 | 46.5 µs | 50.5 µs | 92% |

輪郭を書かない機体は 549 ns のままなので、コストは輪郭を書いた機体だけが払う。6 → 22 枚（2.75 倍）で SRP が 32 倍になる。

drag は姿勢を 2 つ測っている。流れが `-y` から来る姿勢では SAP の法線 ±x が edge-on で、力の打ち切りが幾何の前に落とすため、影の計算について何も言えない数字になる。

| | 流れが edge-on | 流れを 45° 傾けた姿勢 |
|---|---|---|
| 8 枚 | 976 ns | 5.8 µs |
| 22 枚 | 3.6 µs | 44.6 µs |

## これはテストではない

時間を測るだけで `assert` は 1 つも無い。`[[bench]]` + `harness = false` なので `cargo test` では走らず、CI にも入れていない。したがってこれ自体が回帰を検出することはなく、人が走らせて読むためのものである。

```
cargo bench -p orts --bench panel_shadow
```

絶対時間はマシンに依存する。#444 の前後比較（マージ前の main との比較）もしていないので、「#444 が何倍にしたか」はこのベンチマークでは答えていない。
