### PR TITLE
fix(cli): give every satellite's CSV rows the columns the header names

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -419,6 +419,14 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
   client への error も無い状態になっていた。([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
+- CSV の全衛星の行が、header が名前を挙げた列を持つようになった。header は先頭の衛星の
+  component から作られ、各衛星の行はその衛星自身の component から書かれていたので、
+  持ち物が違う艦隊では行の幅が揃わなかった。2 機のうち先頭だけが magnetorquer の指令を
+  持つ場合、header は 17 列で 2 機目の行は 14 列になり、CSV として読み戻せない。
+  列を艦隊全体の和として 1 度作り、header と全衛星の行が同じものを歩くようにした。
+  その component を持たない衛星は欄を空にする (ステップで値が欠けたときに既にそうしていた
+  のと同じ扱い)。列名は recording の component registry から取る。log と `.rrd` の
+  読み込みのどちらも registry を埋める。([#465](https://github.com/sksat/orts/pull/465))
 - controlled loop が、積分 step より短い燃焼も伝播に入れるようになった。
   `propagate_controlled` は span の始まりから終わりまで積分器を 1 回走らせていたので、schedule を
   持つ dynamics では #453 以前の group ループと同じ取りこぼしが起きていた。`ScheduledBurn` で

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -421,9 +421,10 @@ orts は マルチパッケージ workspace (crates.io Rust crate + npm package)
 #### Fixed
 - CSV の全衛星の行が、header が名前を挙げた列を持つようになった。header は先頭の衛星の
   component から作られ、各衛星の行はその衛星自身の component から書かれていたので、
-  持ち物が違う艦隊では行の幅が揃わなかった。2 機のうち先頭だけが magnetorquer の指令を
+  衛星ごとに記録している component が違うと行の列数が揃わなかった。2 機のうち先頭だけが magnetorquer の指令を
   持つ場合、header は 17 列で 2 機目の行は 14 列になり、CSV として読み戻せない。
-  列を艦隊全体の和として 1 度作り、header と全衛星の行が同じものを歩くようにした。
+  その CSV に出てくる全 component を合わせた列のリストを 1 度作り、header と全衛星の行が
+  同じリストを歩くようにした。
   その component を持たない衛星は欄を空にする (ステップで値が欠けたときに既にそうしていた
   のと同じ扱い)。列名は recording の component registry から取る。log と `.rrd` の
   読み込みのどちらも registry を埋める。([#465](https://github.com/sksat/orts/pull/465))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -501,6 +501,16 @@ section is subdivided by package.
   no error to the client. ([#351](https://github.com/sksat/orts/pull/351))
 
 #### Fixed
+- Every satellite's CSV rows carry the columns the header names. The header was
+  built from the first satellite's components and each satellite's rows from its
+  own, so a fleet whose satellites differ wrote rows of different widths: two
+  satellites where only the first has a magnetorquer command give a 17-column
+  header and 14-column rows for the second, which no CSV reader can line up.
+  The columns are now the union over the fleet, taken once and walked by the
+  header and by every row, and a satellite without a component writes its
+  fields empty — the same thing a row already did for a component missing at
+  that step. Field names come from the recording's component registry, which
+  both logging and reading an `.rrd` populate. ([#465](https://github.com/sksat/orts/pull/465))
 - The controlled loop flies a scheduled burn shorter than an integration step.
   `propagate_controlled` ran the integrator from the span's start straight to
   its end, so dynamics carrying a schedule lost it the way the group loops did

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -864,15 +864,23 @@ pub fn write_recording_as_csv(
         )?;
     }
 
-    if let Some((first_path, _)) = sat_entries.first() {
-        writeln!(w, "{}", build_csv_header(rec, first_path, multi_sat))?;
+    // One column list for the whole file. Satellites need not carry the same
+    // components — a magnetorquer command or a panel model belongs to the
+    // satellite that has one — and every row has to line up with the single
+    // header, so the columns are the union over the fleet and a satellite
+    // without one writes its fields empty.
+    let paths: Vec<&EntityPath> = sat_entries.iter().map(|(path, _)| path).collect();
+    let columns = csv_columns(rec, &paths);
+
+    if !sat_entries.is_empty() {
+        writeln!(w, "{}", build_csv_header(&columns, multi_sat))?;
     }
 
     for (sat_path, id) in &sat_entries {
         if multi_sat {
             writeln!(w, "# --- {id} ---")?;
         }
-        write_satellite_csv(w, rec, sat_path, mu, multi_sat)?;
+        write_satellite_csv(w, rec, sat_path, mu, multi_sat, &columns)?;
     }
 
     Ok(())
@@ -885,6 +893,7 @@ pub fn write_satellite_csv(
     sat_path: &EntityPath,
     mu: f64,
     with_id: bool,
+    columns: &[CsvColumn],
 ) -> std::io::Result<()> {
     use orts::record::component::Component;
     use orts::record::components::{Position3D, Velocity3D};
@@ -906,15 +915,6 @@ pub fn write_satellite_csv(
         Some(t) => t,
         None => return Ok(()),
     };
-
-    // Collect extra columns (everything except Position3D and Velocity3D), sorted by name
-    let skip = [Position3D::component_name(), Velocity3D::component_name()];
-    let mut extra_cols: Vec<_> = store
-        .columns
-        .iter()
-        .filter(|(name, _)| !skip.contains(name))
-        .collect();
-    extra_cols.sort_by_key(|(a, _)| *a);
 
     let id = sat_path.to_string();
     let id = id.rsplit('/').next().unwrap_or("default");
@@ -958,17 +958,22 @@ pub fn write_satellite_csv(
             elements.true_anomaly,
         ));
 
-        for (_name, col) in &extra_cols {
-            // The header names every extra column, so a component with no value at
-            // this step contributes empty fields rather than none: a short line
-            // would put the remaining values under the wrong headings.
-            match col.at_logical_row(logical) {
+        for column in columns {
+            // The header names every extra column, so a component with no value
+            // at this step — or none on this satellite at all — contributes
+            // empty fields rather than none: a short line would put the
+            // remaining values under the wrong headings.
+            match store
+                .columns
+                .get(&column.name)
+                .and_then(|col| col.at_logical_row(logical))
+            {
                 Some(row) => {
                     for val in row {
                         line.push_str(&format!(",{:.10}", val));
                     }
                 }
-                None => line.push_str(&",".repeat(col.scalars_per_row())),
+                None => line.push_str(&",".repeat(column.fields.len())),
             }
         }
 
@@ -977,11 +982,62 @@ pub fn write_satellite_csv(
     Ok(())
 }
 
-/// Build the CSV header line dynamically from the Recording's columns.
-pub fn build_csv_header(rec: &Recording, sat_path: &EntityPath, with_id: bool) -> String {
+/// One group of CSV columns: a component and the field name of each of its
+/// scalars.
+///
+/// The header and every satellite's rows walk the same list, which is what
+/// keeps a fleet whose satellites carry different components readable: the
+/// satellites without one write its fields empty rather than shortening their
+/// rows.
+#[derive(Debug, Clone)]
+pub struct CsvColumn {
+    /// Component name, as the entity stores it.
+    pub name: orts::record::component::ComponentName,
+    /// Column heading for each scalar the component contributes.
+    pub fields: Vec<String>,
+}
+
+/// The extra columns of a fleet: every component any of `sat_paths` records,
+/// apart from position and velocity, which the fixed leading columns carry.
+///
+/// Field names come from the recording's component registry, which both
+/// logging and loading an `.rrd` populate. A component the registry does not
+/// know falls back to the built-in table, and then to one field per scalar.
+pub fn csv_columns(rec: &Recording, sat_paths: &[&EntityPath]) -> Vec<CsvColumn> {
     use orts::record::component::Component;
     use orts::record::components::{Position3D, Velocity3D};
 
+    let skip = [Position3D::component_name(), Velocity3D::component_name()];
+    let mut widths: std::collections::BTreeMap<orts::record::component::ComponentName, usize> =
+        std::collections::BTreeMap::new();
+    for path in sat_paths {
+        let Some(store) = rec.entity(path) else {
+            continue;
+        };
+        for (name, col) in &store.columns {
+            if skip.contains(name) {
+                continue;
+            }
+            widths.insert(name.clone(), col.scalars_per_row());
+        }
+    }
+
+    widths
+        .into_iter()
+        .map(|(name, width)| {
+            let registered = rec
+                .component_registry
+                .get(&name)
+                .map(|info| info.field_names.clone())
+                .filter(|fields| fields.len() == width);
+            let fields = registered.unwrap_or_else(|| lookup_field_names(&name, width));
+            CsvColumn { name, fields }
+        })
+        .collect()
+}
+
+/// Build the CSV header line from the fleet's columns.
+pub fn build_csv_header(columns: &[CsvColumn], with_id: bool) -> String {
     let mut header = String::new();
     header.push_str("# ");
     if with_id {
@@ -989,30 +1045,9 @@ pub fn build_csv_header(rec: &Recording, sat_path: &EntityPath, with_id: bool) -
     }
     header.push_str("t[s],x[km],y[km],z[km],vx[km/s],vy[km/s],vz[km/s],a[km],e[-],i[rad],raan[rad],omega[rad],nu[rad]");
 
-    if let Some(store) = rec.entity(sat_path) {
-        let skip = [Position3D::component_name(), Velocity3D::component_name()];
-        let mut extra_cols: Vec<_> = store
-            .columns
-            .keys()
-            .filter(|name| !skip.contains(name))
-            .collect();
-        extra_cols.sort();
-
-        for name in extra_cols {
-            // Use component name as column prefix (strip "orts." prefix)
-            let short = name.strip_prefix("orts.").unwrap_or(name);
-            if let Some(col) = store.columns.get(name) {
-                let n = col.scalars_per_row();
-                if n == 1 {
-                    header.push_str(&format!(",{short}"));
-                } else {
-                    // Look up field names from known components
-                    let field_names = lookup_field_names(name, n);
-                    for fname in field_names {
-                        header.push_str(&format!(",{fname}"));
-                    }
-                }
-            }
+    for column in columns {
+        for field in &column.fields {
+            header.push_str(&format!(",{field}"));
         }
     }
 
@@ -1439,7 +1474,8 @@ mod tests {
         }
 
         let mut out = Vec::new();
-        write_satellite_csv(&mut out, &rec, &sat, 398600.4418, false).expect("csv");
+        let columns = csv_columns(&rec, &[&sat]);
+        write_satellite_csv(&mut out, &rec, &sat, 398600.4418, false, &columns).expect("csv");
         let body = String::from_utf8(out).expect("utf-8");
         let lines: Vec<&str> = body.lines().filter(|l| !l.starts_with('#')).collect();
 
@@ -1511,7 +1547,8 @@ mod tests {
         let loaded = load_as_recording(&path_str).expect("load");
         let _ = std::fs::remove_file(&path);
 
-        let header = build_csv_header(&loaded, &sat, false);
+        let columns = csv_columns(&loaded, &[&sat]);
+        let header = build_csv_header(&columns, false);
         assert!(
             header.contains("mtq_mx"),
             "the command column survives the file: {header}"
@@ -1519,7 +1556,7 @@ mod tests {
         let want = header.trim_start_matches("# ").matches(',').count() + 1;
 
         let mut out = Vec::new();
-        write_satellite_csv(&mut out, &loaded, &sat, 398600.4418, false).expect("csv");
+        write_satellite_csv(&mut out, &loaded, &sat, 398600.4418, false, &columns).expect("csv");
         let body = String::from_utf8(out).expect("utf-8");
         let lines: Vec<&str> = body.lines().filter(|l| !l.starts_with('#')).collect();
 
@@ -1577,11 +1614,13 @@ mod tests {
             }
         }
 
-        let header = build_csv_header(&rec, &sat, false);
+        let columns = csv_columns(&rec, &[&sat]);
+        let header = build_csv_header(&columns, false);
         let want = header.trim_start_matches("# ").matches(',').count() + 1;
 
         let mut out = Vec::new();
-        write_satellite_csv(&mut out, &rec, &sat, 398600.4418, false).expect("csv");
+        let columns = csv_columns(&rec, &[&sat]);
+        write_satellite_csv(&mut out, &rec, &sat, 398600.4418, false, &columns).expect("csv");
         let body = String::from_utf8(out).expect("utf-8");
 
         let lines: Vec<&str> = body.lines().filter(|l| !l.starts_with('#')).collect();
@@ -1675,5 +1714,63 @@ mod tests {
         assert!(
             validate_output_contract(&DataSink::File("out.rrd"), OutputFormat::Rrd, false).is_ok()
         );
+    }
+
+    /// **Reproduction**: the CSV header is built from the first satellite's
+    /// columns, so a fleet whose satellites carry different components writes
+    /// rows that disagree with it. Here one satellite has a magnetorquer
+    /// command and the other does not: the header names its three fields and
+    /// the plain satellite's rows stop three columns short, which no CSV reader
+    /// can parse back.
+    #[test]
+    fn every_satellite_writes_the_columns_the_header_names() {
+        use orts::record::archetypes::OrbitalState as RecOrbitalState;
+        use orts::record::components::MtqCommand3D;
+        use orts::record::timeline::TimePoint;
+
+        let mut rec = Recording::new();
+        let with_mtq = EntityPath::parse("/world/sat/a_has_mtq");
+        let plain = EntityPath::parse("/world/sat/b_plain");
+        let r0 = 6778.137;
+        let v0 = (398600.4418_f64 / r0).sqrt();
+        for i in 0..3u64 {
+            let tp = TimePoint::new().with_sim_time(i as f64).with_step(i);
+            let os = RecOrbitalState::new(
+                nalgebra::Vector3::new(r0, 0.0, 0.0),
+                nalgebra::Vector3::new(0.0, v0, 0.0),
+            );
+            rec.log_orbital_state(&with_mtq, &tp, &os);
+            rec.log_orbital_state(&plain, &tp, &os);
+            rec.log_temporal(
+                &with_mtq,
+                &tp,
+                &MtqCommand3D(nalgebra::Vector3::new(1.0, 0.0, 0.0)),
+            );
+        }
+
+        let mut out = Vec::new();
+        write_recording_as_csv(&mut out, &rec, None).expect("csv");
+        let body = String::from_utf8(out).expect("utf-8");
+
+        let header = body
+            .lines()
+            .find(|l| l.starts_with("# satellite_id,"))
+            .expect("header line");
+        let want = header.matches(',').count() + 1;
+        let rows: Vec<&str> = body.lines().filter(|l| !l.starts_with('#')).collect();
+        assert_eq!(rows.len(), 6, "three rows for each of the two satellites");
+        for row in &rows {
+            assert_eq!(
+                row.matches(',').count() + 1,
+                want,
+                "row disagrees with the header, which names {want} columns: {row}"
+            );
+        }
+        // The satellite without the command leaves those fields empty.
+        let plain_rows: Vec<&&str> = rows.iter().filter(|r| r.starts_with("b_plain,")).collect();
+        assert_eq!(plain_rows.len(), 3);
+        for row in plain_rows {
+            assert!(row.ends_with(",,,"), "expected three empty fields: {row}");
+        }
     }
 }


### PR DESCRIPTION
複数の衛星を 1 つの CSV に書くとき、衛星ごとに記録している component が違うと、行の列数が header と揃わない。header は先頭の衛星の component から作られ、各衛星の行はその衛星自身の component から書かれていた。

2 機のうち先頭だけが magnetorquer の指令を持つ場合の実測:

```
header      17 列  # satellite_id,t[s],...,nu[rad],mtq_mx,mtq_my,mtq_mz
a_has_mtq   17 列
b_plain     14 列
```

header に合わせて 2 機目の行を読むと、値が別の見出しの下に来る。

## 直し方

列のリストを 1 本にまとめ、header と全衛星の行が同じリストを歩くようにした。リストはその CSV に出てくる全 component を合わせたもので、その component を持たない衛星は欄を空にする。ステップで値が欠けたときには既に空欄を出していたので、同じ扱いを「衛星がその component を持たない」場合まで広げたことになる。

```rust
pub struct CsvColumn {
    pub name: ComponentName,
    pub fields: Vec<String>,
}

pub fn csv_columns(rec: &Recording, sat_paths: &[&EntityPath]) -> Vec<CsvColumn>
```

`build_csv_header` と `write_satellite_csv` は列リストを受け取る形にした。各自が導出すると、行を書いた基準と印字された header が食い違いうる。

列名は recording の component registry から取る。`log_temporal` と `.rrd` の読み込み (`register_component_fields`) のどちらも registry を埋めるので、静的な名前表に載っていない component にも名前が付く。registry に無ければ従来の名前表、それも無ければ scalar ごとに 1 列。

## テスト

`every_satellite_writes_the_columns_the_header_names` — 2 機のうち 1 機だけが magnetorquer の指令を持つ recording を CSV に書き、header が挙げた列数と全行の列数が一致すること、指令を持たない衛星の行は該当欄が空であることを確認する。修正前は 17 列の header に対し 14 列の行で落ちる。

## 確認したこと

`cargo test -p orts-cli` 367 passed、`cargo clippy --locked --workspace` はこの変更由来 0 件、`cargo fmt --all --check` clean、codex review 指摘なし。ts-rs の binding に差分なし。
